### PR TITLE
fix: remove empty datastores override in production config

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -32,7 +32,7 @@ module.exports = {
    * (http://sailsjs.com/config/datastores)                                  *
    *                                                                         *
    **************************************************************************/
-  datastores: {},
+  // datastores: inherited from config/datastores.js (SQLite for all environments)
 
   models: {
     /**************************************************************************


### PR DESCRIPTION
The empty `datastores: {}` in config/env/production.js was overriding the base SQLite config from config/datastores.js, causing the ORM to load with zero datastores. Every query failed with "no matching datastore entry".

Closes #5