### PR TITLE
feat: create Caddy route when instanceDomain is set

### DIFF
--- a/api/controllers/setting/update-instance.js
+++ b/api/controllers/setting/update-instance.js
@@ -31,6 +31,21 @@ module.exports = {
         .replace(/^https?:\/\//, '')
         .replace(/\/+$/, '')
       await sails.helpers.setting.set('instanceDomain', cleanDomain)
+
+      // Update Caddy route for the dashboard domain
+      if (cleanDomain) {
+        try {
+          await sails.helpers.caddy.updateDashboardRoute(cleanDomain)
+        } catch (err) {
+          sails.log.warn('Failed to create Caddy dashboard route:', err.message)
+        }
+      } else {
+        try {
+          await sails.helpers.caddy.removeDashboardRoute()
+        } catch (err) {
+          sails.log.warn('Failed to remove Caddy dashboard route:', err.message)
+        }
+      }
     }
 
     if (instanceName !== undefined) {

--- a/api/helpers/caddy/remove-dashboard-route.js
+++ b/api/helpers/caddy/remove-dashboard-route.js
@@ -1,0 +1,42 @@
+const http = require('http')
+
+module.exports = {
+  friendlyName: 'Remove dashboard route',
+
+  description: 'Remove the Caddy route for the Slipway dashboard domain.',
+
+  inputs: {},
+
+  exits: {
+    success: {
+      description: 'Dashboard route removed successfully'
+    }
+  },
+
+  fn: async function () {
+    const caddyAdminUrl = sails.config.custom.caddyAdminUrl || 'http://localhost:2019'
+    const routeId = 'slipway-dashboard'
+
+    return new Promise((resolve) => {
+      const url = new URL(`${caddyAdminUrl}/id/${routeId}`)
+
+      const req = http.request(
+        {
+          hostname: url.hostname,
+          port: url.port,
+          path: url.pathname,
+          method: 'DELETE'
+        },
+        (res) => {
+          if (res.statusCode === 200) {
+            sails.log.info('Caddy dashboard route removed')
+          }
+          resolve()
+        }
+      )
+
+      req.on('error', () => { resolve() })
+      req.end()
+    })
+  }
+}

--- a/api/helpers/caddy/update-dashboard-route.js
+++ b/api/helpers/caddy/update-dashboard-route.js
@@ -1,0 +1,100 @@
+const http = require('http')
+
+module.exports = {
+  friendlyName: 'Update dashboard route',
+
+  description: 'Create or update a Caddy route for the Slipway dashboard domain.',
+
+  inputs: {
+    domain: {
+      type: 'string',
+      required: true,
+      description: 'The dashboard domain (e.g. slipway.example.com)'
+    }
+  },
+
+  exits: {
+    success: {
+      description: 'Dashboard route updated successfully'
+    },
+    caddyError: {
+      description: 'Failed to update Caddy config'
+    }
+  },
+
+  fn: async function ({ domain }) {
+    const caddyAdminUrl = sails.config.custom.caddyAdminUrl || 'http://localhost:2019'
+    const routeId = 'slipway-dashboard'
+    const port = sails.config.port || 1337
+
+    const route = {
+      '@id': routeId,
+      match: [{ host: [domain] }],
+      handle: [
+        {
+          handler: 'reverse_proxy',
+          upstreams: [{ dial: `host.docker.internal:${port}` }]
+        }
+      ],
+      terminal: true
+    }
+
+    const routeData = JSON.stringify(route)
+
+    return new Promise((resolve, reject) => {
+      const createRoute = () => {
+        const url = new URL(`${caddyAdminUrl}/config/apps/http/servers/srv0/routes`)
+
+        const req = http.request(
+          {
+            hostname: url.hostname,
+            port: url.port,
+            path: url.pathname,
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Content-Length': Buffer.byteLength(routeData)
+            }
+          },
+          (res) => {
+            let body = ''
+            res.on('data', (chunk) => { body += chunk })
+            res.on('end', () => {
+              if (res.statusCode >= 200 && res.statusCode < 300) {
+                sails.log.info(`Caddy dashboard route created for ${domain}`)
+                resolve({ domain, routeId, action: 'created' })
+              } else {
+                sails.log.error(`Caddy API error: ${res.statusCode} - ${body}`)
+                reject(new Error(`Caddy API error: ${res.statusCode}`))
+              }
+            })
+          }
+        )
+
+        req.on('error', (error) => {
+          sails.log.error(`Caddy request error: ${error.message}`)
+          reject(error)
+        })
+
+        req.write(routeData)
+        req.end()
+      }
+
+      // Delete existing route first (ignore errors if not found)
+      const deleteUrl = new URL(`${caddyAdminUrl}/id/${routeId}`)
+
+      const deleteReq = http.request(
+        {
+          hostname: deleteUrl.hostname,
+          port: deleteUrl.port,
+          path: deleteUrl.pathname,
+          method: 'DELETE'
+        },
+        () => { createRoute() }
+      )
+
+      deleteReq.on('error', () => { createRoute() })
+      deleteReq.end()
+    })
+  }
+}

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -64,7 +64,7 @@ module.exports.bootstrap = async function () {
     sails.log.verbose(error)
   }
 
-  // Configure Caddy TLS if ACME email is set
+  // Configure Caddy TLS and dashboard route if set up
   if (genesisUser) {
     try {
       const acmeEmail = await sails.helpers.setting.get('acmeEmail')
@@ -74,6 +74,16 @@ module.exports.bootstrap = async function () {
       }
     } catch (error) {
       sails.log.verbose('Could not configure Caddy TLS:', error.message)
+    }
+
+    try {
+      const instanceDomain = await sails.helpers.setting.get('instanceDomain')
+      if (instanceDomain) {
+        await sails.helpers.caddy.updateDashboardRoute(instanceDomain)
+        sails.log.info('Caddy dashboard route configured for:', instanceDomain)
+      }
+    } catch (error) {
+      sails.log.verbose('Could not configure Caddy dashboard route:', error.message)
     }
   }
 }


### PR DESCRIPTION
When a user sets instanceDomain in settings, a Caddy reverse proxy route is created for that domain pointing to the Slipway dashboard. Caddy auto-provisions TLS via ACME. Clearing the domain removes the route.

The route is also restored on bootstrap so it survives container restarts.

Closes #11