### PR TITLE
Fix configure backup link to navigate to settings/uploads

### DIFF
--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -1164,7 +1164,7 @@ onBeforeUnmount(() => {
                     </button>
                     <Link
                       v-else-if="!backupConfigured"
-                      href="/settings/global-env"
+                      href="/settings/uploads"
                       class="rounded px-2 py-0.5 text-xs font-medium text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
                       Configure storage


### PR DESCRIPTION
## Summary
- Changed "Configure storage" link on the environment page from `/settings/global-env` to `/settings/uploads` where the actual S3/R2 backup configuration lives

Closes #42