### PR TITLE
Disable save button on update forms when not dirty

### DIFF
--- a/assets/js/pages/dashboard/profile.vue
+++ b/assets/js/pages/dashboard/profile.vue
@@ -146,7 +146,7 @@ function logout() {
             <div class="flex items-center justify-end px-4 py-3">
               <button
                 type="submit"
-                :disabled="form.processing"
+                :disabled="form.processing || !form.isDirty"
                 class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ form.processing ? 'Saving...' : 'Save changes' }}
@@ -197,7 +197,7 @@ function logout() {
             <div class="flex items-center justify-end px-4 py-3">
               <button
                 type="submit"
-                :disabled="form.processing || !form.currentPassword || !form.password"
+                :disabled="form.processing || !form.isDirty || !form.currentPassword || !form.password"
                 class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ form.processing ? 'Updating...' : 'Update password' }}

--- a/assets/js/pages/projects/settings.vue
+++ b/assets/js/pages/projects/settings.vue
@@ -174,7 +174,7 @@ function deleteProject() {
           <div class="flex justify-end">
             <button
               type="submit"
-              :disabled="form.processing"
+              :disabled="form.processing || !form.isDirty"
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ form.processing ? 'Saving...' : 'Save changes' }}

--- a/assets/js/pages/settings/instance.vue
+++ b/assets/js/pages/settings/instance.vue
@@ -17,9 +17,9 @@ const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 
 const form = useForm({
-  instanceDomain: props.instanceDomain,
-  instanceName: props.instanceName,
-  acmeEmail: props.acmeEmail
+  instanceDomain: props.instanceDomain || '',
+  instanceName: props.instanceName || '',
+  acmeEmail: props.acmeEmail || ''
 })
 
 function save() {
@@ -156,7 +156,7 @@ function save() {
           <div class="flex justify-end">
             <button
               type="submit"
-              :disabled="form.processing"
+              :disabled="form.processing || !form.isDirty"
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ form.processing ? 'Saving...' : 'Save changes' }}

--- a/assets/js/pages/settings/notifications.vue
+++ b/assets/js/pages/settings/notifications.vue
@@ -26,23 +26,23 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 const search = ref('')
 
 const form = useForm({
-  telegramBotToken: props.telegram.botToken,
-  telegramChatId: props.telegram.chatId,
-  telegramThreadId: props.telegram.threadId,
-  telegramEnabled: props.telegram.enabled,
+  telegramBotToken: props.telegram.botToken || '',
+  telegramChatId: props.telegram.chatId || '',
+  telegramThreadId: props.telegram.threadId || '',
+  telegramEnabled: props.telegram.enabled || false,
   discordWebhookUrl: props.discord?.webhookUrl || '',
   discordEnabled: props.discord?.enabled || false,
   slackWebhookUrl: props.slack?.webhookUrl || '',
   slackEnabled: props.slack?.enabled || false,
   webhookUrl: props.webhook?.url || '',
   webhookEnabled: props.webhook?.enabled || false,
-  smtpHost: props.smtp.host,
-  smtpPort: props.smtp.port,
-  smtpUser: props.smtp.user,
+  smtpHost: props.smtp.host || '',
+  smtpPort: props.smtp.port || '',
+  smtpUser: props.smtp.user || '',
   smtpPassword: '',
-  smtpFrom: props.smtp.from,
-  smtpEnabled: props.smtp.enabled,
-  notificationEmails: props.notificationEmails,
+  smtpFrom: props.smtp.from || '',
+  smtpEnabled: props.smtp.enabled || false,
+  notificationEmails: props.notificationEmails || '',
   // Deployment
   notifyOnDeploySuccess: props.preferences.deploySuccess,
   notifyOnDeployFailure: props.preferences.deployFailure,
@@ -1068,7 +1068,7 @@ const categoryIcons = {
           >
             <button
               type="submit"
-              :disabled="form.processing"
+              :disabled="form.processing || !form.isDirty"
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ form.processing ? 'Saving...' : 'Save changes' }}


### PR DESCRIPTION
## Summary
- Added `!form.isDirty` to `:disabled` on save buttons across all update forms so the button is disabled until the user actually changes something
- Fixed form field initializations to use `|| ''` for string fields to prevent `null` vs `''` mismatch that kept `isDirty` stuck as `true`

### Forms updated
- `projects/settings.vue` — project settings
- `settings/instance.vue` — instance settings
- `settings/notifications.vue` — notification settings
- `dashboard/profile.vue` — profile info + password change
- `settings/team-profile.vue` — already had `isDirty` (no change)

Closes #35