### PR TITLE
Fix breadcrumb overflow on mobile with reusable Breadcrumb component

### DIFF
--- a/assets/js/components/Breadcrumb.vue
+++ b/assets/js/components/Breadcrumb.vue
@@ -1,0 +1,39 @@
+<script setup>
+import { Link } from '@inertiajs/vue3'
+
+defineProps({
+  items: {
+    type: Array,
+    required: true
+    // Each item: { label: string, href?: string }
+    // Last item (no href) is the current page
+  }
+})
+</script>
+
+<template>
+  <!-- Mobile: parent + current page -->
+  <nav class="flex items-center space-x-2 text-sm md:hidden">
+    <template v-if="items.length > 1">
+      <Link :href="items[items.length - 2].href" class="text-gray-500 dark:text-gray-400">
+        {{ items[items.length - 2].label }}
+      </Link>
+      <span class="text-gray-400 dark:text-gray-600">/</span>
+    </template>
+    <span class="font-medium text-gray-900 dark:text-white">{{ items[items.length - 1].label }}</span>
+  </nav>
+  <!-- Desktop: full breadcrumb -->
+  <nav class="hidden items-center space-x-2 text-sm md:flex">
+    <template v-for="(item, index) in items" :key="index">
+      <span v-if="index > 0" class="text-gray-400 dark:text-gray-600">/</span>
+      <Link
+        v-if="item.href"
+        :href="item.href"
+        class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+      >
+        {{ item.label }}
+      </Link>
+      <span v-else class="font-medium text-gray-900 dark:text-white">{{ item.label }}</span>
+    </template>
+  </nav>
+</template>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -31,7 +31,9 @@ const tabs = [
 ]
 
 // ─── Console state ───
-const sqlQuery = ref("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;")
+const sqlQuery = ref(
+  "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+)
 const validDbs = ['app', 'observability', 'cache']
 const initialDb = new URLSearchParams(window.location.search).get('db')
 const selectedDatabase = ref(validDbs.includes(initialDb) ? initialDb : 'app')
@@ -70,36 +72,118 @@ const highlightedQuery = computed(() => highlightSQL(sqlQuery.value))
 function highlightSQL(sql) {
   if (!sql) return ''
 
-  const keywords = new Set(['SELECT', 'FROM', 'WHERE', 'AND', 'OR', 'NOT', 'IN', 'IS', 'NULL', 'LIKE', 'BETWEEN',
-    'JOIN', 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'ON', 'AS', 'ORDER', 'BY', 'ASC', 'DESC', 'LIMIT', 'OFFSET',
-    'GROUP', 'HAVING', 'UNION', 'ALL', 'DISTINCT', 'INSERT', 'INTO', 'VALUES', 'UPDATE', 'SET', 'DELETE',
-    'CREATE', 'TABLE', 'ALTER', 'DROP', 'INDEX', 'PRIMARY', 'KEY', 'FOREIGN', 'REFERENCES', 'CONSTRAINT',
-    'DEFAULT', 'AUTOINCREMENT', 'INTEGER', 'TEXT', 'VARCHAR', 'BOOLEAN', 'REAL', 'BIGINT', 'TIMESTAMP',
-    'JSON', 'JSONB', 'UNIQUE', 'PRAGMA', 'EXPLAIN', 'COUNT', 'SUM', 'AVG', 'MIN', 'MAX', 'CASE', 'WHEN',
-    'THEN', 'ELSE', 'END', 'CAST', 'TYPE', 'EXISTS', 'IF'])
+  const keywords = new Set([
+    'SELECT',
+    'FROM',
+    'WHERE',
+    'AND',
+    'OR',
+    'NOT',
+    'IN',
+    'IS',
+    'NULL',
+    'LIKE',
+    'BETWEEN',
+    'JOIN',
+    'LEFT',
+    'RIGHT',
+    'INNER',
+    'OUTER',
+    'ON',
+    'AS',
+    'ORDER',
+    'BY',
+    'ASC',
+    'DESC',
+    'LIMIT',
+    'OFFSET',
+    'GROUP',
+    'HAVING',
+    'UNION',
+    'ALL',
+    'DISTINCT',
+    'INSERT',
+    'INTO',
+    'VALUES',
+    'UPDATE',
+    'SET',
+    'DELETE',
+    'CREATE',
+    'TABLE',
+    'ALTER',
+    'DROP',
+    'INDEX',
+    'PRIMARY',
+    'KEY',
+    'FOREIGN',
+    'REFERENCES',
+    'CONSTRAINT',
+    'DEFAULT',
+    'AUTOINCREMENT',
+    'INTEGER',
+    'TEXT',
+    'VARCHAR',
+    'BOOLEAN',
+    'REAL',
+    'BIGINT',
+    'TIMESTAMP',
+    'JSON',
+    'JSONB',
+    'UNIQUE',
+    'PRAGMA',
+    'EXPLAIN',
+    'COUNT',
+    'SUM',
+    'AVG',
+    'MIN',
+    'MAX',
+    'CASE',
+    'WHEN',
+    'THEN',
+    'ELSE',
+    'END',
+    'CAST',
+    'TYPE',
+    'EXISTS',
+    'IF'
+  ])
 
   const tokens = []
-  const tokenPattern = /('(?:[^'\\]|\\.)*')|(\d+(?:\.\d+)?)|(\b[a-zA-Z_]\w*\b)|(\s+)|(.)/g
+  const tokenPattern =
+    /('(?:[^'\\]|\\.)*')|(\d+(?:\.\d+)?)|(\b[a-zA-Z_]\w*\b)|(\s+)|(.)/g
   let match
 
   while ((match = tokenPattern.exec(sql)) !== null) {
     const [, str, num, word, ws, other] = match
     if (str) tokens.push({ type: 'string', value: str })
     else if (num) tokens.push({ type: 'number', value: num })
-    else if (word) tokens.push({ type: keywords.has(word.toUpperCase()) ? 'keyword' : 'identifier', value: word })
+    else if (word)
+      tokens.push({
+        type: keywords.has(word.toUpperCase()) ? 'keyword' : 'identifier',
+        value: word
+      })
     else if (ws) tokens.push({ type: 'whitespace', value: ws })
     else if (other) tokens.push({ type: 'other', value: other })
   }
 
-  return tokens.map(t => {
-    const escaped = t.value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    switch (t.type) {
-      case 'keyword': return `<span class="text-pink-600 dark:text-pink-400">${escaped}</span>`
-      case 'string': return `<span class="text-amber-600 dark:text-amber-400">${escaped}</span>`
-      case 'number': return `<span class="text-purple-600 dark:text-purple-400">${escaped}</span>`
-      default: return escaped
-    }
-  }).join('')
+  return tokens
+    .map((t) => {
+      const escaped = t.value
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+      switch (t.type) {
+        case 'keyword':
+          return `<span class="text-pink-600 dark:text-pink-400">${escaped}</span>`
+        case 'string':
+          return `<span class="text-amber-600 dark:text-amber-400">${escaped}</span>`
+        case 'number':
+          return `<span class="text-purple-600 dark:text-purple-400">${escaped}</span>`
+        default:
+          return escaped
+      }
+    })
+    .join('')
 }
 
 async function executeQuery() {
@@ -130,7 +214,10 @@ async function executeQuery() {
 
     // Add to history (deduplicate)
     const q = sqlQuery.value.trim()
-    queryHistory.value = [q, ...queryHistory.value.filter(h => h !== q)].slice(0, 20)
+    queryHistory.value = [
+      q,
+      ...queryHistory.value.filter((h) => h !== q)
+    ].slice(0, 20)
   } catch (err) {
     consoleError.value = err.message || 'Network error'
   } finally {
@@ -140,7 +227,9 @@ async function executeQuery() {
 
 function copyAsJSON() {
   if (!consoleResults.value?.rows) return
-  navigator.clipboard.writeText(JSON.stringify(consoleResults.value.rows, null, 2))
+  navigator.clipboard.writeText(
+    JSON.stringify(consoleResults.value.rows, null, 2)
+  )
 }
 
 function copyAsCSV() {
@@ -148,7 +237,7 @@ function copyAsCSV() {
   const { columns, rows } = consoleResults.value
   const csvLines = [columns.join(',')]
   for (const row of rows) {
-    const values = columns.map(col => {
+    const values = columns.map((col) => {
       const val = row[col]
       if (val === null) return ''
       const str = String(val)
@@ -164,7 +253,11 @@ function copyAsCSV() {
 
 function downloadAsJSON() {
   if (!consoleResults.value?.rows) return
-  downloadFile(JSON.stringify(consoleResults.value.rows, null, 2), 'query-result.json', 'application/json')
+  downloadFile(
+    JSON.stringify(consoleResults.value.rows, null, 2),
+    'query-result.json',
+    'application/json'
+  )
 }
 
 function downloadAsCSV() {
@@ -172,7 +265,7 @@ function downloadAsCSV() {
   const { columns, rows } = consoleResults.value
   const csvLines = [columns.join(',')]
   for (const row of rows) {
-    const values = columns.map(col => {
+    const values = columns.map((col) => {
       const val = row[col]
       if (val === null) return ''
       const str = String(val)
@@ -194,6 +287,11 @@ function downloadFile(content, filename, mimeType) {
   a.download = filename
   a.click()
   URL.revokeObjectURL(url)
+}
+
+function exportAction(fn) {
+  fn()
+  showExportMenu.value = false
 }
 
 // ─── Environment variables state ───
@@ -275,7 +373,11 @@ function changeActivityFilter(filter) {
 // ─── Computed ───
 const heapPercent = computed(() => {
   if (!props.processInfo.memoryUsage) return 0
-  return Math.round((props.processInfo.memoryUsage.heapUsed / props.processInfo.memoryUsage.heapTotal) * 100)
+  return Math.round(
+    (props.processInfo.memoryUsage.heapUsed /
+      props.processInfo.memoryUsage.heapTotal) *
+      100
+  )
 })
 
 const statCards = computed(() => [
@@ -318,16 +420,24 @@ function timeAgo(timestamp) {
 
 function statusColor(status) {
   const colors = {
-    running: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
-    completed: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    running:
+      'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
+    completed:
+      'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400',
     failed: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400',
     cancelled: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
-    pending: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
-    building: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-    deploying: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    pending:
+      'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400',
+    building:
+      'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+    deploying:
+      'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
     stopped: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
   }
-  return colors[status] || 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+  return (
+    colors[status] ||
+    'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+  )
 }
 
 function activityTypeIcon(type) {
@@ -335,11 +445,15 @@ function activityTypeIcon(type) {
 }
 
 function activityTypeColor(type) {
-  return {
-    deployment: 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
-    backup: 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
-    audit: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-  }[type] || 'bg-gray-100 text-gray-600'
+  return (
+    {
+      deployment:
+        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400',
+      backup:
+        'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-400',
+      audit: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+    }[type] || 'bg-gray-100 text-gray-600'
+  )
 }
 
 // Close menus on click outside
@@ -365,52 +479,131 @@ onUnmounted(() => {
   <Head title="Bosun | Slipway"></Head>
   <div class="flex h-full flex-col">
     <!-- Header -->
-    <div class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6">
+    <div
+      class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6"
+    >
       <div class="flex items-center space-x-3">
         <button
           @click="toggleMobileMenu"
           class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
         >
-          <svg class="h-5 w-5" viewBox="-0.5 -0.5 16 16" fill="none" stroke="currentColor">
-            <path d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
-            <path d="M5.615 14.285V.715" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
-            <path d="M2.6 5.992 3.919 7.5 2.6 9.008" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
+          <svg
+            class="h-5 w-5"
+            viewBox="-0.5 -0.5 16 16"
+            fill="none"
+            stroke="currentColor"
+          >
+            <path
+              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
+            <path
+              d="M5.615 14.285V.715"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
+            <path
+              d="M2.6 5.992 3.919 7.5 2.6 9.008"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
           </svg>
         </button>
         <button
           @click="toggleSidebar"
           class="hidden text-gray-400 dark:text-gray-500 md:block"
         >
-          <svg v-if="sidebarCollapsed" class="h-5 w-5" viewBox="-0.5 -0.5 16 16" fill="none" stroke="currentColor">
-            <path d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
-            <path d="M5.615 14.285V.715" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
-            <path d="M2.6 5.992 3.919 7.5 2.6 9.008" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
+          <svg
+            v-if="sidebarCollapsed"
+            class="h-5 w-5"
+            viewBox="-0.5 -0.5 16 16"
+            fill="none"
+            stroke="currentColor"
+          >
+            <path
+              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
+            <path
+              d="M5.615 14.285V.715"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
+            <path
+              d="M2.6 5.992 3.919 7.5 2.6 9.008"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
           </svg>
-          <svg v-else class="h-5 w-5" viewBox="-0.5 -0.5 16 16" fill="none" stroke="currentColor">
-            <path d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
-            <path d="M5.615 14.285V.715" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
-            <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
+          <svg
+            v-else
+            class="h-5 w-5"
+            viewBox="-0.5 -0.5 16 16"
+            fill="none"
+            stroke="currentColor"
+          >
+            <path
+              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
+            <path
+              d="M5.615 14.285V.715"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
+            <path
+              d="M3.919 5.992 2.6 7.5l1.319 1.508"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1"
+            />
           </svg>
         </button>
         <span class="font-medium text-gray-900 dark:text-white">Bosun</span>
       </div>
       <div class="flex items-center space-x-2 sm:space-x-3">
-        <span class="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400">v{{ version }}</span>
+        <span
+          class="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+          >v{{ version }}</span
+        >
         <a
           href="https://docs.sailscasts.com/slipway/bosun"
           target="_blank"
           class="flex items-center space-x-1 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
         >
           <span>Docs</span>
-          <svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+          <svg
+            class="h-3.5 w-3.5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+            />
           </svg>
         </a>
       </div>
     </div>
 
     <!-- Tab bar (Dock-style pills with frosted glass) -->
-    <div class="flex items-center space-x-1 border-b border-gray-200/50 bg-white/80 px-4 py-2 backdrop-blur-md dark:border-gray-800/50 dark:bg-gray-950/80 sm:px-6">
+    <div
+      class="flex items-center space-x-1 border-b border-gray-200/50 bg-white/80 px-4 py-2 backdrop-blur-md dark:border-gray-800/50 dark:bg-gray-950/80 sm:px-6"
+    >
       <button
         v-for="tab in tabs"
         :key="tab.id"
@@ -427,20 +620,25 @@ onUnmounted(() => {
     </div>
 
     <!-- ═══ Console Tab (full-height layout matching Dock) ═══ -->
-    <div v-if="activeTab === 'console'" class="flex flex-1 flex-col overflow-hidden">
+    <div
+      v-if="activeTab === 'console'"
+      class="flex flex-1 flex-col overflow-hidden"
+    >
       <!-- Editor -->
-      <div class="flex-1 overflow-hidden border-b border-gray-200 dark:border-gray-800">
+      <div
+        class="flex-1 overflow-hidden border-b border-gray-200 dark:border-gray-800"
+      >
         <div class="relative h-full">
           <!-- Highlighted layer -->
           <pre
-            class="pointer-events-none absolute inset-0 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-sm leading-6 text-gray-900 dark:text-gray-100"
+            class="wrap-break-word pointer-events-none absolute inset-0 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm leading-6 text-gray-900 dark:text-gray-100"
             aria-hidden="true"
             v-html="highlightedQuery"
           ></pre>
           <!-- Actual textarea (transparent text, visible caret) -->
           <textarea
             v-model="sqlQuery"
-            class="absolute inset-0 h-full w-full resize-none bg-transparent p-4 font-mono text-sm leading-6 text-transparent caret-gray-900 placeholder-gray-400 focus:outline-none dark:caret-white dark:placeholder-gray-600"
+            class="absolute inset-0 h-full w-full resize-none bg-transparent p-4 font-mono text-sm leading-6 text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none dark:placeholder-gray-600 dark:caret-white"
             placeholder="SELECT * FROM ..."
             spellcheck="false"
             @keydown.ctrl.enter="executeQuery"
@@ -450,7 +648,9 @@ onUnmounted(() => {
       </div>
 
       <!-- Actions bar -->
-      <div class="flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-800 sm:px-6">
+      <div
+        class="flex items-center justify-between border-b border-gray-200 px-4 py-2 dark:border-gray-800 sm:px-6"
+      >
         <div class="flex items-center gap-4">
           <!-- Database selector pills -->
           <div class="flex items-center gap-1">
@@ -468,9 +668,17 @@ onUnmounted(() => {
               {{ db }}
             </button>
           </div>
-          <div class="hidden items-center space-x-2 text-xs text-gray-500 dark:text-gray-400 sm:flex">
-            <kbd class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-gray-600 dark:bg-gray-800 dark:text-gray-400">&#8984;</kbd>
-            <kbd class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-gray-600 dark:bg-gray-800 dark:text-gray-400">Enter</kbd>
+          <div
+            class="hidden items-center space-x-2 text-xs text-gray-500 dark:text-gray-400 sm:flex"
+          >
+            <kbd
+              class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+              >&#8984;</kbd
+            >
+            <kbd
+              class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+              >Enter</kbd
+            >
             <span>to run</span>
           </div>
         </div>
@@ -488,18 +696,27 @@ onUnmounted(() => {
       <div class="flex-1 overflow-auto">
         <!-- Error -->
         <div v-if="consoleError" class="p-4">
-          <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/30">
-            <p class="font-mono text-sm text-red-600 dark:text-red-400">{{ consoleError }}</p>
+          <div
+            class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/30"
+          >
+            <p class="font-mono text-sm text-red-600 dark:text-red-400">
+              {{ consoleError }}
+            </p>
           </div>
         </div>
 
         <!-- Results table/json -->
         <div v-else-if="consoleResults" class="flex h-full min-h-0 flex-col">
           <!-- Table view -->
-          <div v-if="consoleResults.columns && resultView === 'table'" class="flex-1 overflow-auto">
+          <div
+            v-if="consoleResults.columns && resultView === 'table'"
+            class="flex-1 overflow-auto"
+          >
             <table class="min-w-full">
               <thead class="sticky top-0">
-                <tr class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
+                <tr
+                  class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50"
+                >
                   <th
                     v-for="col in consoleResults.columns"
                     :key="col"
@@ -520,7 +737,11 @@ onUnmounted(() => {
                     :key="col"
                     class="whitespace-nowrap px-4 py-2 font-mono text-sm text-gray-700 dark:text-gray-300"
                   >
-                    <span v-if="row[col] === null" class="text-gray-400 dark:text-gray-600">NULL</span>
+                    <span
+                      v-if="row[col] === null"
+                      class="text-gray-400 dark:text-gray-600"
+                      >NULL</span
+                    >
                     <span v-else>{{ row[col] }}</span>
                   </td>
                 </tr>
@@ -529,18 +750,29 @@ onUnmounted(() => {
           </div>
 
           <!-- JSON view -->
-          <div v-else-if="consoleResults.columns && resultView === 'json'" class="flex-1 overflow-auto p-4">
-            <pre class="font-mono text-xs text-gray-700 dark:text-gray-300">{{ JSON.stringify(consoleResults.rows, null, 2) }}</pre>
+          <div
+            v-else-if="consoleResults.columns && resultView === 'json'"
+            class="flex-1 overflow-auto p-4"
+          >
+            <pre class="font-mono text-xs text-gray-700 dark:text-gray-300">{{
+              JSON.stringify(consoleResults.rows, null, 2)
+            }}</pre>
           </div>
 
           <!-- No columns result -->
-          <div v-else class="flex flex-1 items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+          <div
+            v-else
+            class="flex flex-1 items-center justify-center text-sm text-gray-500 dark:text-gray-400"
+          >
             Query executed successfully
           </div>
         </div>
 
         <!-- Empty state -->
-        <div v-else class="flex h-full items-center justify-center text-sm text-gray-500 dark:text-gray-400">
+        <div
+          v-else
+          class="flex h-full items-center justify-center text-sm text-gray-500 dark:text-gray-400"
+        >
           Run a query to see results
         </div>
       </div>
@@ -552,7 +784,10 @@ onUnmounted(() => {
       >
         <div class="flex items-center gap-4">
           <!-- Table / JSON toggle -->
-          <div v-if="consoleResults.columns" class="flex overflow-hidden rounded-md border border-gray-300 dark:border-gray-700">
+          <div
+            v-if="consoleResults.columns"
+            class="flex overflow-hidden rounded-md border border-gray-300 dark:border-gray-700"
+          >
             <button
               @click="resultView = 'table'"
               :class="[
@@ -562,8 +797,18 @@ onUnmounted(() => {
                   : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
               ]"
             >
-              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0112 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125" />
+              <svg
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0112 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125"
+                />
               </svg>
             </button>
             <button
@@ -580,7 +825,9 @@ onUnmounted(() => {
           </div>
           <!-- Row info -->
           <span class="text-xs text-gray-500 dark:text-gray-400">
-            {{ consoleResults.rowCount }} row{{ consoleResults.rowCount !== 1 ? 's' : '' }}
+            {{ consoleResults.rowCount }} row{{
+              consoleResults.rowCount !== 1 ? 's' : ''
+            }}
             <span v-if="consoleResults.truncated"> (showing first 1,000)</span>
             &middot; {{ consoleResults.durationMs }}ms
           </span>
@@ -591,16 +838,36 @@ onUnmounted(() => {
             @click="executeQuery"
             class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
           >
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99" />
+            <svg
+              class="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
+              />
             </svg>
           </button>
           <button
             @click="resultView === 'json' ? copyAsJSON() : copyAsCSV()"
             class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
           >
-            <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184" />
+            <svg
+              class="h-4 w-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              stroke-width="1.5"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
+              />
             </svg>
           </button>
           <!-- Export dropdown -->
@@ -609,25 +876,49 @@ onUnmounted(() => {
               @click="showExportMenu = !showExportMenu"
               class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
             >
-              <svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
+              <svg
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                />
               </svg>
             </button>
             <div
               v-if="showExportMenu"
               class="absolute bottom-full right-0 z-10 mb-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
             >
-              <button @click="copyAsJSON(); showExportMenu = false" class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+              <button
+                @click="exportAction(copyAsJSON)"
+                class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
                 Copy as JSON
               </button>
-              <button @click="copyAsCSV(); showExportMenu = false" class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+              <button
+                @click="exportAction(copyAsCSV)"
+                class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
                 Copy as CSV
               </button>
-              <div class="my-1 border-t border-gray-200 dark:border-gray-700"></div>
-              <button @click="downloadAsJSON(); showExportMenu = false" class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+              <div
+                class="my-1 border-t border-gray-200 dark:border-gray-700"
+              ></div>
+              <button
+                @click="exportAction(downloadAsJSON)"
+                class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
                 Download JSON
               </button>
-              <button @click="downloadAsCSV(); showExportMenu = false" class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700">
+              <button
+                @click="exportAction(downloadAsCSV)"
+                class="block w-full px-3 py-1.5 text-left text-xs text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700"
+              >
                 Download CSV
               </button>
             </div>
@@ -637,31 +928,51 @@ onUnmounted(() => {
     </div>
 
     <!-- ═══ Scrollable tabs (Overview, Environment, Activity) ═══ -->
-    <div v-if="activeTab !== 'console'" class="flex-1 overflow-y-auto px-4 py-6 sm:px-8 sm:py-8">
+    <div
+      v-if="activeTab !== 'console'"
+      class="flex-1 overflow-y-auto px-4 py-6 sm:px-8 sm:py-8"
+    >
       <div class="mx-auto max-w-6xl">
-
         <!-- ═══ Overview Tab ═══ -->
         <div v-if="activeTab === 'overview'">
           <!-- Status line -->
-          <div class="mb-6 flex flex-wrap items-center gap-3 rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-3 dark:border-gray-800 dark:bg-gray-900/50">
+          <div
+            class="mb-6 flex flex-wrap items-center gap-3 rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-3 dark:border-gray-800 dark:bg-gray-900/50"
+          >
             <span class="flex items-center gap-1.5 text-xs">
               <span class="h-1.5 w-1.5 rounded-full bg-emerald-500"></span>
-              <span class="font-medium text-gray-900 dark:text-white">Running</span>
+              <span class="font-medium text-gray-900 dark:text-white"
+                >Running</span
+              >
             </span>
             <span class="text-gray-300 dark:text-gray-700">&middot;</span>
             <span class="text-xs text-gray-500 dark:text-gray-400">
-              <span class="font-medium text-gray-900 dark:text-white">{{ formatUptime(processInfo.uptime) }}</span> uptime
+              <span class="font-medium text-gray-900 dark:text-white">{{
+                formatUptime(processInfo.uptime)
+              }}</span>
+              uptime
             </span>
             <span class="text-gray-300 dark:text-gray-700">&middot;</span>
             <span class="text-xs text-gray-500 dark:text-gray-400">
-              Node <span class="font-medium text-gray-900 dark:text-white">{{ processInfo.nodeVersion }}</span>
+              Node
+              <span class="font-medium text-gray-900 dark:text-white">{{
+                processInfo.nodeVersion
+              }}</span>
             </span>
             <span class="text-gray-300 dark:text-gray-700">&middot;</span>
             <span class="text-xs text-gray-500 dark:text-gray-400">
-              PID <span class="font-mono font-medium text-gray-900 dark:text-white">{{ processInfo.pid }}</span>
+              PID
+              <span
+                class="font-mono font-medium text-gray-900 dark:text-white"
+                >{{ processInfo.pid }}</span
+              >
             </span>
-            <span class="hidden text-gray-300 dark:text-gray-700 sm:inline">&middot;</span>
-            <span class="hidden text-xs text-gray-500 dark:text-gray-400 sm:inline">
+            <span class="hidden text-gray-300 dark:text-gray-700 sm:inline"
+              >&middot;</span
+            >
+            <span
+              class="hidden text-xs text-gray-500 dark:text-gray-400 sm:inline"
+            >
               {{ processInfo.platform }}
             </span>
           </div>
@@ -673,7 +984,9 @@ onUnmounted(() => {
               :key="stat.label"
               class="rounded-lg border border-gray-200 px-4 py-3 dark:border-gray-800"
             >
-              <div class="text-2xl font-semibold tabular-nums text-gray-900 dark:text-white">
+              <div
+                class="text-2xl font-semibold tabular-nums text-gray-900 dark:text-white"
+              >
                 {{ stat.value.toLocaleString() }}
               </div>
               <div class="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
@@ -686,50 +999,96 @@ onUnmounted(() => {
           <div class="grid gap-6 lg:grid-cols-2">
             <!-- Memory -->
             <div class="rounded-lg border border-gray-200 dark:border-gray-800">
-              <div class="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
-                <h3 class="text-sm font-medium text-gray-900 dark:text-white">Memory</h3>
+              <div
+                class="border-b border-gray-200 px-4 py-3 dark:border-gray-800"
+              >
+                <h3 class="text-sm font-medium text-gray-900 dark:text-white">
+                  Memory
+                </h3>
               </div>
               <div class="space-y-4 px-4 py-4">
                 <!-- Heap usage with bar -->
                 <div>
                   <div class="flex items-center justify-between text-xs">
-                    <span class="text-gray-500 dark:text-gray-400">Heap Used</span>
-                    <span class="font-mono font-medium text-gray-900 dark:text-white">
+                    <span class="text-gray-500 dark:text-gray-400"
+                      >Heap Used</span
+                    >
+                    <span
+                      class="font-mono font-medium text-gray-900 dark:text-white"
+                    >
                       {{ formatBytes(processInfo.memoryUsage?.heapUsed) }}
-                      <span class="text-gray-400 dark:text-gray-600">/ {{ formatBytes(processInfo.memoryUsage?.heapTotal) }}</span>
+                      <span class="text-gray-400 dark:text-gray-600"
+                        >/
+                        {{
+                          formatBytes(processInfo.memoryUsage?.heapTotal)
+                        }}</span
+                      >
                     </span>
                   </div>
-                  <div class="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800">
+                  <div
+                    class="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-gray-100 dark:bg-gray-800"
+                  >
                     <div
                       class="h-full rounded-full bg-blue-500 transition-all"
                       :style="{ width: heapPercent + '%' }"
                     ></div>
                   </div>
-                  <div class="mt-1 flex justify-between text-[10px] text-gray-400 dark:text-gray-500">
+                  <div
+                    class="mt-1 flex justify-between text-[10px] text-gray-400 dark:text-gray-500"
+                  >
                     <span>{{ heapPercent }}% used</span>
-                    <span>{{ formatBytes(processInfo.memoryUsage?.heapTotal - processInfo.memoryUsage?.heapUsed) }} free</span>
+                    <span
+                      >{{
+                        formatBytes(
+                          processInfo.memoryUsage?.heapTotal -
+                            processInfo.memoryUsage?.heapUsed
+                        )
+                      }}
+                      free</span
+                    >
                   </div>
                 </div>
                 <!-- RSS -->
                 <div class="flex items-center justify-between">
-                  <span class="text-xs text-gray-500 dark:text-gray-400">RSS (Total)</span>
-                  <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ formatBytes(processInfo.memoryUsage?.rss) }}</span>
+                  <span class="text-xs text-gray-500 dark:text-gray-400"
+                    >RSS (Total)</span
+                  >
+                  <span
+                    class="font-mono text-sm font-medium text-gray-900 dark:text-white"
+                    >{{ formatBytes(processInfo.memoryUsage?.rss) }}</span
+                  >
                 </div>
               </div>
             </div>
 
             <!-- Databases -->
             <div class="rounded-lg border border-gray-200 dark:border-gray-800">
-              <div class="border-b border-gray-200 px-4 py-3 dark:border-gray-800">
-                <h3 class="text-sm font-medium text-gray-900 dark:text-white">Databases</h3>
+              <div
+                class="border-b border-gray-200 px-4 py-3 dark:border-gray-800"
+              >
+                <h3 class="text-sm font-medium text-gray-900 dark:text-white">
+                  Databases
+                </h3>
               </div>
               <div class="space-y-1 px-4 pb-3">
-                <div v-for="(db, name) in databases" :key="name" class="flex items-center justify-between py-1.5">
+                <div
+                  v-for="(db, name) in databases"
+                  :key="name"
+                  class="flex items-center justify-between py-1.5"
+                >
                   <div class="flex items-center gap-2">
-                    <span class="text-sm font-medium text-gray-900 dark:text-white">{{ name }}</span>
-                    <span class="text-xs text-gray-400 dark:text-gray-500">{{ db.path.split('/').pop() }}</span>
+                    <span
+                      class="text-sm font-medium text-gray-900 dark:text-white"
+                      >{{ name }}</span
+                    >
+                    <span class="text-xs text-gray-400 dark:text-gray-500">{{
+                      db.path.split('/').pop()
+                    }}</span>
                   </div>
-                  <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ formatBytes(db.sizeBytes) }}</span>
+                  <span
+                    class="font-mono text-sm font-medium text-gray-900 dark:text-white"
+                    >{{ formatBytes(db.sizeBytes) }}</span
+                  >
                 </div>
               </div>
             </div>
@@ -753,50 +1112,99 @@ onUnmounted(() => {
               <h2 class="text-sm font-medium text-gray-900 dark:text-white">
                 Environment variables
               </h2>
-              <span class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400">
+              <span
+                class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+              >
                 {{ sortedEnvKeys.length }}
               </span>
             </div>
 
             <!-- Variable rows -->
             <div v-if="sortedEnvKeys.length > 0" class="space-y-1 px-4 pb-2">
-              <div
-                v-for="key in sortedEnvKeys"
-                :key="key"
-                class="group py-2"
-              >
+              <div v-for="key in sortedEnvKeys" :key="key" class="group py-2">
                 <div class="flex items-center justify-between">
-                  <span class="font-mono text-sm font-medium text-gray-900 dark:text-white">{{ key }}</span>
-                  <div class="flex items-center space-x-1 opacity-0 transition-opacity group-hover:opacity-100">
+                  <span
+                    class="font-mono text-sm font-medium text-gray-900 dark:text-white"
+                    >{{ key }}</span
+                  >
+                  <div
+                    class="flex items-center space-x-1 opacity-0 transition-opacity group-hover:opacity-100"
+                  >
                     <button
                       @click="toggleReveal(key)"
                       class="rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                     >
-                      <svg v-if="revealedKeys.has(key)" class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.5 6.5m7.378 7.378L17.5 17.5M3 3l18 18" />
+                      <svg
+                        v-if="revealedKeys.has(key)"
+                        class="h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.878 9.878L6.5 6.5m7.378 7.378L17.5 17.5M3 3l18 18"
+                        />
                       </svg>
-                      <svg v-else class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+                      <svg
+                        v-else
+                        class="h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                        />
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
+                        />
                       </svg>
                     </button>
                     <button
                       @click="removeEnvVar(key)"
                       class="rounded p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
                     >
-                      <svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                      <svg
+                        class="h-4 w-4"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                        />
                       </svg>
                     </button>
                   </div>
                 </div>
-                <p class="mt-1 truncate font-mono text-sm text-gray-500 dark:text-gray-400">
-                  {{ revealedKeys.has(key) ? localVars[key] : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022' }}
+                <p
+                  class="mt-1 truncate font-mono text-sm text-gray-500 dark:text-gray-400"
+                >
+                  {{
+                    revealedKeys.has(key)
+                      ? localVars[key]
+                      : '\u2022\u2022\u2022\u2022\u2022\u2022\u2022\u2022'
+                  }}
                 </p>
               </div>
             </div>
 
-            <div v-else class="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400">
+            <div
+              v-else
+              class="px-4 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
+            >
               No instance environment variables configured.
             </div>
 
@@ -807,14 +1215,14 @@ onUnmounted(() => {
                   v-model="envNewKey"
                   type="text"
                   placeholder="KEY"
-                  class="w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-brand focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:flex-1"
+                  class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:flex-1"
                   @keydown.enter="addEnvVar"
                 />
                 <input
                   v-model="envNewValue"
                   type="text"
                   placeholder="value"
-                  class="w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-brand focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:flex-1"
+                  class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:flex-1"
                   @keydown.enter="addEnvVar"
                 />
                 <button
@@ -842,7 +1250,9 @@ onUnmounted(() => {
             </div>
 
             <!-- Filter -->
-            <div class="flex items-center space-x-1 rounded-md border border-gray-200 p-0.5 dark:border-gray-800">
+            <div
+              class="flex items-center space-x-1 rounded-md border border-gray-200 p-0.5 dark:border-gray-800"
+            >
               <button
                 v-for="f in [
                   { id: 'all', label: 'All' },
@@ -866,25 +1276,55 @@ onUnmounted(() => {
 
           <!-- Loading -->
           <div v-if="activityLoading" class="py-16 text-center">
-            <svg class="mx-auto h-5 w-5 animate-spin text-gray-400 dark:text-gray-600" fill="none" viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+            <svg
+              class="mx-auto h-5 w-5 animate-spin text-gray-400 dark:text-gray-600"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <circle
+                class="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                stroke-width="4"
+              ></circle>
+              <path
+                class="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+              ></path>
             </svg>
           </div>
 
           <!-- Empty state -->
           <div v-else-if="activities.length === 0" class="py-20 text-center">
-            <svg class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+            <svg
+              class="mx-auto h-12 w-12 text-gray-300 dark:text-gray-600"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
             </svg>
-            <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">No activity yet</h3>
+            <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">
+              No activity yet
+            </h3>
             <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
               Deploy an application or create a backup to see activity here.
             </p>
           </div>
 
           <!-- Activity feed -->
-          <div v-else class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800">
+          <div
+            v-else
+            class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+          >
             <div
               v-for="(activity, i) in activities"
               :key="activity.id"
@@ -906,21 +1346,39 @@ onUnmounted(() => {
               <!-- Description -->
               <div class="min-w-0 flex-1">
                 <div class="flex items-center gap-2">
-                  <span class="truncate text-sm font-medium text-gray-900 dark:text-white">{{ activity.description }}</span>
+                  <span
+                    class="truncate text-sm font-medium text-gray-900 dark:text-white"
+                    >{{ activity.description }}</span
+                  >
                   <span
                     v-if="activity.status"
                     :class="[
                       'inline-flex shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium',
                       statusColor(activity.status)
                     ]"
-                  >{{ activity.status }}</span>
+                    >{{ activity.status }}</span
+                  >
                 </div>
-                <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                <div
+                  class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400"
+                >
                   <span>{{ activity.resource }}</span>
-                  <span v-if="activity.user" class="text-gray-300 dark:text-gray-600">&middot;</span>
-                  <span v-if="activity.user">{{ activity.user.fullName || activity.user.email }}</span>
-                  <span v-if="activity.metadata?.environment" class="text-gray-300 dark:text-gray-600">&middot;</span>
-                  <span v-if="activity.metadata?.environment">{{ activity.metadata.environment }}</span>
+                  <span
+                    v-if="activity.user"
+                    class="text-gray-300 dark:text-gray-600"
+                    >&middot;</span
+                  >
+                  <span v-if="activity.user">{{
+                    activity.user.fullName || activity.user.email
+                  }}</span>
+                  <span
+                    v-if="activity.metadata?.environment"
+                    class="text-gray-300 dark:text-gray-600"
+                    >&middot;</span
+                  >
+                  <span v-if="activity.metadata?.environment">{{
+                    activity.metadata.environment
+                  }}</span>
                 </div>
               </div>
 
@@ -947,13 +1405,14 @@ onUnmounted(() => {
               </div>
 
               <!-- Timestamp -->
-              <span class="w-14 shrink-0 text-right text-xs text-gray-400 dark:text-gray-500">
+              <span
+                class="w-14 shrink-0 text-right text-xs text-gray-400 dark:text-gray-500"
+              >
                 {{ timeAgo(activity.createdAt) }}
               </span>
             </div>
           </div>
         </div>
-
       </div>
     </div>
   </div>

--- a/assets/js/pages/projects/app-settings.vue
+++ b/assets/js/pages/projects/app-settings.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router } from '@inertiajs/vue3'
 import { ref, inject } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import { useToast } from '@/composables/toast'
 
@@ -96,15 +97,12 @@ async function deleteApp() {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">projects</Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link :href="`/projects/${project.slug}`" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">{{ project.name.toLowerCase() }}</Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link :href="`/projects/${project.slug}/environments/${environment.slug}`" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">{{ environment.name.toLowerCase() }}</Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">{{ app.name }} settings</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase(), href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: `${app.name} settings` }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router, usePoll } from '@inertiajs/vue3'
 import { inject, ref, reactive, computed, watch, nextTick, onMounted, onBeforeUnmount } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { useToast } from '@/composables/toast'
@@ -588,27 +589,12 @@ onBeforeUnmount(() => {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">{{ app.name.toLowerCase() }}</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase(), href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: app.name.toLowerCase() }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/content-manager.vue
+++ b/assets/js/pages/projects/content-manager.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, onMounted, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 
 defineOptions({
   layout: AppLayout
@@ -115,27 +116,12 @@ function refresh() {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">content</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase(), href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: 'content' }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -2,6 +2,7 @@
 import { Link, Head, usePoll, router } from '@inertiajs/vue3'
 import { inject, ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 
 defineOptions({
   layout: AppLayout
@@ -265,29 +266,12 @@ function executeRollback() {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">
-            {{ deployment.id }}
-          </span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase(), href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: String(deployment.id) }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/environment-settings.vue
+++ b/assets/js/pages/projects/environment-settings.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import { useToast } from '@/composables/toast'
 
@@ -216,32 +217,12 @@ if (!props.canDelete) {
             />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link
-            href="/"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.slug }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white"
-            >settings</span
-          >
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.slug, href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: 'settings' }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router, usePoll } from '@inertiajs/vue3'
 import { inject, ref, reactive, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
@@ -645,20 +646,11 @@ onBeforeUnmount(() => {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">{{ environment.name.toLowerCase() }}</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase() }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router, usePoll } from '@inertiajs/vue3'
 import { inject, ref, computed, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 import { useQueryState } from '@/composables/useQueryState'
 
 defineOptions({
@@ -241,27 +242,12 @@ async function copyToken() {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">lookout</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase(), href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: 'lookout' }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/quest.vue
+++ b/assets/js/pages/projects/quest.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 import Tooltip from '@/components/Tooltip.vue'
 
 defineOptions({
@@ -141,27 +142,12 @@ function refresh() {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">quest</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase(), href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: 'quest' }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/assets/js/pages/projects/service.vue
+++ b/assets/js/pages/projects/service.vue
@@ -2,6 +2,7 @@
 import { Link, Head, usePage } from '@inertiajs/vue3'
 import { inject, ref, computed, onMounted, onUnmounted, nextTick } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
 
@@ -340,23 +341,11 @@ onUnmounted(() => {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="text-sm">
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">{{ serviceName }}</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: environment.name.toLowerCase(), href: `/projects/${project.slug}/environments/${environment.slug}` },
+          { label: serviceName }
+        ]" />
       </div>
     </div>
 

--- a/assets/js/pages/projects/settings.vue
+++ b/assets/js/pages/projects/settings.vue
@@ -2,6 +2,7 @@
 import { Link, Head, useForm, router } from '@inertiajs/vue3'
 import { inject, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
 
 defineOptions({
   layout: AppLayout
@@ -96,20 +97,11 @@ function deleteProject() {
             <path d="M3.919 5.992 2.6 7.5l1.319 1.508" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" />
           </svg>
         </button>
-        <nav class="flex items-center space-x-2 text-sm">
-          <Link href="/" class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white">
-            projects
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">settings</span>
-        </nav>
+        <Breadcrumb :items="[
+          { label: 'projects', href: '/' },
+          { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
+          { label: 'settings' }
+        ]" />
       </div>
       <div class="flex items-center space-x-4">
         <a

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "prettier": "^2.8.8",
         "prettier-plugin-tailwindcss": "^0.4.1",
         "sails-hook-dev": "^1.3.0",
-        "sails-hook-shipwright": "^1.1.0",
+        "sails-hook-shipwright": "^1.2.0",
         "sails.io.js": "^1.2.1",
         "socket.io-client": "^4.7.5",
         "tailwindcss": "^4.1.16"
@@ -1102,6 +1102,7 @@
       "integrity": "sha512-kI1oQvCXbQYxUvQPnDLdjSX4gFsbrFNpuUj6jXEJ7IcJ74Q+n4oeFj74/8tKerhxhe0L90m/ZQfzLeN5ORGA9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rspack/core": "~1.7.5",
         "@rspack/lite-tapable": "~1.1.0",
@@ -1122,6 +1123,7 @@
       "integrity": "sha512-4DdKAocXrNLghdFfunFRyc3YXKCnYbmAng5FLQD4mqt2imcgf7gggbAreKI1lAc6cd5SMhyIrHTruvWz+oMVWQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "rspack-vue-loader": "^17.5.0"
       },
@@ -1294,6 +1296,7 @@
       "integrity": "sha512-Iax6UhrfZqJajA778c1d5DBFbSIqPOSrI34kpNIiNpWd8Jq7mFIa+Z60SQb5ZQDZuUxcCZikjz5BxinFjTkg7Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.22.0",
         "@rspack/binding": "1.7.6",
@@ -1525,6 +1528,7 @@
       "integrity": "sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -5596,6 +5600,7 @@
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -6279,6 +6284,7 @@
       "resolved": "https://registry.npmjs.org/sails/-/sails-1.5.16.tgz",
       "integrity": "sha512-QGTM8tTrPDDgBs8wO+v9GYozlNvURPHVyFel8W9eMa5JJ6gV1/N9Ntupx1YXpn8V5SOWunRTnXRunTjrETFYWg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@sailshq/csurf": "1.11.1",
         "@sailshq/lodash": "^3.10.6",
@@ -6351,6 +6357,7 @@
       "resolved": "https://registry.npmjs.org/sails-flash/-/sails-flash-0.0.1.tgz",
       "integrity": "sha512-8F9h8U/YFCnJR23Q6nR1I2TH2Si1dfQvPqO2YW0VoS15QleTWk2NTzfrAyNasGU182BRXNx+W4Tv33dc5cNJ+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "connect-flash": "^0.1.1"
       }
@@ -6566,13 +6573,13 @@
       }
     },
     "node_modules/sails-hook-shipwright": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/sails-hook-shipwright/-/sails-hook-shipwright-1.1.0.tgz",
-      "integrity": "sha512-x5uB60+Z7i1sws7d79+RK8dho55kaKE8ZXOTiy/VrpQ8YyjvROu1L58aWoXQNFY317oF7kOv4i3ktZeQ3RDdOw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/sails-hook-shipwright/-/sails-hook-shipwright-1.2.0.tgz",
+      "integrity": "sha512-9n3CSu1JBwLkTFPgfRiuh7KI/993cEOqDxginERqquMG3lGcPmFFIml0Xd0D4rvkJYB4YrgV09StUcWBouBg4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rsbuild/core": "^1.7.0",
+        "@rsbuild/core": "^1.7.3",
         "fast-glob": "^3.3.3"
       }
     },
@@ -7933,6 +7940,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -8007,6 +8015,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.28.tgz",
       "integrity": "sha512-BRdrNfeoccSoIZeIhyPBfvWSLFP4q8J3u8Ju8Ug5vu3LdD+yTM13Sg4sKtljxozbnuMu1NB1X5HBHRYUzFocKg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.28",
         "@vue/compiler-sfc": "3.5.28",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "prettier": "^2.8.8",
     "prettier-plugin-tailwindcss": "^0.4.1",
     "sails-hook-dev": "^1.3.0",
-    "sails-hook-shipwright": "^1.1.0",
+    "sails-hook-shipwright": "^1.2.0",
     "sails.io.js": "^1.2.1",
     "socket.io-client": "^4.7.5",
     "tailwindcss": "^4.1.16"


### PR DESCRIPTION
## Summary
- Created a reusable `Breadcrumb.vue` component that handles mobile/desktop breadcrumb display automatically
- Mobile (below `md`): shows only parent + current page
- Desktop (`md`+): shows full breadcrumb path
- Refactored 10 project pages to use the component, eliminating ~20 lines of duplicated nav markup per page
- Fixed multi-line `@click` handlers in bosun/index.vue that broke the Vue compiler

### Pages updated
- environment, settings, app, app-settings, deployment, environment-settings, lookout, quest, service, content-manager

### Usage
```vue
<Breadcrumb :items="[
  { label: 'projects', href: '/' },
  { label: project.name.toLowerCase(), href: `/projects/${project.slug}` },
  { label: 'settings' }
]" />
```

Closes #38