### PR TITLE
Add power user actions and navigation to command palette

### DIFF
--- a/api/hooks/custom/index.js
+++ b/api/hooks/custom/index.js
@@ -61,11 +61,49 @@ module.exports = function defineCustomHook(sails) {
                   .sort('name ASC')
               })
 
+              sails.inertia.share('navApps', async () => {
+                try {
+                  const user = await User.findOne({ id: userId }).select(['team'])
+                  if (!user || !user.team) { return [] }
+                  const projects = await Project.find({ team: user.team }).select(['id', 'name', 'slug'])
+                  const projectIds = projects.map(p => p.id)
+                  const environments = await Environment.find({ project: projectIds }).select(['id', 'slug', 'name', 'project', 'domain'])
+                  const envIds = environments.map(e => e.id)
+                  const apps = await App.find({ environment: envIds }).select(['name', 'slug', 'environment'])
+                  const wildcardDomain = await sails.helpers.setting.get('wildcardDomain')
+                  const slipwayDomain = sails.config.custom.slipwayDomain
+                  return apps.map(app => {
+                    const env = environments.find(e => e.id === app.environment)
+                    const project = projects.find(p => p.id === env?.project)
+                    let domain = null
+                    if (env?.domain) {
+                      domain = env.domain
+                    } else if (project && env) {
+                      const subdomain = `${project.slug}-${env.slug}`
+                      domain = wildcardDomain ? `${subdomain}.${wildcardDomain}` : (slipwayDomain ? `${subdomain}.${slipwayDomain}` : null)
+                    }
+                    return {
+                      name: app.name,
+                      slug: app.slug,
+                      projectName: project?.name,
+                      projectSlug: project?.slug,
+                      envName: env?.name,
+                      envSlug: env?.slug,
+                      domain
+                    }
+                  })
+                } catch (err) {
+                  sails.log.error('navApps shared prop error:', err)
+                  return []
+                }
+              })
+
               res.setHeader('Cache-Control', 'no-cache, no-store')
               return next()
             } else {
               sails.inertia.flushShared('loggedInUser')
               sails.inertia.flushShared('navProjects')
+              sails.inertia.flushShared('navApps')
             }
             return next()
           }

--- a/assets/js/components/CommandPalette.vue
+++ b/assets/js/components/CommandPalette.vue
@@ -1,10 +1,14 @@
 <script setup>
-import { ref, computed, watch, nextTick, onMounted, onUnmounted } from 'vue'
+import { ref, computed, watch, nextTick, inject, onMounted, onUnmounted } from 'vue'
 import { router, usePage } from '@inertiajs/vue3'
 import { useCommandPalette } from '@/composables/useCommandPalette'
+import { useToast } from '@/composables/toast'
 import { fuzzySearch } from '@/lib/fuzzySearch'
 
 const { isOpen, history, register, unregister, getAll, execute, close } = useCommandPalette()
+const toast = useToast()
+const toggleSidebar = inject('toggleSidebar')
+const sidebarCollapsed = inject('sidebarCollapsed')
 
 const query = ref('')
 const selectedIndex = ref(0)
@@ -15,6 +19,8 @@ const parentCommand = ref(null)
 
 const page = usePage()
 const currentUrl = computed(() => page.url)
+const navProjects = computed(() => page.props.navProjects || [])
+const navApps = computed(() => page.props.navApps || [])
 
 // ─── Register core commands ──────────────────────────────────────────
 
@@ -144,9 +150,194 @@ register({
   action: () => window.open('https://docs.sailscasts.com/slipway', '_blank')
 })
 
+register({
+  id: 'action.toggle-sidebar',
+  title: 'Toggle Sidebar',
+  keywords: ['sidebar', 'panel', 'collapse', 'expand', 'hide', 'show'],
+  group: 'Actions',
+  icon: 'sidebar',
+  action: () => toggleSidebar()
+})
+
+register({
+  id: 'nav.bosun',
+  title: 'Go to Bosun',
+  keywords: ['bosun', 'database', 'sql', 'console', 'query'],
+  group: 'Navigation',
+  icon: 'database',
+  action: () => router.visit('/bosun')
+})
+
+register({
+  id: 'action.logout',
+  title: 'Logout',
+  keywords: ['logout', 'sign out', 'exit'],
+  group: 'Actions',
+  icon: 'logout',
+  destructive: true,
+  action: () => router.post('/logout')
+})
+
+register({
+  id: 'action.sponsor',
+  title: 'Sponsor Slipway',
+  keywords: ['sponsor', 'donate', 'support', 'funding'],
+  group: 'Actions',
+  icon: 'heart',
+  action: () => window.open('https://github.com/sponsors/DominusKelvin', '_blank')
+})
+
+// ─── Action submenus (deploy, restart, stop, copy URL) ──────────────
+
+register({
+  id: 'action.deploy',
+  title: 'Deploy App',
+  keywords: ['deploy', 'build', 'ship', 'release', 'push'],
+  group: 'Actions',
+  icon: 'rocket',
+  children: () => navApps.value.map(app => ({
+    id: `action.deploy.${app.projectSlug}.${app.envSlug}.${app.slug}`,
+    title: app.name,
+    subtitle: `${app.projectName} / ${app.envName}`,
+    keywords: [app.slug, app.projectName, app.envName],
+    group: `${app.projectName} / ${app.envName}`,
+    icon: 'rocket',
+    action: async () => {
+      try {
+        const res = await fetch(
+          `/api/v1/projects/${app.projectSlug}/environments/${app.envSlug}/apps/${app.slug}/deploy`,
+          { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+        )
+        const data = await res.json()
+        if (data.deployment) {
+          router.visit(`/projects/${app.projectSlug}/deployments/${data.deployment.id}`)
+        } else {
+          toast({ message: `Failed to deploy ${app.name}`, type: 'error' })
+        }
+      } catch {
+        toast({ message: `Failed to deploy ${app.name}`, type: 'error' })
+      }
+    }
+  }))
+})
+
+register({
+  id: 'action.restart',
+  title: 'Restart App',
+  keywords: ['restart', 'reboot', 'reload'],
+  group: 'Actions',
+  icon: 'refresh',
+  children: () => navApps.value.map(app => ({
+    id: `action.restart.${app.projectSlug}.${app.envSlug}.${app.slug}`,
+    title: app.name,
+    subtitle: `${app.projectName} / ${app.envName}`,
+    keywords: [app.slug, app.projectName, app.envName],
+    group: `${app.projectName} / ${app.envName}`,
+    icon: 'refresh',
+    action: async () => {
+      try {
+        await fetch(
+          `/api/v1/projects/${app.projectSlug}/environments/${app.envSlug}/apps/${app.slug}/restart`,
+          { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+        )
+        toast({ message: `${app.name} restarted`, type: 'success' })
+      } catch {
+        toast({ message: `Failed to restart ${app.name}`, type: 'error' })
+      }
+    }
+  }))
+})
+
+register({
+  id: 'action.stop',
+  title: 'Stop App',
+  keywords: ['stop', 'shutdown', 'kill', 'halt'],
+  group: 'Actions',
+  icon: 'stop',
+  destructive: true,
+  children: () => navApps.value.map(app => ({
+    id: `action.stop.${app.projectSlug}.${app.envSlug}.${app.slug}`,
+    title: app.name,
+    subtitle: `${app.projectName} / ${app.envName}`,
+    keywords: [app.slug, app.projectName, app.envName],
+    group: `${app.projectName} / ${app.envName}`,
+    icon: 'stop',
+    destructive: true,
+    action: async () => {
+      try {
+        await fetch(
+          `/api/v1/projects/${app.projectSlug}/environments/${app.envSlug}/apps/${app.slug}/stop`,
+          { method: 'POST', headers: { 'Content-Type': 'application/json' } }
+        )
+        toast({ message: `${app.name} stopped`, type: 'success' })
+      } catch {
+        toast({ message: `Failed to stop ${app.name}`, type: 'error' })
+      }
+    }
+  }))
+})
+
+register({
+  id: 'action.copy-app-url',
+  title: 'Copy App URL',
+  keywords: ['copy', 'url', 'link', 'domain', 'clipboard'],
+  group: 'Actions',
+  icon: 'clipboard',
+  children: () => navApps.value.filter(app => app.domain).map(app => ({
+    id: `action.copy-url.${app.projectSlug}.${app.envSlug}.${app.slug}`,
+    title: app.name,
+    subtitle: `https://${app.domain}`,
+    keywords: [app.slug, app.projectName, app.envName, app.domain],
+    group: `${app.projectName} / ${app.envName}`,
+    icon: 'clipboard',
+    action: async () => {
+      try {
+        await navigator.clipboard.writeText(`https://${app.domain}`)
+        toast({ message: `Copied URL for ${app.name}`, type: 'success' })
+      } catch {
+        toast({ message: 'Failed to copy URL', type: 'error' })
+      }
+    }
+  }))
+})
+
+// ─── Navigation submenus ────────────────────────────────────────────
+
+register({
+  id: 'nav.app-env-vars',
+  title: 'Go to App Env Vars',
+  keywords: ['env', 'variables', 'secrets', 'environment', 'config'],
+  group: 'Navigation',
+  icon: 'code',
+  children: () => navApps.value.map(app => ({
+    id: `nav.env-vars.${app.projectSlug}.${app.envSlug}.${app.slug}`,
+    title: app.name,
+    subtitle: `${app.projectName} / ${app.envName}`,
+    keywords: [app.slug, app.projectName, app.envName],
+    group: `${app.projectName} / ${app.envName}`,
+    icon: 'code',
+    action: () => router.visit(`/projects/${app.projectSlug}/environments/${app.envSlug}/apps/${app.slug}/settings`)
+  }))
+})
+
+register({
+  id: 'nav.project-settings',
+  title: 'Go to Project Settings',
+  keywords: ['project', 'settings', 'configure'],
+  group: 'Navigation',
+  icon: 'settings',
+  children: () => navProjects.value.map(project => ({
+    id: `nav.project-settings.${project.slug}`,
+    title: project.name,
+    keywords: [project.slug],
+    group: 'Projects',
+    icon: 'settings',
+    action: () => router.visit(`/projects/${project.slug}/settings`)
+  }))
+})
+
 // ─── Dynamic project commands ───────────────────────────────────────
 
-const navProjects = computed(() => page.props.navProjects || [])
 const registeredProjectIds = ref([])
 
 watch(navProjects, (projects) => {
@@ -167,6 +358,28 @@ watch(navProjects, (projects) => {
     return id
   })
   registeredProjectIds.value = ids
+}, { immediate: true })
+
+// ─── Dynamic app commands ───────────────────────────────────────────
+
+const registeredAppIds = ref([])
+
+watch(navApps, (apps) => {
+  registeredAppIds.value.forEach(id => unregister(id))
+
+  const ids = apps.map(app => {
+    const id = `nav.app.${app.projectSlug}.${app.envSlug}.${app.slug}`
+    register({
+      id,
+      title: app.name,
+      keywords: [app.slug, app.projectName, app.envName],
+      group: 'Apps',
+      icon: 'server',
+      action: () => router.visit(`/projects/${app.projectSlug}/environments/${app.envSlug}/apps/${app.slug}`)
+    })
+    return id
+  })
+  registeredAppIds.value = ids
 }, { immediate: true })
 
 // ─── Filtering & grouping ────────────────────────────────────────────
@@ -326,7 +539,7 @@ onUnmounted(() => {
 // ─── Icons ───────────────────────────────────────────────────────────
 // Using inline SVG paths to match codebase style (no emoji)
 
-const icons = {
+const icons = computed(() => ({
   folder: 'M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-6l-2-2H5a2 2 0 00-2 2z',
   chart: 'M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z',
   settings: 'M10.5 6h9.75M10.5 6a1.5 1.5 0 11-3 0m3 0a1.5 1.5 0 10-3 0M3.75 6H7.5m3 12h9.75m-9.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-3.75 0H7.5m9-6h3.75m-3.75 0a1.5 1.5 0 01-3 0m3 0a1.5 1.5 0 00-3 0m-9.75 0h9.75',
@@ -340,9 +553,31 @@ const icons = {
   user: 'M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z',
   plus: 'M12 4v16m8-8H4',
   book: 'M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253',
+  sidebar: {
+    viewBox: '-0.5 -0.5 16 16',
+    paths: sidebarCollapsed.value
+      ? [
+          'M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z',
+          'M5.615 14.285V.715',
+          'M2.6 5.992 3.919 7.5 2.6 9.008'
+        ]
+      : [
+          'M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z',
+          'M5.615 14.285V.715',
+          'M3.919 5.992 2.6 7.5l1.319 1.508'
+        ]
+  },
+  database: 'M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4m0 5c0 2.21-3.582 4-8 4s-8-1.79-8-4',
+  heart: 'M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z',
+  logout: 'M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1',
+  rocket: 'M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.63 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z',
+  refresh: 'M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15',
+  stop: 'M5.25 7.5A2.25 2.25 0 017.5 5.25h9a2.25 2.25 0 012.25 2.25v9a2.25 2.25 0 01-2.25 2.25h-9a2.25 2.25 0 01-2.25-2.25v-9z',
+  clipboard: 'M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184',
+  code: 'M17.25 6.75L22.5 12l-5.25 5.25m-10.5 0L1.5 12l5.25-5.25m7.5-3l-4.5 16.5',
   search: 'M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z',
   chevronRight: 'M9 5l7 7-7 7'
-}
+}))
 </script>
 
 <template>
@@ -415,17 +650,27 @@ const icons = {
                   :data-selected="flatResults.indexOf(cmd) === selectedIndex"
                   :class="[
                     'flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left text-sm transition-colors',
-                    flatResults.indexOf(cmd) === selectedIndex
-                      ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
-                      : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/50'
+                    cmd.destructive
+                      ? flatResults.indexOf(cmd) === selectedIndex
+                        ? 'bg-red-50 text-red-600 dark:bg-red-950 dark:text-red-400'
+                        : 'text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/50'
+                      : flatResults.indexOf(cmd) === selectedIndex
+                        ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
+                        : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/50'
                   ]"
                 >
-                  <span class="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-gray-100 dark:bg-gray-800">
-                    <svg class="h-3.5 w-3.5 text-gray-500 dark:text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <span :class="['flex h-7 w-7 shrink-0 items-center justify-center rounded-md', cmd.destructive ? 'bg-red-50 dark:bg-red-950' : 'bg-gray-100 dark:bg-gray-800']">
+                    <svg v-if="typeof icons[cmd.icon] === 'object'" :class="['h-3.5 w-3.5', cmd.destructive ? 'text-red-500 dark:text-red-400' : 'text-gray-500 dark:text-gray-400']" fill="none" stroke="currentColor" :viewBox="icons[cmd.icon].viewBox">
+                      <path v-for="(d, i) in icons[cmd.icon].paths" :key="i" stroke-linecap="round" stroke-linejoin="round" stroke-width="1" :d="d" />
+                    </svg>
+                    <svg v-else :class="['h-3.5 w-3.5', cmd.destructive ? 'text-red-500 dark:text-red-400' : 'text-gray-500 dark:text-gray-400']" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" :d="icons[cmd.icon] || icons.folder" />
                     </svg>
                   </span>
-                  <span class="flex-1 truncate">{{ cmd.title }}</span>
+                  <span class="flex min-w-0 flex-1 flex-col">
+                    <span class="truncate">{{ cmd.title }}</span>
+                    <span v-if="cmd.subtitle" class="truncate text-xs text-gray-400 dark:text-gray-500">{{ cmd.subtitle }}</span>
+                  </span>
                   <svg v-if="cmd.children" class="h-3.5 w-3.5 shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" :d="icons.chevronRight" />
                   </svg>


### PR DESCRIPTION
## Summary

Resolves #21
Resolves #22
Resolves #34
Resolves #45

- **#21**: Toggle Sidebar command with dynamic icon matching sidebar state
- **#22**: Bosun navigation command
- **#34**: Dynamic apps listing (navApps shared prop with project/env context)
- **#45**: Power user actions — deploy, restart, stop, copy app URL, logout, sponsor, env vars navigation, project settings navigation

## Changes

### Backend (`api/hooks/custom/index.js`)
- Add `navApps` shared prop with full app metadata (name, slug, project/env context, domain)
- Domain resolution inline (custom domain → wildcard → slipway fallback)
- Flush `navApps` on logout

### Frontend (`assets/js/components/CommandPalette.vue`)
- **Actions**: Deploy App, Restart App, Stop App (destructive), Copy App URL, Toggle Sidebar, Logout (destructive), Sponsor Slipway
- **Navigation**: Go to Bosun, Go to App Env Vars, Go to Project Settings (all with submenus)
- **Dynamic listings**: Apps and Projects populate submenus from shared props
- Submenu items show subtitle with project/environment context
- Destructive commands styled red (logout, stop)
- Sidebar icon dynamically reflects collapsed/expanded state
- Toast feedback for action results (restart, stop, copy URL, errors)
- New icons: rocket, refresh, stop, clipboard, code, sidebar, database, heart, logout

## Known issues
- `navApps` shared prop returns empty in dev — needs investigation (try-catch with logging added)

## Test plan
- [x] Open command palette with `Cmd+K`
- [x] Type "sidebar" — verify Toggle Sidebar works and icon reflects state
- [x] Type "bosun" — verify navigation to /bosun
- [x] Type "deploy" — verify submenu lists apps, clicking triggers deployment
- [x] Type "restart" — verify submenu lists apps, clicking restarts with toast
- [x] Type "stop" — verify red styling, submenu lists apps, clicking stops with toast
- [x] Type "copy" — verify Copy App URL submenu shows domain, copies to clipboard
- [x] Type "env" — verify Go to App Env Vars navigates to app settings
- [x] Type "logout" — verify red styling, clicking logs out
- [x] Type "sponsor" — verify opens GitHub sponsors in new tab