### PR TITLE
feat: add syntax highlighting to table and JSON result views

### DIFF
--- a/assets/js/components/Tooltip.vue
+++ b/assets/js/components/Tooltip.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref, computed, onBeforeUnmount } from 'vue'
+import { ref, computed, nextTick, onBeforeUnmount } from 'vue'
 
 const props = defineProps({
   text: {
@@ -19,75 +19,114 @@ const props = defineProps({
 
 const show = ref(false)
 const triggerRef = ref(null)
+const tooltipRef = ref(null)
 const tooltipStyle = ref({})
+const arrowStyle = ref({})
 const actualPosition = ref(props.position)
 let timeout = null
 
-function updatePosition() {
+const GAP = 8
+const EDGE_MARGIN = 10
+const ARROW_HALF_WIDTH = 6 // must match border-x size
+const BORDER_RADIUS = 6 // rounded-md
+
+function positionTooltip() {
   if (!triggerRef.value) return
 
   const rect = triggerRef.value.getBoundingClientRect()
-  const gap = 8 // Space between trigger and tooltip
-  const tooltipHeight = 32 // Approximate tooltip height
-  const tooltipWidth = 100 // Approximate tooltip width
+  const approxHeight = 32
+  const approxWidth = 100
 
-  let top, left
   let finalPosition = props.position
 
-  // Auto-detect if we need to flip vertical position
-  if (props.position === 'top' && rect.top < tooltipHeight + gap) {
+  // Flip if not enough space (uses approximations — that's fine for flipping)
+  if (props.position === 'top' && rect.top < approxHeight + GAP) {
     finalPosition = 'bottom'
-  } else if (props.position === 'bottom' && window.innerHeight - rect.bottom < tooltipHeight + gap) {
+  } else if (props.position === 'bottom' && window.innerHeight - rect.bottom < approxHeight + GAP) {
     finalPosition = 'top'
-  } else if (props.position === 'left' && rect.left < tooltipWidth + gap) {
+  } else if (props.position === 'left' && rect.left < approxWidth + GAP) {
     finalPosition = 'right'
-  } else if (props.position === 'right' && window.innerWidth - rect.right < tooltipWidth + gap) {
+  } else if (props.position === 'right' && window.innerWidth - rect.right < approxWidth + GAP) {
     finalPosition = 'left'
   }
 
   actualPosition.value = finalPosition
 
+  // Initial position: centered on trigger (overflow adjusted after render)
+  let top, left
   switch (finalPosition) {
     case 'top':
-      top = rect.top - gap
+      top = rect.top - GAP
       left = rect.left + rect.width / 2
       break
     case 'bottom':
-      top = rect.bottom + gap
+      top = rect.bottom + GAP
       left = rect.left + rect.width / 2
       break
     case 'left':
       top = rect.top + rect.height / 2
-      left = rect.left - gap
+      left = rect.left - GAP
       break
     case 'right':
       top = rect.top + rect.height / 2
-      left = rect.right + gap
+      left = rect.right + GAP
       break
   }
 
-  // Check if tooltip would overflow right edge and adjust
-  const centerX = rect.left + rect.width / 2
-  if (finalPosition === 'top' || finalPosition === 'bottom') {
-    if (centerX + tooltipWidth / 2 > window.innerWidth - 10) {
-      // Would overflow right - align to right edge instead
-      left = window.innerWidth - tooltipWidth / 2 - 10
-    } else if (centerX - tooltipWidth / 2 < 10) {
-      // Would overflow left - align to left edge instead
-      left = tooltipWidth / 2 + 10
-    }
-  }
+  tooltipStyle.value = { top: `${top}px`, left: `${left}px` }
 
-  tooltipStyle.value = {
-    top: `${top}px`,
-    left: `${left}px`
+  // Default arrow: centered, overlapping by 0.5px to prevent sub-pixel gaps
+  if (finalPosition === 'top' || finalPosition === 'bottom') {
+    arrowStyle.value = { left: '50%', transform: 'translateX(-50%)' }
+  } else {
+    arrowStyle.value = { top: '50%', transform: 'translateY(-50%)' }
   }
 }
 
-function handleMouseEnter() {
-  timeout = setTimeout(() => {
-    updatePosition()
+function adjustForOverflow() {
+  if (!tooltipRef.value || !triggerRef.value) return
+
+  const pos = actualPosition.value
+  if (pos !== 'top' && pos !== 'bottom') return
+
+  const tooltipRect = tooltipRef.value.getBoundingClientRect()
+  const triggerRect = triggerRef.value.getBoundingClientRect()
+  const triggerCenterX = triggerRect.left + triggerRect.width / 2
+
+  let shiftX = 0
+  if (tooltipRect.right > window.innerWidth - EDGE_MARGIN) {
+    shiftX = tooltipRect.right - (window.innerWidth - EDGE_MARGIN)
+  } else if (tooltipRect.left < EDGE_MARGIN) {
+    shiftX = tooltipRect.left - EDGE_MARGIN
+  }
+
+  if (shiftX === 0) return
+
+  // Shift tooltip to stay within viewport
+  const currentLeft = parseFloat(tooltipStyle.value.left)
+  tooltipStyle.value = {
+    ...tooltipStyle.value,
+    left: `${currentLeft - shiftX}px`
+  }
+
+  // Arrow must still point at trigger center
+  // After shifting, the tooltip center moved by -shiftX, so arrow needs +shiftX offset
+  // Clamp so arrow stays within the rounded corners of the tooltip
+  const maxOffset = (tooltipRect.width / 2) - BORDER_RADIUS - ARROW_HALF_WIDTH
+  const clampedOffset = Math.max(-maxOffset, Math.min(maxOffset, shiftX))
+
+  arrowStyle.value = {
+    left: `calc(50% + ${clampedOffset}px)`,
+    transform: 'translateX(-50%)'
+  }
+}
+
+async function handleMouseEnter() {
+  timeout = setTimeout(async () => {
+    positionTooltip()
     show.value = true
+    await nextTick()
+    adjustForOverflow()
   }, props.delay)
 }
 
@@ -115,10 +154,10 @@ const tooltipClasses = computed(() => {
 
 const arrowClasses = computed(() => {
   const arrows = {
-    top: 'top-full left-1/2 -translate-x-1/2 border-t-gray-900 dark:border-t-gray-100 border-x-transparent border-b-transparent',
-    bottom: 'bottom-full left-1/2 -translate-x-1/2 border-b-gray-900 dark:border-b-gray-100 border-x-transparent border-t-transparent',
-    left: 'left-full top-1/2 -translate-y-1/2 border-l-gray-900 dark:border-l-gray-100 border-y-transparent border-r-transparent',
-    right: 'right-full top-1/2 -translate-y-1/2 border-r-gray-900 dark:border-r-gray-100 border-y-transparent border-l-transparent'
+    top: 'top-full border-t-gray-900 dark:border-t-gray-100 border-x-transparent border-b-transparent',
+    bottom: 'bottom-full border-b-gray-900 dark:border-b-gray-100 border-x-transparent border-t-transparent',
+    left: 'left-full border-l-gray-900 dark:border-l-gray-100 border-y-transparent border-r-transparent',
+    right: 'right-full border-r-gray-900 dark:border-r-gray-100 border-y-transparent border-l-transparent'
   }
   return arrows[actualPosition.value]
 })
@@ -150,6 +189,7 @@ const arrowBorderSize = computed(() => {
       >
         <div
           v-if="show && text"
+          ref="tooltipRef"
           :class="tooltipClasses"
           :style="tooltipStyle"
         >
@@ -161,6 +201,7 @@ const arrowBorderSize = computed(() => {
               arrowClasses,
               arrowBorderSize
             ]"
+            :style="arrowStyle"
           />
         </div>
       </Transition>

--- a/assets/js/lib/highlightJSON.js
+++ b/assets/js/lib/highlightJSON.js
@@ -1,0 +1,43 @@
+// JSON syntax highlighter — colorizes JSON.stringify output
+// Colors match SQL highlighter: keys pink, strings amber, numbers purple, booleans blue, null gray
+
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+// Tokenize pre-formatted JSON string
+const jsonTokenPattern = /("(?:[^"\\]|\\.)*")\s*(:)?|(-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?)|(\btrue\b|\bfalse\b)|(\bnull\b)|(\s+)|(.)/g
+
+export function highlightJSON(data) {
+  const json = JSON.stringify(data, null, 2)
+  if (!json) return ''
+
+  const parts = []
+  let match
+
+  while ((match = jsonTokenPattern.exec(json)) !== null) {
+    const [, str, colon, num, bool, nul, ws, other] = match
+    if (str) {
+      const escaped = escapeHtml(str)
+      if (colon) {
+        // Key (string followed by colon)
+        parts.push(`<span class="text-pink-600 dark:text-pink-400">${escaped}</span>: `)
+      } else {
+        // String value
+        parts.push(`<span class="text-amber-600 dark:text-amber-400">${escaped}</span>`)
+      }
+    } else if (num) {
+      parts.push(`<span class="text-purple-600 dark:text-purple-400">${num}</span>`)
+    } else if (bool) {
+      parts.push(`<span class="text-blue-600 dark:text-blue-400">${bool}</span>`)
+    } else if (nul) {
+      parts.push(`<span class="text-gray-400 dark:text-gray-600">${nul}</span>`)
+    } else if (ws) {
+      parts.push(ws)
+    } else if (other) {
+      parts.push(escapeHtml(other))
+    }
+  }
+
+  return parts.join('')
+}

--- a/assets/js/lib/highlightSQL.js
+++ b/assets/js/lib/highlightSQL.js
@@ -1,0 +1,48 @@
+// Shared SQL syntax highlighter — merged keyword set from Dock + Bosun
+// Colors: keywords pink, strings amber, numbers purple
+
+const keywords = new Set([
+  'SELECT', 'FROM', 'WHERE', 'AND', 'OR', 'NOT', 'IN', 'IS', 'NULL', 'LIKE', 'BETWEEN',
+  'JOIN', 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'ON', 'AS', 'ORDER', 'BY', 'ASC', 'DESC',
+  'LIMIT', 'OFFSET', 'GROUP', 'HAVING', 'UNION', 'ALL', 'DISTINCT',
+  'INSERT', 'INTO', 'VALUES', 'UPDATE', 'SET', 'DELETE',
+  'CREATE', 'TABLE', 'ALTER', 'DROP', 'INDEX', 'PRIMARY', 'KEY', 'FOREIGN', 'REFERENCES',
+  'CONSTRAINT', 'DEFAULT', 'AUTOINCREMENT', 'AUTO_INCREMENT', 'SERIAL',
+  'IF', 'EXISTS', 'CASCADE', 'ADD', 'COLUMN',
+  'INTEGER', 'TEXT', 'VARCHAR', 'BOOLEAN', 'REAL', 'BIGINT', 'TIMESTAMP', 'JSON', 'JSONB', 'UNIQUE',
+  'PRAGMA', 'EXPLAIN',
+  'COUNT', 'SUM', 'AVG', 'MIN', 'MAX',
+  'CASE', 'WHEN', 'THEN', 'ELSE', 'END', 'CAST', 'TYPE'
+])
+
+const tokenPattern = /('(?:[^'\\]|\\.)*')|(\d+(?:\.\d+)?)|(\b[a-zA-Z_]\w*\b)|(\s+)|(.)/g
+
+function escapeHtml(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+export function highlightSQL(sql) {
+  if (!sql) return ''
+
+  const tokens = []
+  let match
+
+  while ((match = tokenPattern.exec(sql)) !== null) {
+    const [, str, num, word, ws, other] = match
+    if (str) tokens.push({ type: 'string', value: str })
+    else if (num) tokens.push({ type: 'number', value: num })
+    else if (word) tokens.push({ type: keywords.has(word.toUpperCase()) ? 'keyword' : 'identifier', value: word })
+    else if (ws) tokens.push({ type: 'whitespace', value: ws })
+    else if (other) tokens.push({ type: 'other', value: other })
+  }
+
+  return tokens.map(t => {
+    const escaped = escapeHtml(t.value)
+    switch (t.type) {
+      case 'keyword': return `<span class="text-pink-600 dark:text-pink-400">${escaped}</span>`
+      case 'string': return `<span class="text-amber-600 dark:text-amber-400">${escaped}</span>`
+      case 'number': return `<span class="text-purple-600 dark:text-purple-400">${escaped}</span>`
+      default: return escaped
+    }
+  }).join('')
+}

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -2,6 +2,10 @@
 import { Head } from '@inertiajs/vue3'
 import { ref, computed, inject, watch, onMounted, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import ToastContainer from '@/components/ToastContainer.vue'
+import Tooltip from '@/components/Tooltip.vue'
+import { highlightSQL } from '@/lib/highlightSQL'
+import { highlightJSON } from '@/lib/highlightJSON'
 
 defineOptions({
   layout: AppLayout
@@ -66,125 +70,22 @@ const queryHistory = ref([])
 const resultView = ref('table')
 const showExportMenu = ref(false)
 
-// SQL syntax highlighting (matching Dock)
-const highlightedQuery = computed(() => highlightSQL(sqlQuery.value))
+// Toast state
+const toasts = ref([])
+let toastId = 0
 
-function highlightSQL(sql) {
-  if (!sql) return ''
-
-  const keywords = new Set([
-    'SELECT',
-    'FROM',
-    'WHERE',
-    'AND',
-    'OR',
-    'NOT',
-    'IN',
-    'IS',
-    'NULL',
-    'LIKE',
-    'BETWEEN',
-    'JOIN',
-    'LEFT',
-    'RIGHT',
-    'INNER',
-    'OUTER',
-    'ON',
-    'AS',
-    'ORDER',
-    'BY',
-    'ASC',
-    'DESC',
-    'LIMIT',
-    'OFFSET',
-    'GROUP',
-    'HAVING',
-    'UNION',
-    'ALL',
-    'DISTINCT',
-    'INSERT',
-    'INTO',
-    'VALUES',
-    'UPDATE',
-    'SET',
-    'DELETE',
-    'CREATE',
-    'TABLE',
-    'ALTER',
-    'DROP',
-    'INDEX',
-    'PRIMARY',
-    'KEY',
-    'FOREIGN',
-    'REFERENCES',
-    'CONSTRAINT',
-    'DEFAULT',
-    'AUTOINCREMENT',
-    'INTEGER',
-    'TEXT',
-    'VARCHAR',
-    'BOOLEAN',
-    'REAL',
-    'BIGINT',
-    'TIMESTAMP',
-    'JSON',
-    'JSONB',
-    'UNIQUE',
-    'PRAGMA',
-    'EXPLAIN',
-    'COUNT',
-    'SUM',
-    'AVG',
-    'MIN',
-    'MAX',
-    'CASE',
-    'WHEN',
-    'THEN',
-    'ELSE',
-    'END',
-    'CAST',
-    'TYPE',
-    'EXISTS',
-    'IF'
-  ])
-
-  const tokens = []
-  const tokenPattern =
-    /('(?:[^'\\]|\\.)*')|(\d+(?:\.\d+)?)|(\b[a-zA-Z_]\w*\b)|(\s+)|(.)/g
-  let match
-
-  while ((match = tokenPattern.exec(sql)) !== null) {
-    const [, str, num, word, ws, other] = match
-    if (str) tokens.push({ type: 'string', value: str })
-    else if (num) tokens.push({ type: 'number', value: num })
-    else if (word)
-      tokens.push({
-        type: keywords.has(word.toUpperCase()) ? 'keyword' : 'identifier',
-        value: word
-      })
-    else if (ws) tokens.push({ type: 'whitespace', value: ws })
-    else if (other) tokens.push({ type: 'other', value: other })
-  }
-
-  return tokens
-    .map((t) => {
-      const escaped = t.value
-        .replace(/&/g, '&amp;')
-        .replace(/</g, '&lt;')
-        .replace(/>/g, '&gt;')
-      switch (t.type) {
-        case 'keyword':
-          return `<span class="text-pink-600 dark:text-pink-400">${escaped}</span>`
-        case 'string':
-          return `<span class="text-amber-600 dark:text-amber-400">${escaped}</span>`
-        case 'number':
-          return `<span class="text-purple-600 dark:text-purple-400">${escaped}</span>`
-        default:
-          return escaped
-      }
-    })
-    .join('')
+function showToast(message, type = 'success') {
+  const id = ++toastId
+  toasts.value.push({ id, message, type })
+  setTimeout(() => dismissToast(id), 5000)
 }
+
+function dismissToast(id) {
+  toasts.value = toasts.value.filter(t => t.id !== id)
+}
+
+// SQL syntax highlighting (shared utility)
+const highlightedQuery = computed(() => highlightSQL(sqlQuery.value))
 
 async function executeQuery() {
   if (!sqlQuery.value.trim() || consoleLoading.value) return
@@ -230,6 +131,7 @@ function copyAsJSON() {
   navigator.clipboard.writeText(
     JSON.stringify(consoleResults.value.rows, null, 2)
   )
+  showToast('Copied JSON to clipboard')
 }
 
 function copyAsCSV() {
@@ -249,6 +151,7 @@ function copyAsCSV() {
     csvLines.push(values.join(','))
   }
   navigator.clipboard.writeText(csvLines.join('\n'))
+  showToast('Copied CSV to clipboard')
 }
 
 function downloadAsJSON() {
@@ -258,6 +161,7 @@ function downloadAsJSON() {
     'query-result.json',
     'application/json'
   )
+  showToast('Downloaded query-result.json')
 }
 
 function downloadAsCSV() {
@@ -277,6 +181,7 @@ function downloadAsCSV() {
     csvLines.push(values.join(','))
   }
   downloadFile(csvLines.join('\n'), 'query-result.csv', 'text/csv')
+  showToast('Downloaded query-result.csv')
 }
 
 function downloadFile(content, filename, mimeType) {
@@ -573,10 +478,12 @@ onUnmounted(() => {
         <span class="font-medium text-gray-900 dark:text-white">Bosun</span>
       </div>
       <div class="flex items-center space-x-2 sm:space-x-3">
-        <span
-          class="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-          >v{{ version }}</span
-        >
+        <Tooltip text="Slipway version" position="bottom">
+          <span
+            class="rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
+            >v{{ version }}</span
+          >
+        </Tooltip>
         <a
           href="https://docs.sailscasts.com/slipway/bosun"
           target="_blank"
@@ -715,7 +622,7 @@ onUnmounted(() => {
             <table class="min-w-full">
               <thead class="sticky top-0">
                 <tr
-                  class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50"
+                  class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900"
                 >
                   <th
                     v-for="col in consoleResults.columns"
@@ -742,6 +649,8 @@ onUnmounted(() => {
                       class="text-gray-400 dark:text-gray-600"
                       >NULL</span
                     >
+                    <span v-else-if="typeof row[col] === 'number'" class="text-purple-600 dark:text-purple-400">{{ row[col] }}</span>
+                    <span v-else-if="typeof row[col] === 'boolean'" class="text-blue-600 dark:text-blue-400">{{ row[col] }}</span>
                     <span v-else>{{ row[col] }}</span>
                   </td>
                 </tr>
@@ -754,9 +663,7 @@ onUnmounted(() => {
             v-else-if="consoleResults.columns && resultView === 'json'"
             class="flex-1 overflow-auto p-4"
           >
-            <pre class="font-mono text-xs text-gray-700 dark:text-gray-300">{{
-              JSON.stringify(consoleResults.rows, null, 2)
-            }}</pre>
+            <pre class="font-mono text-xs text-gray-700 dark:text-gray-300" v-html="highlightJSON(consoleResults.rows)"></pre>
           </div>
 
           <!-- No columns result -->
@@ -788,40 +695,44 @@ onUnmounted(() => {
             v-if="consoleResults.columns"
             class="flex overflow-hidden rounded-md border border-gray-300 dark:border-gray-700"
           >
-            <button
-              @click="resultView = 'table'"
-              :class="[
-                'p-1.5',
-                resultView === 'table'
-                  ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
-              ]"
-            >
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="1.5"
+            <Tooltip text="Table view" position="top">
+              <button
+                @click="resultView = 'table'"
+                :class="[
+                  'p-1.5',
+                  resultView === 'table'
+                    ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+                ]"
               >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0112 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125"
-                />
-              </svg>
-            </button>
-            <button
-              @click="resultView = 'json'"
-              :class="[
-                'border-l border-gray-300 px-1.5 py-1 font-mono text-sm font-bold dark:border-gray-700',
-                resultView === 'json'
-                  ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
-              ]"
-            >
-              {}
-            </button>
+                <svg
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0112 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125M12 10.875v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 10.875c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125M13.125 12h7.5m-7.5 0c-.621 0-1.125.504-1.125 1.125M20.625 12c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125m-17.25 0h7.5M12 14.625v-1.5m0 1.5c0 .621-.504 1.125-1.125 1.125M12 14.625c0 .621.504 1.125 1.125 1.125m-2.25 0c.621 0 1.125.504 1.125 1.125m0 0v1.5c0 .621-.504 1.125-1.125 1.125"
+                  />
+                </svg>
+              </button>
+            </Tooltip>
+            <Tooltip text="JSON view" position="top">
+              <button
+                @click="resultView = 'json'"
+                :class="[
+                  'border-l border-gray-300 px-1.5 py-1 font-mono text-sm font-bold dark:border-gray-700',
+                  resultView === 'json'
+                    ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+                    : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+                ]"
+              >
+                {}
+              </button>
+            </Tooltip>
           </div>
           <!-- Row info -->
           <span class="text-xs text-gray-500 dark:text-gray-400">
@@ -834,46 +745,9 @@ onUnmounted(() => {
         </div>
         <!-- Actions -->
         <div v-if="consoleResults.columns" class="flex items-center gap-1">
-          <button
-            @click="executeQuery"
-            class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-          >
-            <svg
-              class="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="1.5"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
-              />
-            </svg>
-          </button>
-          <button
-            @click="resultView === 'json' ? copyAsJSON() : copyAsCSV()"
-            class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-          >
-            <svg
-              class="h-4 w-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              stroke-width="1.5"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
-              />
-            </svg>
-          </button>
-          <!-- Export dropdown -->
-          <div class="relative" data-export-menu>
+          <Tooltip text="Re-run query" position="top">
             <button
-              @click="showExportMenu = !showExportMenu"
+              @click="executeQuery"
               class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
             >
               <svg
@@ -886,10 +760,53 @@ onUnmounted(() => {
                 <path
                   stroke-linecap="round"
                   stroke-linejoin="round"
-                  d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                  d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182m0-4.991v4.99"
                 />
               </svg>
             </button>
+          </Tooltip>
+          <Tooltip :text="resultView === 'json' ? 'Copy as JSON' : 'Copy as CSV'" position="top">
+            <button
+              @click="resultView === 'json' ? copyAsJSON() : copyAsCSV()"
+              class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+            >
+              <svg
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
+                />
+              </svg>
+            </button>
+          </Tooltip>
+          <!-- Export dropdown -->
+          <div class="relative" data-export-menu>
+            <Tooltip text="Download" position="top">
+              <button
+                @click="showExportMenu = !showExportMenu"
+                class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
+              >
+                <svg
+                  class="h-4 w-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.5"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3"
+                  />
+                </svg>
+              </button>
+            </Tooltip>
             <div
               v-if="showExportMenu"
               class="absolute bottom-full right-0 z-10 mb-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
@@ -1415,5 +1332,6 @@ onUnmounted(() => {
         </div>
       </div>
     </div>
+    <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
   </div>
 </template>

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -5,6 +5,8 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import { highlightSQL } from '@/lib/highlightSQL'
+import { highlightJSON } from '@/lib/highlightJSON'
 
 defineOptions({
   layout: AppLayout
@@ -231,46 +233,10 @@ function apiUrl(endpoint, extraParams = '') {
   return `${apiBasePath.value}${endpoint}${queryPart}`
 }
 
-// SQL syntax highlighting with tokenizer approach to avoid nested span issues
+// SQL syntax highlighting (shared utility)
 const highlightedQuery = computed(() => {
   return highlightSQL(query.value)
 })
-
-function highlightSQL(sql) {
-  if (!sql) return ''
-
-  const keywords = new Set(['SELECT', 'FROM', 'WHERE', 'AND', 'OR', 'NOT', 'IN', 'IS', 'NULL', 'LIKE', 'BETWEEN',
-    'JOIN', 'LEFT', 'RIGHT', 'INNER', 'OUTER', 'ON', 'AS', 'ORDER', 'BY', 'ASC', 'DESC', 'LIMIT', 'OFFSET',
-    'GROUP', 'HAVING', 'UNION', 'ALL', 'DISTINCT', 'INSERT', 'INTO', 'VALUES', 'UPDATE', 'SET', 'DELETE',
-    'CREATE', 'TABLE', 'ALTER', 'DROP', 'INDEX', 'PRIMARY', 'KEY', 'FOREIGN', 'REFERENCES', 'CONSTRAINT',
-    'DEFAULT', 'AUTOINCREMENT', 'AUTO_INCREMENT', 'SERIAL', 'IF', 'EXISTS', 'CASCADE', 'ADD', 'COLUMN',
-    'INTEGER', 'TEXT', 'VARCHAR', 'BOOLEAN', 'REAL', 'BIGINT', 'TIMESTAMP', 'JSON', 'JSONB', 'UNIQUE'])
-
-  // Tokenize: strings, numbers, words, whitespace, other
-  const tokens = []
-  const tokenPattern = /('(?:[^'\\]|\\.)*')|(\d+(?:\.\d+)?)|(\b[a-zA-Z_]\w*\b)|(\s+)|(.)/g
-  let match
-
-  while ((match = tokenPattern.exec(sql)) !== null) {
-    const [, str, num, word, ws, other] = match
-    if (str) tokens.push({ type: 'string', value: str })
-    else if (num) tokens.push({ type: 'number', value: num })
-    else if (word) tokens.push({ type: keywords.has(word.toUpperCase()) ? 'keyword' : 'identifier', value: word })
-    else if (ws) tokens.push({ type: 'whitespace', value: ws })
-    else if (other) tokens.push({ type: 'other', value: other })
-  }
-
-  // Render tokens with colors (using colors that work in both modes)
-  return tokens.map(t => {
-    const escaped = t.value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    switch (t.type) {
-      case 'keyword': return `<span class="text-pink-600 dark:text-pink-400">${escaped}</span>`
-      case 'string': return `<span class="text-amber-600 dark:text-amber-400">${escaped}</span>`
-      case 'number': return `<span class="text-purple-600 dark:text-purple-400">${escaped}</span>`
-      default: return escaped
-    }
-  }).join('')
-}
 
 // Execute SQL query
 async function executeQuery() {
@@ -1150,7 +1116,7 @@ onUnmounted(() => {
             <div v-if="queryResult.columns && queryResult.columns.length > 0 && resultView === 'table'" class="overflow-auto flex-1">
               <table class="min-w-full">
                 <thead class="sticky top-0">
-                  <tr class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50">
+                  <tr class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900">
                     <th
                       v-for="col in queryResult.columns"
                       :key="col"
@@ -1172,6 +1138,8 @@ onUnmounted(() => {
                       class="whitespace-nowrap px-4 py-2 font-mono text-sm text-gray-700 dark:text-gray-300"
                     >
                       <span v-if="row[col] === null" class="text-gray-400 dark:text-gray-600">NULL</span>
+                      <span v-else-if="typeof row[col] === 'number'" class="text-purple-600 dark:text-purple-400">{{ row[col] }}</span>
+                      <span v-else-if="typeof row[col] === 'boolean'" class="text-blue-600 dark:text-blue-400">{{ row[col] }}</span>
                       <span v-else>{{ row[col] }}</span>
                     </td>
                   </tr>
@@ -1181,7 +1149,7 @@ onUnmounted(() => {
 
             <!-- JSON view -->
             <div v-else-if="queryResult.columns && queryResult.columns.length > 0 && resultView === 'json'" class="flex-1 overflow-auto p-4">
-              <pre class="font-mono text-xs text-gray-700 dark:text-gray-300">{{ JSON.stringify(queryResult.rows, null, 2) }}</pre>
+              <pre class="font-mono text-xs text-gray-700 dark:text-gray-300" v-html="highlightJSON(queryResult.rows)"></pre>
             </div>
 
             <!-- No columns (DDL result) -->
@@ -1366,6 +1334,8 @@ onUnmounted(() => {
                     class="whitespace-nowrap px-3 py-2 font-mono text-xs text-gray-700 dark:text-gray-300"
                   >
                     <span v-if="row[col] === null" class="text-gray-400 dark:text-gray-600">NULL</span>
+                    <span v-else-if="typeof row[col] === 'number'" class="text-purple-600 dark:text-purple-400">{{ row[col] }}</span>
+                    <span v-else-if="typeof row[col] === 'boolean'" class="text-blue-600 dark:text-blue-400">{{ row[col] }}</span>
                     <span v-else>{{ row[col] }}</span>
                   </td>
                 </tr>


### PR DESCRIPTION
## Summary
- Add type-based coloring to table cells in Dock and Bosun consoles (numbers purple, booleans blue, null gray, strings default)
- Add JSON syntax highlighting to JSON result views (keys pink, strings amber, numbers purple, booleans blue, null gray)
- Extract duplicated `highlightSQL` function into shared `assets/js/lib/highlightSQL.js` utility with merged keyword set from both pages
- Add tooltips and toast feedback to Bosun console action buttons (re-run, copy, download) and version badge
- Fix Tooltip component arrow alignment when tooltip shifts to avoid viewport overflow (measure-then-adjust approach)
- Fix sticky table header transparency in dark mode (`bg-gray-900/50` → `bg-gray-900`)

## Test plan
- [x] Open Dock, run a SQL query — verify table cells show numbers in purple, booleans in blue, NULL in gray
- [x] Switch to JSON view — verify keys are pink, strings amber, numbers purple, booleans blue, null gray
- [x] Open Bosun Console, run a query — verify same table and JSON highlighting
- [x] Verify SQL editor highlighting still works in both Dock and Bosun
- [x] Hover action buttons in Bosun status bar — verify tooltips appear (Re-run, Copy, Download, Table/JSON toggle)
- [x] Click copy/download in Bosun — verify toast notifications appear
- [x] Hover version badge in Bosun — verify "Slipway version" tooltip
- [x] Test tooltip positioning near viewport edges — verify arrow stays aligned
- [x] Verify dark mode colors for all highlighting
- [x] Scroll table results — verify sticky header is opaque (no content bleed-through)

Resolves #25