### PR TITLE
feat: migrate to Docker BuildKit and fix local health checks

### DIFF
--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -120,10 +120,11 @@ module.exports = {
         resourceLimits
       })
 
-      // 10. HTTP health check on the new container (via Docker network DNS)
+      // 10. HTTP health check on the new container (Docker DNS, with localhost fallback for local dev)
       await sails.helpers.docker.healthCheck.with({
         containerName: deployContainerName,
         port: 1337,
+        hostPort: deployHostPort,
         deploymentId
       })
 

--- a/api/helpers/docker/build-image.js
+++ b/api/helpers/docker/build-image.js
@@ -55,8 +55,9 @@ module.exports = {
 
   fn: async function ({ contextPath, imageName, dockerfilePath, deploymentId, buildArgs, timeout, noCache }) {
     return new Promise((resolve, reject) => {
+      const dockerPath = sails.config.docker?.binaryPath || 'docker'
       const fullDockerfilePath = path.resolve(contextPath, dockerfilePath)
-      const args = ['build', '-t', imageName, '-f', fullDockerfilePath]
+      const args = ['buildx', 'build', '--load', '--progress=plain', '-t', imageName, '-f', fullDockerfilePath]
 
       // Only disable cache if explicitly requested
       if (noCache) {
@@ -70,9 +71,9 @@ module.exports = {
 
       args.push(contextPath)
 
-      sails.log.info(`Building image: docker ${args.join(' ')}`)
+      sails.log.info(`Building image: ${dockerPath} ${args.join(' ')}`)
 
-      const buildProcess = spawn('docker', args)
+      const buildProcess = spawn(dockerPath, args)
       let stdout = ''
       let stderr = ''
       let killed = false

--- a/api/helpers/docker/health-check.js
+++ b/api/helpers/docker/health-check.js
@@ -16,6 +16,10 @@ module.exports = {
       required: true,
       description: 'Internal port the app listens on'
     },
+    hostPort: {
+      type: 'number',
+      description: 'Host-mapped port — used as localhost fallback when Docker DNS is unavailable (e.g. local dev on macOS)'
+    },
     path: {
       type: 'string',
       defaultsTo: '/',
@@ -46,10 +50,11 @@ module.exports = {
     }
   },
 
-  fn: async function ({ containerName, port, path, timeout, interval, deploymentId }) {
+  fn: async function ({ containerName, port, hostPort, path, timeout, interval, deploymentId }) {
     const startTime = Date.now()
     let lastError = null
     let attempts = 0
+    let usingFallback = false
 
     if (deploymentId) {
       await Deployment.appendDeployLog(deploymentId, `Health check: polling http://${containerName}:${port}${path} (timeout: ${Math.round(timeout / 1000)}s)\n`)
@@ -58,11 +63,14 @@ module.exports = {
     while (Date.now() - startTime < timeout) {
       attempts++
 
+      const checkHost = usingFallback ? 'localhost' : containerName
+      const checkPort = usingFallback ? hostPort : port
+
       try {
-        const statusCode = await httpGet(containerName, port, path)
+        const statusCode = await httpGet(checkHost, checkPort, path)
 
         if (statusCode < 500) {
-          sails.log.info(`Health check passed on ${containerName}:${port} (HTTP ${statusCode}, attempt ${attempts})`)
+          sails.log.info(`Health check passed on ${checkHost}:${checkPort} (HTTP ${statusCode}, attempt ${attempts})`)
           if (deploymentId) {
             await Deployment.appendDeployLog(deploymentId, `Health check passed (HTTP ${statusCode}, attempt ${attempts})\n`)
           }
@@ -71,6 +79,15 @@ module.exports = {
 
         lastError = `HTTP ${statusCode}`
       } catch (err) {
+        // If Docker DNS can't resolve the container name, fall back to localhost:hostPort
+        if (!usingFallback && hostPort && err.code === 'ENOTFOUND') {
+          usingFallback = true
+          sails.log.info(`Docker DNS unavailable, falling back to localhost:${hostPort}`)
+          if (deploymentId) {
+            await Deployment.appendDeployLog(deploymentId, `Docker DNS unavailable, falling back to localhost:${hostPort}\n`)
+          }
+          continue // Retry immediately with fallback
+        }
         lastError = err.message
       }
 


### PR DESCRIPTION
## Summary
- Migrated `docker build` to `docker buildx build` with `--load` and `--progress=plain` flags to resolve the legacy builder deprecation warning
- Fixed health check DNS failure on local dev (macOS) by falling back to `localhost:hostPort` when Docker container name can't be resolved
- Fixed `build-image.js` not using `sails.config.docker.binaryPath` (every other Docker helper already did)

## Test plan
- [x] Deploy an app on a server box — verify build uses BuildKit (no deprecation warning) and health check passes via Docker DNS
- [x] Deploy an app locally on macOS — verify health check falls back to `localhost:hostPort` after ENOTFOUND and passes
- [x] Verify `--no-cache` builds still work
- [x] Verify build timeout still kills the process correctly
- [x] Check deployment logs show `--progress=plain` output (line-by-line, no TTY artifacts)

Resolves #26