### PR TITLE
feat: maritime loading messages and notification fixes

### DIFF
--- a/api/helpers/notification/send-deployment-notification.js
+++ b/api/helpers/notification/send-deployment-notification.js
@@ -42,10 +42,12 @@ module.exports = {
 
     const instanceName = await sails.helpers.setting.get('instanceName', 'Slipway')
     const instanceDomain = await sails.helpers.setting.get('instanceDomain', '')
+    const app = deployment.app ? await App.findOne({ id: deployment.app }) : null
+    const appName = app ? app.name : project.name
 
     const emoji = isSuccess ? '\u2705' : '\u274C'
     const statusText = isSuccess ? 'succeeded' : 'failed'
-    const slippyTitle = isSuccess ? 'Ship shipped!' : 'Deployment hit a snag'
+    const slippyTitle = isSuccess ? 'Deployment successful' : 'Deployment failed'
     const deploymentUrl = instanceDomain
       ? `https://${instanceDomain}/projects/${project.slug}/deployments/${deployment.id}`
       : null
@@ -54,7 +56,7 @@ module.exports = {
     const telegramEnabled = await sails.helpers.setting.get('telegramEnabled', 'false')
     if (telegramEnabled === 'true') {
       let message = `${emoji} <b>${slippyTitle}</b>\n\n`
-      message += `<b>Project:</b> ${escapeHtml(project.name)}\n`
+      message += `<b>App:</b> ${escapeHtml(appName)}\n`
       message += `<b>Environment:</b> ${escapeHtml(environment.name)}\n`
       if (deployment.gitBranch) {
         message += `<b>Branch:</b> ${escapeHtml(deployment.gitBranch)}\n`
@@ -74,7 +76,7 @@ module.exports = {
     const slackEnabled = await sails.helpers.setting.get('slackEnabled', 'false')
     if (slackEnabled === 'true') {
       let message = `${emoji} *${slippyTitle}*\n\n`
-      message += `*Project:* ${project.name}\n`
+      message += `*App:* ${appName}\n`
       message += `*Environment:* ${environment.name}\n`
       if (deployment.gitBranch) {
         message += `*Branch:* ${deployment.gitBranch}\n`
@@ -96,7 +98,7 @@ module.exports = {
       const discordWebhookUrl = await sails.helpers.setting.get('discordWebhookUrl', '')
       if (discordWebhookUrl) {
         const fields = [
-          { name: 'Project', value: project.name, inline: true },
+          { name: 'App', value: appName, inline: true },
           { name: 'Environment', value: environment.name, inline: true }
         ]
         if (deployment.gitBranch) {
@@ -128,10 +130,11 @@ module.exports = {
     if (smtpEnabled === 'true') {
       await sails.helpers.notification.sendEmail.with({
         template: 'email-deployment-notification',
-        subject: `${emoji} ${slippyTitle} \u2014 ${project.name} (${environment.name})`,
+        subject: `${slippyTitle} \u2014 ${appName} (${environment.name})`,
         templateData: {
           isSuccess,
           statusText,
+          appName,
           project,
           environment,
           deployment,
@@ -147,6 +150,7 @@ module.exports = {
       await sails.helpers.notification.sendWebhook.with({
         event: isSuccess ? 'deployment.success' : 'deployment.failed',
         data: {
+          app: { name: appName },
           project: { name: project.name, slug: project.slug },
           environment: { name: environment.name },
           deployment: {

--- a/api/helpers/notification/send-email.js
+++ b/api/helpers/notification/send-email.js
@@ -38,6 +38,8 @@ module.exports = {
     }
 
     try {
+      await sails.helpers.setting.syncSmtpConfig()
+
       for (const to of emails) {
         await sails.helpers.mail.send.with({
           to,

--- a/assets/js/components/DeploymentToast.vue
+++ b/assets/js/components/DeploymentToast.vue
@@ -17,6 +17,65 @@ const exiting = ref(false)
 let eventSource = null
 let timerInterval = null
 
+const maritimeMessages = {
+  pending: [
+    'Waiting for the tide...',
+    'Checking the compass...',
+    'Reading the stars...',
+    'Gathering the crew...',
+  ],
+  building: [
+    'Hoisting the sails...',
+    'Loading the cargo...',
+    'Checking the rigging...',
+    'Swabbing the deck...',
+    'Tying the knots...',
+    'Hammering the hull...',
+  ],
+  pushing: [
+    'Signaling the fleet...',
+    'Sending up a flare...',
+    'Raising the flag...',
+  ],
+  deploying: [
+    'Charting the course...',
+    'Setting sail...',
+    'Catching the wind...',
+    'Navigating the waters...',
+    'Full speed ahead...',
+    'Approaching the harbor...',
+  ],
+}
+
+const maritimeMessage = ref('')
+let messageInterval = null
+let messageIndex = 0
+
+function rotateMessage() {
+  const messages = maritimeMessages[status.value]
+  if (!messages) {
+    maritimeMessage.value = ''
+    return
+  }
+  maritimeMessage.value = messages[messageIndex % messages.length]
+  messageIndex++
+}
+
+function startMessageRotation() {
+  stopMessageRotation()
+  messageIndex = 0
+  rotateMessage()
+  messageInterval = setInterval(rotateMessage, 4000)
+}
+
+function stopMessageRotation() {
+  if (messageInterval) {
+    clearInterval(messageInterval)
+    messageInterval = null
+  }
+  maritimeMessage.value = ''
+}
+
 const statusConfig = computed(() => {
   const configs = {
     pending: {
@@ -132,15 +191,25 @@ function goToDeployment() {
 onMounted(() => {
   connectToStream()
   startTimer()
+  if (isActive.value) startMessageRotation()
 })
 
 onUnmounted(() => {
   if (eventSource) eventSource.close()
   if (timerInterval) clearInterval(timerInterval)
+  stopMessageRotation()
 })
 
 watch(() => props.deployment.status, (newStatus) => {
   status.value = newStatus
+})
+
+watch(status, (newStatus) => {
+  if (['pending', 'building', 'pushing', 'deploying'].includes(newStatus)) {
+    startMessageRotation()
+  } else {
+    stopMessageRotation()
+  }
 })
 </script>
 
@@ -219,6 +288,13 @@ watch(() => props.deployment.status, (newStatus) => {
                 {{ deployment.app.name }}
               </template>
             </button>
+
+            <p
+              v-if="isActive && maritimeMessage"
+              class="mt-1 truncate text-xs text-gray-400 dark:text-gray-500"
+            >
+              {{ maritimeMessage }}
+            </p>
 
             <div class="mt-2 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400">
               <span v-if="deployment.gitBranch" class="flex items-center gap-1">

--- a/packages/cli/src/commands/slide.js
+++ b/packages/cli/src/commands/slide.js
@@ -4,6 +4,56 @@ import { api } from '../lib/api.js'
 import { isLoggedIn, getCredentials } from '../lib/config.js'
 import { error, requireProject, createSpinner } from '../lib/utils.js'
 
+const maritimeMessages = {
+  pending: [
+    'Waiting for the tide...',
+    'Checking the compass...',
+    'Reading the stars...',
+    'Gathering the crew...',
+  ],
+  building: [
+    'Hoisting the sails...',
+    'Loading the cargo...',
+    'Checking the rigging...',
+    'Swabbing the deck...',
+    'Tying the knots...',
+    'Hammering the hull...',
+  ],
+  pushing: [
+    'Signaling the fleet...',
+    'Sending up a flare...',
+    'Raising the flag...',
+  ],
+  deploying: [
+    'Charting the course...',
+    'Setting sail...',
+    'Catching the wind...',
+    'Navigating the waters...',
+    'Full speed ahead...',
+    'Approaching the harbor...',
+  ],
+}
+
+const statusLabels = {
+  pending: 'Waiting',
+  building: 'Building',
+  pushing: 'Pushing',
+  deploying: 'Deploying',
+}
+
+function createMessageRotator(spinner, status) {
+  const messages = maritimeMessages[status]
+  if (!messages) return null
+  let index = 0
+  const label = statusLabels[status] || status
+  spinner.setText(`${label} — ${c.dim(messages[0])}`)
+  index = 1
+  return setInterval(() => {
+    spinner.setText(`${label} — ${c.dim(messages[index % messages.length])}`)
+    index++
+  }, 4000)
+}
+
 export default async function slide(options) {
   if (!isLoggedIn()) {
     error('Not logged in. Run `slipway login` first.')
@@ -183,9 +233,11 @@ function watchDeploymentSSE(deploymentId) {
     const controller = new AbortController()
     let currentSpin = null
     let lastStatus = ''
+    let messageRotatorInterval = null
 
     const timeout = setTimeout(() => {
       controller.abort()
+      if (messageRotatorInterval) clearInterval(messageRotatorInterval)
       if (currentSpin) currentSpin.stop()
       reject(new Error('timeout'))
     }, 10 * 60 * 1000) // 10 minute timeout
@@ -207,6 +259,7 @@ function watchDeploymentSSE(deploymentId) {
         let buffer = ''
 
         currentSpin = createSpinner('Building...').start()
+        messageRotatorInterval = createMessageRotator(currentSpin, 'building')
 
         while (true) {
           const { done, value } = await reader.read()
@@ -227,12 +280,12 @@ function watchDeploymentSSE(deploymentId) {
                 // Update spinner based on status
                 if (data.status !== lastStatus) {
                   lastStatus = data.status
+                  if (messageRotatorInterval) clearInterval(messageRotatorInterval)
                   if (currentSpin) currentSpin.stop()
 
-                  if (data.status === 'building') {
-                    currentSpin = createSpinner('Building...').start()
-                  } else if (data.status === 'deploying') {
-                    currentSpin = createSpinner('Deploying...').start()
+                  if (['building', 'pushing', 'deploying'].includes(data.status)) {
+                    currentSpin = createSpinner('...').start()
+                    messageRotatorInterval = createMessageRotator(currentSpin, data.status)
                   } else if (data.status === 'running' || data.status === 'failed' || data.status === 'cancelled') {
                     clearTimeout(timeout)
                     controller.abort()
@@ -243,10 +296,12 @@ function watchDeploymentSSE(deploymentId) {
 
                 // Show build output if available
                 if (data.output) {
+                  if (messageRotatorInterval) clearInterval(messageRotatorInterval)
                   if (currentSpin) currentSpin.stop()
                   console.log(`  ${c.dim(data.output)}`)
-                  if (lastStatus === 'building' || lastStatus === 'deploying') {
-                    currentSpin = createSpinner(lastStatus === 'building' ? 'Building...' : 'Deploying...').start()
+                  if (['building', 'pushing', 'deploying'].includes(lastStatus)) {
+                    currentSpin = createSpinner('...').start()
+                    messageRotatorInterval = createMessageRotator(currentSpin, lastStatus)
                   }
                 }
               } catch {
@@ -258,6 +313,7 @@ function watchDeploymentSSE(deploymentId) {
 
         // Stream ended — resolve with last known status or fall back to polling
         clearTimeout(timeout)
+        if (messageRotatorInterval) clearInterval(messageRotatorInterval)
         if (currentSpin) currentSpin.stop()
         if (lastStatus && ['running', 'failed', 'cancelled'].includes(lastStatus)) {
           resolve({ status: lastStatus })
@@ -267,6 +323,7 @@ function watchDeploymentSSE(deploymentId) {
       })
       .catch((err) => {
         clearTimeout(timeout)
+        if (messageRotatorInterval) clearInterval(messageRotatorInterval)
         if (currentSpin) currentSpin.stop()
         if (err.name !== 'AbortError') {
           reject(err)
@@ -281,6 +338,7 @@ function watchDeploymentSSE(deploymentId) {
 async function watchDeploymentPolling(deploymentId) {
   const spin = createSpinner('Building...').start()
   let lastStatus = ''
+  let messageRotatorInterval = createMessageRotator(spin, 'building')
 
   const maxAttempts = 300 // 10 minutes at 2s intervals
   let attempts = 0
@@ -296,13 +354,12 @@ async function watchDeploymentPolling(deploymentId) {
       // Update spinner text based on status
       if (status !== lastStatus) {
         lastStatus = status
-        spin.stop()
+        if (messageRotatorInterval) clearInterval(messageRotatorInterval)
 
-        if (status === 'building') {
-          createSpinner('Building...').start()
-        } else if (status === 'deploying') {
-          createSpinner('Deploying...').start()
+        if (['building', 'pushing', 'deploying'].includes(status)) {
+          messageRotatorInterval = createMessageRotator(spin, status)
         } else if (status === 'running' || status === 'failed' || status === 'cancelled') {
+          spin.stop()
           return { status }
         }
       }
@@ -311,6 +368,7 @@ async function watchDeploymentPolling(deploymentId) {
     }
   }
 
+  if (messageRotatorInterval) clearInterval(messageRotatorInterval)
   spin.stop()
   return { status: 'timeout' }
 }

--- a/packages/cli/src/lib/utils.js
+++ b/packages/cli/src/lib/utils.js
@@ -68,14 +68,19 @@ export function createSpinner(text) {
   const frames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏']
   let i = 0
   let interval = null
+  let currentText = text
 
   return {
     start() {
-      process.stdout.write(`\r${c.info(frames[0])} ${text}`)
+      process.stdout.write(`\r${c.info(frames[0])} ${currentText}`)
       interval = setInterval(() => {
         i = (i + 1) % frames.length
-        process.stdout.write(`\r${c.info(frames[i])} ${text}`)
+        process.stdout.write(`\x1b[2K\r${c.info(frames[i])} ${currentText}`)
       }, 80)
+      return this
+    },
+    setText(newText) {
+      currentText = newText
       return this
     },
     stop(finalText) {
@@ -83,7 +88,7 @@ export function createSpinner(text) {
         clearInterval(interval)
         interval = null
       }
-      process.stdout.write('\r' + ' '.repeat(text.length + 4) + '\r')
+      process.stdout.write(`\x1b[2K\r`)
       if (finalText) console.log(finalText)
       return this
     },

--- a/views/emails/email-deployment-notification.ejs
+++ b/views/emails/email-deployment-notification.ejs
@@ -3,12 +3,12 @@
     <span style="display: inline-block; background-color: <%= isSuccess ? '#ecfdf5' : '#fef2f2' %>; color: <%= isSuccess ? '#059669' : '#dc2626' %>; font-size: 11px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; padding: 4px 10px; border-radius: 20px;"><%= statusText %></span>
   </div>
   <h2 style="margin: 0 0 12px 0; color: #18181b; font-size: 20px; font-weight: 600; line-height: 1.3;">
-    <%= isSuccess ? 'Ship shipped!' : 'Deployment hit a snag' %>
+    <%= isSuccess ? 'Deployment successful' : 'Deployment failed' %>
   </h2>
   <table style="width: 100%; border-collapse: collapse; margin-bottom: 24px;">
     <tr>
-      <td style="padding: 10px 0; border-bottom: 1px solid #f4f4f5; color: #a1a1aa; font-size: 13px; font-weight: 500; width: 110px; vertical-align: top;">Project</td>
-      <td style="padding: 10px 0; border-bottom: 1px solid #f4f4f5; color: #18181b; font-size: 14px;"><%= project.name %></td>
+      <td style="padding: 10px 0; border-bottom: 1px solid #f4f4f5; color: #a1a1aa; font-size: 13px; font-weight: 500; width: 110px; vertical-align: top;">App</td>
+      <td style="padding: 10px 0; border-bottom: 1px solid #f4f4f5; color: #18181b; font-size: 14px;"><%= appName %></td>
     </tr>
     <tr>
       <td style="padding: 10px 0; border-bottom: 1px solid #f4f4f5; color: #a1a1aa; font-size: 13px; font-weight: 500; vertical-align: top;">Environment</td>


### PR DESCRIPTION
## Summary
- Add rotating maritime-themed messages during deployments in both the web UI toast and CLI spinner (every ~4s, phase-aware)
- Fix deployment email notifications failing with `ECONNREFUSED` by syncing SMTP config from database before sending
- Update all notification channels (email, Telegram, Slack, Discord, webhook) to show app name instead of project name
- Clean up email subject lines: remove emojis, use professional copy ("Deployment successful" / "Deployment failed")

## Test plan
- [x] Trigger a deployment and verify maritime messages rotate in the web UI toast
- [x] Run `slipway slide` and verify CLI spinner shows rotating maritime messages (e.g. `⠋ Building — Hoisting the sails...`)
- [x] Verify deployment email sends successfully with correct SMTP config
- [x] Check email subject shows app name and environment, no emojis
- [x] Verify Telegram/Slack/Discord notifications show "App" label with app name