### PR TITLE
Fix production issues: rate limiting, auto-update, install script

### DIFF
--- a/api/controllers/api/v1/project/push-source.js
+++ b/api/controllers/api/v1/project/push-source.js
@@ -14,6 +14,10 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'Project slug'
+    },
+    source: {
+      type: 'ref',
+      description: 'Source tarball file upload'
     }
   },
 

--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -128,36 +128,16 @@ module.exports = {
     // Image (always use latest)
     runArgs.push(pullTarget)
 
-    // 6. Extract the DB volume name for migration
-    const dbMount = (containerInfo.Mounts || []).find(
-      (m) => m.Type === 'volume' && m.Destination === '/app/db'
-    )
-    const dbVolumeName = dbMount ? dbMount.Name : 'slipway-db'
-
-    // 7. Spawn the bosun — a detached sidecar container that performs the swap
+    // 6. Spawn the bosun — a detached sidecar container that performs the swap
     // Uses Node.js + execFileSync to avoid shell injection entirely
+    // Skips migration since production uses migrate: 'safe' (no-op)
     const argsJson = JSON.stringify(runArgs)
-    const migrateArgs = JSON.stringify([
-      'run',
-      '--rm',
-      '-v',
-      `${dbVolumeName}:/app/db`,
-      pullTarget,
-      'node',
-      '-e',
-      'const sails = require("sails"); sails.lift({ port: 0 }, (err) => { if (err) { console.error(err); process.exit(1); } console.log("Migration complete"); sails.lower(() => process.exit(0)); })'
-    ])
     const script =
       'const{execFileSync}=require("child_process");' +
       'setTimeout(()=>{' +
       'try{' +
       'console.log("Stopping old Slipway container...");' +
       'execFileSync("docker",["rm","-f","slipway"]);' +
-      'console.log("Running database migration...");' +
-      'execFileSync("docker",' +
-      migrateArgs +
-      ',{stdio:"inherit"});' +
-      'console.log("Migration step complete.");' +
       'console.log("Starting new Slipway container...");' +
       'execFileSync("docker",' +
       argsJson +
@@ -165,6 +145,10 @@ module.exports = {
       'console.log("Update complete!");' +
       '}catch(e){' +
       'console.error("Update failed:",e.message);' +
+      'try{console.log("Attempting recovery...");' +
+      'execFileSync("docker",' +
+      argsJson +
+      ');}catch(e2){console.error("Recovery failed:",e2.message)}' +
       'process.exit(1)' +
       '}' +
       '},3000)'

--- a/api/policies/rate-limit-auth.js
+++ b/api/policies/rate-limit-auth.js
@@ -6,6 +6,7 @@ const standardLimiter = rateLimit({
   max: 5,
   standardHeaders: true,
   legacyHeaders: false,
+  validate: { trustProxy: false },
   handler: rateLimitHandler
 })
 
@@ -15,6 +16,7 @@ const forgotPasswordLimiter = rateLimit({
   max: 3,
   standardHeaders: true,
   legacyHeaders: false,
+  validate: { trustProxy: false },
   handler: rateLimitHandler
 })
 

--- a/install.sh
+++ b/install.sh
@@ -32,12 +32,26 @@ else
     echo -e "${GREEN}Docker already installed${NC}"
 fi
 
-# 2. Create network for Slipway and apps
+# 2. Ensure Docker BuildKit (buildx) is available
+if docker buildx version &> /dev/null; then
+    echo -e "${GREEN}Docker BuildKit already installed${NC}"
+else
+    echo "Installing Docker BuildKit..."
+    apt-get update -qq && apt-get install -y -qq docker-buildx-plugin 2>/dev/null || {
+        # Manual install if package not available
+        mkdir -p ~/.docker/cli-plugins
+        BUILDX_URL="https://github.com/docker/buildx/releases/latest/download/buildx-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m)"
+        curl -fsSL "$BUILDX_URL" -o ~/.docker/cli-plugins/docker-buildx && chmod +x ~/.docker/cli-plugins/docker-buildx
+    }
+    echo -e "${GREEN}Docker BuildKit installed${NC}"
+fi
+
+# 3. Create network for Slipway and apps
 echo "Creating Docker network..."
 docker network create slipway 2>/dev/null || true
 echo -e "${GREEN}Network ready${NC}"
 
-# 3. Detect server's public IPv4 address
+# 4. Detect server's public IPv4 address
 echo "Detecting server IP..."
 IP=$(curl -4 -s --max-time 5 ifconfig.me 2>/dev/null || curl -4 -s --max-time 5 icanhazip.com 2>/dev/null || echo "")
 if [ -z "$IP" ]; then
@@ -47,7 +61,7 @@ fi
 SLIPWAY_URL="http://$IP:1337"
 echo -e "${GREEN}Server URL: $SLIPWAY_URL${NC}"
 
-# 4. Load or generate secrets
+# 5. Load or generate secrets
 if [ -f "$SLIPWAY_ENV_FILE" ]; then
     # Update: reuse existing secrets
     echo -e "${GREEN}Existing installation detected — reusing secrets${NC}"
@@ -68,7 +82,7 @@ EOF
     echo -e "${GREEN}Secrets generated and saved to $SLIPWAY_ENV_FILE${NC}"
 fi
 
-# 5. Start Caddy (reverse proxy with automatic HTTPS)
+# 6. Start Caddy (reverse proxy with automatic HTTPS)
 echo "Starting Caddy proxy..."
 docker rm -f slipway-proxy 2>/dev/null || true
 docker run -d \
@@ -83,12 +97,12 @@ docker run -d \
     lucaslorentz/caddy-docker-proxy:latest
 echo -e "${GREEN}Caddy proxy running${NC}"
 
-# 6. Pull latest images
+# 7. Pull latest images
 echo "Pulling latest Slipway image..."
 docker pull ghcr.io/sailscastshq/slipway:latest
 docker pull alpine
 
-# 7. Start Slipway dashboard
+# 8. Start Slipway dashboard
 echo "Starting Slipway dashboard..."
 docker rm -f slipway 2>/dev/null || true
 
@@ -124,12 +138,12 @@ docker run -d \
     ghcr.io/sailscastshq/slipway:latest
 echo -e "${GREEN}Slipway dashboard running${NC}"
 
-# 8. Wait for startup
+# 9. Wait for startup
 echo ""
 echo "Waiting for Slipway to start..."
 sleep 5
 
-# 9. Show access info
+# 10. Show access info
 echo ""
 echo -e "${GREEN}========================================================${NC}"
 if [ "$IS_UPDATE" = true ]; then


### PR DESCRIPTION
## Summary

- **Fix rate-limit trust proxy error** — Added `validate: { trustProxy: false }` to suppress `ERR_ERL_PERMISSIVE_TRUST_PROXY` since Slipway runs behind Caddy (trusted proxy). Fixes #69
- **Fix auto-update timeout** — Removed the `sails.lift()` migration step from the bosun sidecar that caused hangs in production (`migrate: 'safe'` makes it a no-op anyway). Added recovery logic so the new container always attempts to start. Fixes #71
- **Install Docker BuildKit in install script** — Added buildx installation step (apt package with manual fallback) so `docker build --progress=plain` works on all servers. Fixes #68
- **Fix push-source extraneous input warning** — Added `source: { type: 'ref' }` to inputs to suppress Sails warning about unrecognized file upload parameter. Fixes #70

## Test plan

- [x] Run `install.sh` on a fresh server — verify buildx is installed
- [x] Run `install.sh` on a server with buildx — verify it skips installation
- [x] Trigger an auto-update from Bosun — verify it completes without timeout
- [x] Push source code via CLI — verify no extraneous values warning in logs
- [x] Hit rate-limited auth endpoints — verify no `ERR_ERL_PERMISSIVE_TRUST_PROXY` error
