### PR TITLE
Fix hardcoded SMTP from address

### DIFF
--- a/api/controllers/setting/test-notification.js
+++ b/api/controllers/setting/test-notification.js
@@ -213,6 +213,8 @@ module.exports = {
 
         // Sync saved settings into sails.config.mail
         await sails.helpers.setting.syncSmtpConfig()
+        const fromAddress = sails.config.mail.from.address
+        const fromName = sails.config.mail.from.name
 
         const emails = notificationEmails.split(',').map(e => e.trim()).filter(Boolean)
         const instanceName = await sails.helpers.setting.get('instanceName', 'Slipway')
@@ -220,6 +222,8 @@ module.exports = {
         for (const to of emails) {
           await sails.helpers.mail.send.with({
             to,
+            from: fromAddress,
+            fromName,
             subject: 'Slipway Test Notification',
             template: 'email-test-notification',
             templateData: { instanceName }

--- a/api/helpers/notification/send-email.js
+++ b/api/helpers/notification/send-email.js
@@ -39,10 +39,14 @@ module.exports = {
 
     try {
       await sails.helpers.setting.syncSmtpConfig()
+      const fromAddress = sails.config.mail.from.address
+      const fromName = sails.config.mail.from.name
 
       for (const to of emails) {
         await sails.helpers.mail.send.with({
           to,
+          from: fromAddress,
+          fromName,
           subject,
           template,
           templateData

--- a/api/helpers/setting/sync-smtp-config.js
+++ b/api/helpers/setting/sync-smtp-config.js
@@ -24,7 +24,7 @@ module.exports = {
       sails.config.mail.mailers.smtp.password = password
     }
     if (from) {
-      sails.config.mail.from.address = from
+      sails.config.mail.from = { name: 'Slippy from Slipway', address: from }
     }
   }
 }

--- a/config/mail.js
+++ b/config/mail.js
@@ -53,8 +53,5 @@ module.exports.mail = {
    * outgoing emails have a consistent sender identity.
    *
    */
-  from: {
-    address: 'slipway@sailscasts.com',
-    name: 'Slippy from Slipway'
-  }
+  from: {}
 }


### PR DESCRIPTION
## Summary
- Removed hardcoded `slipway@sailscasts.com` from `config/mail.js` so the from address comes entirely from the user's notification settings
- Pass `from` and `fromName` explicitly to `sails.helpers.mail.send` to bypass sails-hook-mail's stale boot-time defaults
- Updated `syncSmtpConfig` to build the full `from` object with both name and address

Fixes #74

## Test plan
- [x] Configure SMTP from address in Settings > Notifications
- [x] Send a test email and verify the from field shows the configured address and name
- [x] Verify deployment/backup notification emails also use the correct from address