### PR TITLE
Add public URL field for S3/R2 file storage

### DIFF
--- a/api/controllers/setting/update-uploads.js
+++ b/api/controllers/setting/update-uploads.js
@@ -25,6 +25,10 @@ module.exports = {
       type: 'string',
       allowNull: true
     },
+    publicUrl: {
+      type: 'string',
+      allowNull: true
+    },
     backupSchedule: {
       type: 'json',
       description: 'Backup schedule config: { enabled, intervalHours }'
@@ -40,7 +44,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ provider, accessKey, secretKey, bucket, endpoint, region, backupSchedule }) {
+  fn: async function ({ provider, accessKey, secretKey, bucket, endpoint, region, publicUrl, backupSchedule }) {
     // Handle backup schedule update
     if (backupSchedule !== undefined) {
       const existing = await sails.helpers.setting.get('backupSchedule')
@@ -67,9 +71,9 @@ module.exports = {
 
     // Clear any existing provider keys first
     const keysToRemove = [
-      'R2_ACCESS_KEY', 'R2_SECRET_KEY', 'R2_BUCKET', 'R2_ENDPOINT',
-      'S3_ACCESS_KEY', 'S3_SECRET_KEY', 'S3_BUCKET', 'S3_REGION', 'S3_ENDPOINT',
-      'SPACES_ACCESS_KEY', 'SPACES_SECRET_KEY', 'SPACES_BUCKET', 'SPACES_REGION', 'SPACES_ENDPOINT'
+      'R2_ACCESS_KEY', 'R2_SECRET_KEY', 'R2_BUCKET', 'R2_ENDPOINT', 'R2_PUBLIC_URL',
+      'S3_ACCESS_KEY', 'S3_SECRET_KEY', 'S3_BUCKET', 'S3_REGION', 'S3_ENDPOINT', 'S3_PUBLIC_URL',
+      'SPACES_ACCESS_KEY', 'SPACES_SECRET_KEY', 'SPACES_BUCKET', 'SPACES_REGION', 'SPACES_ENDPOINT', 'SPACES_PUBLIC_URL'
     ]
     for (const key of keysToRemove) {
       delete globalEnvVars[key]
@@ -81,18 +85,21 @@ module.exports = {
       globalEnvVars.R2_SECRET_KEY = secretKey
       globalEnvVars.R2_BUCKET = bucket
       if (endpoint) globalEnvVars.R2_ENDPOINT = endpoint
+      if (publicUrl) globalEnvVars.R2_PUBLIC_URL = publicUrl
     } else if (provider === 's3') {
       globalEnvVars.S3_ACCESS_KEY = accessKey
       globalEnvVars.S3_SECRET_KEY = secretKey
       globalEnvVars.S3_BUCKET = bucket
       if (region) globalEnvVars.S3_REGION = region
       if (endpoint) globalEnvVars.S3_ENDPOINT = endpoint
+      if (publicUrl) globalEnvVars.S3_PUBLIC_URL = publicUrl
     } else if (provider === 'spaces') {
       globalEnvVars.SPACES_ACCESS_KEY = accessKey
       globalEnvVars.SPACES_SECRET_KEY = secretKey
       globalEnvVars.SPACES_BUCKET = bucket
       if (region) globalEnvVars.SPACES_REGION = region
       if (endpoint) globalEnvVars.SPACES_ENDPOINT = endpoint
+      if (publicUrl) globalEnvVars.SPACES_PUBLIC_URL = publicUrl
     }
 
     // Save back to settings

--- a/api/controllers/setting/view-uploads.js
+++ b/api/controllers/setting/view-uploads.js
@@ -45,18 +45,21 @@ module.exports = {
       r2SecretKey: globalEnvVars.R2_SECRET_KEY ? '••••••••' : '',
       r2Bucket: globalEnvVars.R2_BUCKET || '',
       r2Endpoint: globalEnvVars.R2_ENDPOINT || '',
+      r2PublicUrl: globalEnvVars.R2_PUBLIC_URL || '',
       // S3
       s3AccessKey: globalEnvVars.S3_ACCESS_KEY ? '••••' + globalEnvVars.S3_ACCESS_KEY.slice(-4) : '',
       s3SecretKey: globalEnvVars.S3_SECRET_KEY ? '••••••••' : '',
       s3Bucket: globalEnvVars.S3_BUCKET || '',
       s3Region: globalEnvVars.S3_REGION || '',
       s3Endpoint: globalEnvVars.S3_ENDPOINT || '',
+      s3PublicUrl: globalEnvVars.S3_PUBLIC_URL || '',
       // Spaces
       spacesAccessKey: globalEnvVars.SPACES_ACCESS_KEY ? '••••' + globalEnvVars.SPACES_ACCESS_KEY.slice(-4) : '',
       spacesSecretKey: globalEnvVars.SPACES_SECRET_KEY ? '••••••••' : '',
       spacesBucket: globalEnvVars.SPACES_BUCKET || '',
       spacesRegion: globalEnvVars.SPACES_REGION || '',
-      spacesEndpoint: globalEnvVars.SPACES_ENDPOINT || ''
+      spacesEndpoint: globalEnvVars.SPACES_ENDPOINT || '',
+      spacesPublicUrl: globalEnvVars.SPACES_PUBLIC_URL || ''
     }
 
     // Get backup schedule

--- a/api/controllers/team/upload-team-logo.js
+++ b/api/controllers/team/upload-team-logo.js
@@ -90,16 +90,18 @@ module.exports = {
 
     const uploadedFile = uploadedFiles[0]
 
-    // Construct the public URL
-    // For R2/S3, the URL pattern is typically: endpoint/bucket/key or bucket.endpoint/key
+    // Construct the public URL using the configured public URL base
+    const publicUrl = globalEnvVars.R2_PUBLIC_URL || globalEnvVars.S3_PUBLIC_URL || globalEnvVars.SPACES_PUBLIC_URL
+    const fileName = uploadedFile.fd.split('/').pop()
     let logoUrl
-    if (s3Config.endpoint) {
-      // R2/custom endpoint pattern
+    if (publicUrl) {
+      const baseUrl = publicUrl.replace(/\/$/, '')
+      logoUrl = `${baseUrl}/${dirname}/${fileName}`
+    } else if (s3Config.endpoint) {
       const endpointClean = s3Config.endpoint.replace(/\/$/, '')
-      logoUrl = `${endpointClean}/${dirname}/${uploadedFile.fd.split('/').pop()}`
+      logoUrl = `${endpointClean}/${dirname}/${fileName}`
     } else {
-      // Standard S3 pattern
-      logoUrl = `https://${s3Config.bucket}.s3.${s3Config.region}.amazonaws.com/${dirname}/${uploadedFile.fd.split('/').pop()}`
+      logoUrl = `https://${s3Config.bucket}.s3.${s3Config.region}.amazonaws.com/${dirname}/${fileName}`
     }
 
     // Update team with new logo URL

--- a/assets/js/pages/settings/uploads.vue
+++ b/assets/js/pages/settings/uploads.vue
@@ -30,20 +30,24 @@ const secretKey = ref('')
 const bucket = ref('')
 const endpoint = ref('')
 const region = ref('')
+const publicUrl = ref('')
 
 // Populate form based on selected provider
 function initForm() {
   if (selectedProvider.value === 'r2') {
     bucket.value = props.config.r2Bucket || ''
     endpoint.value = props.config.r2Endpoint || ''
+    publicUrl.value = props.config.r2PublicUrl || ''
   } else if (selectedProvider.value === 's3') {
     bucket.value = props.config.s3Bucket || ''
     region.value = props.config.s3Region || 'us-east-1'
     endpoint.value = props.config.s3Endpoint || ''
+    publicUrl.value = props.config.s3PublicUrl || ''
   } else if (selectedProvider.value === 'spaces') {
     bucket.value = props.config.spacesBucket || ''
     region.value = props.config.spacesRegion || 'nyc3'
     endpoint.value = props.config.spacesEndpoint || ''
+    publicUrl.value = props.config.spacesPublicUrl || ''
   }
   // Keys are not pre-populated for security
   accessKey.value = ''
@@ -72,7 +76,8 @@ async function save() {
         secretKey: secretKey.value,
         bucket: bucket.value,
         endpoint: endpoint.value || null,
-        region: region.value || null
+        region: region.value || null,
+        publicUrl: publicUrl.value || null
       })
     })
     if (!res.ok) throw new Error('Failed to save')
@@ -345,6 +350,23 @@ const providers = [
                   :required="selectedProvider === 'r2' || selectedProvider === 'spaces'"
                   class="w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-brand focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                 />
+              </div>
+
+              <!-- Public URL -->
+              <div>
+                <label class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">
+                  Public URL
+                  <span class="text-gray-400">(for serving files to browsers)</span>
+                </label>
+                <input
+                  v-model="publicUrl"
+                  type="text"
+                  :placeholder="selectedProvider === 'r2' ? 'https://pub-xxx.r2.dev' : selectedProvider === 'spaces' ? 'https://my-bucket.nyc3.cdn.digitaloceanspaces.com' : 'https://my-bucket.s3.us-east-1.amazonaws.com'"
+                  class="w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-brand focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                />
+                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  The public-facing URL for accessing uploaded files (e.g. R2 public bucket URL, CloudFront distribution, or custom domain)
+                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Added a "Public URL" field to Settings > File Storage for all three providers (R2, S3, Spaces)
- Stored as `R2_PUBLIC_URL` / `S3_PUBLIC_URL` / `SPACES_PUBLIC_URL` in global env vars
- `upload-team-logo.js` now uses the public URL base when constructing `logoUrl`, falling back to the API endpoint if not configured

Fixes #76

## Test plan
- [x] Configure R2/S3/Spaces with a public URL in Settings > File Storage
- [x] Upload a team logo in Settings > Team Profile
- [x] Verify the logo displays correctly (no CORS error)
- [x] Verify the stored `logoUrl` uses the public URL domain, not the API endpoint
- [x] Verify switching providers clears the old public URL key