### PR TITLE
Fix database backup upload: set skipperFd property

### DIFF
--- a/api/helpers/backup/run-backup.js
+++ b/api/helpers/backup/run-backup.js
@@ -126,6 +126,7 @@ module.exports = {
         const readStream = fs.createReadStream(tmpFile)
 
         // Skipper receivers expect file metadata
+        readStream.skipperFd = s3Key
         readStream.fd = s3Key
         readStream.filename = path.basename(s3Key)
         readStream.headers = { 'content-type': 'application/octet-stream' }

--- a/api/helpers/system/backup-database.js
+++ b/api/helpers/system/backup-database.js
@@ -76,6 +76,7 @@ module.exports = {
         const receiver = adapter.receive({ dirname: '', saveAs: s3Key })
         const readStream = fs.createReadStream(tmpFile)
 
+        readStream.skipperFd = s3Key
         readStream.fd = s3Key
         readStream.filename = path.basename(s3Key)
         readStream.headers = { 'content-type': 'application/octet-stream' }


### PR DESCRIPTION
## Summary
- Add `skipperFd` property to backup upload streams in both `backup-database.js` and `run-backup.js`
- Keeps `.fd` for backwards compatibility with older skipper-s3 versions

## Root cause
`fs.createReadStream().fd` is a native Node.js property that gets asynchronously overwritten with the numeric OS file descriptor. skipper-s3 checks `skipperFd` first, then falls back to `fd` — but by the time it checks, `fd` is a number, not the S3 key string.

## Test plan
- [x] Trigger a service database backup with S3/R2 storage configured — upload should succeed
- [x] Trigger a system backup (pre-update) — upload should succeed

Closes #87