### PR TITLE
Add SlippyLoader to Lookout detail loading state

### DIFF
--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -3,6 +3,7 @@ import { Link, Head, router, usePoll } from '@inertiajs/vue3'
 import { inject, ref, computed, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
 import { useQueryState } from '@/composables/useQueryState'
 
 defineOptions({
@@ -491,8 +492,9 @@ async function copyToken() {
               >
                 <div v-if="expandedContainer === container.name" class="overflow-hidden border-t border-gray-100 dark:border-gray-800">
                   <div class="p-4">
-                    <div v-if="loadingDetail" class="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
-                      Loading 24h history...
+                    <div v-if="loadingDetail" class="py-8 text-center">
+                      <SlippyLoader class="mx-auto mb-2 text-gray-400 dark:text-gray-500" />
+                      <p class="text-sm text-gray-400 dark:text-gray-500">Loading 24h history...</p>
                     </div>
 
                     <div v-else-if="container.metric" class="space-y-6">


### PR DESCRIPTION
## Summary
- Import `SlippyLoader` in lookout.vue and use it for the 24h history loading state
- Audited Bosun — all loading states already use SlippyLoader

## Test plan
- [x] Open Lookout → expand a container → see squiddy animation while 24h history loads

Closes #88