### PR TITLE
fix: update instance URL fallback order and descriptions in get-instance-url.js

### DIFF
--- a/api/helpers/get-instance-url.js
+++ b/api/helpers/get-instance-url.js
@@ -2,9 +2,10 @@
  * get-instance-url.js
  *
  * Gets the instance URL with fallback chain:
- * 1. Database setting (instanceUrl) - can be updated from dashboard
- * 2. SLIPWAY_URL environment variable - set during install
- * 3. sails.config.custom.baseUrl - default config value
+ * 1. instanceDomain setting (set from settings UI, bare domain)
+ * 2. instanceUrl setting (legacy, full URL)
+ * 3. SLIPWAY_URL environment variable - set during install
+ * 4. sails.config.custom.baseUrl - default config value
  */
 
 module.exports = {
@@ -21,18 +22,25 @@ module.exports = {
   },
 
   fn: async function () {
-    // 1. Try database setting first (allows changing without restart)
+    // 1. Try instanceDomain first (set from settings UI)
+    const instanceDomain = await sails.helpers.setting.get('instanceDomain')
+    if (instanceDomain) {
+      const domain = instanceDomain.replace(/^https?:\/\//, '').replace(/\/+$/, '')
+      return `https://${domain}`
+    }
+
+    // 2. Try instanceUrl setting (legacy)
     const dbValue = await sails.helpers.setting.get('instanceUrl')
     if (dbValue) {
       return dbValue
     }
 
-    // 2. Try environment variable (set by install script)
+    // 3. Try environment variable (set by install script)
     if (process.env.SLIPWAY_URL) {
       return process.env.SLIPWAY_URL
     }
 
-    // 3. Fall back to config (default: http://localhost:1337)
+    // 4. Fall back to config (default: http://localhost:1337)
     return sails.config.custom.baseUrl || `http://localhost:${sails.config.port || 1337}`
   }
 }


### PR DESCRIPTION
Resolves #106 
This pull request updates the logic for determining the instance URL in the `get-instance-url.js` helper. The main change is to prioritize a new `instanceDomain` setting as the primary source for the instance URL, followed by the legacy `instanceUrl`, then the `SLIPWAY_URL` environment variable, and finally the default config value. This provides more flexibility and a clearer precedence order for configuring the instance URL.

URL resolution logic changes:

* The helper now first checks for an `instanceDomain` setting (bare domain, set from the settings UI), and if present, constructs the instance URL from it. [[1]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL5-R8) [[2]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL24-R43)
* The legacy `instanceUrl` setting is used as a fallback if `instanceDomain` is not set. [[1]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL5-R8) [[2]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL24-R43)
* The environment variable `SLIPWAY_URL` is now the third option in the fallback chain. [[1]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL5-R8) [[2]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL24-R43)
* The default config value (`sails.config.custom.baseUrl` or `http://localhost:1337`) is now the last fallback. [[1]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL5-R8) [[2]](diffhunk://#diff-2f7979e351caaf32d2904056ac85d9ae6488d277c36377f7546dbe86ecc1764fL24-R43)