### PR TITLE
fix: use instanceDomain for OAuth and webhook URLs

### DIFF
--- a/api/controllers/project/connect-repo.js
+++ b/api/controllers/project/connect-repo.js
@@ -104,7 +104,8 @@ module.exports = {
 
     // Generate webhook secret and create webhook
     const webhookSecret = await sails.helpers.strings.random('url-friendly')
-    const webhookUrl = `${sails.config.custom.baseUrl}/webhook/github`
+    const instanceUrl = await sails.helpers.getInstanceUrl()
+    const webhookUrl = `${instanceUrl}/webhook/github`
 
     let webhookId
     try {

--- a/api/controllers/project/create-app.js
+++ b/api/controllers/project/create-app.js
@@ -109,7 +109,8 @@ module.exports = {
 
             // Generate webhook secret and create webhook
             const webhookSecret = await sails.helpers.strings.random('url-friendly')
-            const webhookUrl = `${sails.config.custom.baseUrl}/webhook/github`
+            const instanceUrl = await sails.helpers.getInstanceUrl()
+            const webhookUrl = `${instanceUrl}/webhook/github`
 
             let webhookId
             try {

--- a/api/controllers/project/view-project-settings.js
+++ b/api/controllers/project/view-project-settings.js
@@ -29,7 +29,7 @@ module.exports = {
       throw { notFound: '/' }
     }
 
-    const baseUrl = sails.config.custom.baseUrl || `${this.req.protocol}://${this.req.get('host')}`
+    const baseUrl = await sails.helpers.getInstanceUrl()
     const webhookUrl = `${baseUrl}/api/v1/webhooks/github/${project.slug}`
 
     return {

--- a/api/helpers/git/exchange-github-code.js
+++ b/api/helpers/git/exchange-github-code.js
@@ -37,7 +37,8 @@ module.exports = {
       throw new Error('GitHub OAuth not configured. Configure it in Settings → Git Integration.')
     }
 
-    const callback = redirectUri || `${sails.config.custom.baseUrl}/auth/github/callback`
+    const instanceUrl = await sails.helpers.getInstanceUrl()
+    const callback = redirectUri || `${instanceUrl}/auth/github/callback`
 
     const response = await fetch('https://github.com/login/oauth/access_token', {
       method: 'POST',

--- a/api/helpers/git/get-github-oauth-url.js
+++ b/api/helpers/git/get-github-oauth-url.js
@@ -26,7 +26,8 @@ module.exports = {
     }
 
     const baseUrl = 'https://github.com/login/oauth/authorize'
-    const callback = redirectUri || `${sails.config.custom.baseUrl}/auth/github/callback`
+    const instanceUrl = await sails.helpers.getInstanceUrl()
+    const callback = redirectUri || `${instanceUrl}/auth/github/callback`
 
     const params = new URLSearchParams({
       client_id: clientId,


### PR DESCRIPTION
## Summary

- Replace hardcoded `sails.config.custom.baseUrl` with `await sails.helpers.getInstanceUrl()` in 5 files
- OAuth callbacks and webhook URLs now respect the `instanceDomain` setting from the UI
- Fixes GitHub OAuth "redirect_uri not associated" error when `SLIPWAY_URL` is set to a raw IP

## Test plan

- [x] Set `instanceDomain` to your domain in Settings → Instance
- [x] Go to Settings → Git → Connect GitHub — verify OAuth redirect uses the domain URL
- [x] Connect a repo to an app — verify webhook URL uses the domain URL

Closes #120