### PR TITLE
Fix: install git and openssh-client in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 # Install tini, curl, build tools (for better-sqlite3), and Docker CLI
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends tini curl ca-certificates gnupg python3 make g++ && \
+    apt-get install -y --no-install-recommends tini curl ca-certificates gnupg python3 make g++ git openssh-client && \
     install -m 0755 -d /etc/apt/keyrings && \
     curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
     chmod a+r /etc/apt/keyrings/docker.gpg && \


### PR DESCRIPTION
Closes #122

## Summary
- Webhook deployments via GitHub push fail with `spawn git ENOENT` because the Docker image (`node:22-slim`) doesn't include `git` or `openssh-client`
- Added both packages to the Dockerfile `apt-get install` line so the `clone-or-pull` helper can clone repos using SSH deploy keys

## Test plan
- [x] Rebuild the Docker image and verify `git` and `ssh` are available in the container
- [x] Push to a connected GitHub repo and confirm the webhook deployment succeeds