### PR TITLE
Fix: reset update progress cache after spawning bosun

### DIFF
--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -199,6 +199,10 @@ module.exports = {
 
       sails.log.info('[slipway] Bosun spawned — container swap in ~3 seconds')
 
+      // Reset progress so the stale "swapping" phase (persisted in SQLite
+      // cache) doesn't block the next update after the container restarts.
+      await setProgress('idle', null)
+
       return {
         status: 'updating',
         currentVersion: updateInfo.currentVersion,


### PR DESCRIPTION
Closes #124

## Summary
- After a successful self-update, the SQLite-backed cache retains `{phase: "swapping"}` across container restarts, causing the controller to falsely report "An update is already in progress"
- Reset the progress to `"idle"` after spawning the bosun (which has a 3-second delay before killing the container), so the cache write completes before the swap

## Test plan
- [x] Trigger a self-update and verify it completes successfully
- [x] After the update, visit the update page and confirm clicking "Update Now" does not show a false "already in progress" error