### PR TITLE
Fix deploy key format causing webhook deployments to fail

### DIFF
--- a/api/controllers/webhook/github.js
+++ b/api/controllers/webhook/github.js
@@ -122,6 +122,9 @@ async function handlePush(repo, payload) {
 
     // Clone or pull the repo source code before building
     const targetDir = path.join(sails.config.custom.slipwayAppsDir, project.slug)
+    if (!repo.deployKeyPrivate) {
+      sails.log.warn(`[webhook] No deploy key found for ${repo.fullName} — was the key decrypted?`)
+    }
     await sails.helpers.git.cloneOrPull.with({
       cloneUrl: repo.cloneUrl,
       branch,

--- a/api/helpers/git/clone-or-pull.js
+++ b/api/helpers/git/clone-or-pull.js
@@ -38,9 +38,18 @@ module.exports = {
   },
 
   fn: async function ({ cloneUrl, branch, targetDir, deployKeyPrivate, deploymentId }) {
+    // Normalize the key: fix escaped newlines and ensure trailing newline
+    let key = deployKeyPrivate.replace(/\\n/g, '\n')
+    if (!key.endsWith('\n')) { key += '\n' }
+
+    if (!key.includes('-----BEGIN')) {
+      throw new Error('Deploy key is not in a valid SSH format — it may be corrupted or not decrypted. Re-connect the repository to regenerate the key.')
+    }
+
     // Write deploy key to a temp file
     const keyFile = path.join(os.tmpdir(), `slipway-deploy-key-${Date.now()}-${Math.random().toString(36).slice(2)}`)
-    fs.writeFileSync(keyFile, deployKeyPrivate, { mode: 0o600 })
+    sails.log.debug(`[git] Writing deploy key (${key.length} chars, format: ${key.substring(0, 36).trim()})`)
+    fs.writeFileSync(keyFile, key, { mode: 0o600, encoding: 'utf8' })
 
     const sshCommand = `ssh -i ${keyFile} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null`
     const env = { ...process.env, GIT_SSH_COMMAND: sshCommand }

--- a/api/helpers/git/generate-deploy-key.js
+++ b/api/helpers/git/generate-deploy-key.js
@@ -1,4 +1,7 @@
-const crypto = require('crypto')
+const { execFileSync } = require('child_process')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
 
 module.exports = {
   friendlyName: 'Generate Deploy Key',
@@ -14,40 +17,26 @@ module.exports = {
   },
 
   fn: async function ({ repoName }) {
-    // Generate ED25519 keypair using Node.js crypto
-    const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519', {
-      publicKeyEncoding: {
-        type: 'spki',
-        format: 'pem'
-      },
-      privateKeyEncoding: {
-        type: 'pkcs8',
-        format: 'pem'
-      }
-    })
+    // Generate ED25519 keypair using ssh-keygen for native OpenSSH format.
+    // Node's crypto.generateKeyPairSync produces PKCS8 PEM which some SSH
+    // clients reject with "invalid format" for ED25519 keys.
+    const keyFile = path.join(os.tmpdir(), `slipway-keygen-${Date.now()}-${Math.random().toString(36).slice(2)}`)
 
-    // Convert to OpenSSH format
-    const publicKeyBuffer = crypto.createPublicKey(publicKey).export({
-      type: 'spki',
-      format: 'der'
-    })
+    try {
+      execFileSync('ssh-keygen', [
+        '-t', 'ed25519',
+        '-f', keyFile,
+        '-N', '',
+        '-C', `slipway-deploy-${repoName}`
+      ], { timeout: 10_000 })
 
-    // ED25519 public key is last 32 bytes of SPKI DER
-    const keyData = publicKeyBuffer.slice(-32)
-    const sshPublicKey = `ssh-ed25519 ${Buffer.concat([
-      Buffer.from([0, 0, 0, 11]), // length of "ssh-ed25519"
-      Buffer.from('ssh-ed25519'),
-      Buffer.from([0, 0, 0, 32]), // length of key data
-      keyData
-    ]).toString('base64')} slipway-deploy-${repoName}`
+      const privateKey = fs.readFileSync(keyFile, 'utf8')
+      const publicKey = fs.readFileSync(`${keyFile}.pub`, 'utf8').trim()
 
-    // Convert private key to OpenSSH format
-    // Node's PKCS8 PEM works with ssh, but we'll keep it simple
-    const sshPrivateKey = privateKey
-
-    return {
-      publicKey: sshPublicKey,
-      privateKey: sshPrivateKey
+      return { publicKey, privateKey }
+    } finally {
+      try { fs.unlinkSync(keyFile) } catch { /* ignore */ }
+      try { fs.unlinkSync(`${keyFile}.pub`) } catch { /* ignore */ }
     }
   }
 }


### PR DESCRIPTION
## Summary

- Switch deploy key generation from `crypto.generateKeyPairSync` (PKCS8 PEM) to `ssh-keygen` (native OpenSSH format) — PKCS8's `-----BEGIN PRIVATE KEY-----` is rejected by SSH for ED25519 keys with "invalid format"
- Add key validation and newline normalization in `clone-or-pull` before writing to disk — corrupted keys now throw a clear error instead of a cryptic SSH failure
- Add warning log when deploy key is missing after `.decrypt()` in the webhook handler

## Test plan

- [x] Connect a new private GitHub repo and verify the deploy key is generated in OpenSSH format (`-----BEGIN OPENSSH PRIVATE KEY-----`)
- [x] Push to the connected repo and verify webhook-triggered deployment clones successfully
- [x] Disconnect and reconnect an existing repo to regenerate its deploy key
- [x] Verify corrupted/missing deploy keys produce a clear error message in logs

Closes #133