### PR TITLE
Fix health check DNS fallback for EAI_AGAIN errors

### DIFF
--- a/api/helpers/docker/health-check.js
+++ b/api/helpers/docker/health-check.js
@@ -80,7 +80,8 @@ module.exports = {
         lastError = `HTTP ${statusCode}`
       } catch (err) {
         // If Docker DNS can't resolve the container name, fall back to localhost:hostPort
-        if (!usingFallback && hostPort && err.code === 'ENOTFOUND') {
+        // EAI_AGAIN is a transient DNS failure that also indicates Docker DNS is unavailable
+        if (!usingFallback && hostPort && (err.code === 'ENOTFOUND' || err.code === 'EAI_AGAIN')) {
           usingFallback = true
           sails.log.info(`Docker DNS unavailable, falling back to localhost:${hostPort}`)
           if (deploymentId) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slipway",
-  "version": "0.0.25",
+  "version": "0.0.37",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slipway",
-      "version": "0.0.25",
+      "version": "0.0.37",
       "workspaces": [
         "packages/*"
       ],
@@ -17,7 +17,7 @@
         "@sailshq/lodash": "^3.10.3",
         "@sailshq/socket.io-redis": "^6.1.2",
         "express-rate-limit": "^8.2.1",
-        "inertia-sails": "^1.0.1",
+        "inertia-sails": "^1.3.1",
         "nodemailer": "^6.9.15",
         "sails": "^1.5.14",
         "sails-flash": "^0.0.1",
@@ -4208,9 +4208,9 @@
       }
     },
     "node_modules/inertia-sails": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.1.0.tgz",
-      "integrity": "sha512-HxeDiX1Bw5xVcd9wsLYnGrsjlCYP/HKyxDx9pF0GxICOjFN1Z+BKNX3cC3rwyJCSg2NbaQodZ8jLDZViFp/OQA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/inertia-sails/-/inertia-sails-1.3.1.tgz",
+      "integrity": "sha512-U1CYdt/tgrI9tbmEADgjV1d0eQfTkgXwHnN372EojZtL+do/49L8Pa9SIZJ2I99CRU5Rlzlba9o4JDE0Ggq/7g==",
       "license": "MIT",
       "peerDependencies": {
         "sails": ">=1",
@@ -8351,7 +8351,7 @@
     },
     "packages/hook": {
       "name": "sails-hook-slipway",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@sailshq/lodash": "^3.10.3",
     "@sailshq/socket.io-redis": "^6.1.2",
     "express-rate-limit": "^8.2.1",
-    "inertia-sails": "^1.0.1",
+    "inertia-sails": "^1.3.1",
     "nodemailer": "^6.9.15",
     "sails": "^1.5.14",
     "sails-flash": "^0.0.1",


### PR DESCRIPTION
## Summary

- Health check now handles `EAI_AGAIN` (transient DNS failure) in addition to `ENOTFOUND`, triggering the `localhost:hostPort` fallback correctly

Fixes #144

## Test plan

- [x] Deploy an app and verify health check passes
- [x] Confirm fallback to `localhost:hostPort` triggers on DNS failures