### PR TITLE
Capture container logs on deployment failure

### DIFF
--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -232,7 +232,23 @@ module.exports = {
     } catch (err) {
       sails.log.error(`Deployment ${deploymentId} failed: ${err.message || err}`)
 
-      // Rollback: stop and remove the new (unhealthy) container if it was started
+      // Capture container logs before removing — shows the actual crash reason
+      if (deployContainerName) {
+        try {
+          const containerLogs = await sails.helpers.docker.getContainerLogs.with({
+            containerName: deployContainerName,
+            tail: 50,
+            timestamps: false
+          })
+          if (containerLogs && containerLogs.trim()) {
+            await Deployment.appendDeployLog(deploymentId, `\n--- Container logs ---\n${containerLogs.trim()}\n`)
+          }
+        } catch {
+          // Container may not have started — no logs to capture
+        }
+      }
+
+      // Rollback: stop and remove the new (unhealthy) container
       if (deployContainerName) {
         try {
           await sails.helpers.docker.stopContainer.with({ containerName: deployContainerName })


### PR DESCRIPTION
## Summary

- When a health check fails, fetch the container's runtime logs (`docker logs`) and append them to the deploy log before removing the container
- Users now see the actual crash reason (missing module, config error, etc.) directly in the deploy log instead of just "health check failed"

Fixes #146

## Example output (after fix)

```
Health check failed after 30s (15 attempts). Last error: connect ECONNREFUSED

--- Container logs ---
Error: Cannot find module 'some-package'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1145:15)
    ...
```

## Test plan

- [x] Deploy an app that crashes on startup (e.g. missing dependency) and verify the crash reason appears in the deploy log
- [x] Deploy a healthy app and verify no change in behavior
- [x] Deploy an app where the container never starts (e.g. bad image) and verify it handles the missing logs gracefully