### PR TITLE
Fix stale 'update available' banner after self-update

### DIFF
--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -203,6 +203,10 @@ module.exports = {
       // cache) doesn't block the next update after the container restarts.
       await setProgress('idle', null)
 
+      // Clear the update check cache so the new version doesn't show
+      // a stale "update available" banner after restart.
+      await sails.cache.set('slipway_update_check', null, 1)
+
       return {
         status: 'updating',
         currentVersion: updateInfo.currentVersion,


### PR DESCRIPTION
## Summary

- Clear the `slipway_update_check` cache entry before the container swap so the new version doesn't read a stale "update available" result from SQLite

Fixes #148

## Test plan

- [x] Trigger a self-update from the dashboard
- [x] After the app restarts and the page reloads, verify the update banner is gone (no manual refresh needed)