### PR TITLE
fix: require sustained high usage before firing resource alerts

### DIFF
--- a/api/hooks/lookout/index.js
+++ b/api/hooks/lookout/index.js
@@ -3,7 +3,7 @@
  *
  * Collects Docker container resource metrics on a 30-second interval.
  * Stores snapshots in the ContainerMetric model and prunes data older than 24h.
- * Triggers resource alerts when CPU or memory exceeds 90%.
+ * Triggers resource alerts when CPU or memory exceeds 90% for 3 consecutive samples (~90s).
  *
  * Also:
  * - Health checks: detects containers that should be running but aren't
@@ -86,7 +86,7 @@ module.exports = function defineLookoutHook(sails) {
             environment: matchedApp.environment.id,
             app: matchedApp.id
           })
-          checkResourceAlert(stat, matchedApp.containerName, now)
+          await checkResourceAlert(stat, matchedApp.containerName, now)
           continue
         }
 
@@ -107,7 +107,7 @@ module.exports = function defineLookoutHook(sails) {
             environment: matchedService.environment.id,
             service: matchedService.id
           })
-          checkResourceAlert(stat, matchedService.containerName, now)
+          await checkResourceAlert(stat, matchedService.containerName, now)
           continue
         }
 
@@ -267,6 +267,27 @@ module.exports = function defineLookoutHook(sails) {
       return
     }
 
+    // Require sustained high usage: check last 3 consecutive samples (~90s)
+    // to filter out transient spikes from GC, request bursts, etc.
+    const SUSTAINED_SAMPLES = 3
+    const recentMetrics = await ContainerMetric.find({
+      where: { containerName },
+      sort: 'recordedAt DESC',
+      limit: SUSTAINED_SAMPLES
+    })
+
+    // Not enough history yet — skip alerting until we have enough samples
+    if (recentMetrics.length < SUSTAINED_SAMPLES) {
+      return
+    }
+
+    const sustainedCpuHigh = cpuHigh && recentMetrics.every(m => m.cpuPercent > 90)
+    const sustainedMemHigh = memHigh && recentMetrics.every(m => m.memoryPercent > 90)
+
+    if (!sustainedCpuHigh && !sustainedMemHigh) {
+      return
+    }
+
     alertCooldowns.set(containerName, now)
 
     try {
@@ -274,8 +295,8 @@ module.exports = function defineLookoutHook(sails) {
         containerName,
         cpuPercent: stat.cpuPercent,
         memoryPercent: stat.memPercent,
-        cpuHigh,
-        memHigh
+        cpuHigh: sustainedCpuHigh,
+        memHigh: sustainedMemHigh
       })
     } catch (alertErr) {
       sails.log.verbose('Lookout: Failed to send resource alert:', alertErr.message)


### PR DESCRIPTION
## Summary
- Resource alerts now require **3 consecutive samples** (~90s) above the 90% threshold before firing, instead of triggering on a single transient spike
- Adds missing `await` on `checkResourceAlert` calls so DB query errors are properly caught by the outer try/catch

## Context
`docker stats --no-stream` measures CPU over a ~1-second window. Brief spikes from GC, request bursts, or asset compilation would trigger alerts even though average usage was low. The 15-minute cooldown would expire, and the next transient spike would trigger another alert — causing repeated false positives on containers like Hagfish and African Engineer.

## Test plan
- [x] Deploy to staging and verify that brief CPU spikes (< 90s) no longer trigger alerts
- [x] Verify that sustained high CPU/memory (> 90s) still triggers alerts correctly
- [x] Verify alert cooldown still works as expected after the sustained check

Closes #152