### PR TITLE
feat: harden backup resilience and disk monitoring

### DIFF
--- a/api/controllers/setting/update-uploads.js
+++ b/api/controllers/setting/update-uploads.js
@@ -53,6 +53,7 @@ module.exports = {
 
       current.enabled = !!backupSchedule.enabled
       if (backupSchedule.intervalHours) current.intervalHours = backupSchedule.intervalHours
+      if (backupSchedule.retentionCount) current.retentionCount = backupSchedule.retentionCount
 
       await sails.helpers.setting.set('backupSchedule', JSON.stringify(current))
 

--- a/api/controllers/setting/view-uploads.js
+++ b/api/controllers/setting/view-uploads.js
@@ -63,7 +63,7 @@ module.exports = {
     }
 
     // Get backup schedule
-    let backupSchedule = { enabled: false, intervalHours: 24, lastRunAt: null }
+    let backupSchedule = { enabled: false, intervalHours: 24, retentionCount: 10, lastRunAt: null }
     try {
       const scheduleJson = await sails.helpers.setting.get('backupSchedule')
       if (scheduleJson) backupSchedule = JSON.parse(scheduleJson)

--- a/api/helpers/backup/delete-backup-object.js
+++ b/api/helpers/backup/delete-backup-object.js
@@ -1,0 +1,46 @@
+module.exports = {
+  friendlyName: 'Delete S3 object',
+
+  description: 'Delete a single object from S3-compatible storage by key.',
+
+  inputs: {
+    s3Key: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ s3Key }) {
+    let globalEnvVars = {}
+    try {
+      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
+      globalEnvVars = JSON.parse(globalJson)
+    } catch { /* ignore */ }
+
+    const uploadsConfig = {
+      key: globalEnvVars.R2_ACCESS_KEY || globalEnvVars.S3_ACCESS_KEY || globalEnvVars.SPACES_ACCESS_KEY || (sails.config.uploads || {}).key,
+      secret: globalEnvVars.R2_SECRET_KEY || globalEnvVars.S3_SECRET_KEY || globalEnvVars.SPACES_SECRET_KEY || (sails.config.uploads || {}).secret,
+      bucket: globalEnvVars.R2_BUCKET || globalEnvVars.S3_BUCKET || globalEnvVars.SPACES_BUCKET || (sails.config.uploads || {}).bucket,
+      endpoint: globalEnvVars.R2_ENDPOINT || globalEnvVars.S3_ENDPOINT || globalEnvVars.SPACES_ENDPOINT || (sails.config.uploads || {}).endpoint,
+      region: globalEnvVars.S3_REGION || globalEnvVars.SPACES_REGION || (sails.config.uploads || {}).region
+    }
+
+    const skipperS3 = require('skipper-s3')
+    const adapterOpts = {
+      key: uploadsConfig.key,
+      secret: uploadsConfig.secret,
+      bucket: uploadsConfig.bucket,
+      s3ForcePathStyle: true
+    }
+    if (uploadsConfig.endpoint) adapterOpts.endpoint = uploadsConfig.endpoint
+    if (uploadsConfig.region) adapterOpts.region = uploadsConfig.region
+    const adapter = skipperS3(adapterOpts)
+
+    await new Promise((resolve, reject) => {
+      adapter.rm(s3Key, (err) => {
+        if (err) return reject(err)
+        resolve()
+      })
+    })
+  }
+}

--- a/api/helpers/backup/restore-backup.js
+++ b/api/helpers/backup/restore-backup.js
@@ -33,6 +33,20 @@ module.exports = {
 
     const service = await Service.findOne({ id: backup.service }).decrypt()
 
+    // Create a safety snapshot before restoring so the current state is recoverable
+    try {
+      sails.log.info(`Creating pre-restore snapshot for service ${service.name}`)
+      const snapshot = await Backup.create({
+        status: 'pending',
+        type: 'manual',
+        service: service.id
+      }).fetch()
+      await sails.helpers.backup.runBackup(snapshot.id)
+      sails.log.info(`Pre-restore snapshot completed: ${snapshot.id}`)
+    } catch (err) {
+      sails.log.warn(`Pre-restore snapshot failed (proceeding with restore): ${err.message}`)
+    }
+
     // Read S3 config (same pattern as run-backup.js)
     let globalEnvVars = {}
     try {

--- a/api/helpers/backup/run-backup.js
+++ b/api/helpers/backup/run-backup.js
@@ -112,37 +112,31 @@ module.exports = {
         throw new Error('Dump produced an empty file')
       }
 
-      // Upload to S3 using skipper-s3 adapter
-      const skipperS3 = require('skipper-s3')
-      const adapterOpts = {
+      // Verify dump file integrity by checking format-specific headers
+      const header = Buffer.alloc(5)
+      const fd = fs.openSync(tmpFile, 'r')
+      fs.readSync(fd, header, 0, 5, 0)
+      fs.closeSync(fd)
+      if (service.type === 'postgresql' && header.toString('ascii', 0, 5) !== 'PGDMP') {
+        throw new Error('PostgreSQL dump has invalid header — expected PGDMP format')
+      }
+      if (service.type === 'mongodb' && (header[0] !== 0x1f || header[1] !== 0x8b)) {
+        throw new Error('MongoDB dump has invalid header — expected gzip format')
+      }
+
+      // Upload to S3 via sails-hook-uploads (uses skipper-s3 under the hood)
+      const readStream = fs.createReadStream(tmpFile)
+      readStream.filename = path.basename(s3Key)
+
+      await sails.uploadOne(readStream, {
+        adapter: require('skipper-s3'),
         key: uploadsConfig.key,
         secret: uploadsConfig.secret,
         bucket: uploadsConfig.bucket,
-        s3ForcePathStyle: true
-      }
-      if (uploadsConfig.endpoint) adapterOpts.endpoint = uploadsConfig.endpoint
-      if (uploadsConfig.region) adapterOpts.region = uploadsConfig.region
-      const adapter = skipperS3(adapterOpts)
-
-      await new Promise((resolve, reject) => {
-        const receiver = adapter.receive({ dirname: '', saveAs: s3Key })
-        const readStream = fs.createReadStream(tmpFile)
-
-        // Skipper receivers expect file metadata on the stream object
-        readStream.skipperFd = s3Key
-        readStream.fd = s3Key
-        readStream.filename = path.basename(s3Key)
-        readStream.headers = { 'content-type': 'application/octet-stream' }
-        readStream.byteCount = sizeBytes
-
-        // The receiver is an objectMode writable — it expects stream objects,
-        // not raw Buffer chunks. Using .write() passes the stream object itself;
-        // .pipe() would send Buffer chunks and lose the metadata properties.
-        receiver.write(readStream)
-        receiver.end()
-
-        receiver.on('finish', () => resolve())
-        receiver.on('error', (err) => reject(err))
+        endpoint: uploadsConfig.endpoint,
+        region: uploadsConfig.region,
+        s3ForcePathStyle: true,
+        saveAs: s3Key
       })
 
       // Update backup record

--- a/api/helpers/docker/create-service.js
+++ b/api/helpers/docker/create-service.js
@@ -38,6 +38,19 @@ module.exports = {
     // Build docker run args based on service type
     const args = ['run', '-d', '--name', service.containerName, '--network', networkName, '--restart', 'unless-stopped']
 
+    // Mount a named volume so data persists independently of the container
+    const dataDirs = {
+      postgresql: '/var/lib/postgresql',
+      mysql: '/var/lib/mysql',
+      mongodb: '/data/db',
+      redis: '/data'
+    }
+    const dataDir = dataDirs[service.type]
+    if (dataDir) {
+      const volumeName = `slipway-${service.containerName}-data`
+      args.push('-v', `${volumeName}:${dataDir}`)
+    }
+
     // Add resource limits (per-type defaults for databases vs Redis)
     const typeDefaults = {
       postgresql: { cpus: '1', memory: '512m' },

--- a/api/helpers/notification/send-disk-space-alert.js
+++ b/api/helpers/notification/send-disk-space-alert.js
@@ -1,0 +1,83 @@
+module.exports = {
+  friendlyName: 'Send disk space alert',
+
+  description: 'Send a notification when host disk usage exceeds threshold.',
+
+  inputs: {
+    usedPercent: {
+      type: 'number',
+      required: true
+    },
+    availableGb: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ usedPercent, availableGb }) {
+    const notifyOnHighResourceUsage = await sails.helpers.setting.get('notifyOnHighResourceUsage', 'true')
+    if (notifyOnHighResourceUsage !== 'true') return
+
+    const instanceName = await sails.helpers.setting.get('instanceName', 'Slipway')
+
+    const telegramEnabled = await sails.helpers.setting.get('telegramEnabled', 'false')
+    if (telegramEnabled === 'true') {
+      let message = `\u26A0\uFE0F <b>Disk space is running low</b>\n\n`
+      message += `<b>Used:</b> ${usedPercent}%\n`
+      message += `<b>Available:</b> ${escapeHtml(availableGb)}\n`
+      message += `\nYour server is filling up. Consider cleaning up old images, pruning Docker, or expanding your disk.\n`
+      message += `\n<b>\u2014 Slippy \uD83D\uDC19, from ${escapeHtml(instanceName)}</b>`
+      await sails.helpers.notification.sendTelegram.with({ message }).tolerate('error')
+    }
+
+    const slackEnabled = await sails.helpers.setting.get('slackEnabled', 'false')
+    if (slackEnabled === 'true') {
+      let message = `\u26A0\uFE0F *Disk space is running low*\n\n`
+      message += `*Used:* ${usedPercent}%\n`
+      message += `*Available:* ${availableGb}\n`
+      message += `Your server is filling up. Consider cleaning up old images, pruning Docker, or expanding your disk.\n`
+      message += `\n*\u2014 Slippy \uD83D\uDC19, from ${instanceName}*`
+      await sails.helpers.notification.sendSlack.with({ message }).tolerate('error')
+    }
+
+    const discordEnabled = await sails.helpers.setting.get('discordEnabled', 'false')
+    if (discordEnabled === 'true') {
+      const discordWebhookUrl = await sails.helpers.setting.get('discordWebhookUrl', '')
+      if (discordWebhookUrl) {
+        await fetch(discordWebhookUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            embeds: [{
+              title: '\u26A0\uFE0F Disk space is running low',
+              description: 'Your server is filling up. Consider cleaning up old images, pruning Docker, or expanding your disk.',
+              color: 0xef4444,
+              fields: [
+                { name: 'Used', value: `${usedPercent}%`, inline: true },
+                { name: 'Available', value: availableGb, inline: true }
+              ],
+              footer: { text: `\u2014 Slippy \uD83D\uDC19, from ${instanceName}` },
+              timestamp: new Date().toISOString()
+            }]
+          })
+        }).catch(err => sails.log.warn('Discord disk alert failed:', err.message))
+      }
+    }
+
+    const webhookEnabled = await sails.helpers.setting.get('webhookEnabled', 'false')
+    if (webhookEnabled === 'true') {
+      await sails.helpers.notification.sendWebhook.with({
+        event: 'disk.low_space',
+        data: { usedPercent, availableGb, instanceName }
+      }).tolerate('error')
+    }
+  }
+}
+
+function escapeHtml(text) {
+  if (!text) return ''
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}

--- a/api/hooks/lookout/index.js
+++ b/api/hooks/lookout/index.js
@@ -151,6 +151,9 @@ module.exports = function defineLookoutHook(sails) {
       await TelemetryException.destroy({ occurredAt: { '<': telemetryCutoff } }).tolerate('error')
       await TelemetryMetric.destroy({ recordedAt: { '<': telemetryCutoff } }).tolerate('error')
 
+      // Check host disk space (every cycle, but alert on cooldown)
+      await checkDiskSpace(now)
+
     } catch (err) {
       sails.log.warn('Lookout: Error collecting metrics:', err.message)
     }
@@ -250,6 +253,36 @@ module.exports = function defineLookoutHook(sails) {
       await AppLog.destroy({ endedAt: { '<': logCutoff } })
     } catch (err) {
       sails.log.verbose('Lookout: Error collecting logs:', err.message)
+    }
+  }
+
+  async function checkDiskSpace(now) {
+    try {
+      const cooldownKey = 'disk:space'
+      const lastAlert = alertCooldowns.get(cooldownKey)
+      if (lastAlert && (now - lastAlert) < ALERT_COOLDOWN_MS) return
+
+      const { execFile: execFileCb } = require('child_process')
+      const diskInfo = await new Promise((resolve, reject) => {
+        execFileCb('df', ['-h', '/'], (err, stdout) => {
+          if (err) return reject(err)
+          const lines = stdout.trim().split('\n')
+          if (lines.length < 2) return reject(new Error('Unexpected df output'))
+          const parts = lines[1].split(/\s+/)
+          resolve({ usedPercent: parseInt(parts[4], 10), available: parts[3] })
+        })
+      })
+
+      if (diskInfo.usedPercent >= 90) {
+        alertCooldowns.set(cooldownKey, now)
+        sails.log.warn(`Lookout: Disk space critical — ${diskInfo.usedPercent}% used, ${diskInfo.available} available`)
+        await sails.helpers.notification.sendDiskSpaceAlert.with({
+          usedPercent: diskInfo.usedPercent,
+          availableGb: diskInfo.available
+        }).tolerate('error')
+      }
+    } catch (err) {
+      sails.log.verbose('Lookout: Disk space check error:', err.message)
     }
   }
 

--- a/assets/js/pages/settings/uploads.vue
+++ b/assets/js/pages/settings/uploads.vue
@@ -83,7 +83,8 @@ function save() {
 const scheduleForm = useForm({
   backupSchedule: {
     enabled: props.backupSchedule?.enabled || false,
-    intervalHours: props.backupSchedule?.intervalHours || 24
+    intervalHours: props.backupSchedule?.intervalHours || 24,
+    retentionCount: props.backupSchedule?.retentionCount || 10
   }
 })
 
@@ -391,18 +392,32 @@ const providers = [
               </button>
             </div>
 
-            <div v-if="scheduleForm.backupSchedule.enabled">
-              <label class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">Backup Interval</label>
-              <select
-                v-model="scheduleForm.backupSchedule.intervalHours"
-                class="rounded-md border border-gray-200 bg-transparent px-3 py-1.5 text-sm text-gray-900 focus:border-brand focus:outline-none dark:border-gray-700 dark:text-white"
-              >
-                <option :value="6">Every 6 hours</option>
-                <option :value="12">Every 12 hours</option>
-                <option :value="24">Every 24 hours</option>
-                <option :value="48">Every 48 hours</option>
-                <option :value="168">Weekly</option>
-              </select>
+            <div v-if="scheduleForm.backupSchedule.enabled" class="grid grid-cols-2 gap-4">
+              <div>
+                <label class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">Backup Interval</label>
+                <select
+                  v-model="scheduleForm.backupSchedule.intervalHours"
+                  class="w-full rounded-md border border-gray-200 bg-transparent px-3 py-1.5 text-sm text-gray-900 focus:border-brand focus:outline-none dark:border-gray-700 dark:text-white"
+                >
+                  <option :value="6">Every 6 hours</option>
+                  <option :value="12">Every 12 hours</option>
+                  <option :value="24">Every 24 hours</option>
+                  <option :value="48">Every 48 hours</option>
+                  <option :value="168">Weekly</option>
+                </select>
+              </div>
+              <div>
+                <label class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400">Retention</label>
+                <select
+                  v-model="scheduleForm.backupSchedule.retentionCount"
+                  class="w-full rounded-md border border-gray-200 bg-transparent px-3 py-1.5 text-sm text-gray-900 focus:border-brand focus:outline-none dark:border-gray-700 dark:text-white"
+                >
+                  <option :value="5">Keep last 5</option>
+                  <option :value="10">Keep last 10</option>
+                  <option :value="20">Keep last 20</option>
+                  <option :value="50">Keep last 50</option>
+                </select>
+              </div>
             </div>
 
             <div class="flex justify-end">

--- a/scripts/run-scheduled-backups.js
+++ b/scripts/run-scheduled-backups.js
@@ -66,7 +66,36 @@ module.exports = {
       }
     }
 
-    // 5. Update lastRunAt
+    // 5. Prune old backups beyond retention count
+    const retentionCount = schedule.retentionCount || 10
+    for (const service of backupableServices) {
+      try {
+        const completed = await Backup.find({
+          where: { service: service.id, status: 'completed' },
+          sort: 'completedAt DESC'
+        })
+        if (completed.length <= retentionCount) continue
+
+        const toDelete = completed.slice(retentionCount)
+        sails.log.info(`Pruning ${toDelete.length} old backup(s) for service ${service.name}`)
+
+        for (const old of toDelete) {
+          // Delete from S3 if key exists
+          if (old.s3Key) {
+            try {
+              await sails.helpers.backup.deleteBackupObject(old.s3Key)
+            } catch (err) {
+              sails.log.warn(`Failed to delete S3 object ${old.s3Key}: ${err.message}`)
+            }
+          }
+          await Backup.destroyOne({ id: old.id })
+        }
+      } catch (err) {
+        sails.log.error(`Backup pruning failed for ${service.name}: ${err.message}`)
+      }
+    }
+
+    // 6. Update lastRunAt
     schedule.lastRunAt = now
     await sails.helpers.setting.set('backupSchedule', JSON.stringify(schedule))
   }


### PR DESCRIPTION
## Summary
- Named Docker volumes for new database services (existing services use anonymous volumes from the official images, which are safe)
- Backup uploads refactored from raw skipper-s3 to `sails.uploadOne()` for consistency
- Dump file header verification before S3 upload (catches corrupt dumps early)
- Auto safety snapshot before any restore operation
- Backup retention pruning after scheduled backup runs (configurable count, default 10)
- Retention count dropdown added to Settings > File Storage
- Host disk space monitoring in Lookout with alerts at 90% usage

## Test plan
- [x] Trigger a manual backup on a database service — confirm it completes
- [x] Trigger a restore — confirm a pre-restore snapshot appears in the backup list
- [x] Settings > File Storage — enable scheduled backups, verify Backup Interval and Retention dropdowns appear side by side, save and refresh to confirm persistence

Ref #154