### PR TITLE
fix: pin PGDATA for PostgreSQL 18+ compat and fix service delete modal

### DIFF
--- a/api/helpers/docker/create-service.js
+++ b/api/helpers/docker/create-service.js
@@ -73,6 +73,7 @@ module.exports = {
         args.push('-e', `POSTGRES_USER=${service.username}`)
         args.push('-e', `POSTGRES_PASSWORD=${service.password}`)
         args.push('-e', `POSTGRES_DB=${service.database}`)
+        args.push('-e', 'PGDATA=/var/lib/postgresql/data')
         break
 
       case 'mysql':

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -1713,7 +1713,7 @@ onBeforeUnmount(() => {
 
     <!-- Delete Service Confirmation -->
     <ConfirmModal
-      v-if="deletingServiceId"
+      :show="!!deletingServiceId"
       title="Delete service"
       message="This will stop the service container and permanently delete all data. This action cannot be undone."
       confirm-label="Delete service"


### PR DESCRIPTION
Resolves #159 
## Summary
- Set `PGDATA=/var/lib/postgresql/data` explicitly when creating PostgreSQL service containers, preventing breakage when PG 18+ uses its new `pg_ctlcluster` directory layout
- Fix delete service confirmation modal not appearing by passing `:show` prop to `ConfirmModal` instead of `v-if` (the `show` prop defaults to `false`)

## Test plan
- [x] Verified PGDATA is set in docker run args for new PostgreSQL services
- [x] Verified delete service modal now appears on the environment page