### PR TITLE
Fix deploys that fail on missing build context

### DIFF
--- a/api/helpers/deploy/ensure-build-context.js
+++ b/api/helpers/deploy/ensure-build-context.js
@@ -1,0 +1,153 @@
+const fs = require('fs')
+const path = require('path')
+
+module.exports = {
+  friendlyName: 'Ensure build context',
+
+  description:
+    'Ensure a deployable source tree exists for a project before Docker build runs.',
+
+  inputs: {
+    project: {
+      type: 'ref',
+      required: true
+    },
+    environment: {
+      type: 'ref',
+      required: true
+    },
+    app: {
+      type: 'ref'
+    },
+    deploymentId: {
+      type: 'string'
+    },
+    gitBranch: {
+      type: 'string'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ project, environment, app, deploymentId, gitBranch }) {
+    const contextPath = path.join(sails.config.custom.slipwayAppsDir, project.slug)
+
+    if (fs.existsSync(contextPath)) {
+      return {
+        contextPath,
+        hydrated: false
+      }
+    }
+
+    const repo = await findConnectedRepository(app, environment)
+    if (repo && repo.cloneUrl && repo.deployKeyPrivate) {
+      const branch = resolveDeployBranch(repo, environment.slug, gitBranch)
+
+      await appendBuildLog(
+        deploymentId,
+        `Build context missing at ${contextPath}. Syncing source from ${
+          repo.fullName || repo.cloneUrl
+        } (${branch})...\n`
+      )
+
+      try {
+        await sails.helpers.git.cloneOrPull.with({
+          cloneUrl: repo.cloneUrl,
+          branch,
+          targetDir: contextPath,
+          deployKeyPrivate: repo.deployKeyPrivate,
+          deploymentId
+        })
+      } catch (err) {
+        const errorMessage = `Source sync failed for ${project.slug}: ${
+          err.message || err
+        }`
+        await appendBuildLog(deploymentId, `${errorMessage}\n`)
+        throw new Error(errorMessage)
+      }
+
+      if (fs.existsSync(contextPath)) {
+        return {
+          contextPath,
+          hydrated: true,
+          branch
+        }
+      }
+    }
+
+    const guidance = repo
+      ? 'A repository is connected, but Slipway could not use it to restore source. Reconnect the repository or push source before deploying.'
+      : 'Push source to Slipway or connect a repository before deploying.'
+    const errorMessage = `Build context missing at ${contextPath}. ${guidance}`
+
+    await appendBuildLog(deploymentId, `${errorMessage}\n`)
+    throw new Error(errorMessage)
+  }
+}
+
+module.exports._private = {
+  resolveDeployBranch,
+  findConnectedRepository
+}
+
+async function appendBuildLog(deploymentId, message) {
+  if (!deploymentId) return
+
+  try {
+    await Deployment.appendBuildLog(deploymentId, message)
+  } catch {
+    /* best-effort */
+  }
+}
+
+async function findConnectedRepository(app, environment) {
+  if (app && app.id) {
+    const appRepo = await findOneDecrypted({ app: app.id })
+    if (appRepo) {
+      return appRepo
+    }
+  }
+
+  if (environment && environment.id) {
+    return findOneDecrypted({ environment: environment.id })
+  }
+
+  return null
+}
+
+async function findOneDecrypted(criteria) {
+  const query = GitRepository.findOne(criteria)
+
+  if (query && typeof query.decrypt === 'function') {
+    return query.decrypt()
+  }
+
+  return query
+}
+
+function resolveDeployBranch(repo, environmentSlug, gitBranch) {
+  if (gitBranch) {
+    return gitBranch
+  }
+
+  if (repo?.branchMappings && typeof repo.branchMappings === 'object') {
+    for (const [branch, mappedEnvironmentSlug] of Object.entries(
+      repo.branchMappings
+    )) {
+      if (mappedEnvironmentSlug === environmentSlug) {
+        return branch
+      }
+    }
+
+    const firstMappedBranch = Object.keys(repo.branchMappings)[0]
+    if (firstMappedBranch) {
+      return firstMappedBranch
+    }
+  }
+
+  return repo?.defaultBranch || 'main'
+}

--- a/api/helpers/deploy/ensure-build-context.js
+++ b/api/helpers/deploy/ensure-build-context.js
@@ -34,7 +34,10 @@ module.exports = {
   },
 
   fn: async function ({ project, environment, app, deploymentId, gitBranch }) {
-    const contextPath = path.join(sails.config.custom.slipwayAppsDir, project.slug)
+    const contextPath = path.join(
+      sails.config.custom.slipwayAppsDir,
+      project.slug
+    )
 
     if (fs.existsSync(contextPath)) {
       return {

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -42,6 +42,8 @@ module.exports = {
     let deployHostPort = null
 
     try {
+      const deployment = await Deployment.findOne({ id: deploymentId })
+
       // 1. Set status to building
       await Deployment.updateOne({ id: deploymentId }).set({
         status: 'building'
@@ -76,10 +78,15 @@ module.exports = {
         deploymentId,
         appSlug
       )
-      const contextPath = require('path').join(
-        sails.config.custom.slipwayAppsDir,
-        project.slug
-      )
+
+      const { contextPath } =
+        await sails.helpers.deploy.ensureBuildContext.with({
+          project,
+          environment,
+          app: targetApp,
+          deploymentId,
+          gitBranch: deployment?.gitBranch
+        })
 
       // 4. Build the Docker image (use app's dockerfilePath, fall back to project's)
       const dockerfilePath =

--- a/tests/unit/helpers/deploy/ensure-build-context.test.js
+++ b/tests/unit/helpers/deploy/ensure-build-context.test.js
@@ -44,7 +44,8 @@ test('missing build context is hydrated from a connected repository', async ({
               fullName: 'acme/sailscasts',
               cloneUrl: 'git@github.com:acme/sailscasts.git',
               defaultBranch: 'main',
-              deployKeyPrivate: '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----',
+              deployKeyPrivate:
+                '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----',
               branchMappings: {
                 production: 'production'
               }
@@ -75,7 +76,8 @@ test('missing build context is hydrated from a connected repository', async ({
         cloneUrl: 'git@github.com:acme/sailscasts.git',
         branch: 'production',
         targetDir: path.join(tempRoot, 'sailscasts'),
-        deployKeyPrivate: '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----',
+        deployKeyPrivate:
+          '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----',
         deploymentId: 'dep-1'
       }
     ])

--- a/tests/unit/helpers/deploy/ensure-build-context.test.js
+++ b/tests/unit/helpers/deploy/ensure-build-context.test.js
@@ -1,0 +1,160 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { test } = require('sounding')
+
+const ensureBuildContext = require('../../../../api/helpers/deploy/ensure-build-context')
+
+test('missing build context is hydrated from a connected repository', async ({
+  expect
+}) => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-ensure-build-context-')
+  )
+  const cloneCalls = []
+  const buildLogs = []
+  const originalSails = global.sails
+  const originalGitRepository = global.GitRepository
+  const originalDeployment = global.Deployment
+
+  global.sails = {
+    config: {
+      custom: {
+        slipwayAppsDir: tempRoot
+      }
+    },
+    helpers: {
+      git: {
+        cloneOrPull: {
+          with: async (options) => {
+            cloneCalls.push(options)
+            fs.mkdirSync(options.targetDir, { recursive: true })
+          }
+        }
+      }
+    }
+  }
+
+  global.GitRepository = {
+    findOne: (criteria) => ({
+      decrypt: async () =>
+        criteria.app === 1
+          ? {
+              fullName: 'acme/sailscasts',
+              cloneUrl: 'git@github.com:acme/sailscasts.git',
+              defaultBranch: 'main',
+              deployKeyPrivate: '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----',
+              branchMappings: {
+                production: 'production'
+              }
+            }
+          : null
+    })
+  }
+
+  global.Deployment = {
+    appendBuildLog: async (_deploymentId, message) => {
+      buildLogs.push(message)
+    }
+  }
+
+  try {
+    const result = await ensureBuildContext.fn({
+      project: { slug: 'sailscasts' },
+      environment: { id: 1, slug: 'production' },
+      app: { id: 1 },
+      deploymentId: 'dep-1'
+    })
+
+    expect(result.contextPath).toBe(path.join(tempRoot, 'sailscasts'))
+    expect(result.hydrated).toBe(true)
+    expect(result.branch).toBe('production')
+    expect(cloneCalls).toEqual([
+      {
+        cloneUrl: 'git@github.com:acme/sailscasts.git',
+        branch: 'production',
+        targetDir: path.join(tempRoot, 'sailscasts'),
+        deployKeyPrivate: '-----BEGIN TEST KEY-----\nabc\n-----END TEST KEY-----',
+        deploymentId: 'dep-1'
+      }
+    ])
+    expect(buildLogs[0]).toContain('Build context missing at')
+    expect(fs.existsSync(path.join(tempRoot, 'sailscasts'))).toBe(true)
+  } finally {
+    global.sails = originalSails
+    global.GitRepository = originalGitRepository
+    global.Deployment = originalDeployment
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('missing build context fails early with guidance when no repository is connected', async ({
+  expect
+}) => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-ensure-build-context-')
+  )
+  const buildLogs = []
+  const originalSails = global.sails
+  const originalGitRepository = global.GitRepository
+  const originalDeployment = global.Deployment
+
+  global.sails = {
+    config: {
+      custom: {
+        slipwayAppsDir: tempRoot
+      }
+    },
+    helpers: {
+      git: {
+        cloneOrPull: {
+          with: async () => {
+            throw new Error('clone should not be called')
+          }
+        }
+      }
+    }
+  }
+
+  global.GitRepository = {
+    findOne: () => ({
+      decrypt: async () => null
+    })
+  }
+
+  global.Deployment = {
+    appendBuildLog: async (_deploymentId, message) => {
+      buildLogs.push(message)
+    }
+  }
+
+  try {
+    let caughtError
+    try {
+      await ensureBuildContext.fn({
+        project: { slug: 'sailscasts' },
+        environment: { id: 1, slug: 'production' },
+        app: { id: 1 },
+        deploymentId: 'dep-1'
+      })
+    } catch (err) {
+      caughtError = err
+    }
+
+    expect(caughtError?.message).toBe(
+      `Build context missing at ${path.join(
+        tempRoot,
+        'sailscasts'
+      )}. Push source to Slipway or connect a repository before deploying.`
+    )
+    expect(buildLogs[0]).toContain(
+      'Push source to Slipway or connect a repository before deploying.'
+    )
+  } finally {
+    global.sails = originalSails
+    global.GitRepository = originalGitRepository
+    global.Deployment = originalDeployment
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- ensure deploy build context exists before Docker build runs
- hydrate missing source from a connected Git repository when possible
- fail early with a clear deployment error when no source is available

## Root cause
Manual/API deploys were jumping straight into Docker build with `/var/slipway/apps/<project>` as the context path, but that directory only exists after `push source` or a repo sync path has populated it. When the source tree was missing, Docker surfaced the raw `unable to prepare context` error.

## Testing
- `node --test tests/unit/helpers/deploy/ensure-build-context.test.js`
- `npm run test`

Closes #185
