### PR TITLE
Standardize localStorage key naming

### DIFF
--- a/assets/js/components/CommandPalette.vue
+++ b/assets/js/components/CommandPalette.vue
@@ -12,6 +12,7 @@ import { router, usePage } from '@inertiajs/vue3'
 import { useCommandPalette } from '@/composables/useCommandPalette'
 import { useToast } from '@/composables/toast'
 import { fuzzySearch } from '@/lib/fuzzySearch'
+import { LOCAL_STORAGE_KEYS } from '@/lib/localStorageKeys'
 
 const { isOpen, history, register, unregister, getAll, execute, close } =
   useCommandPalette()
@@ -618,7 +619,7 @@ function selectCommand(cmd) {
       ...history.value.filter((h) => h !== cmd.id)
     ].slice(0, 10)
     localStorage.setItem(
-      'slipway:command-history',
+      LOCAL_STORAGE_KEYS.commandHistory,
       JSON.stringify(history.value)
     )
     mode.value = 'submenu'

--- a/assets/js/components/UpdateBanner.vue
+++ b/assets/js/components/UpdateBanner.vue
@@ -3,6 +3,11 @@ import { ref, onMounted } from 'vue'
 import { Link } from '@inertiajs/vue3'
 import Tooltip from '@/components/Tooltip.vue'
 import { useUpdateCheck } from '@/composables/useUpdateCheck'
+import {
+  LEGACY_LOCAL_STORAGE_KEYS,
+  LOCAL_STORAGE_KEYS,
+  readLocalStorageValue
+} from '@/lib/localStorageKeys'
 
 const { updateInfo, check } = useUpdateCheck()
 const dismissed = ref(false)
@@ -12,7 +17,7 @@ function dismiss() {
   // Store dismissal in localStorage with version to not show again for same version
   if (updateInfo.value?.latestVersion) {
     localStorage.setItem(
-      'slipway_update_dismissed',
+      LOCAL_STORAGE_KEYS.updateDismissed,
       updateInfo.value.latestVersion
     )
   }
@@ -20,7 +25,10 @@ function dismiss() {
 
 onMounted(() => {
   // Check if this version was already dismissed
-  const dismissedVersion = localStorage.getItem('slipway_update_dismissed')
+  const dismissedVersion = readLocalStorageValue(
+    LOCAL_STORAGE_KEYS.updateDismissed,
+    LEGACY_LOCAL_STORAGE_KEYS.updateDismissed
+  )
 
   check().then(() => {
     if (updateInfo.value?.latestVersion === dismissedVersion) {

--- a/assets/js/composables/useCommandPalette.js
+++ b/assets/js/composables/useCommandPalette.js
@@ -1,4 +1,5 @@
 import { ref, provide, inject } from 'vue'
+import { LOCAL_STORAGE_KEYS } from '@/lib/localStorageKeys'
 
 const COMMAND_PALETTE_KEY = Symbol('commandPalette')
 
@@ -7,14 +8,19 @@ const commands = new Map()
 
 function loadHistory() {
   try {
-    return JSON.parse(localStorage.getItem('slipway:command-history') || '[]')
+    return JSON.parse(
+      localStorage.getItem(LOCAL_STORAGE_KEYS.commandHistory) || '[]'
+    )
   } catch {
     return []
   }
 }
 
 function saveHistory(history) {
-  localStorage.setItem('slipway:command-history', JSON.stringify(history))
+  localStorage.setItem(
+    LOCAL_STORAGE_KEYS.commandHistory,
+    JSON.stringify(history)
+  )
 }
 
 export function createCommandPalette() {

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -16,6 +16,11 @@ import {
 } from '@/composables/service-actions'
 import { createCommandPalette } from '@/composables/useCommandPalette'
 import { useUpdateCheck } from '@/composables/useUpdateCheck'
+import {
+  LEGACY_LOCAL_STORAGE_KEYS,
+  LOCAL_STORAGE_KEYS,
+  readLocalStorageValue
+} from '@/lib/localStorageKeys'
 
 const page = usePage()
 const loggedInUser = page.props.loggedInUser
@@ -56,7 +61,10 @@ const sidebarCollapsed = ref(false)
 
 const toggleSidebar = () => {
   sidebarCollapsed.value = !sidebarCollapsed.value
-  localStorage.setItem('sidebarCollapsed', sidebarCollapsed.value)
+  localStorage.setItem(
+    LOCAL_STORAGE_KEYS.sidebarCollapsed,
+    String(sidebarCollapsed.value)
+  )
 }
 
 // Provide toggle functions to child components
@@ -207,7 +215,10 @@ function dismissDeployment(deploymentId) {
 // Initialize on mount
 onMounted(() => {
   // Restore sidebar state
-  const saved = localStorage.getItem('sidebarCollapsed')
+  const saved = readLocalStorageValue(
+    LOCAL_STORAGE_KEYS.sidebarCollapsed,
+    LEGACY_LOCAL_STORAGE_KEYS.sidebarCollapsed
+  )
   if (saved !== null) {
     sidebarCollapsed.value = saved === 'true'
   }

--- a/assets/js/lib/localStorageKeys.js
+++ b/assets/js/lib/localStorageKeys.js
@@ -1,0 +1,28 @@
+export const LOCAL_STORAGE_KEYS = Object.freeze({
+  sidebarCollapsed: 'slipway:sidebar-collapsed',
+  commandHistory: 'slipway:command-history',
+  updateDismissed: 'slipway:update-dismissed'
+})
+
+export const LEGACY_LOCAL_STORAGE_KEYS = Object.freeze({
+  sidebarCollapsed: ['sidebarCollapsed'],
+  updateDismissed: ['slipway_update_dismissed']
+})
+
+export function readLocalStorageValue(key, legacyKeys = []) {
+  const value = localStorage.getItem(key)
+  if (value !== null) {
+    return value
+  }
+
+  for (const legacyKey of legacyKeys) {
+    const legacyValue = localStorage.getItem(legacyKey)
+    if (legacyValue !== null) {
+      localStorage.setItem(key, legacyValue)
+      localStorage.removeItem(legacyKey)
+      return legacyValue
+    }
+  }
+
+  return null
+}


### PR DESCRIPTION
## Summary
- Standardizes Slipway browser localStorage keys on `slipway:<kebab-name>`.
- Adds shared localStorage key constants and a small legacy-key migration helper.
- Updates sidebar, update banner, and command palette storage call sites to use the shared keys.

## Validation
- `npm run lint`

Closes #189