### PR TITLE
fix: pin update installs to release image tags

### DIFF
--- a/api/controllers/system/apply-update.js
+++ b/api/controllers/system/apply-update.js
@@ -53,7 +53,8 @@ module.exports = {
     return {
       status: 'started',
       currentVersion: updateInfo.currentVersion,
-      targetVersion: updateInfo.latestVersion
+      targetVersion: updateInfo.latestVersion,
+      targetImage: updateInfo.imageRef
     }
   }
 }

--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -27,7 +27,9 @@ module.exports = {
 
   fn: async function () {
     const dockerPath = sails.config.docker?.binaryPath || 'docker'
-    const image = 'ghcr.io/sailscastshq/slipway'
+    const githubRepo =
+      sails.config.slipway?.githubRepo || 'sailscastshq/slipway'
+    const imageRepository = `ghcr.io/${githubRepo}`
     const CACHE_KEY = 'slipway_update_progress'
     const appsDir = sails.config.custom.slipwayAppsDir || '/var/slipway/apps'
 
@@ -51,17 +53,22 @@ module.exports = {
         throw 'noUpdate'
       }
 
-      const pullTarget = `${image}:latest`
+      const pullTarget = await sails.helpers.system.getUpdateImageRef.with({
+        updateInfo,
+        imageRepository
+      })
 
-      // 2. Pull the latest image
+      // 2. Pull the advertised image
       await setProgress('pulling', `Pulling ${pullTarget}`)
       try {
         await execFileAsync(dockerPath, ['pull', pullTarget], {
           timeout: 300000
         })
       } catch (err) {
-        sails.log.error(`[slipway] Failed to pull image: ${err.message}`)
-        await setProgress('failed', 'Failed to pull the latest image')
+        sails.log.error(
+          `[slipway] Failed to pull ${pullTarget}: ${err.message}`
+        )
+        await setProgress('failed', `Failed to pull ${pullTarget}`)
         throw 'pullFailed'
       }
 
@@ -97,8 +104,9 @@ module.exports = {
         })
       }
 
-      // 5. Build base docker run arguments from current container config
-      const baseArgs = buildRunArgs(containerInfo, {
+      // 5. Build reusable Docker arguments from current container config
+      const dockerArgs = await sails.helpers.system.buildUpdateDockerArgs.with({
+        containerInfo,
         extraMounts: [
           {
             type: 'bind',
@@ -107,6 +115,7 @@ module.exports = {
           }
         ]
       })
+      const baseArgs = dockerArgs.runArgs
 
       // 6. Start a validation container (slipway-next) on a temporary port
       await setProgress(
@@ -126,13 +135,7 @@ module.exports = {
         tempArgs.push('--network', networks[0])
       }
 
-      appendMountArgs(tempArgs, containerInfo.Mounts, [
-        {
-          type: 'bind',
-          source: appsDir,
-          destination: appsDir
-        }
-      ])
+      tempArgs.push(...dockerArgs.mountArgs)
 
       // Temp port binding (different from production port)
       tempArgs.push('-p', `${tempPort}:1337`)
@@ -281,95 +284,14 @@ module.exports = {
       return {
         status: 'updating',
         currentVersion: updateInfo.currentVersion,
-        targetVersion: updateInfo.latestVersion
+        targetVersion: updateInfo.latestVersion,
+        targetImage: pullTarget
       }
     } catch (err) {
       // Re-throw Sails exit signals
       if (typeof err === 'string') throw err
       await setProgress('failed', err.message)
       throw 'pullFailed'
-    }
-  }
-}
-
-/**
- * Extract reusable docker run arguments from a container's inspect output.
- * Returns an array of args (network, volumes, ports, env, labels) without
- * the `run -d --name ... --restart ...` prefix or the image suffix.
- */
-function buildRunArgs(containerInfo, { extraMounts = [] } = {}) {
-  const args = []
-
-  // Network
-  const networks = Object.keys(containerInfo.NetworkSettings?.Networks || {})
-  if (networks.length > 0) {
-    args.push('--network', networks[0])
-  }
-
-  appendMountArgs(args, containerInfo.Mounts, extraMounts)
-
-  // Port bindings
-  const portBindings = containerInfo.HostConfig?.PortBindings || {}
-  for (const [containerPort, bindings] of Object.entries(portBindings)) {
-    for (const binding of bindings || []) {
-      const hostPort = binding.HostPort || ''
-      if (hostPort) {
-        args.push('-p', `${hostPort}:${containerPort.replace('/tcp', '')}`)
-      }
-    }
-  }
-
-  // Environment variables
-  for (const envVar of containerInfo.Config?.Env || []) {
-    args.push('-e', envVar)
-  }
-
-  // Labels (skip internal Docker labels)
-  for (const [key, value] of Object.entries(
-    containerInfo.Config?.Labels || {}
-  )) {
-    if (
-      key.startsWith('org.opencontainers.') ||
-      key.startsWith('com.docker.')
-    ) {
-      continue
-    }
-    args.push('-l', `${key}=${value}`)
-  }
-
-  return args
-}
-
-function appendMountArgs(args, mounts = [], extraMounts = []) {
-  const seenDestinations = new Set()
-
-  for (const mount of [...(mounts || []), ...(extraMounts || [])]) {
-    const type = mount.Type || mount.type
-    const destination = mount.Destination || mount.destination
-
-    if (!type || !destination || seenDestinations.has(destination)) {
-      continue
-    }
-
-    seenDestinations.add(destination)
-
-    if (type === 'volume') {
-      const source = mount.Name || mount.name || mount.Source || mount.source
-      if (source) {
-        args.push('-v', `${source}:${destination}`)
-      }
-      continue
-    }
-
-    if (type === 'bind') {
-      const source = mount.Source || mount.source
-      if (!source) {
-        continue
-      }
-
-      const readOnly =
-        mount.RW === false || mount.readOnly === true ? ':ro' : ''
-      args.push('-v', `${source}:${destination}${readOnly}`)
     }
   }
 }
@@ -538,11 +460,4 @@ async function getContainerLogs(dockerPath, containerName) {
   } catch (err) {
     return err.stderr ? String(err.stderr).trim() : null
   }
-}
-
-module.exports._private = {
-  appendMountArgs,
-  buildRunArgs,
-  getContainerLogs,
-  hasMountDestination
 }

--- a/api/helpers/system/build-update-docker-args.js
+++ b/api/helpers/system/build-update-docker-args.js
@@ -1,0 +1,100 @@
+module.exports = {
+  friendlyName: 'Build update docker args',
+
+  description:
+    'Build reusable Docker arguments for the Slipway self-update containers.',
+
+  inputs: {
+    containerInfo: {
+      type: 'ref',
+      required: true,
+      description: 'Docker inspect output for the current Slipway container.'
+    },
+    extraMounts: {
+      type: 'ref',
+      description: 'Additional mounts that must be present in the next run.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerInfo, extraMounts = [] }) {
+    const mountArgs = []
+    appendMountArgs(mountArgs, containerInfo.Mounts, extraMounts)
+
+    const runArgs = []
+
+    const networks = Object.keys(containerInfo.NetworkSettings?.Networks || {})
+    if (networks.length > 0) {
+      runArgs.push('--network', networks[0])
+    }
+
+    runArgs.push(...mountArgs)
+
+    const portBindings = containerInfo.HostConfig?.PortBindings || {}
+    for (const [containerPort, bindings] of Object.entries(portBindings)) {
+      for (const binding of bindings || []) {
+        const hostPort = binding.HostPort || ''
+        if (hostPort) {
+          runArgs.push('-p', `${hostPort}:${containerPort.replace('/tcp', '')}`)
+        }
+      }
+    }
+
+    for (const envVar of containerInfo.Config?.Env || []) {
+      runArgs.push('-e', envVar)
+    }
+
+    for (const [key, value] of Object.entries(
+      containerInfo.Config?.Labels || {}
+    )) {
+      if (
+        key.startsWith('org.opencontainers.') ||
+        key.startsWith('com.docker.')
+      ) {
+        continue
+      }
+      runArgs.push('-l', `${key}=${value}`)
+    }
+
+    return { runArgs, mountArgs }
+  }
+}
+
+function appendMountArgs(args, mounts = [], extraMounts = []) {
+  const seenDestinations = new Set()
+
+  for (const mount of [...(mounts || []), ...(extraMounts || [])]) {
+    const type = mount.Type || mount.type
+    const destination = mount.Destination || mount.destination
+
+    if (!type || !destination || seenDestinations.has(destination)) {
+      continue
+    }
+
+    seenDestinations.add(destination)
+
+    if (type === 'volume') {
+      const source = mount.Name || mount.name || mount.Source || mount.source
+      if (source) {
+        args.push('-v', `${source}:${destination}`)
+      }
+      continue
+    }
+
+    if (type === 'bind') {
+      const source = mount.Source || mount.source
+      if (!source) {
+        continue
+      }
+
+      const readOnly =
+        mount.RW === false || mount.readOnly === true ? ':ro' : ''
+      args.push('-v', `${source}:${destination}${readOnly}`)
+    }
+  }
+}

--- a/api/helpers/system/check-for-updates.js
+++ b/api/helpers/system/check-for-updates.js
@@ -22,6 +22,7 @@ module.exports = {
     const currentVersion = sailsApp?.config?.slipway?.version || '0.1.0'
     const githubRepo =
       sailsApp?.config?.slipway?.githubRepo || 'sailscastshq/slipway'
+    const imageRepository = `ghcr.io/${githubRepo}`
 
     // Cache key for rate limiting - only check once per hour
     const cacheKey = 'slipway_update_check'
@@ -70,6 +71,7 @@ module.exports = {
       const release = await response.json()
       const latestVersion =
         release.tag_name?.replace(/^v/, '') || currentVersion
+      const imageRef = `${imageRepository}:${latestVersion}`
 
       // Simple semver comparison (major.minor.patch)
       const isNewer = compareVersions(latestVersion, currentVersion) > 0
@@ -89,6 +91,7 @@ module.exports = {
         currentVersion,
         latestVersion,
         updateAvailable: isNewer && imageReady,
+        imageRef,
         releaseUrl: release.html_url,
         releaseNotes: release.body?.substring(0, 500) || '',
         publishedAt: release.published_at,

--- a/api/helpers/system/get-update-image-ref.js
+++ b/api/helpers/system/get-update-image-ref.js
@@ -1,0 +1,37 @@
+module.exports = {
+  friendlyName: 'Get update image ref',
+
+  description:
+    'Resolve the exact Slipway Docker image ref for an advertised update.',
+
+  inputs: {
+    updateInfo: {
+      type: 'ref',
+      required: true,
+      description: 'Update metadata returned by system.checkForUpdates.'
+    },
+    imageRepository: {
+      type: 'string',
+      required: true,
+      description: 'Docker image repository without a tag.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ updateInfo, imageRepository }) {
+    const targetVersion = String(updateInfo?.latestVersion || '')
+      .trim()
+      .replace(/^v/, '')
+
+    if (!targetVersion) {
+      throw new Error('Update check did not include a target version.')
+    }
+
+    return `${imageRepository}:${targetVersion}`
+  }
+}

--- a/assets/js/components/UpdateModal.vue
+++ b/assets/js/components/UpdateModal.vue
@@ -102,7 +102,7 @@ async function waitForHealthy(maxAttempts = 30) {
 const phaseLabels = {
   starting: 'Initiating update...',
   checking: 'Checking for updates...',
-  pulling: 'Pulling latest image...',
+  pulling: 'Pulling image...',
   'backing-up': 'Backing up database...',
   inspecting: 'Reading container configuration...',
   validating: 'Validating new version...',
@@ -275,7 +275,7 @@ function formatDate(dateString) {
                 {{ phaseLabels[updatePhase] || 'Updating...' }}
               </p>
               <p
-                v-if="updateDetail && !phaseLabels[updatePhase]"
+                v-if="updateDetail"
                 class="mt-0.5 text-xs text-gray-500 dark:text-gray-400"
               >
                 {{ updateDetail }}

--- a/assets/js/pages/settings/update.vue
+++ b/assets/js/pages/settings/update.vue
@@ -127,7 +127,7 @@ async function waitForHealthy(maxAttempts = 30) {
 const phaseLabels = {
   starting: 'Initiating update...',
   checking: 'Checking for updates...',
-  pulling: 'Pulling latest image...',
+  pulling: 'Pulling image...',
   'backing-up': 'Backing up database...',
   inspecting: 'Reading container configuration...',
   validating: 'Validating new version...',
@@ -548,7 +548,7 @@ function formatDate(dateString) {
                 {{ phaseLabels[updatePhase] || 'Updating...' }}
               </p>
               <p
-                v-if="updateDetail && !phaseLabels[updatePhase]"
+                v-if="updateDetail"
                 class="mt-0.5 text-xs text-gray-500 dark:text-gray-400"
               >
                 {{ updateDetail }}
@@ -654,12 +654,12 @@ function formatDate(dateString) {
               <div class="mt-4 space-y-3">
                 <p class="text-sm text-gray-600 dark:text-gray-400">
                   SSH into your server and re-run the install script. It detects
-                  the existing installation, reuses your secrets, pulls the
-                  latest image, and restarts Slipway.
+                  the existing installation, reuses your secrets, pulls this
+                  release, and restarts Slipway.
                 </p>
                 <pre
                   class="overflow-x-auto rounded-lg bg-gray-900 p-3 text-sm text-gray-100 dark:bg-gray-950"
-                ><code>curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh | bash</code></pre>
+                ><code>curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh | bash -s -- {{ localUpdateInfo.latestVersion }}</code></pre>
                 <p class="text-xs text-gray-500 dark:text-gray-400">
                   Your data is stored on Docker volumes and is preserved across
                   updates.

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # Slipway Installation Script
 # Usage: curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh | bash
+# Pin a version: curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh | bash -s -- 0.0.49
 
 set -e
 
@@ -15,6 +16,8 @@ NC='\033[0m' # No Color
 
 SLIPWAY_ENV_FILE="/etc/slipway/.env"
 SLIPWAY_APPS_DIR="/var/slipway/apps"
+SLIPWAY_IMAGE_REPOSITORY="${SLIPWAY_IMAGE_REPOSITORY:-ghcr.io/sailscastshq/slipway}"
+SLIPWAY_VERSION="${SLIPWAY_VERSION:-${1:-}}"
 IS_UPDATE=false
 
 # Check if running as root
@@ -98,9 +101,27 @@ docker run -d \
     lucaslorentz/caddy-docker-proxy:latest
 echo -e "${GREEN}Caddy proxy running${NC}"
 
-# 7. Pull latest images
-echo "Pulling latest Slipway image..."
-docker pull ghcr.io/sailscastshq/slipway:latest
+# 7. Resolve and pull the target Slipway image
+if [ -z "$SLIPWAY_VERSION" ]; then
+    echo "Resolving latest Slipway release..."
+    RELEASE_JSON=$(curl -fsSL https://api.github.com/repos/sailscastshq/slipway/releases/latest 2>/dev/null || true)
+    SLIPWAY_VERSION=$(printf '%s' "$RELEASE_JSON" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -n 1)
+
+    if [ -z "$SLIPWAY_VERSION" ]; then
+        echo -e "${RED}Could not resolve the latest Slipway release.${NC}"
+        echo "Pass an explicit version, for example: bash install.sh 0.0.49"
+        echo "To intentionally use the moving tag, pass: bash install.sh latest"
+        exit 1
+    fi
+fi
+
+if [ "$SLIPWAY_VERSION" != "latest" ]; then
+    SLIPWAY_VERSION="${SLIPWAY_VERSION#v}"
+fi
+
+SLIPWAY_IMAGE="$SLIPWAY_IMAGE_REPOSITORY:$SLIPWAY_VERSION"
+echo "Pulling Slipway image $SLIPWAY_IMAGE..."
+docker pull "$SLIPWAY_IMAGE"
 docker pull alpine
 
 # 7b. Ensure deployed app source survives container replacement
@@ -124,14 +145,14 @@ docker rm -f slipway 2>/dev/null || true
 # Check if database needs initial table creation
 NEEDS_MIGRATION=$(docker run --rm \
     -v slipway-db:/app/db \
-    ghcr.io/sailscastshq/slipway:latest \
+    "$SLIPWAY_IMAGE" \
     node -e "try { const D = require('better-sqlite3'); const db = new D('/app/db/app.db'); const r = db.prepare(\"SELECT count(*) as c FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'\").get(); console.log(r.c > 0 ? 'no' : 'yes'); db.close(); } catch(e) { console.log('yes'); }" 2>/dev/null)
 
 if [ "$NEEDS_MIGRATION" = "yes" ]; then
     echo "Running database migration..."
     docker run --rm \
         -v slipway-db:/app/db \
-        ghcr.io/sailscastshq/slipway:latest \
+        "$SLIPWAY_IMAGE" \
         node -e "const sails = require('sails'); sails.lift({ port: 0 }, (err) => { if (err) { console.error(err); process.exit(1); } console.log('Migration complete'); sails.lower(() => process.exit(0)); })"
     echo -e "${GREEN}Database migrated${NC}"
 else
@@ -151,7 +172,7 @@ docker run -d \
     -e SLIPWAY_URL="$SLIPWAY_URL" \
     -e SESSION_SECRET="$SESSION_SECRET" \
     -e DATA_ENCRYPTION_KEY="$DATA_ENCRYPTION_KEY" \
-    ghcr.io/sailscastshq/slipway:latest
+    "$SLIPWAY_IMAGE"
 echo -e "${GREEN}Slipway dashboard running${NC}"
 
 # 9. Wait for startup

--- a/scripts/check-for-updates.js
+++ b/scripts/check-for-updates.js
@@ -18,7 +18,7 @@ module.exports = {
 
     if (result.updateAvailable) {
       sails.log.info(
-        `[slipway] Update available: ${result.currentVersion} → ${result.latestVersion}`
+        `[slipway] Update available: ${result.currentVersion} → ${result.latestVersion} (${result.imageRef})`
       )
     } else if (result.error) {
       sails.log.verbose(`[slipway] Update check: ${result.error}`)

--- a/tests/unit/helpers/system/apply-update.test.js
+++ b/tests/unit/helpers/system/apply-update.test.js
@@ -1,10 +1,7 @@
 const { test } = require('sounding')
 
-const applyUpdate = require('../../../../api/helpers/system/apply-update')
-
-const { buildRunArgs, hasMountDestination } = applyUpdate._private
-
-test('buildRunArgs injects the Slipway apps bind mount when it is missing', async ({
+test('buildUpdateDockerArgs injects the Slipway apps bind mount when it is missing', async ({
+  sails,
   expect
 }) => {
   const containerInfo = {
@@ -31,7 +28,8 @@ test('buildRunArgs injects the Slipway apps bind mount when it is missing', asyn
     }
   }
 
-  const args = buildRunArgs(containerInfo, {
+  const { runArgs } = await sails.helpers.system.buildUpdateDockerArgs.with({
+    containerInfo,
     extraMounts: [
       {
         type: 'bind',
@@ -41,17 +39,18 @@ test('buildRunArgs injects the Slipway apps bind mount when it is missing', asyn
     ]
   })
 
-  expect(args.includes('--network')).toBe(true)
-  expect(args.includes('slipway')).toBe(true)
-  expect(args.includes('-v')).toBe(true)
-  expect(args.includes('/app/db')).toBe(false)
-  expect(args.includes('slipway-db:/app/db')).toBe(true)
-  expect(args.includes('/var/slipway/apps:/var/slipway/apps')).toBe(true)
-  expect(args.includes('-p')).toBe(true)
-  expect(args.includes('1337:1337')).toBe(true)
+  expect(runArgs.includes('--network')).toBe(true)
+  expect(runArgs.includes('slipway')).toBe(true)
+  expect(runArgs.includes('-v')).toBe(true)
+  expect(runArgs.includes('/app/db')).toBe(false)
+  expect(runArgs.includes('slipway-db:/app/db')).toBe(true)
+  expect(runArgs.includes('/var/slipway/apps:/var/slipway/apps')).toBe(true)
+  expect(runArgs.includes('-p')).toBe(true)
+  expect(runArgs.includes('1337:1337')).toBe(true)
 })
 
-test('buildRunArgs does not duplicate the apps bind mount when it already exists', async ({
+test('buildUpdateDockerArgs does not duplicate the apps bind mount when it already exists', async ({
+  sails,
   expect
 }) => {
   const containerInfo = {
@@ -75,7 +74,8 @@ test('buildRunArgs does not duplicate the apps bind mount when it already exists
     }
   }
 
-  const args = buildRunArgs(containerInfo, {
+  const { runArgs } = await sails.helpers.system.buildUpdateDockerArgs.with({
+    containerInfo,
     extraMounts: [
       {
         type: 'bind',
@@ -86,8 +86,20 @@ test('buildRunArgs does not duplicate the apps bind mount when it already exists
   })
 
   expect(
-    args.filter((value) => value === '/var/slipway/apps:/var/slipway/apps')
+    runArgs.filter((value) => value === '/var/slipway/apps:/var/slipway/apps')
       .length
   ).toBe(1)
-  expect(hasMountDestination(containerInfo, '/var/slipway/apps')).toBe(true)
+})
+
+test('getUpdateImageRef pins updates to the advertised release version', async ({
+  sails,
+  expect
+}) => {
+  const imageRef = await sails.helpers.system.getUpdateImageRef.with({
+    updateInfo: { latestVersion: 'v0.0.50' },
+    imageRepository: 'ghcr.io/sailscastshq/slipway'
+  })
+
+  expect(imageRef).toBe('ghcr.io/sailscastshq/slipway:0.0.50')
+  expect(imageRef.includes(':latest')).toBe(false)
 })

--- a/tests/unit/helpers/system/install-config.test.js
+++ b/tests/unit/helpers/system/install-config.test.js
@@ -17,3 +17,20 @@ test('dashboard install excludes the published hook workspace', async ({
   expect(packageJson.devDependencies?.['sails-hook-slipway']).toBe(undefined)
   expect(npmrc.includes('workspaces=false')).toBe(true)
 })
+
+test('installer pulls and runs the resolved Slipway image ref', async ({
+  expect
+}) => {
+  const script = fs.readFileSync(path.join(appRoot, 'install.sh'), 'utf8')
+
+  expect(script.includes('SLIPWAY_VERSION="${SLIPWAY_VERSION:-${1:-}}"')).toBe(
+    true
+  )
+  expect(
+    script.includes(
+      'SLIPWAY_IMAGE="$SLIPWAY_IMAGE_REPOSITORY:$SLIPWAY_VERSION"'
+    )
+  ).toBe(true)
+  expect(script.includes('docker pull "$SLIPWAY_IMAGE"')).toBe(true)
+  expect(script.includes('ghcr.io/sailscastshq/slipway:latest')).toBe(false)
+})


### PR DESCRIPTION
## Summary
- pin self-update pulls and runs to the advertised release image ref
- let install.sh resolve or accept an explicit Slipway release tag before pulling
- expose update Docker arg/image-ref logic as Sails helpers so Sounding tests use sails.helpers
- update the UI/manual update copy to show the pinned install command

## Tests
- bash -n install.sh
- npm run test:unit
- npm run lint

Closes #181