### PR TITLE
Fix self-update rollback restoration

### DIFF
--- a/api/controllers/health/check.js
+++ b/api/controllers/health/check.js
@@ -10,6 +10,9 @@ module.exports = {
   },
 
   fn: async function () {
-    return { status: 'ok' }
+    return {
+      status: 'ok',
+      version: sails.config.slipway?.version || 'unknown'
+    }
   }
 }

--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -225,30 +225,12 @@ module.exports = {
       // 10. Spawn the bosun sidecar to perform the swap
       await setProgress(
         'swapping',
-        'Swapping containers — Slipway will restart momentarily'
+        'Swapping containers — previous version will be kept until the new one is healthy'
       )
 
-      const argsJson = JSON.stringify(runArgs)
-      const script =
-        'const{execFileSync}=require("child_process");' +
-        'setTimeout(()=>{' +
-        'try{' +
-        'console.log("Stopping old Slipway container...");' +
-        'execFileSync("docker",["rm","-f","slipway"]);' +
-        'console.log("Starting new Slipway container...");' +
-        'execFileSync("docker",' +
-        argsJson +
-        ');' +
-        'console.log("Update complete!");' +
-        '}catch(e){' +
-        'console.error("Update failed:",e.message);' +
-        'try{console.log("Attempting recovery...");' +
-        'execFileSync("docker",' +
-        argsJson +
-        ');}catch(e2){console.error("Recovery failed:",e2.message)}' +
-        'process.exit(1)' +
-        '}' +
-        '},3000)'
+      const script = await sails.helpers.system.buildUpdateSwapScript.with({
+        runArgs
+      })
 
       // Remove any leftover bosun container from a previous attempt
       try {

--- a/api/helpers/system/build-update-swap-script.js
+++ b/api/helpers/system/build-update-swap-script.js
@@ -1,0 +1,113 @@
+module.exports = {
+  friendlyName: 'Build update swap script',
+
+  description:
+    'Build the sidecar script that swaps Slipway containers with rollback.',
+
+  inputs: {
+    runArgs: {
+      type: 'ref',
+      required: true,
+      description: 'Docker run arguments for the new Slipway container.'
+    },
+    containerName: {
+      type: 'string',
+      defaultsTo: 'slipway'
+    },
+    backupContainerName: {
+      type: 'string',
+      defaultsTo: 'slipway-previous'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ runArgs, containerName, backupContainerName }) {
+    return `
+  const { execFileSync } = require("child_process")
+  const containerName = ${JSON.stringify(containerName)}
+  const backupName = ${JSON.stringify(backupContainerName)}
+  const runArgs = ${JSON.stringify(runArgs)}
+
+  function docker(args, options = {}) {
+    return execFileSync("docker", args, { stdio: "inherit", ...options })
+  }
+
+  function dockerQuiet(args) {
+    return execFileSync("docker", args, { stdio: "pipe" })
+  }
+
+  function tryDocker(args) {
+    try {
+      docker(args)
+      return true
+    } catch (error) {
+      console.error("Docker command failed:", args.join(" "), error.message)
+      return false
+    }
+  }
+
+  function sleep(ms) {
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
+  }
+
+  function waitForHealth() {
+    for (let attempt = 0; attempt < 30; attempt++) {
+      try {
+        dockerQuiet([
+          "exec",
+          containerName,
+          "curl",
+          "-fsS",
+          "http://localhost:1337/health"
+        ])
+        return
+      } catch {
+        sleep(2000)
+      }
+    }
+
+    throw new Error("New Slipway container did not pass health check")
+  }
+
+  function restorePrevious() {
+    console.log("Restoring previous Slipway container...")
+    tryDocker(["rm", "-f", containerName])
+    docker(["rename", backupName, containerName])
+    docker(["start", containerName])
+    console.log("Rollback complete; previous Slipway container restored.")
+  }
+
+  setTimeout(() => {
+    try {
+      console.log("Preparing rollback target...")
+      tryDocker(["rm", "-f", backupName])
+      docker(["rename", containerName, backupName])
+      docker(["stop", backupName])
+
+      console.log("Starting new Slipway container...")
+      docker(runArgs)
+
+      console.log("Health-checking new Slipway container...")
+      waitForHealth()
+
+      console.log("New Slipway container is healthy. Removing rollback target...")
+      tryDocker(["rm", "-f", backupName])
+      console.log("Update complete!")
+    } catch (error) {
+      console.error("Swap failed:", error.message)
+      try {
+        restorePrevious()
+      } catch (rollbackError) {
+        console.error("Rollback failed:", rollbackError.message)
+      }
+      process.exit(1)
+    }
+  }, 3000)
+`.trim()
+  }
+}

--- a/assets/js/components/UpdateModal.vue
+++ b/assets/js/components/UpdateModal.vue
@@ -16,6 +16,7 @@ const updating = ref(false)
 const updateError = ref(null)
 const updatePhase = ref('') // 'pulling', 'backing-up', 'validating', 'swapping', 'waiting', 'success'
 const updateDetail = ref('')
+const updateTargetVersion = ref(props.updateInfo.latestVersion || null)
 
 const {
   connected: sseConnected,
@@ -47,14 +48,15 @@ watch(sseConnected, (isConnected, wasConnected) => {
   ) {
     updatePhase.value = 'waiting'
     updateDetail.value = ''
-    waitForHealthy()
+    waitForHealthy(updateTargetVersion.value)
       .then(() => {
         updatePhase.value = 'success'
         updateDetail.value = ''
         setTimeout(() => window.location.reload(), 1500)
       })
-      .catch(() => {
-        updateError.value = 'Slipway did not come back up. Check your server.'
+      .catch((err) => {
+        updateError.value =
+          err.message || 'Slipway did not come back up. Check your server.'
         updating.value = false
         updatePhase.value = ''
       })
@@ -78,6 +80,9 @@ async function applyUpdate() {
       throw new Error(data.message || 'Failed to initiate update')
     }
 
+    const data = await response.json().catch(() => ({}))
+    updateTargetVersion.value =
+      data.targetVersion || props.updateInfo.latestVersion || null
     connectSSE()
   } catch (err) {
     updateError.value = err.message
@@ -86,15 +91,31 @@ async function applyUpdate() {
   }
 }
 
-async function waitForHealthy(maxAttempts = 30) {
+async function waitForHealthy(expectedVersion, maxAttempts = 30) {
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise((resolve) => setTimeout(resolve, 2000))
+    let res
     try {
-      const res = await fetch('/health')
-      if (res.ok) return
+      res = await fetch('/health')
     } catch {
-      // Still down — keep polling
+      // Still down — keep polling.
+      continue
     }
+
+    if (!res.ok) continue
+
+    const health = await res.json().catch(() => ({}))
+    if (!expectedVersion || health.version === expectedVersion) return
+
+    if (health.version) {
+      throw new Error(
+        `Slipway came back on v${health.version}, so the update likely rolled back before v${expectedVersion} finished.`
+      )
+    }
+
+    throw new Error(
+      `Slipway came back without version metadata, so v${expectedVersion} could not be confirmed.`
+    )
   }
   throw new Error('timeout')
 }

--- a/assets/js/pages/settings/update.vue
+++ b/assets/js/pages/settings/update.vue
@@ -26,6 +26,7 @@ const updatePhase = ref('')
 const updateDetail = ref('')
 const localUpdateInfo = ref(props.updateInfo)
 const lastChecked = ref(new Date())
+const updateTargetVersion = ref(props.updateInfo.latestVersion || null)
 
 const {
   connected: sseConnected,
@@ -57,14 +58,15 @@ watch(sseConnected, (isConnected, wasConnected) => {
   ) {
     updatePhase.value = 'waiting'
     updateDetail.value = ''
-    waitForHealthy()
+    waitForHealthy(updateTargetVersion.value)
       .then(() => {
         updatePhase.value = 'success'
         updateDetail.value = ''
         setTimeout(() => window.location.reload(), 1500)
       })
-      .catch(() => {
-        updateError.value = 'Slipway did not come back up. Check your server.'
+      .catch((err) => {
+        updateError.value =
+          err.message || 'Slipway did not come back up. Check your server.'
         updating.value = false
         updatePhase.value = ''
       })
@@ -103,6 +105,9 @@ async function applyUpdate() {
       throw new Error(data.message || 'Failed to initiate update')
     }
 
+    const data = await response.json().catch(() => ({}))
+    updateTargetVersion.value =
+      data.targetVersion || localUpdateInfo.value.latestVersion || null
     connectSSE()
   } catch (err) {
     updateError.value = err.message
@@ -111,15 +116,31 @@ async function applyUpdate() {
   }
 }
 
-async function waitForHealthy(maxAttempts = 30) {
+async function waitForHealthy(expectedVersion, maxAttempts = 30) {
   for (let i = 0; i < maxAttempts; i++) {
     await new Promise((resolve) => setTimeout(resolve, 2000))
+    let res
     try {
-      const res = await fetch('/health')
-      if (res.ok) return
+      res = await fetch('/health')
     } catch {
-      // Still down — keep polling
+      // Still down — keep polling.
+      continue
     }
+
+    if (!res.ok) continue
+
+    const health = await res.json().catch(() => ({}))
+    if (!expectedVersion || health.version === expectedVersion) return
+
+    if (health.version) {
+      throw new Error(
+        `Slipway came back on v${health.version}, so the update likely rolled back before v${expectedVersion} finished.`
+      )
+    }
+
+    throw new Error(
+      `Slipway came back without version metadata, so v${expectedVersion} could not be confirmed.`
+    )
   }
   throw new Error('timeout')
 }

--- a/tests/functional/api/health.test.js
+++ b/tests/functional/api/health.test.js
@@ -1,0 +1,13 @@
+const { test } = require('sounding')
+
+test('health check reports the running Slipway version', async ({
+  get,
+  sails,
+  expect
+}) => {
+  const response = await get('/health')
+
+  expect(response).toHaveStatus(200)
+  expect(response).toHaveJsonPath('status', 'ok')
+  expect(response).toHaveJsonPath('version', sails.config.slipway.version)
+})

--- a/tests/unit/helpers/capitalize.test.js
+++ b/tests/unit/helpers/capitalize.test.js
@@ -1,13 +1,13 @@
 const { test } = require('sounding')
 
-test('capitalize formats a single word for the UI', async ({
+test('display labels start a single word with a capital letter', async ({
   sails,
   expect
 }) => {
   expect(sails.helpers.capitalize('hello')).toBe('Hello')
 })
 
-test('capitalize formats hyphenated names for the UI', async ({
+test('display labels turn hyphenated names into readable words', async ({
   sails,
   expect
 }) => {

--- a/tests/unit/helpers/dock/get-models-static.test.js
+++ b/tests/unit/helpers/dock/get-models-static.test.js
@@ -4,7 +4,7 @@ const path = require('path')
 
 const { test } = require('sounding')
 
-test('static model parsing removes default timestamp attributes explicitly set to false', async ({
+test('model discovery omits default timestamp columns explicitly disabled by the app', async ({
   sails,
   expect
 }) => {
@@ -43,7 +43,7 @@ test('static model parsing removes default timestamp attributes explicitly set t
   })
 })
 
-test('static model parsing only treats top-level false attributes as disabled columns', async ({
+test('model discovery only treats top-level false attributes as disabled columns', async ({
   sails,
   expect
 }) => {
@@ -76,7 +76,7 @@ test('static model parsing only treats top-level false attributes as disabled co
   expect(models.profile.attributes.updatedAt).toBe(undefined)
 })
 
-test('static model parsing preserves configured snake_case timestamp and column names', async ({
+test('model discovery preserves configured snake_case timestamp and column names', async ({
   sails,
   expect
 }) => {

--- a/tests/unit/helpers/get-user-initials.test.js
+++ b/tests/unit/helpers/get-user-initials.test.js
@@ -1,13 +1,13 @@
 const { test } = require('sounding')
 
-test('getUserInitials derives initials from first and last name', async ({
+test('user initials use the first letters from a full name', async ({
   sails,
   expect
 }) => {
   expect(sails.helpers.getUserInitials('Kelvin Omereshone')).toBe('KO')
 })
 
-test('getUserInitials derives initials from a single name', async ({
+test('user initials use the first two letters when only one name is present', async ({
   sails,
   expect
 }) => {

--- a/tests/unit/helpers/lookout/get-disk-space.test.js
+++ b/tests/unit/helpers/lookout/get-disk-space.test.js
@@ -4,7 +4,7 @@ const getDiskSpace = require('../../../../api/helpers/lookout/get-disk-space')
 
 const { parseDiskSpaceOutput, formatBytes } = getDiskSpace._private
 
-test('disk space parser reads the root volume stats from df output', async ({
+test('disk usage reads the root volume stats from df output', async ({
   expect
 }) => {
   const disk =
@@ -19,9 +19,7 @@ test('disk space parser reads the root volume stats from df output', async ({
   expect(disk.total).toBe('39 GB')
 })
 
-test('disk space formatter keeps smaller byte values readable', async ({
-  expect
-}) => {
+test('disk usage keeps smaller byte values readable', async ({ expect }) => {
   expect(formatBytes(0)).toBe('0 B')
   expect(formatBytes(1536)).toBe('1.5 KB')
   expect(formatBytes(5 * 1024 * 1024)).toBe('5.0 MB')

--- a/tests/unit/helpers/mail/send-configured.test.js
+++ b/tests/unit/helpers/mail/send-configured.test.js
@@ -73,7 +73,9 @@ test('configured mail syncs UI SMTP settings before delegating', async ({
   }
 })
 
-test('app mail sends go through configured mail helper', async ({ expect }) => {
+test('outgoing app mail goes through the configured mail helper', async ({
+  expect
+}) => {
   const root = process.cwd()
   const apiDir = path.join(root, 'api')
   const configuredHelper = path.join(

--- a/tests/unit/helpers/system/apply-update.test.js
+++ b/tests/unit/helpers/system/apply-update.test.js
@@ -1,6 +1,8 @@
+const vm = require('node:vm')
+
 const { test } = require('sounding')
 
-test('buildUpdateDockerArgs injects the Slipway apps bind mount when it is missing', async ({
+test('self-update docker args include the persistent apps mount when it is missing', async ({
   sails,
   expect
 }) => {
@@ -49,7 +51,7 @@ test('buildUpdateDockerArgs injects the Slipway apps bind mount when it is missi
   expect(runArgs.includes('1337:1337')).toBe(true)
 })
 
-test('buildUpdateDockerArgs does not duplicate the apps bind mount when it already exists', async ({
+test('self-update docker args keep an existing apps mount without duplicating it', async ({
   sails,
   expect
 }) => {
@@ -91,7 +93,7 @@ test('buildUpdateDockerArgs does not duplicate the apps bind mount when it alrea
   ).toBe(1)
 })
 
-test('getUpdateImageRef pins updates to the advertised release version', async ({
+test('self-update image refs use the advertised release tag instead of latest', async ({
   sails,
   expect
 }) => {
@@ -102,4 +104,35 @@ test('getUpdateImageRef pins updates to the advertised release version', async (
 
   expect(imageRef).toBe('ghcr.io/sailscastshq/slipway:0.0.50')
   expect(imageRef.includes(':latest')).toBe(false)
+})
+
+test('self-update swap keeps the previous container available for rollback', async ({
+  sails,
+  expect
+}) => {
+  const targetImage = 'ghcr.io/sailscastshq/slipway:test-target'
+  const script = await sails.helpers.system.buildUpdateSwapScript.with({
+    runArgs: ['run', '-d', '--name', 'slipway', targetImage]
+  })
+
+  expect(script.includes(targetImage)).toBe(true)
+  expect(script.includes('docker(["rename", containerName, backupName])')).toBe(
+    true
+  )
+  expect(script.includes('docker(["stop", backupName])')).toBe(true)
+  expect(script.includes('tryDocker(["rm", "-f", containerName])')).toBe(true)
+  expect(script.includes('docker(["rename", backupName, containerName])')).toBe(
+    true
+  )
+  expect(script.includes('waitForHealth()')).toBe(true)
+  expect(script.includes('Rollback complete')).toBe(true)
+  expect((script.match(/docker\(runArgs\)/g) || []).length).toBe(1)
+
+  let syntaxError
+  try {
+    new vm.Script(script)
+  } catch (error) {
+    syntaxError = error
+  }
+  expect(syntaxError).toBe(undefined)
 })

--- a/tests/unit/helpers/system/local-script.test.js
+++ b/tests/unit/helpers/system/local-script.test.js
@@ -5,7 +5,7 @@ const { test } = require('sounding')
 
 const appRoot = path.resolve(__dirname, '../../../../')
 
-test('local installer is wired into package scripts with production-like Docker assumptions', async ({
+test('local dev scripts preserve production-like Docker assumptions', async ({
   expect
 }) => {
   const packageJson = JSON.parse(


### PR DESCRIPTION
## Summary

- keep the previous Slipway container as the rollback target during self-update swaps
- restore the previous container if the replacement fails its post-swap health check
- expose the running Slipway version from `/health` so the UI can tell an updated instance from a rollback-restored old one
- make the update UI treat `healthy but old version` as rollback instead of success
- clean up related helper test descriptions around the self-update flow

## Why

The old swap path removed the live container before proving the replacement could run on the production name and port. That made rollback unreliable, and the live SSE stream could disappear once the old app stopped. After restart, `/health` alone was not enough because a successful rollback also returns `200 OK`.

## Validation

- `node --test --test-concurrency=1 tests/functional/api/health.test.js`
- `npm run test:unit`
- `npm run test:functional`
- `npm run lint`
- `git diff --check`

Closes #180