### PR TITLE
Tighten app deployment health checks

### DIFF
--- a/api/controllers/api/v1/app/update-app.js
+++ b/api/controllers/api/v1/app/update-app.js
@@ -6,7 +6,7 @@ module.exports = {
   friendlyName: 'Update app',
 
   description:
-    'Update app settings (name, dockerfilePath, routePath, envVars, resourceLimits).',
+    'Update app settings (name, dockerfilePath, routePath, healthPath, envVars, resourceLimits).',
 
   inputs: {
     projectSlug: {
@@ -31,6 +31,9 @@ module.exports = {
       type: 'string',
       allowNull: true
     },
+    healthPath: {
+      type: 'string'
+    },
     envVars: {
       type: 'json'
     },
@@ -52,6 +55,7 @@ module.exports = {
     name,
     dockerfilePath,
     routePath,
+    healthPath,
     envVars,
     resourceLimits
   }) {
@@ -78,6 +82,7 @@ module.exports = {
     if (name !== undefined) updates.name = name
     if (dockerfilePath !== undefined) updates.dockerfilePath = dockerfilePath
     if (routePath !== undefined) updates.routePath = routePath
+    if (healthPath !== undefined) updates.healthPath = healthPath
     if (envVars !== undefined) updates.envVars = envVars
     if (resourceLimits !== undefined) {
       updates.resourceLimits = resourceLimits

--- a/api/controllers/api/v1/deploy/rollback-deployment.js
+++ b/api/controllers/api/v1/deploy/rollback-deployment.js
@@ -190,6 +190,10 @@ async function executeRollback(
       targetApp ||
       (await App.findOne({ environment: environment.id, isDefault: true })) ||
       (await App.findOne({ environment: environment.id }))
+    const healthPath = App.normalizeHealthPath(
+      (targetApp && targetApp.healthPath) ||
+        (existingApp && existingApp.healthPath)
+    )
 
     // 7. Run the container with the existing image
     const containerResult = await sails.helpers.docker.runContainer.with({
@@ -201,7 +205,16 @@ async function executeRollback(
       deploymentId: rollbackId
     })
 
-    // 8. Create or update the App record
+    // 8. HTTP health check before switching traffic to the rollback image
+    await sails.helpers.docker.healthCheck.with({
+      containerName: containerResult.containerName,
+      port: 1337,
+      hostPort: containerResult.hostPort,
+      path: healthPath,
+      deploymentId: rollbackId
+    })
+
+    // 9. Create or update the App record
     if (existingApp) {
       await App.updateOne({ id: existingApp.id }).set({
         status: 'running',
@@ -227,11 +240,12 @@ async function executeRollback(
         currentDeployment: rollbackId,
         slug: appSlugForName || 'app',
         name: appSlugForName || 'app',
+        healthPath,
         isDefault: true
       })
     }
 
-    // 9. Update Caddy reverse proxy route
+    // 10. Update Caddy reverse proxy route
     try {
       await sails.helpers.caddy.updateRoute(environment.id)
     } catch (caddyErr) {
@@ -244,7 +258,7 @@ async function executeRollback(
       )
     }
 
-    // 10. Mark previous running deployments as stopped (scoped to app)
+    // 11. Mark previous running deployments as stopped (scoped to app)
     const stopCriteria = {
       environment: environment.id,
       status: 'running',
@@ -253,7 +267,7 @@ async function executeRollback(
     if (existingApp) stopCriteria.app = existingApp.id
     await Deployment.update(stopCriteria).set({ status: 'stopped' })
 
-    // 11. Mark deployment as running
+    // 12. Mark deployment as running
     await Deployment.updateOne({ id: rollbackId }).set({
       status: 'running',
       finishedAt: Date.now()

--- a/api/controllers/project/create-app.js
+++ b/api/controllers/project/create-app.js
@@ -30,6 +30,11 @@ module.exports = {
       defaultsTo: '/',
       description: 'Caddy route path (/, /api, or null for workers)'
     },
+    healthPath: {
+      type: 'string',
+      defaultsTo: '/health',
+      description: 'HTTP path to probe before this app receives traffic'
+    },
     repoId: {
       type: 'string',
       description: 'GitHub repository ID to connect (optional)'
@@ -55,6 +60,7 @@ module.exports = {
     name,
     dockerfilePath,
     routePath,
+    healthPath,
     repoId,
     branch
   }) {
@@ -75,6 +81,7 @@ module.exports = {
         name,
         dockerfilePath,
         routePath,
+        healthPath,
         environment: environment.id,
         isDefault: false
       }).fetch()

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -160,6 +160,10 @@ module.exports = {
         targetApp ||
         (await App.findOne({ environment: environment.id, isDefault: true })) ||
         (await App.findOne({ environment: environment.id }))
+      const healthPath = App.normalizeHealthPath(
+        (targetApp && targetApp.healthPath) ||
+          (existingApp && existingApp.healthPath)
+      )
       const resourceLimits = (existingApp && existingApp.resourceLimits) || {
         cpus: '1',
         memory: '1.5g'
@@ -182,6 +186,7 @@ module.exports = {
         containerName: deployContainerName,
         port: 1337,
         hostPort: deployHostPort,
+        path: healthPath,
         deploymentId
       })
 
@@ -213,6 +218,7 @@ module.exports = {
           currentDeployment: deploymentId,
           slug: appSlug || 'app',
           name: appSlug || 'app',
+          healthPath,
           isDefault: true
         })
       }

--- a/api/helpers/docker/health-check.js
+++ b/api/helpers/docker/health-check.js
@@ -25,7 +25,7 @@ module.exports = {
     },
     path: {
       type: 'string',
-      defaultsTo: '/',
+      defaultsTo: '/health',
       description: 'HTTP path to check'
     },
     timeout: {
@@ -62,6 +62,7 @@ module.exports = {
     interval,
     deploymentId
   }) {
+    const healthPath = normalizePath(path)
     const startTime = Date.now()
     let lastError = null
     let attempts = 0
@@ -70,7 +71,7 @@ module.exports = {
     if (deploymentId) {
       await Deployment.appendDeployLog(
         deploymentId,
-        `Health check: polling http://${containerName}:${port}${path} (timeout: ${Math.round(
+        `Health check: polling http://${containerName}:${port}${healthPath} (timeout: ${Math.round(
           timeout / 1000
         )}s)\n`
       )
@@ -81,24 +82,25 @@ module.exports = {
 
       const checkHost = usingFallback ? 'localhost' : containerName
       const checkPort = usingFallback ? hostPort : port
+      const endpoint = `http://${checkHost}:${checkPort}${healthPath}`
 
       try {
-        const statusCode = await httpGet(checkHost, checkPort, path)
+        const statusCode = await httpGet(checkHost, checkPort, healthPath)
 
-        if (statusCode < 500) {
+        if (statusCode >= 200 && statusCode < 300) {
           sails.log.info(
-            `Health check passed on ${checkHost}:${checkPort} (HTTP ${statusCode}, attempt ${attempts})`
+            `Health check passed: ${endpoint} returned HTTP ${statusCode} (attempt ${attempts})`
           )
           if (deploymentId) {
             await Deployment.appendDeployLog(
               deploymentId,
-              `Health check passed (HTTP ${statusCode}, attempt ${attempts})\n`
+              `Health check passed: ${endpoint} returned HTTP ${statusCode} (attempt ${attempts})\n`
             )
           }
           return { statusCode, attempts }
         }
 
-        lastError = `HTTP ${statusCode}`
+        lastError = `${endpoint} returned HTTP ${statusCode}`
       } catch (err) {
         // If Docker DNS can't resolve the container name, fall back to localhost:hostPort
         // EAI_AGAIN is a transient DNS failure that also indicates Docker DNS is unavailable
@@ -158,4 +160,10 @@ function httpGet(hostname, port, path) {
       reject(new Error('Request timed out'))
     })
   })
+}
+
+function normalizePath(path) {
+  const normalized = String(path || '/health').trim()
+  if (!normalized) return '/health'
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
 }

--- a/api/models/App.js
+++ b/api/models/App.js
@@ -52,6 +52,13 @@ module.exports = {
       columnName: 'route_path'
     },
 
+    healthPath: {
+      type: 'string',
+      defaultsTo: '/health',
+      description: 'HTTP path probed before deployment traffic switches',
+      columnName: 'health_path'
+    },
+
     envVars: {
       type: 'json',
       defaultsTo: {},
@@ -148,6 +155,8 @@ module.exports = {
    * Enforce compound uniqueness (environment + slug) and auto-set isDefault.
    */
   beforeCreate: async function (values, proceed) {
+    values.healthPath = App.normalizeHealthPath(values.healthPath)
+
     // Auto-generate slug from name if name was provided but slug wasn't explicitly set
     if (
       values.name &&
@@ -190,6 +199,20 @@ module.exports = {
     }
 
     return proceed()
+  },
+
+  beforeUpdate: async function (values, proceed) {
+    if (values.healthPath !== undefined) {
+      values.healthPath = App.normalizeHealthPath(values.healthPath)
+    }
+
+    return proceed()
+  },
+
+  normalizeHealthPath: function (healthPath) {
+    const path = String(healthPath || '/health').trim()
+    if (!path) return '/health'
+    return path.startsWith('/') ? path : `/${path}`
   },
 
   /**

--- a/assets/js/pages/projects/app-settings.vue
+++ b/assets/js/pages/projects/app-settings.vue
@@ -34,6 +34,7 @@ const basePath = computed(
 // --- Form state ---
 const name = ref(props.app.name)
 const dockerfilePath = ref(props.app.dockerfilePath || 'Dockerfile')
+const healthPath = ref(props.app.healthPath || '/health')
 const routePath = ref(
   props.app.routePath === null ? 'none' : props.app.routePath || '/'
 )
@@ -46,6 +47,7 @@ const isDirty = computed(
   () =>
     name.value !== props.app.name ||
     dockerfilePath.value !== (props.app.dockerfilePath || 'Dockerfile') ||
+    healthPath.value !== (props.app.healthPath || '/health') ||
     routePath.value !==
       (props.app.routePath === null ? 'none' : props.app.routePath || '/') ||
     cpus.value !== (props.app.resourceLimits?.cpus || '1') ||
@@ -70,6 +72,7 @@ async function saveSettings({ restart = false } = {}) {
         body: JSON.stringify({
           name: name.value,
           dockerfilePath: dockerfilePath.value,
+          healthPath: healthPath.value,
           routePath: routePath.value === 'none' ? null : routePath.value,
           resourceLimits: { cpus: cpus.value, memory: memory.value }
         })
@@ -382,7 +385,8 @@ async function deleteApp() {
             {{ app.name }} settings
           </h1>
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Configure this app's Dockerfile, routing, and resource limits.
+            Configure this app's Dockerfile, readiness, routing, and resource
+            limits.
           </p>
         </div>
 
@@ -401,6 +405,25 @@ async function deleteApp() {
               type="text"
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
             />
+          </div>
+
+          <div>
+            <label
+              for="healthPath"
+              class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Health path
+            </label>
+            <input
+              id="healthPath"
+              v-model="healthPath"
+              type="text"
+              placeholder="/health"
+              class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            />
+            <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              Deployment waits for this path to return a 2xx response.
+            </p>
           </div>
 
           <div>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -56,6 +56,7 @@ const addAppOpen = ref(false)
 const createAppForm = useForm({
   name: '',
   dockerfilePath: 'Dockerfile',
+  healthPath: '/health',
   routePath: '/',
   repoId: null,
   branch: null
@@ -1524,6 +1525,12 @@ onBeforeUnmount(() => {
                       v-model="createAppForm.dockerfilePath"
                       placeholder="Dockerfile"
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:w-32"
+                      @keydown.enter="createApp"
+                    />
+                    <input
+                      v-model="createAppForm.healthPath"
+                      placeholder="/health"
+                      class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:w-28"
                       @keydown.enter="createApp"
                     />
                     <select

--- a/tests/unit/helpers/deploy/health-path.test.js
+++ b/tests/unit/helpers/deploy/health-path.test.js
@@ -1,0 +1,54 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const appRoot = path.resolve(__dirname, '../../../../')
+
+test('deploy pipeline probes the app readiness path before switching traffic', async ({
+  expect
+}) => {
+  const source = fs.readFileSync(
+    path.join(appRoot, 'api/helpers/deploy/execute-pipeline.js'),
+    'utf8'
+  )
+  const healthPathIndex = source.indexOf(
+    'const healthPath = App.normalizeHealthPath'
+  )
+  const healthCheckIndex = source.indexOf(
+    'await sails.helpers.docker.healthCheck.with({'
+  )
+  const appRecordIndex = source.indexOf('// 11. Update App record')
+  const routeIndex = source.indexOf('// 12. Update Caddy reverse proxy route')
+
+  expect(healthPathIndex > -1).toBe(true)
+  expect(source.includes('path: healthPath')).toBe(true)
+  expect(source.includes('healthPath,')).toBe(true)
+  expect(healthPathIndex < healthCheckIndex).toBe(true)
+  expect(healthCheckIndex < appRecordIndex).toBe(true)
+  expect(appRecordIndex < routeIndex).toBe(true)
+})
+
+test('rollback probes the app readiness path before switching traffic', async ({
+  expect
+}) => {
+  const source = fs.readFileSync(
+    path.join(appRoot, 'api/controllers/api/v1/deploy/rollback-deployment.js'),
+    'utf8'
+  )
+  const healthPathIndex = source.indexOf(
+    'const healthPath = App.normalizeHealthPath'
+  )
+  const healthCheckIndex = source.indexOf(
+    'await sails.helpers.docker.healthCheck.with({'
+  )
+  const appRecordIndex = source.indexOf('// 9. Create or update the App record')
+  const routeIndex = source.indexOf('// 10. Update Caddy reverse proxy route')
+
+  expect(healthPathIndex > -1).toBe(true)
+  expect(source.includes('path: healthPath')).toBe(true)
+  expect(source.includes('healthPath,')).toBe(true)
+  expect(healthPathIndex < healthCheckIndex).toBe(true)
+  expect(healthCheckIndex < appRecordIndex).toBe(true)
+  expect(appRecordIndex < routeIndex).toBe(true)
+})

--- a/tests/unit/helpers/docker/health-check.test.js
+++ b/tests/unit/helpers/docker/health-check.test.js
@@ -1,0 +1,110 @@
+const http = require('http')
+
+const { test } = require('sounding')
+
+test('docker health check passes when the configured path returns a 2xx response', async ({
+  sails,
+  expect
+}) => {
+  const deployLogs = []
+  const originalAppendDeployLog = Deployment.appendDeployLog
+  const server = http.createServer((req, res) => {
+    if (req.url === '/ready') {
+      res.writeHead(204)
+      res.end()
+      return
+    }
+
+    res.writeHead(404)
+    res.end()
+  })
+
+  Deployment.appendDeployLog = async (deploymentId, line) => {
+    deployLogs.push({ deploymentId, line })
+  }
+
+  try {
+    const port = await listen(server)
+
+    const result = await sails.helpers.docker.healthCheck.with({
+      containerName: '127.0.0.1',
+      port,
+      path: 'ready',
+      timeout: 300,
+      interval: 10,
+      deploymentId: 'deployment-1'
+    })
+
+    expect(result.statusCode).toBe(204)
+    expect(result.attempts).toBe(1)
+    expect(deployLogs).toEqual([
+      {
+        deploymentId: 'deployment-1',
+        line: `Health check: polling http://127.0.0.1:${port}/ready (timeout: 0s)\n`
+      },
+      {
+        deploymentId: 'deployment-1',
+        line: `Health check passed: http://127.0.0.1:${port}/ready returned HTTP 204 (attempt 1)\n`
+      }
+    ])
+  } finally {
+    Deployment.appendDeployLog = originalAppendDeployLog
+    await close(server)
+  }
+})
+
+test('docker health check rejects non-2xx responses from the configured path', async ({
+  sails,
+  expect
+}) => {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/login') {
+      res.writeHead(302, { Location: '/dashboard' })
+      res.end()
+      return
+    }
+
+    res.writeHead(404)
+    res.end()
+  })
+
+  try {
+    const port = await listen(server)
+    let error
+
+    try {
+      await sails.helpers.docker.healthCheck.with({
+        containerName: '127.0.0.1',
+        port,
+        path: '/login',
+        timeout: 80,
+        interval: 10
+      })
+    } catch (err) {
+      error = err
+    }
+
+    expect(error).toBeDefined()
+    expect(error.message).toMatch(
+      /127\.0\.0\.1:[0-9]+\/login returned HTTP 302/
+    )
+  } finally {
+    await close(server)
+  }
+})
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject)
+      resolve(server.address().port)
+    })
+  })
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()))
+  })
+}

--- a/tests/unit/models/app-health.test.js
+++ b/tests/unit/models/app-health.test.js
@@ -1,0 +1,11 @@
+const { test } = require('sounding')
+
+test('app health paths normalize to an absolute readiness route', async ({
+  expect
+}) => {
+  expect(App.normalizeHealthPath()).toBe('/health')
+  expect(App.normalizeHealthPath('')).toBe('/health')
+  expect(App.normalizeHealthPath('   ')).toBe('/health')
+  expect(App.normalizeHealthPath('ready')).toBe('/ready')
+  expect(App.normalizeHealthPath('/api/health')).toBe('/api/health')
+})


### PR DESCRIPTION
## Summary
- Add an app-level health path with `/health` as the normalized default.
- Probe that configured path during deploy and rollback before switching traffic.
- Treat only `2xx` responses as healthy and log the exact endpoint/status.
- Add focused Sounding coverage for path normalization, strict health checks, and deploy/rollback wiring.

## Why
Deployment readiness was too loose: the old check defaulted to `/` and accepted any response below `500`, so redirects or missing readiness endpoints could still pass.

## Validation
- `npm run test:unit`
- `npm run lint`
- `git diff --check`

Fixes #182