### PR TITLE
Reserve host ports before deployment

### DIFF
--- a/api/controllers/api/v1/deploy/rollback-deployment.js
+++ b/api/controllers/api/v1/deploy/rollback-deployment.js
@@ -137,6 +137,9 @@ async function executeRollback(
   environment,
   targetApp
 ) {
+  let hostPort = null
+  let hostPortReserved = false
+
   try {
     // 1. Set status to deploying (no build needed)
     await Deployment.updateOne({ id: rollbackId }).set({
@@ -164,7 +167,11 @@ async function executeRollback(
     )
 
     // 4. Allocate a host port
-    const hostPort = await sails.helpers.docker.allocatePort()
+    hostPort = await sails.helpers.docker.allocatePort.with({
+      ownerType: 'deployment',
+      ownerId: String(rollbackId)
+    })
+    hostPortReserved = true
 
     // 5. Get env vars (3-tier merge: global < environment < app)
     let globalEnvVars = {}
@@ -244,6 +251,8 @@ async function executeRollback(
         isDefault: true
       })
     }
+    await releaseDeployPort({ hostPort, deploymentId: rollbackId })
+    hostPortReserved = false
 
     // 10. Update Caddy reverse proxy route
     try {
@@ -306,6 +315,11 @@ async function executeRollback(
   } catch (err) {
     sails.log.error(`Rollback ${rollbackId} failed: ${err.message}`)
 
+    if (hostPortReserved && hostPort) {
+      await releaseDeployPort({ hostPort, deploymentId: rollbackId })
+      hostPortReserved = false
+    }
+
     const current = await Deployment.findOne({ id: rollbackId })
     if (current && current.status !== 'failed') {
       await Deployment.updateOne({ id: rollbackId }).set({
@@ -314,5 +328,19 @@ async function executeRollback(
         finishedAt: Date.now()
       })
     }
+  }
+}
+
+async function releaseDeployPort({ hostPort, deploymentId }) {
+  try {
+    await sails.helpers.docker.releasePort.with({
+      hostPort,
+      ownerType: 'deployment',
+      ownerId: String(deploymentId)
+    })
+  } catch (err) {
+    sails.log.warn(
+      `Could not release port reservation ${hostPort}: ${err.message || err}`
+    )
   }
 }

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -40,6 +40,7 @@ module.exports = {
   fn: async function ({ deploymentId, project, environment, app: appInput }) {
     let deployContainerName = null
     let deployHostPort = null
+    let deployHostPortReserved = false
 
     try {
       const deployment = await Deployment.findOne({ id: deploymentId })
@@ -121,7 +122,11 @@ module.exports = {
       })
 
       // 6. Allocate a host port
-      deployHostPort = await sails.helpers.docker.allocatePort()
+      deployHostPort = await sails.helpers.docker.allocatePort.with({
+        ownerType: 'deployment',
+        ownerId: String(deploymentId)
+      })
+      deployHostPortReserved = true
 
       // 7. 3-tier env var merge: global < environment < app-specific
       let globalEnvVars = {}
@@ -222,6 +227,8 @@ module.exports = {
           isDefault: true
         })
       }
+      await releaseDeployPort({ hostPort: deployHostPort, deploymentId })
+      deployHostPortReserved = false
 
       // 12. Update Caddy reverse proxy route — traffic now goes to new container
       try {
@@ -377,6 +384,11 @@ module.exports = {
         }
       }
 
+      if (deployHostPortReserved && deployHostPort) {
+        await releaseDeployPort({ hostPort: deployHostPort, deploymentId })
+        deployHostPortReserved = false
+      }
+
       // Mark deployment as failed (only if not already marked by build-image)
       const current = await Deployment.findOne({ id: deploymentId })
       if (current && current.status !== 'failed') {
@@ -404,5 +416,19 @@ module.exports = {
 
       throw err
     }
+  }
+}
+
+async function releaseDeployPort({ hostPort, deploymentId }) {
+  try {
+    await sails.helpers.docker.releasePort.with({
+      hostPort,
+      ownerType: 'deployment',
+      ownerId: String(deploymentId)
+    })
+  } catch (err) {
+    sails.log.warn(
+      `Could not release port reservation ${hostPort}: ${err.message || err}`
+    )
   }
 }

--- a/api/helpers/docker/allocate-port.js
+++ b/api/helpers/docker/allocate-port.js
@@ -1,9 +1,38 @@
+const net = require('node:net')
+
+const DEFAULT_RESERVATION_TTL = 15 * 60 * 1000
+
 module.exports = {
   friendlyName: 'Allocate port',
 
   description: 'Allocate an available port from the Slipway port range.',
 
-  inputs: {},
+  inputs: {
+    host: {
+      type: 'string',
+      description:
+        'Host interface the port will bind to. Defaults to the Slipway host bind address.'
+    },
+    ownerType: {
+      type: 'string',
+      description: 'Type of process reserving the port.'
+    },
+    ownerId: {
+      type: 'string',
+      description: 'ID of the process reserving the port.'
+    },
+    ttl: {
+      type: 'number',
+      defaultsTo: DEFAULT_RESERVATION_TTL,
+      description:
+        'How long the reservation can survive without being promoted or released.'
+    },
+    checkHost: {
+      type: 'boolean',
+      defaultsTo: true,
+      description: 'Whether to verify the port is available on the host.'
+    }
+  },
 
   exits: {
     success: {
@@ -15,8 +44,13 @@ module.exports = {
     }
   },
 
-  fn: async function () {
+  fn: async function ({ host, ownerType, ownerId, ttl, checkHost }) {
     const portRange = sails.config.custom.slipwayPortRange
+    const bindHost = normalizeHost(
+      host || sails.config.custom.slipwayPortHost || '0.0.0.0'
+    )
+
+    await releaseExpiredReservations()
 
     // Get ALL apps and filter in JS to avoid Waterline NULL query issues
     const allApps = await App.find().select(['hostPort'])
@@ -28,22 +62,107 @@ module.exports = {
       }
     }
 
+    const reservations = await PortReservation.find({ host: bindHost }).select([
+      'port'
+    ])
+    for (const reservation of reservations) {
+      usedPorts.add(Number(reservation.port))
+    }
+
     sails.log.debug(
-      `Port allocator: ${usedPorts.size} ports in use: ${[...usedPorts].join(
-        ', '
-      )}`
+      `Port allocator (${bindHost}): ${
+        usedPorts.size
+      } ports in use or reserved: ${[...usedPorts].join(', ')}`
     )
 
-    // Find first available port in range not already assigned
+    // Find first available port in range not already assigned or reserved.
     for (let port = portRange.start; port <= portRange.end; port++) {
       if (usedPorts.has(port)) {
         continue
       }
 
-      return port
+      if (checkHost && !(await isHostPortAvailable(bindHost, port))) {
+        sails.log.debug(
+          `Port allocator (${bindHost}): ${port} is already bound on host`
+        )
+        continue
+      }
+
+      const reserved = await reservePort({
+        host: bindHost,
+        port,
+        ownerType,
+        ownerId,
+        ttl
+      })
+      if (reserved) {
+        return port
+      }
+
+      usedPorts.add(port)
     }
 
     sails.log.error('No ports available in configured range')
     throw 'noPortsAvailable'
   }
+}
+
+async function releaseExpiredReservations() {
+  await PortReservation.destroy({
+    expiresAt: { '<': Date.now() }
+  })
+}
+
+async function reservePort({ host, port, ownerType, ownerId, ttl }) {
+  const key = reservationKey(host, port)
+
+  try {
+    await PortReservation.create({
+      reservationKey: key,
+      host,
+      port,
+      ownerType: ownerType || null,
+      ownerId: ownerId || null,
+      expiresAt: Date.now() + ttl
+    })
+    return true
+  } catch (err) {
+    if (isUniqueConflict(err)) {
+      return false
+    }
+
+    throw err
+  }
+}
+
+function isHostPortAvailable(host, port) {
+  return new Promise((resolve) => {
+    const server = net.createServer()
+
+    server.once('error', () => {
+      resolve(false)
+    })
+
+    server.listen({ host, port, exclusive: true }, () => {
+      server.close(() => resolve(true))
+    })
+  })
+}
+
+function isUniqueConflict(err) {
+  const code = err?.code || err?.raw?.code || err?.cause?.code
+
+  return (
+    code === 'E_UNIQUE' ||
+    code === 'SQLITE_CONSTRAINT' ||
+    /unique|constraint/i.test(err?.message || '')
+  )
+}
+
+function normalizeHost(host) {
+  return String(host || '0.0.0.0').trim() || '0.0.0.0'
+}
+
+function reservationKey(host, port) {
+  return `${normalizeHost(host)}:${port}`
 }

--- a/api/helpers/docker/release-port.js
+++ b/api/helpers/docker/release-port.js
@@ -1,0 +1,59 @@
+module.exports = {
+  friendlyName: 'Release port',
+
+  description: 'Release a Slipway host port reservation.',
+
+  inputs: {
+    hostPort: {
+      type: 'number',
+      required: true,
+      description: 'Host port to release.'
+    },
+    host: {
+      type: 'string',
+      description:
+        'Host interface the port was reserved on. Defaults to the Slipway host bind address.'
+    },
+    ownerType: {
+      type: 'string',
+      description: 'Type of process that reserved the port.'
+    },
+    ownerId: {
+      type: 'string',
+      description: 'ID of the process that reserved the port.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ hostPort, host, ownerType, ownerId }) {
+    const bindHost = normalizeHost(
+      host || sails.config.custom.slipwayPortHost || '0.0.0.0'
+    )
+    const criteria = {
+      reservationKey: `${bindHost}:${hostPort}`
+    }
+
+    if (ownerType) {
+      criteria.ownerType = ownerType
+    }
+
+    if (ownerId) {
+      criteria.ownerId = ownerId
+    }
+
+    const released = await PortReservation.destroy(criteria).fetch()
+
+    return {
+      released: released.length
+    }
+  }
+}
+
+function normalizeHost(host) {
+  return String(host || '0.0.0.0').trim() || '0.0.0.0'
+}

--- a/api/helpers/docker/run-container.js
+++ b/api/helpers/docker/run-container.js
@@ -28,6 +28,11 @@ module.exports = {
       required: true,
       description: 'Host port to map to'
     },
+    host: {
+      type: 'string',
+      description:
+        'Host interface to bind. Defaults to the Slipway host bind address.'
+    },
     envVars: {
       type: 'ref',
       defaultsTo: {},
@@ -63,6 +68,7 @@ module.exports = {
     containerName,
     port,
     hostPort,
+    host,
     envVars,
     network,
     deploymentId,
@@ -70,6 +76,9 @@ module.exports = {
   }) {
     const networkName =
       network || sails.config.custom.slipwayNetwork || 'slipway'
+    const bindHost = normalizeHost(
+      host || sails.config.custom.slipwayPortHost || '0.0.0.0'
+    )
 
     // Build docker run args array (no shell — safe from injection)
     const args = [
@@ -80,7 +89,7 @@ module.exports = {
       '--network',
       networkName,
       '-p',
-      hostPort + ':' + port
+      formatPortBinding(bindHost, hostPort, port)
     ]
 
     // Add environment variables
@@ -147,4 +156,14 @@ module.exports = {
       throw 'runFailed'
     }
   }
+}
+
+function normalizeHost(host) {
+  return String(host || '0.0.0.0').trim() || '0.0.0.0'
+}
+
+function formatPortBinding(host, hostPort, containerPort) {
+  return host === '0.0.0.0'
+    ? `${hostPort}:${containerPort}`
+    : `${host}:${hostPort}:${containerPort}`
 }

--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -32,6 +32,9 @@ module.exports = {
     const imageRepository = `ghcr.io/${githubRepo}`
     const CACHE_KEY = 'slipway_update_progress'
     const appsDir = sails.config.custom.slipwayAppsDir || '/var/slipway/apps'
+    const portHost = sails.config.custom.slipwayPortHost || '0.0.0.0'
+    let tempPort = null
+    let tempPortReserved = false
 
     async function setProgress(phase, detail) {
       await sails.cache.set(
@@ -122,7 +125,11 @@ module.exports = {
         'validating',
         'Starting temporary container for health check'
       )
-      const tempPort = await sails.helpers.docker.allocatePort()
+      tempPort = await sails.helpers.docker.allocatePort.with({
+        ownerType: 'system-update',
+        ownerId: 'slipway-next'
+      })
+      tempPortReserved = true
 
       // Build temp container args: same config but different name + temp port
       const tempArgs = ['run', '-d', '--name', 'slipway-next']
@@ -138,7 +145,7 @@ module.exports = {
       tempArgs.push(...dockerArgs.mountArgs)
 
       // Temp port binding (different from production port)
-      tempArgs.push('-p', `${tempPort}:1337`)
+      tempArgs.push('-p', formatPortBinding(portHost, tempPort, 1337))
 
       // Environment variables (same as original)
       for (const envVar of containerInfo.Config?.Env || []) {
@@ -194,6 +201,8 @@ module.exports = {
         } catch {
           /* ignore */
         }
+        await releaseTempPort(tempPort)
+        tempPortReserved = false
         await setProgress(
           'failed',
           'New version failed health check — update aborted, current version untouched'
@@ -209,6 +218,8 @@ module.exports = {
       } catch {
         /* ignore */
       }
+      await releaseTempPort(tempPort)
+      tempPortReserved = false
 
       // 9. Build final run args for the production container
       const runArgs = [
@@ -270,6 +281,11 @@ module.exports = {
         targetImage: pullTarget
       }
     } catch (err) {
+      if (tempPortReserved && tempPort) {
+        await releaseTempPort(tempPort)
+        tempPortReserved = false
+      }
+
       // Re-throw Sails exit signals
       if (typeof err === 'string') throw err
       await setProgress('failed', err.message)
@@ -278,10 +294,34 @@ module.exports = {
   }
 }
 
+async function releaseTempPort(hostPort) {
+  try {
+    await sails.helpers.docker.releasePort.with({
+      hostPort,
+      ownerType: 'system-update',
+      ownerId: 'slipway-next'
+    })
+  } catch (err) {
+    sails.log.warn(
+      `Could not release update port reservation ${hostPort}: ${
+        err.message || err
+      }`
+    )
+  }
+}
+
 function hasMountDestination(containerInfo, destination) {
   return (containerInfo?.Mounts || []).some(
     (mount) => mount.Destination === destination
   )
+}
+
+function formatPortBinding(host, hostPort, containerPort) {
+  const normalizedHost = String(host || '0.0.0.0').trim() || '0.0.0.0'
+
+  return normalizedHost === '0.0.0.0'
+    ? `${hostPort}:${containerPort}`
+    : `${normalizedHost}:${hostPort}:${containerPort}`
 }
 
 async function migrateAppsDirectoryToBindMount({

--- a/api/models/PortReservation.js
+++ b/api/models/PortReservation.js
@@ -1,0 +1,52 @@
+/**
+ * PortReservation.js
+ *
+ * Short-lived host port reservations for deployment and update flows.
+ */
+
+module.exports = {
+  tableName: 'port_reservations',
+
+  attributes: {
+    reservationKey: {
+      type: 'string',
+      required: true,
+      unique: true,
+      description: 'Unique host:port reservation key.',
+      columnName: 'reservation_key'
+    },
+
+    host: {
+      type: 'string',
+      required: true,
+      description: 'Host interface the port is reserved on.'
+    },
+
+    port: {
+      type: 'number',
+      required: true,
+      description: 'Reserved host port.'
+    },
+
+    ownerType: {
+      type: 'string',
+      allowNull: true,
+      description: 'Type of process that owns the reservation.',
+      columnName: 'owner_type'
+    },
+
+    ownerId: {
+      type: 'string',
+      allowNull: true,
+      description: 'ID of the process that owns the reservation.',
+      columnName: 'owner_id'
+    },
+
+    expiresAt: {
+      type: 'number',
+      allowNull: true,
+      description: 'Timestamp after which the reservation can be recycled.',
+      columnName: 'expires_at'
+    }
+  }
+}

--- a/config/custom.js
+++ b/config/custom.js
@@ -60,6 +60,9 @@ module.exports.custom = {
   // Port range for app containers (Slipway allocates from this range)
   slipwayPortRange: { start: 1338, end: 1500 },
 
+  // Host interface used when checking and reserving app container ports
+  slipwayPortHost: '0.0.0.0',
+
   // API version (used for building API URLs)
   apiVersion: 'v1',
 

--- a/tests/unit/helpers/docker/allocate-port.test.js
+++ b/tests/unit/helpers/docker/allocate-port.test.js
@@ -1,0 +1,164 @@
+const net = require('node:net')
+
+const { test } = require('sounding')
+
+test('docker port allocation reserves ports atomically for concurrent deploys', async ({
+  sails,
+  expect
+}) => {
+  const previousRange = sails.config.custom.slipwayPortRange
+  const previousHost = sails.config.custom.slipwayPortHost
+  const start = await findFreePortBlock(2)
+
+  sails.config.custom.slipwayPortRange = { start, end: start + 1 }
+  sails.config.custom.slipwayPortHost = '127.0.0.1'
+
+  try {
+    const ports = await Promise.all([
+      sails.helpers.docker.allocatePort.with({
+        ownerType: 'deployment',
+        ownerId: 'deployment-1'
+      }),
+      sails.helpers.docker.allocatePort.with({
+        ownerType: 'deployment',
+        ownerId: 'deployment-2'
+      })
+    ])
+
+    expect(new Set(ports).size).toBe(2)
+    expect(ports.sort()).toEqual([start, start + 1])
+
+    const reservations = await PortReservation.find({
+      host: '127.0.0.1'
+    }).sort('port ASC')
+
+    expect(reservations.map((reservation) => reservation.port)).toEqual([
+      start,
+      start + 1
+    ])
+  } finally {
+    await PortReservation.destroy({ host: '127.0.0.1' })
+    sails.config.custom.slipwayPortRange = previousRange
+    sails.config.custom.slipwayPortHost = previousHost
+  }
+})
+
+test('docker port allocation skips ports already bound on the host', async ({
+  sails,
+  expect
+}) => {
+  const previousRange = sails.config.custom.slipwayPortRange
+  const previousHost = sails.config.custom.slipwayPortHost
+  const start = await findFreePortBlock(2)
+  const server = net.createServer()
+
+  sails.config.custom.slipwayPortRange = { start, end: start + 1 }
+  sails.config.custom.slipwayPortHost = '127.0.0.1'
+
+  try {
+    await listen(server, start)
+
+    const port = await sails.helpers.docker.allocatePort.with({
+      ownerType: 'deployment',
+      ownerId: 'deployment-host-check'
+    })
+
+    expect(port).toBe(start + 1)
+  } finally {
+    await close(server)
+    await PortReservation.destroy({ host: '127.0.0.1' })
+    sails.config.custom.slipwayPortRange = previousRange
+    sails.config.custom.slipwayPortHost = previousHost
+  }
+})
+
+test('docker port reservations can be released and recycled after failure', async ({
+  sails,
+  expect
+}) => {
+  const previousRange = sails.config.custom.slipwayPortRange
+  const previousHost = sails.config.custom.slipwayPortHost
+  const start = await findFreePortBlock(1)
+
+  sails.config.custom.slipwayPortRange = { start, end: start }
+  sails.config.custom.slipwayPortHost = '127.0.0.1'
+
+  try {
+    const firstPort = await sails.helpers.docker.allocatePort.with({
+      ownerType: 'deployment',
+      ownerId: 'failed-deployment'
+    })
+
+    const release = await sails.helpers.docker.releasePort.with({
+      hostPort: firstPort,
+      ownerType: 'deployment',
+      ownerId: 'failed-deployment'
+    })
+
+    const secondPort = await sails.helpers.docker.allocatePort.with({
+      ownerType: 'deployment',
+      ownerId: 'retry-deployment'
+    })
+
+    expect(firstPort).toBe(start)
+    expect(release.released).toBe(1)
+    expect(secondPort).toBe(start)
+  } finally {
+    await PortReservation.destroy({ host: '127.0.0.1' })
+    sails.config.custom.slipwayPortRange = previousRange
+    sails.config.custom.slipwayPortHost = previousHost
+  }
+})
+
+async function findFreePortBlock(size) {
+  for (let start = 30000; start < 65000 - size; start++) {
+    let available = true
+
+    for (let offset = 0; offset < size; offset++) {
+      if (!(await canListen(start + offset))) {
+        available = false
+        break
+      }
+    }
+
+    if (available) {
+      return start
+    }
+  }
+
+  throw new Error(`Could not find ${size} available host ports`)
+}
+
+function canListen(port) {
+  const server = net.createServer()
+
+  return new Promise((resolve) => {
+    server.once('error', () => {
+      resolve(false)
+    })
+
+    server.listen({ host: '127.0.0.1', port, exclusive: true }, () => {
+      server.close(() => resolve(true))
+    })
+  })
+}
+
+function listen(server, port) {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen({ host: '127.0.0.1', port, exclusive: true }, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+}
+
+function close(server) {
+  if (!server.listening) {
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()))
+  })
+}


### PR DESCRIPTION
Closes #183

## Summary
- Adds atomic host:port reservations before deployment, rollback, and self-update validation.
- Makes Docker port bindings host-aware through the Slipway port host config.
- Adds focused tests for concurrent allocation, occupied host ports, and release/reuse behavior.

## Tests
- node --test --test-concurrency=1 tests/unit/helpers/docker/allocate-port.test.js
- npm run lint
- npm run test:unit
- npm run test:functional
- npm run test:e2e
- git diff --check
- npm run local:rebuild
- npm run local:status