### PR TITLE
Force production environment during self-update

### DIFF
--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -147,10 +147,7 @@ module.exports = {
       // Temp port binding (different from production port)
       tempArgs.push('-p', formatPortBinding(portHost, tempPort, 1337))
 
-      // Environment variables (same as original)
-      for (const envVar of containerInfo.Config?.Env || []) {
-        tempArgs.push('-e', envVar)
-      }
+      tempArgs.push(...dockerArgs.envArgs)
 
       tempArgs.push(pullTarget)
 

--- a/api/helpers/system/build-update-docker-args.js
+++ b/api/helpers/system/build-update-docker-args.js
@@ -45,9 +45,8 @@ module.exports = {
       }
     }
 
-    for (const envVar of containerInfo.Config?.Env || []) {
-      runArgs.push('-e', envVar)
-    }
+    const envArgs = buildEnvArgs(containerInfo.Config?.Env)
+    runArgs.push(...envArgs)
 
     for (const [key, value] of Object.entries(
       containerInfo.Config?.Labels || {}
@@ -61,8 +60,27 @@ module.exports = {
       runArgs.push('-l', `${key}=${value}`)
     }
 
-    return { runArgs, mountArgs }
+    return { runArgs, mountArgs, envArgs }
   }
+}
+
+function buildEnvArgs(envVars = []) {
+  const normalized = []
+
+  for (const envVar of envVars || []) {
+    const value = String(envVar)
+    const key = value.split('=')[0]
+
+    if (key === 'NODE_ENV') {
+      continue
+    }
+
+    normalized.push(value)
+  }
+
+  normalized.push('NODE_ENV=production')
+
+  return normalized.flatMap((envVar) => ['-e', envVar])
 }
 
 function appendMountArgs(args, mounts = [], extraMounts = []) {

--- a/tests/unit/helpers/system/apply-update.test.js
+++ b/tests/unit/helpers/system/apply-update.test.js
@@ -93,6 +93,31 @@ test('self-update docker args keep an existing apps mount without duplicating it
   ).toBe(1)
 })
 
+test('self-update docker args force production node environment', async ({
+  sails,
+  expect
+}) => {
+  const { runArgs, envArgs } =
+    await sails.helpers.system.buildUpdateDockerArgs.with({
+      containerInfo: {
+        Mounts: [],
+        NetworkSettings: { Networks: {} },
+        HostConfig: { PortBindings: {} },
+        Config: {
+          Env: ['NODE_ENV=development', 'PORT=1337', 'SLIPWAY_URL=https://x'],
+          Labels: {}
+        }
+      }
+    })
+
+  expect(envArgs.includes('NODE_ENV=development')).toBe(false)
+  expect(envArgs.includes('NODE_ENV=production')).toBe(true)
+  expect(runArgs.includes('NODE_ENV=development')).toBe(false)
+  expect(runArgs.includes('NODE_ENV=production')).toBe(true)
+  expect(runArgs.includes('PORT=1337')).toBe(true)
+  expect(runArgs.includes('SLIPWAY_URL=https://x')).toBe(true)
+})
+
 test('self-update image refs use the advertised release tag instead of latest', async ({
   sails,
   expect


### PR DESCRIPTION
Closes #199

## Summary
- Normalizes the environment reused by Slipway self-update containers so `NODE_ENV` is always `production`.
- Reuses the same normalized env args for the validation container and the final swap container.
- Adds a regression test for a current container that was accidentally running with `NODE_ENV=development`.

## Root Cause
The live instance was serving development-style Shipwright assets such as `/js/lib-vue.js` instead of hashed production assets. That means the Slipway container was running outside production mode. The existing self-update flow copied `containerInfo.Config.Env` from the old container exactly, so a bad `NODE_ENV` value could persist across updates.

This keeps the app-level Shipwright config aligned with African Engineer, Hagfish, and Tembo AI. The fix belongs in Slipway self-update, not in every Vue app build config.

## Production Repair Note
For the currently broken `slipway.sailscasts.com` instance, rerun the install script over SSH pinned to the current release so Docker starts the dashboard with `NODE_ENV=production`:

```bash
curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh | bash -s -- 0.0.49
```

## Tests
- `node --test --test-concurrency=1 tests/unit/helpers/system/apply-update.test.js`
- `npm run test:unit`
- `npm run lint`
- `NODE_ENV=production node scripts/build-e2e-assets.js`
- `rg -n "process\\.env\\.NODE_ENV|process\\.env" .tmp/public/js -g "*.js"` returned no matches after the production build
