### PR TITLE
Correct deployment history ordering without changing its UI

### DIFF
--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -19,6 +19,15 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'App slug'
+    },
+    deploymentStatus: {
+      type: 'string'
+    },
+    deploymentSource: {
+      type: 'string'
+    },
+    deploymentCursor: {
+      type: 'string'
     }
   },
 
@@ -31,7 +40,14 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug, appSlug }) {
+  fn: async function ({
+    slug,
+    envSlug,
+    appSlug,
+    deploymentStatus,
+    deploymentSource,
+    deploymentCursor
+  }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -80,26 +96,22 @@ module.exports = {
         ? `http://${serverIp}:${app.hostPort}`
         : null
 
-    // Fetch deployments filtered to this app (include legacy deployments without app for default app)
-    let deployments
-    if (app.isDefault) {
-      deployments = await Deployment.find({
-        or: [
-          { environment: environment.id, app: app.id },
-          { environment: environment.id, app: null }
-        ]
-      })
-        .limit(20)
-        .populate('triggeredBy')
-    } else {
-      deployments = await Deployment.find({
-        environment: environment.id,
-        app: app.id
-      })
-        .limit(20)
-        .populate('triggeredBy')
-    }
-    deployments.sort((a, b) => b.id - a.id)
+    const appWithHealth = { ...app, containerHealth }
+    const deploymentHistory = await sails.helpers.deployment.getHistory.with({
+      projectSlug: project.slug,
+      environments: [environment],
+      apps: [appWithHealth],
+      currentApps: [appWithHealth],
+      scopedApp: appWithHealth,
+      includeLegacy: app.isDefault,
+      filters: {
+        status: deploymentStatus,
+        environment: '',
+        app: '',
+        source: deploymentSource
+      },
+      cursor: deploymentCursor || null
+    })
 
     // Enrich services with connection URLs and last backup
     const services = await Promise.all(
@@ -170,7 +182,7 @@ module.exports = {
         app: { ...app, containerHealth, directUrl },
         appEnvVars: decryptedApp.envVars || {},
         inheritedVars,
-        deployments,
+        deploymentHistory,
         services,
         backupConfigured,
         checklist,

--- a/api/controllers/project/view-environment.js
+++ b/api/controllers/project/view-environment.js
@@ -14,6 +14,18 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'Environment slug'
+    },
+    deploymentStatus: {
+      type: 'string'
+    },
+    deploymentApp: {
+      type: 'string'
+    },
+    deploymentSource: {
+      type: 'string'
+    },
+    deploymentCursor: {
+      type: 'string'
     }
   },
 
@@ -26,7 +38,14 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug }) {
+  fn: async function ({
+    slug,
+    envSlug,
+    deploymentStatus,
+    deploymentApp,
+    deploymentSource,
+    deploymentCursor
+  }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -42,7 +61,6 @@ module.exports = {
       project: project.id
     })
       .populate('services')
-      .populate('deployments')
       .decrypt()
 
     if (!environment) {
@@ -122,39 +140,19 @@ module.exports = {
     // Update default app reference after potential status changes
     app = appsWithHealth.find((a) => a.isDefault) || appsWithHealth[0] || null
 
-    // Fix stale running deployments
-    const runningAppDeploymentIds = appsWithHealth
-      .filter((a) => a.containerExists && a.currentDeployment)
-      .map((a) => a.currentDeployment)
-
-    if (runningAppDeploymentIds.length === 0) {
-      await Deployment.update({
-        environment: environment.id,
-        status: 'running'
-      }).set({ status: 'stopped' })
-    } else {
-      await Deployment.update({
-        environment: environment.id,
-        status: 'running',
-        id: { '!=': runningAppDeploymentIds }
-      }).set({ status: 'stopped' })
-    }
-
-    // Get deployments sorted by most recent first
-    const deployments = await Deployment.find({ environment: environment.id })
-      .limit(20)
-      .populate('triggeredBy')
-      .populate('app')
-
-    // Sort by id descending (newest first) - explicit JS sort for reliability
-    deployments.sort((a, b) => b.id - a.id)
-
-    // Backfill app name for legacy deployments (created before multi-app)
-    for (const dep of deployments) {
-      if (!dep.app && app) {
-        dep.app = { id: app.id, name: app.name, slug: app.slug }
-      }
-    }
+    const deploymentHistory = await sails.helpers.deployment.getHistory.with({
+      projectSlug: project.slug,
+      environments: [environment],
+      apps: appsWithHealth,
+      currentApps: appsWithHealth,
+      filters: {
+        status: deploymentStatus,
+        environment: '',
+        app: deploymentApp,
+        source: deploymentSource
+      },
+      cursor: deploymentCursor || null
+    })
 
     // Generate deployment checklist
     const checklist = await sails.helpers.environment.generateChecklist(
@@ -193,7 +191,7 @@ module.exports = {
         app: app || null,
         apps: appsWithHealth,
         envVars: environment.envVars || {},
-        deployments,
+        deploymentHistory,
         checklist,
         backupConfigured,
         githubConnected,

--- a/api/controllers/project/view-project.js
+++ b/api/controllers/project/view-project.js
@@ -8,6 +8,21 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'Project slug'
+    },
+    deploymentStatus: {
+      type: 'string'
+    },
+    deploymentEnvironment: {
+      type: 'string'
+    },
+    deploymentApp: {
+      type: 'string'
+    },
+    deploymentSource: {
+      type: 'string'
+    },
+    deploymentCursor: {
+      type: 'string'
     }
   },
 
@@ -20,7 +35,14 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug }) {
+  fn: async function ({
+    slug,
+    deploymentStatus,
+    deploymentEnvironment,
+    deploymentApp,
+    deploymentSource,
+    deploymentCursor
+  }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -34,32 +56,17 @@ module.exports = {
       throw { notFound: '/' }
     }
 
-    // For each environment, get app status and recent deployments
+    const allApps = await App.find({
+      environment: project.environments.map((environment) => environment.id)
+    })
+
+    // Enrich each environment with its apps and resolved domain.
     const environments = await Promise.all(
       project.environments.map(async (env) => {
-        const apps = await App.find({ environment: env.id })
+        const apps = allApps.filter(
+          (candidate) => candidate.environment === env.id
+        )
         const app = apps.find((a) => a.isDefault) || apps[0] || null
-
-        // Fix stale running deployments
-        if (app && app.currentDeployment) {
-          await Deployment.update({
-            environment: env.id,
-            status: 'running',
-            id: { '!=': app.currentDeployment }
-          }).set({ status: 'stopped' })
-        }
-
-        const deployments = await Deployment.find({ environment: env.id })
-          .sort('id DESC')
-          .limit(5)
-          .populate('triggeredBy')
-
-        // Running deployment always first
-        deployments.sort((a, b) => {
-          if (a.status === 'running' && b.status !== 'running') return -1
-          if (a.status !== 'running' && b.status === 'running') return 1
-          return 0
-        })
 
         const fullDomain = await Environment.getFullDomain(env.id)
 
@@ -67,71 +74,38 @@ module.exports = {
           ...env,
           app: app || null,
           apps,
-          deployments,
           fullDomain
         }
       })
     )
 
-    // Get recent deployments across all environments
-    // First get any running/building/deploying deployments to ensure they're included
-    const activeDeployments = await Deployment.find({
-      environment: project.environments.map((e) => e.id),
-      status: ['running', 'building', 'deploying']
+    const productionEnvironmentIds = new Set(
+      project.environments
+        .filter((environment) => environment.isProduction)
+        .map((environment) => environment.id)
+    )
+    const deploymentHistory = await sails.helpers.deployment.getHistory.with({
+      projectSlug: project.slug,
+      environments: project.environments,
+      apps: allApps,
+      currentApps: allApps.filter((app) =>
+        productionEnvironmentIds.has(app.environment)
+      ),
+      filters: {
+        status: deploymentStatus,
+        environment: deploymentEnvironment,
+        app: deploymentApp,
+        source: deploymentSource
+      },
+      cursor: deploymentCursor || null
     })
-      .populate('triggeredBy')
-      .populate('environment')
-      .populate('app')
-
-    // Then get recent deployments by date
-    const latestDeployments = await Deployment.find({
-      environment: project.environments.map((e) => e.id)
-    })
-      .sort('createdAt DESC')
-      .limit(10)
-      .populate('triggeredBy')
-      .populate('environment')
-      .populate('app')
-
-    // Merge and dedupe, prioritizing active deployments
-    const seenIds = new Set()
-    const recentDeployments = []
-
-    // Add active deployments first
-    for (const dep of activeDeployments) {
-      if (!seenIds.has(dep.id)) {
-        seenIds.add(dep.id)
-        recentDeployments.push(dep)
-      }
-    }
-
-    // Add latest deployments (sorted by date, newest first)
-    for (const dep of latestDeployments) {
-      if (!seenIds.has(dep.id)) {
-        seenIds.add(dep.id)
-        recentDeployments.push(dep)
-      }
-    }
-
-    // Keep only top 5
-    recentDeployments.splice(5)
-
-    // Backfill app name for legacy deployments (created before multi-app)
-    for (const dep of recentDeployments) {
-      if (!dep.app && dep.environment) {
-        const env = environments.find((e) => e.id === dep.environment.id)
-        if (env && env.app) {
-          dep.app = { id: env.app.id, name: env.app.name, slug: env.app.slug }
-        }
-      }
-    }
 
     return {
       page: 'projects/show',
       props: {
         project,
         environments,
-        recentDeployments
+        deploymentHistory
       }
     }
   }

--- a/api/helpers/deployment/get-history.js
+++ b/api/helpers/deployment/get-history.js
@@ -1,0 +1,399 @@
+const ACTIVE_STATUSES = ['pending', 'building', 'pushing', 'deploying']
+const SUCCESS_STATUSES = ['running', 'stopped']
+const VALID_STATUS_FILTERS = [
+  'all',
+  'in-progress',
+  'succeeded',
+  'failed',
+  'cancelled'
+]
+const VALID_SOURCES = ['manual', 'cli', 'webhook', 'api']
+
+function encodeCursor(deployment) {
+  return Buffer.from(
+    JSON.stringify({ createdAt: deployment.createdAt, id: deployment.id })
+  ).toString('base64url')
+}
+
+function decodeCursor(cursor) {
+  if (!cursor) return null
+
+  try {
+    const parsed = JSON.parse(Buffer.from(cursor, 'base64url').toString())
+    if (
+      !Number.isFinite(parsed.createdAt) ||
+      !Number.isFinite(Number(parsed.id))
+    ) {
+      return null
+    }
+    return { createdAt: parsed.createdAt, id: Number(parsed.id) }
+  } catch {
+    return null
+  }
+}
+
+function outcomeFor(deployment, isCurrent) {
+  if (isCurrent) return { key: 'current', label: 'Current' }
+
+  const activeLabels = {
+    pending: 'Queued',
+    building: 'Building',
+    pushing: 'Publishing',
+    deploying: 'Deploying'
+  }
+
+  if (activeLabels[deployment.status]) {
+    return { key: 'in-progress', label: activeLabels[deployment.status] }
+  }
+  if (SUCCESS_STATUSES.includes(deployment.status)) {
+    return { key: 'succeeded', label: 'Succeeded' }
+  }
+  if (deployment.status === 'failed') {
+    return { key: 'failed', label: 'Failed' }
+  }
+  if (deployment.status === 'cancelled') {
+    return { key: 'cancelled', label: 'Cancelled' }
+  }
+
+  return { key: 'neutral', label: deployment.status }
+}
+
+function titleFor(deployment) {
+  if (deployment.gitMessage) return deployment.gitMessage
+  if (deployment.triggerType === 'webhook') return 'Git deployment'
+  if (deployment.triggerType === 'cli') return 'Pushed source deployment'
+  if (deployment.triggerType === 'api') return 'API deployment'
+  return 'Manual deployment'
+}
+
+function sourceLabel(triggerType) {
+  return {
+    webhook: 'Git',
+    cli: 'CLI',
+    api: 'API',
+    manual: 'Manual'
+  }[triggerType]
+}
+
+function serializeDeployment({
+  deployment,
+  currentDeploymentIds,
+  defaultAppByEnvironment,
+  appById,
+  environmentById,
+  projectSlug
+}) {
+  const environmentId = Number(
+    deployment.environment?.id || deployment.environment
+  )
+  const appId = Number(deployment.app?.id || deployment.app)
+  const environment =
+    (deployment.environment?.id && deployment.environment) ||
+    environmentById.get(environmentId) ||
+    null
+  const app =
+    (deployment.app?.id && deployment.app) ||
+    appById.get(appId) ||
+    defaultAppByEnvironment.get(environmentId) ||
+    null
+  const isCurrent = currentDeploymentIds.has(Number(deployment.id))
+  const outcome = outcomeFor(deployment, isCurrent)
+  const duration = Deployment.getDuration(deployment)
+
+  return {
+    id: deployment.id,
+    title: titleFor(deployment),
+    status: deployment.status,
+    outcome: outcome.key,
+    outcomeLabel: outcome.label,
+    isCurrent,
+    isActive: ACTIVE_STATUSES.includes(deployment.status),
+    gitCommit: deployment.gitCommit,
+    gitBranch: deployment.gitBranch,
+    source: deployment.triggerType,
+    sourceLabel: sourceLabel(deployment.triggerType) || 'System',
+    actor:
+      deployment.triggeredBy?.fullName ||
+      (deployment.triggerType === 'webhook' ? 'Git' : 'System'),
+    duration,
+    createdAt: deployment.createdAt,
+    deployedAt: deployment.finishedAt || deployment.createdAt,
+    startedAt: deployment.startedAt,
+    finishedAt: deployment.finishedAt,
+    environment: environment
+      ? { id: environment.id, name: environment.name, slug: environment.slug }
+      : null,
+    app: app ? { id: app.id, name: app.name, slug: app.slug } : null,
+    href: `/projects/${projectSlug}/deployments/${deployment.id}`
+  }
+}
+
+function normalizeFilters({ filters, environments, apps }) {
+  const status = VALID_STATUS_FILTERS.includes(filters.status)
+    ? filters.status
+    : 'all'
+  const environment = environments.find(
+    (item) => item.slug === filters.environment
+  )
+  const app = apps.find((item) => String(item.id) === String(filters.app))
+  const source = VALID_SOURCES.includes(filters.source) ? filters.source : ''
+
+  return {
+    status,
+    environment: environment?.slug || '',
+    app: app ? String(app.id) : '',
+    source,
+    environmentRecord: environment || null,
+    appRecord: app || null
+  }
+}
+
+function statusCriteria(status) {
+  if (status === 'in-progress') return ACTIVE_STATUSES
+  if (status === 'succeeded') return SUCCESS_STATUSES
+  if (status === 'failed') return ['failed']
+  if (status === 'cancelled') return ['cancelled']
+  return null
+}
+
+function buildScopeClause({ environmentIds, scopedApp, includeLegacy }) {
+  if (!scopedApp) return { environment: environmentIds }
+  if (!includeLegacy) return { app: scopedApp.id }
+
+  return {
+    or: [
+      { app: scopedApp.id },
+      { app: null, environment: scopedApp.environment }
+    ]
+  }
+}
+
+module.exports = {
+  friendlyName: 'Get deployment history',
+
+  description:
+    'Return current releases, active work, and a deterministic cursor page of deployment history.',
+
+  inputs: {
+    projectSlug: { type: 'string', required: true },
+    environments: { type: 'ref', required: true },
+    apps: { type: 'ref', required: true },
+    currentApps: { type: 'ref', required: true },
+    scopedApp: { type: 'ref' },
+    includeLegacy: { type: 'boolean', defaultsTo: false },
+    filters: { type: 'ref', required: true },
+    cursor: { type: 'string', allowNull: true },
+    limit: { type: 'number', defaultsTo: 25, max: 50 }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: async function ({
+    projectSlug,
+    environments,
+    apps,
+    currentApps,
+    scopedApp,
+    includeLegacy,
+    filters,
+    cursor,
+    limit
+  }) {
+    const environmentIds = environments.map((item) => item.id)
+    const normalized = normalizeFilters({ filters, environments, apps })
+    const currentDeploymentIds = new Set(
+      currentApps
+        .map((app) => app.currentDeployment)
+        .filter(Boolean)
+        .map(Number)
+        .filter((id) => Number.isFinite(id))
+    )
+    const environmentById = new Map(
+      environments.map((item) => [Number(item.id), item])
+    )
+    const appById = new Map(apps.map((item) => [Number(item.id), item]))
+    const defaultAppByEnvironment = new Map(
+      apps
+        .filter((item) => item.isDefault)
+        .map((item) => [Number(item.environment), item])
+    )
+    const serialize = (deployment) =>
+      serializeDeployment({
+        deployment,
+        currentDeploymentIds,
+        defaultAppByEnvironment,
+        appById,
+        environmentById,
+        projectSlug
+      })
+
+    if (environmentIds.length === 0) {
+      return {
+        currentReleases: [],
+        activeDeployments: [],
+        items: [],
+        nextCursor: null,
+        filters: {
+          status: normalized.status,
+          environment: '',
+          app: '',
+          source: ''
+        },
+        options: { environments: [], apps: [], sources: [] }
+      }
+    }
+
+    const baseScope = buildScopeClause({
+      environmentIds,
+      scopedApp,
+      includeLegacy
+    })
+    const historyClauses = [baseScope]
+    const rawStatuses = statusCriteria(normalized.status)
+
+    if (normalized.environmentRecord) {
+      historyClauses.push({ environment: normalized.environmentRecord.id })
+    }
+    if (normalized.appRecord) {
+      historyClauses.push(
+        buildScopeClause({
+          environmentIds,
+          scopedApp: normalized.appRecord,
+          includeLegacy: normalized.appRecord.isDefault
+        })
+      )
+    }
+    if (rawStatuses) historyClauses.push({ status: rawStatuses })
+    if (normalized.source)
+      historyClauses.push({ triggerType: normalized.source })
+
+    const decodedCursor = decodeCursor(cursor)
+    if (decodedCursor) {
+      historyClauses.push({
+        or: [
+          { createdAt: { '<': decodedCursor.createdAt } },
+          {
+            createdAt: decodedCursor.createdAt,
+            id: { '<': decodedCursor.id }
+          }
+        ]
+      })
+    }
+
+    const historyRecords = await Deployment.find({ and: historyClauses })
+      .sort(['createdAt DESC', 'id DESC'])
+      .limit(limit + 1)
+
+    const hasMore = historyRecords.length > limit
+    const pageRecords = historyRecords.slice(0, limit)
+
+    const activeRecords = await Deployment.find({
+      and: [baseScope, { status: ACTIVE_STATUSES }]
+    })
+      .sort(['createdAt DESC', 'id DESC'])
+      .limit(20)
+
+    const currentIds = [...currentDeploymentIds]
+    const currentRecords = currentIds.length
+      ? await Deployment.find({ id: currentIds }).sort([
+          'createdAt DESC',
+          'id DESC'
+        ])
+      : []
+
+    // Enrich after the ordered, limited query so adapter joins cannot alter
+    // the ORDER BY direction or move LIMIT ahead of it.
+    const actorIds = [
+      ...new Set(
+        [...pageRecords, ...activeRecords, ...currentRecords]
+          .map((record) => record.triggeredBy)
+          .filter(Boolean)
+          .map(Number)
+          .filter((id) => Number.isFinite(id))
+      )
+    ]
+    const actors = actorIds.length ? await User.find({ id: actorIds }) : []
+    const actorById = new Map(actors.map((actor) => [Number(actor.id), actor]))
+    const withActor = (record) => ({
+      ...record,
+      triggeredBy: actorById.get(Number(record.triggeredBy)) || null
+    })
+
+    const currentAppByDeployment = new Map(
+      currentApps
+        .filter((app) => app.currentDeployment)
+        .map((app) => [Number(app.currentDeployment), app])
+    )
+    const currentReleases = currentRecords.map((record) => {
+      const serialized = serialize(withActor(record))
+      const currentApp = currentAppByDeployment.get(Number(record.id))
+      return {
+        ...serialized,
+        health:
+          currentApp?.containerHealth === 'unhealthy'
+            ? 'Unhealthy'
+            : currentApp?.status === 'running'
+            ? 'Healthy'
+            : currentApp?.status
+            ? currentApp.status[0].toUpperCase() + currentApp.status.slice(1)
+            : 'Unknown',
+        appHref:
+          serialized.environment && serialized.app
+            ? `/projects/${projectSlug}/environments/${serialized.environment.slug}/apps/${serialized.app.slug}`
+            : null
+      }
+    })
+
+    return {
+      currentReleases,
+      activeDeployments: activeRecords.map((record) =>
+        serialize(withActor(record))
+      ),
+      items: pageRecords.map((record) => serialize(withActor(record))),
+      nextCursor:
+        hasMore && pageRecords.length
+          ? encodeCursor(pageRecords[pageRecords.length - 1])
+          : null,
+      filters: {
+        status: normalized.status,
+        environment: normalized.environment,
+        app: normalized.app,
+        source: normalized.source
+      },
+      options: {
+        environments: environments.map((item) => ({
+          value: item.slug,
+          label: item.name
+        })),
+        apps: apps.map((item) => {
+          const environment = environmentById.get(Number(item.environment))
+          const duplicateName = apps.some(
+            (candidate) =>
+              candidate.id !== item.id && candidate.name === item.name
+          )
+          return {
+            value: String(item.id),
+            label:
+              duplicateName && environment
+                ? `${environment.name} / ${item.name}`
+                : item.name
+          }
+        }),
+        sources: VALID_SOURCES.map((value) => ({
+          value,
+          label: sourceLabel(value)
+        }))
+      }
+    }
+  },
+
+  _private: {
+    ACTIVE_STATUSES,
+    decodeCursor,
+    encodeCursor,
+    outcomeFor,
+    serializeDeployment
+  }
+}

--- a/assets/js/components/DeploymentHistory.vue
+++ b/assets/js/components/DeploymentHistory.vue
@@ -1,0 +1,864 @@
+<script setup>
+import { Link, router } from '@inertiajs/vue3'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  history: {
+    type: Object,
+    required: true
+  },
+  baseUrl: {
+    type: String,
+    required: true
+  },
+  currentTitle: {
+    type: String,
+    default: 'Current release'
+  },
+  currentEmpty: {
+    type: String,
+    default: 'No release is currently serving traffic.'
+  }
+})
+
+const statusFilters = [
+  { value: 'all', label: 'All' },
+  { value: 'in-progress', label: 'In progress' },
+  { value: 'succeeded', label: 'Succeeded' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'cancelled', label: 'Cancelled' }
+]
+
+const items = ref([...(props.history.items || [])])
+const activeDeployments = ref([...(props.history.activeDeployments || [])])
+const selectedStatus = ref(props.history.filters?.status || 'all')
+const selectedEnvironment = ref(props.history.filters?.environment || '')
+const selectedApp = ref(props.history.filters?.app || '')
+const selectedSource = ref(props.history.filters?.source || '')
+const loadingMore = ref(false)
+const appendNextPage = ref(false)
+const updateAvailable = ref(false)
+const liveRegionMessage = ref('')
+const activeSources = new Map()
+const clock = ref(Date.now())
+let clockInterval = null
+
+const showEnvironmentFilter = computed(
+  () => (props.history.options?.environments || []).length > 1
+)
+const showAppFilter = computed(
+  () => (props.history.options?.apps || []).length > 1
+)
+const hasSecondaryFilters = computed(
+  () => showEnvironmentFilter.value || showAppFilter.value
+)
+
+function filterQuery(cursor = null) {
+  const query = {}
+  if (selectedStatus.value !== 'all') {
+    query.deploymentStatus = selectedStatus.value
+  }
+  if (selectedEnvironment.value) {
+    query.deploymentEnvironment = selectedEnvironment.value
+  }
+  if (selectedApp.value) query.deploymentApp = selectedApp.value
+  if (selectedSource.value) query.deploymentSource = selectedSource.value
+  if (cursor) query.deploymentCursor = cursor
+  return query
+}
+
+function applyFilters() {
+  appendNextPage.value = false
+  updateAvailable.value = false
+  router.get(props.baseUrl, filterQuery(), {
+    preserveScroll: true,
+    preserveState: true,
+    replace: true
+  })
+}
+
+function chooseStatus(status) {
+  if (selectedStatus.value === status) return
+  selectedStatus.value = status
+  applyFilters()
+}
+
+function loadMore() {
+  if (!props.history.nextCursor || loadingMore.value) return
+  loadingMore.value = true
+  appendNextPage.value = true
+  router.get(props.baseUrl, filterQuery(props.history.nextCursor), {
+    only: ['deploymentHistory'],
+    preserveScroll: true,
+    preserveState: true,
+    replace: true,
+    onFinish: () => {
+      loadingMore.value = false
+    }
+  })
+}
+
+function refreshActivity() {
+  updateAvailable.value = false
+  router.reload({
+    only: ['deploymentHistory'],
+    preserveScroll: true,
+    onSuccess: () => {
+      liveRegionMessage.value = 'Deployment history updated.'
+    }
+  })
+}
+
+function statusFromEvent(deploymentId, status) {
+  const labels = {
+    pending: 'Queued',
+    building: 'Building',
+    pushing: 'Publishing',
+    deploying: 'Deploying',
+    running: 'Completed',
+    failed: 'Failed',
+    cancelled: 'Cancelled',
+    stopped: 'Stopped'
+  }
+  const activeStatuses = ['pending', 'building', 'pushing', 'deploying']
+  const outcomes = {
+    running: 'succeeded',
+    failed: 'failed',
+    cancelled: 'cancelled',
+    stopped: 'succeeded'
+  }
+  const patch = (deployment) =>
+    deployment.id === deploymentId
+      ? {
+          ...deployment,
+          status,
+          isActive: activeStatuses.includes(status),
+          outcome: outcomes[status] || deployment.outcome,
+          outcomeLabel: labels[status] || deployment.outcomeLabel
+        }
+      : deployment
+
+  activeDeployments.value = activeDeployments.value.map(patch)
+  items.value = items.value.map(patch)
+}
+
+function connectActiveDeployments() {
+  const activeIds = new Set(activeDeployments.value.map((item) => item.id))
+
+  for (const [id, source] of activeSources) {
+    if (!activeIds.has(id)) {
+      source.close()
+      activeSources.delete(id)
+    }
+  }
+
+  for (const deployment of activeDeployments.value) {
+    if (activeSources.has(deployment.id)) continue
+    const source = new EventSource(
+      `/api/v1/deployments/${deployment.id}/stream`
+    )
+
+    source.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data)
+        if (!data.status) return
+        statusFromEvent(deployment.id, data.status)
+        liveRegionMessage.value = `Deployment ${deployment.id} is ${data.status}.`
+
+        if (
+          ['running', 'failed', 'cancelled', 'stopped'].includes(data.status)
+        ) {
+          source.close()
+          activeSources.delete(deployment.id)
+          if (window.scrollY > 240) {
+            updateAvailable.value = true
+            liveRegionMessage.value =
+              'Deployment activity changed. Refresh the history when ready.'
+          } else {
+            refreshActivity()
+          }
+        }
+      } catch {
+        // Ignore malformed stream events and allow EventSource to continue.
+      }
+    }
+    source.onerror = () => {
+      // EventSource reconnects automatically while the deployment is active.
+    }
+    activeSources.set(deployment.id, source)
+  }
+}
+
+watch(
+  () => props.history,
+  (history) => {
+    const nextItems = history.items || []
+    if (appendNextPage.value) {
+      const seen = new Set(items.value.map((item) => item.id))
+      items.value = [
+        ...items.value,
+        ...nextItems.filter((item) => !seen.has(item.id))
+      ]
+      appendNextPage.value = false
+    } else {
+      items.value = [...nextItems]
+    }
+
+    activeDeployments.value = [...(history.activeDeployments || [])]
+    selectedStatus.value = history.filters?.status || 'all'
+    selectedEnvironment.value = history.filters?.environment || ''
+    selectedApp.value = history.filters?.app || ''
+    selectedSource.value = history.filters?.source || ''
+    connectActiveDeployments()
+  },
+  { deep: true }
+)
+
+watch(
+  activeDeployments,
+  () => {
+    connectActiveDeployments()
+  },
+  { deep: true, immediate: true }
+)
+
+onMounted(() => {
+  clockInterval = setInterval(() => {
+    clock.value = Date.now()
+  }, 1000)
+})
+
+onBeforeUnmount(() => {
+  if (clockInterval) clearInterval(clockInterval)
+  for (const source of activeSources.values()) source.close()
+  activeSources.clear()
+})
+
+function outcomeClasses(outcome) {
+  return {
+    current:
+      'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-950/50 dark:text-emerald-300 dark:ring-emerald-400/20',
+    succeeded:
+      'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-950/50 dark:text-emerald-300 dark:ring-emerald-400/20',
+    'in-progress':
+      'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-950/50 dark:text-blue-300 dark:ring-blue-400/20',
+    failed:
+      'bg-red-50 text-red-700 ring-red-600/20 dark:bg-red-950/50 dark:text-red-300 dark:ring-red-400/20',
+    cancelled:
+      'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-400/20',
+    neutral:
+      'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-400/20'
+  }[outcome]
+}
+
+function healthClasses(health) {
+  if (health === 'Healthy') {
+    return 'text-emerald-700 dark:text-emerald-300'
+  }
+  if (health === 'Unhealthy' || health === 'Failed') {
+    return 'text-red-700 dark:text-red-300'
+  }
+  return 'text-gray-600 dark:text-gray-300'
+}
+
+function progressFor(status) {
+  return { pending: 12, building: 38, pushing: 64, deploying: 84 }[status] || 8
+}
+
+function formatDuration(seconds) {
+  if (seconds === null || seconds === undefined) return '—'
+  if (seconds < 1) return '<1s'
+  if (seconds < 60) return `${seconds}s`
+  const minutes = Math.floor(seconds / 60)
+  const remainder = seconds % 60
+  if (minutes < 60)
+    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  return `${hours}h ${minutes % 60}m`
+}
+
+function displayDuration(deployment) {
+  if (deployment.isActive && deployment.startedAt) {
+    return Math.max(
+      0,
+      Math.round((clock.value - Number(deployment.startedAt)) / 1000)
+    )
+  }
+  return deployment.duration
+}
+
+function relativeTime(value) {
+  if (!value) return 'Unknown'
+  const seconds = Math.max(0, Math.floor((Date.now() - Number(value)) / 1000))
+  const intervals = [
+    ['year', 31536000],
+    ['month', 2592000],
+    ['week', 604800],
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60]
+  ]
+  for (const [label, size] of intervals) {
+    const count = Math.floor(seconds / size)
+    if (count >= 1) return `${count} ${label}${count === 1 ? '' : 's'} ago`
+  }
+  return 'Just now'
+}
+
+function exactTime(value) {
+  if (!value) return 'Unknown time'
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(Number(value)))
+}
+
+function isoTime(value) {
+  if (!value) return undefined
+  return new Date(Number(value)).toISOString()
+}
+
+function targetLabel(deployment) {
+  return [deployment.environment?.name, deployment.app?.name]
+    .filter(Boolean)
+    .join(' / ')
+}
+</script>
+
+<template>
+  <section class="space-y-8" data-testid="deployment-overview">
+    <p class="sr-only" aria-live="polite">{{ liveRegionMessage }}</p>
+
+    <div>
+      <div class="mb-3 flex items-center justify-between gap-4">
+        <div>
+          <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
+            {{ currentTitle }}
+          </h2>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            The release currently serving application traffic.
+          </p>
+        </div>
+      </div>
+
+      <div
+        v-if="history.currentReleases?.length"
+        class="grid gap-3 lg:grid-cols-2"
+      >
+        <article
+          v-for="release in history.currentReleases"
+          :key="release.id"
+          class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm shadow-gray-950/[0.02] dark:border-gray-800 dark:bg-gray-950"
+          data-testid="current-release"
+        >
+          <div
+            class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
+          >
+            <div class="min-w-0">
+              <div class="flex flex-wrap items-center gap-2">
+                <span
+                  :class="[
+                    'inline-flex rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+                    outcomeClasses('current')
+                  ]"
+                >
+                  Current
+                </span>
+                <span
+                  :class="[
+                    'text-xs font-medium',
+                    healthClasses(release.health)
+                  ]"
+                >
+                  {{ release.health }}
+                </span>
+              </div>
+              <h3
+                class="mt-3 truncate text-base font-semibold text-gray-950 dark:text-white"
+              >
+                {{ release.title }}
+              </h3>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ targetLabel(release) }}
+                <template v-if="release.gitBranch || release.gitCommit">
+                  <span aria-hidden="true"> · </span>
+                  <span v-if="release.gitBranch">{{ release.gitBranch }}</span>
+                  <code
+                    v-if="release.gitCommit"
+                    class="ml-1 font-mono text-xs"
+                    >{{ release.gitCommit.slice(0, 7) }}</code
+                  >
+                </template>
+              </p>
+            </div>
+            <div class="flex w-full shrink-0 items-center gap-2 sm:w-auto">
+              <Link
+                v-if="release.appHref"
+                :href="release.appHref"
+                class="min-h-11 inline-flex flex-1 items-center justify-center rounded-lg border border-gray-200 px-3 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900 sm:flex-none"
+              >
+                View app
+              </Link>
+              <Link
+                :href="release.href"
+                aria-label="Open current deployment"
+                class="inline-flex h-11 w-11 items-center justify-center rounded-lg bg-gray-950 text-white hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100"
+              >
+                <svg
+                  class="h-4 w-4"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    d="m7 4 6 6-6 6"
+                    stroke-width="1.7"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </Link>
+            </div>
+          </div>
+          <dl class="mt-5 grid grid-cols-2 gap-x-5 gap-y-3 sm:grid-cols-4">
+            <div>
+              <dt class="text-xs text-gray-400 dark:text-gray-500">Source</dt>
+              <dd class="mt-1 text-sm text-gray-700 dark:text-gray-200">
+                {{ release.sourceLabel }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-400 dark:text-gray-500">Actor</dt>
+              <dd
+                class="mt-1 truncate text-sm text-gray-700 dark:text-gray-200"
+              >
+                {{ release.actor }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-400 dark:text-gray-500">Duration</dt>
+              <dd class="mt-1 text-sm text-gray-700 dark:text-gray-200">
+                {{ formatDuration(release.duration) }}
+              </dd>
+            </div>
+            <div>
+              <dt class="text-xs text-gray-400 dark:text-gray-500">Deployed</dt>
+              <dd class="mt-1 text-sm text-gray-700 dark:text-gray-200">
+                <time
+                  :datetime="isoTime(release.deployedAt)"
+                  :title="exactTime(release.deployedAt)"
+                >
+                  {{ relativeTime(release.deployedAt) }}
+                </time>
+              </dd>
+            </div>
+          </dl>
+        </article>
+      </div>
+
+      <div
+        v-else
+        class="rounded-xl border border-dashed border-gray-300 px-5 py-6 dark:border-gray-700"
+        data-testid="no-current-release"
+      >
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">
+          No current release
+        </p>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          {{ currentEmpty }}
+        </p>
+      </div>
+    </div>
+
+    <div v-if="activeDeployments.length" aria-live="polite">
+      <div class="mb-3">
+        <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
+          Active work
+        </h2>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Live deployment progress. This does not change history ordering.
+        </p>
+      </div>
+      <div class="space-y-2">
+        <Link
+          v-for="deployment in activeDeployments"
+          :key="deployment.id"
+          :href="deployment.href"
+          class="block rounded-xl border border-blue-200 bg-blue-50/50 p-4 hover:border-blue-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-blue-900 dark:bg-blue-950/20 dark:hover:border-blue-800"
+          data-testid="active-deployment"
+        >
+          <div class="flex items-start justify-between gap-4">
+            <div class="min-w-0">
+              <div class="flex flex-wrap items-center gap-2">
+                <span
+                  :class="[
+                    'inline-flex rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+                    outcomeClasses('in-progress')
+                  ]"
+                >
+                  {{ deployment.outcomeLabel }}
+                </span>
+                <span class="text-xs text-gray-500 dark:text-gray-400">
+                  {{ targetLabel(deployment) }}
+                </span>
+              </div>
+              <p
+                class="mt-2 truncate text-sm font-medium text-gray-900 dark:text-white"
+              >
+                {{ deployment.title }}
+              </p>
+            </div>
+            <span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">
+              {{ formatDuration(displayDuration(deployment)) }}
+            </span>
+          </div>
+          <div
+            class="mt-4 h-1.5 overflow-hidden rounded-full bg-blue-100 dark:bg-blue-950"
+            aria-hidden="true"
+          >
+            <div
+              class="h-full rounded-full bg-blue-600 transition-[width] duration-500 dark:bg-blue-400"
+              :style="{ width: `${progressFor(deployment.status)}%` }"
+            ></div>
+          </div>
+        </Link>
+      </div>
+    </div>
+
+    <div>
+      <div
+        class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"
+      >
+        <div>
+          <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
+            Deployment history
+          </h2>
+          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Newest first, with deployment outcome separate from runtime state.
+          </p>
+        </div>
+
+        <div class="flex flex-wrap items-end gap-2">
+          <label v-if="showEnvironmentFilter" class="block">
+            <span class="sr-only">Filter by environment</span>
+            <select
+              v-model="selectedEnvironment"
+              class="min-h-11 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
+              @change="applyFilters"
+            >
+              <option value="">All environments</option>
+              <option
+                v-for="option in history.options.environments"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label v-if="showAppFilter" class="block">
+            <span class="sr-only">Filter by app</span>
+            <select
+              v-model="selectedApp"
+              class="min-h-11 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
+              @change="applyFilters"
+            >
+              <option value="">All apps</option>
+              <option
+                v-for="option in history.options.apps"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+          <label class="block">
+            <span class="sr-only">Filter by source</span>
+            <select
+              v-model="selectedSource"
+              class="min-h-11 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
+              @change="applyFilters"
+            >
+              <option value="">All sources</option>
+              <option
+                v-for="option in history.options.sources"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+          </label>
+        </div>
+      </div>
+
+      <fieldset class="mt-4 min-w-0">
+        <legend class="sr-only">Filter deployments by outcome</legend>
+        <div
+          class="flex max-w-full gap-1 overflow-x-auto rounded-lg bg-gray-100 p-1 dark:bg-gray-900"
+          :class="hasSecondaryFilters ? 'lg:max-w-xl' : 'lg:max-w-lg'"
+        >
+          <button
+            v-for="filter in statusFilters"
+            :key="filter.value"
+            type="button"
+            :data-test="`deployment-filter-${filter.value}`"
+            :aria-pressed="selectedStatus === filter.value"
+            :class="[
+              'min-h-11 shrink-0 rounded-md px-3 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-1',
+              selectedStatus === filter.value
+                ? 'bg-white text-gray-950 shadow-sm dark:bg-gray-800 dark:text-white'
+                : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
+            ]"
+            @click="chooseStatus(filter.value)"
+          >
+            {{ filter.label }}
+          </button>
+        </div>
+      </fieldset>
+
+      <div
+        v-if="updateAvailable"
+        class="mt-4 flex items-center justify-between gap-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-900 dark:bg-blue-950/30"
+        role="status"
+      >
+        <p class="text-sm text-blue-800 dark:text-blue-200">
+          Deployment activity changed while you were reading.
+        </p>
+        <button
+          type="button"
+          class="min-h-11 shrink-0 rounded-lg bg-blue-700 px-3 text-sm font-medium text-white hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:bg-blue-500 dark:text-blue-950"
+          @click="refreshActivity"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div
+        v-if="items.length"
+        class="mt-4 overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950"
+      >
+        <div class="hidden overflow-x-auto lg:block">
+          <table class="w-full table-fixed text-left">
+            <caption class="sr-only">
+              Deployment history ordered newest first
+            </caption>
+            <thead
+              class="border-b border-gray-200 bg-gray-50/80 dark:border-gray-800 dark:bg-gray-900/60"
+            >
+              <tr>
+                <th class="w-[30%] px-4 py-3 text-xs font-medium text-gray-500">
+                  Deployment
+                </th>
+                <th class="w-[15%] px-3 py-3 text-xs font-medium text-gray-500">
+                  Target
+                </th>
+                <th class="w-[12%] px-3 py-3 text-xs font-medium text-gray-500">
+                  Outcome
+                </th>
+                <th class="w-[9%] px-3 py-3 text-xs font-medium text-gray-500">
+                  Source
+                </th>
+                <th class="w-[11%] px-3 py-3 text-xs font-medium text-gray-500">
+                  Actor
+                </th>
+                <th class="w-[8%] px-3 py-3 text-xs font-medium text-gray-500">
+                  Duration
+                </th>
+                <th class="w-[15%] px-3 py-3 text-xs font-medium text-gray-500">
+                  Deployed
+                </th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-100 dark:divide-gray-900">
+              <tr
+                v-for="deployment in items"
+                :key="deployment.id"
+                class="transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-900/50"
+                data-testid="deployment-row"
+              >
+                <td class="px-4 py-4 align-top">
+                  <Link
+                    :href="deployment.href"
+                    class="block truncate text-sm font-medium text-gray-950 hover:underline focus:outline-none focus-visible:rounded focus-visible:ring-2 focus-visible:ring-sky-500 dark:text-white"
+                  >
+                    {{ deployment.title }}
+                  </Link>
+                  <p
+                    class="mt-1 truncate text-xs text-gray-500 dark:text-gray-400"
+                  >
+                    <span v-if="deployment.gitBranch">{{
+                      deployment.gitBranch
+                    }}</span>
+                    <code v-if="deployment.gitCommit" class="ml-1 font-mono">{{
+                      deployment.gitCommit.slice(0, 7)
+                    }}</code>
+                    <span v-if="!deployment.gitBranch && !deployment.gitCommit"
+                      >#{{ deployment.id }}</span
+                    >
+                  </p>
+                </td>
+                <td
+                  class="px-3 py-4 align-top text-sm text-gray-600 dark:text-gray-300"
+                >
+                  <span class="block truncate">{{
+                    deployment.environment?.name || 'Unknown'
+                  }}</span>
+                  <span class="mt-1 block truncate text-xs text-gray-400">{{
+                    deployment.app?.name || 'Default app'
+                  }}</span>
+                </td>
+                <td class="px-3 py-4 align-top">
+                  <span
+                    :class="[
+                      'inline-flex rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+                      outcomeClasses(deployment.outcome)
+                    ]"
+                  >
+                    {{ deployment.outcomeLabel }}
+                  </span>
+                </td>
+                <td
+                  class="px-3 py-4 align-top text-sm text-gray-600 dark:text-gray-300"
+                >
+                  {{ deployment.sourceLabel }}
+                </td>
+                <td
+                  class="truncate px-3 py-4 align-top text-sm text-gray-600 dark:text-gray-300"
+                >
+                  {{ deployment.actor }}
+                </td>
+                <td
+                  class="px-3 py-4 align-top font-mono text-xs text-gray-500 dark:text-gray-400"
+                >
+                  {{ formatDuration(displayDuration(deployment)) }}
+                </td>
+                <td class="px-3 py-4 align-top">
+                  <time
+                    :datetime="isoTime(deployment.deployedAt)"
+                    :title="exactTime(deployment.deployedAt)"
+                    class="block text-sm text-gray-600 dark:text-gray-300"
+                  >
+                    {{ relativeTime(deployment.deployedAt) }}
+                  </time>
+                  <span
+                    class="mt-1 block text-xs text-gray-400 dark:text-gray-500"
+                  >
+                    {{ exactTime(deployment.deployedAt) }}
+                  </span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div class="divide-y divide-gray-100 dark:divide-gray-900 lg:hidden">
+          <article
+            v-for="deployment in items"
+            :key="deployment.id"
+            class="p-4"
+            data-testid="deployment-card"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <Link
+                  :href="deployment.href"
+                  class="block truncate text-sm font-semibold text-gray-950 focus:outline-none focus-visible:rounded focus-visible:ring-2 focus-visible:ring-sky-500 dark:text-white"
+                >
+                  {{ deployment.title }}
+                </Link>
+                <p
+                  class="mt-1 truncate text-xs text-gray-500 dark:text-gray-400"
+                >
+                  {{ targetLabel(deployment) || 'Unknown target' }}
+                </p>
+              </div>
+              <span
+                :class="[
+                  'inline-flex shrink-0 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
+                  outcomeClasses(deployment.outcome)
+                ]"
+              >
+                {{ deployment.outcomeLabel }}
+              </span>
+            </div>
+            <dl class="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+              <div>
+                <dt class="text-xs text-gray-400">Source</dt>
+                <dd class="mt-1 text-gray-700 dark:text-gray-200">
+                  {{ deployment.sourceLabel }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs text-gray-400">Actor</dt>
+                <dd class="mt-1 truncate text-gray-700 dark:text-gray-200">
+                  {{ deployment.actor }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs text-gray-400">Duration</dt>
+                <dd
+                  class="mt-1 font-mono text-xs text-gray-700 dark:text-gray-200"
+                >
+                  {{ formatDuration(displayDuration(deployment)) }}
+                </dd>
+              </div>
+              <div>
+                <dt class="text-xs text-gray-400">Deployed</dt>
+                <dd class="mt-1 text-gray-700 dark:text-gray-200">
+                  <time
+                    :datetime="isoTime(deployment.deployedAt)"
+                    :title="exactTime(deployment.deployedAt)"
+                  >
+                    {{ relativeTime(deployment.deployedAt) }}
+                  </time>
+                </dd>
+              </div>
+            </dl>
+            <p
+              class="mt-3 truncate border-t border-gray-100 pt-3 text-xs text-gray-400 dark:border-gray-900 dark:text-gray-500"
+            >
+              <span v-if="deployment.gitBranch">{{
+                deployment.gitBranch
+              }}</span>
+              <code v-if="deployment.gitCommit" class="ml-1 font-mono">{{
+                deployment.gitCommit.slice(0, 7)
+              }}</code>
+              <span v-if="!deployment.gitBranch && !deployment.gitCommit"
+                >Deployment #{{ deployment.id }}</span
+              >
+              <span aria-hidden="true"> · </span>
+              {{ exactTime(deployment.deployedAt) }}
+            </p>
+          </article>
+        </div>
+      </div>
+
+      <div
+        v-else
+        class="mt-4 rounded-xl border border-dashed border-gray-300 px-6 py-10 text-center dark:border-gray-700"
+        data-testid="empty-deployment-history"
+      >
+        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">
+          No matching deployments
+        </p>
+        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Try another filter, or deploy an application to start its history.
+        </p>
+      </div>
+
+      <div v-if="history.nextCursor" class="mt-4 flex justify-center">
+        <button
+          type="button"
+          class="min-h-11 inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-4 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200 dark:hover:bg-gray-900"
+          :disabled="loadingMore"
+          @click="loadMore"
+        >
+          {{ loadingMore ? 'Loading…' : 'Load more' }}
+        </button>
+      </div>
+    </div>
+  </section>
+</template>

--- a/assets/js/components/DeploymentHistory.vue
+++ b/assets/js/components/DeploymentHistory.vue
@@ -33,7 +33,29 @@ const props = defineProps({
   }
 })
 
-const deployments = ref([...(props.history.items || [])])
+function orderedDeployments(history) {
+  const seen = new Set()
+  const ordered = []
+  const newestFirst = (left, right) =>
+    Number(right.createdAt) - Number(left.createdAt) ||
+    Number(right.id) - Number(left.id)
+
+  for (const group of [
+    history.activeDeployments || [],
+    history.currentReleases || [],
+    history.items || []
+  ]) {
+    for (const deployment of [...group].sort(newestFirst)) {
+      if (seen.has(deployment.id)) continue
+      seen.add(deployment.id)
+      ordered.push(deployment)
+    }
+  }
+
+  return ordered
+}
+
+const deployments = ref(orderedDeployments(props.history))
 const activeDeployments = ref([...(props.history.activeDeployments || [])])
 const activeSources = new Map()
 
@@ -105,7 +127,7 @@ function connectActiveDeployments() {
 watch(
   () => props.history,
   (history) => {
-    deployments.value = [...(history.items || [])]
+    deployments.value = orderedDeployments(history)
     activeDeployments.value = [...(history.activeDeployments || [])]
     connectActiveDeployments()
   },

--- a/assets/js/components/DeploymentHistory.vue
+++ b/assets/js/components/DeploymentHistory.vue
@@ -1,149 +1,65 @@
 <script setup>
 import { Link, router } from '@inertiajs/vue3'
-import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { onBeforeUnmount, ref, watch } from 'vue'
 
 const props = defineProps({
   history: {
     type: Object,
     required: true
   },
-  baseUrl: {
+  title: {
     type: String,
-    required: true
+    default: 'Deployments'
   },
-  currentTitle: {
-    type: String,
-    default: 'Current release'
+  showEnvironment: {
+    type: Boolean,
+    default: false
   },
-  currentEmpty: {
+  showStatus: {
+    type: Boolean,
+    default: true
+  },
+  hideWhenEmpty: {
+    type: Boolean,
+    default: false
+  },
+  emptyMessage: {
     type: String,
-    default: 'No release is currently serving traffic.'
+    default: 'No deployments yet.'
+  },
+  emptyHelp: {
+    type: String,
+    default: 'Slide to deploy your first version.'
   }
 })
 
-const statusFilters = [
-  { value: 'all', label: 'All' },
-  { value: 'in-progress', label: 'In progress' },
-  { value: 'succeeded', label: 'Succeeded' },
-  { value: 'failed', label: 'Failed' },
-  { value: 'cancelled', label: 'Cancelled' }
-]
-
-const items = ref([...(props.history.items || [])])
+const deployments = ref([...(props.history.items || [])])
 const activeDeployments = ref([...(props.history.activeDeployments || [])])
-const selectedStatus = ref(props.history.filters?.status || 'all')
-const selectedEnvironment = ref(props.history.filters?.environment || '')
-const selectedApp = ref(props.history.filters?.app || '')
-const selectedSource = ref(props.history.filters?.source || '')
-const loadingMore = ref(false)
-const appendNextPage = ref(false)
-const updateAvailable = ref(false)
-const liveRegionMessage = ref('')
 const activeSources = new Map()
-const clock = ref(Date.now())
-let clockInterval = null
 
-const showEnvironmentFilter = computed(
-  () => (props.history.options?.environments || []).length > 1
-)
-const showAppFilter = computed(
-  () => (props.history.options?.apps || []).length > 1
-)
-const hasSecondaryFilters = computed(
-  () => showEnvironmentFilter.value || showAppFilter.value
-)
-
-function filterQuery(cursor = null) {
-  const query = {}
-  if (selectedStatus.value !== 'all') {
-    query.deploymentStatus = selectedStatus.value
-  }
-  if (selectedEnvironment.value) {
-    query.deploymentEnvironment = selectedEnvironment.value
-  }
-  if (selectedApp.value) query.deploymentApp = selectedApp.value
-  if (selectedSource.value) query.deploymentSource = selectedSource.value
-  if (cursor) query.deploymentCursor = cursor
-  return query
-}
-
-function applyFilters() {
-  appendNextPage.value = false
-  updateAvailable.value = false
-  router.get(props.baseUrl, filterQuery(), {
-    preserveScroll: true,
-    preserveState: true,
-    replace: true
-  })
-}
-
-function chooseStatus(status) {
-  if (selectedStatus.value === status) return
-  selectedStatus.value = status
-  applyFilters()
-}
-
-function loadMore() {
-  if (!props.history.nextCursor || loadingMore.value) return
-  loadingMore.value = true
-  appendNextPage.value = true
-  router.get(props.baseUrl, filterQuery(props.history.nextCursor), {
-    only: ['deploymentHistory'],
-    preserveScroll: true,
-    preserveState: true,
-    replace: true,
-    onFinish: () => {
-      loadingMore.value = false
-    }
-  })
-}
-
-function refreshActivity() {
-  updateAvailable.value = false
+function refreshHistory() {
   router.reload({
     only: ['deploymentHistory'],
-    preserveScroll: true,
-    onSuccess: () => {
-      liveRegionMessage.value = 'Deployment history updated.'
-    }
+    preserveScroll: true
   })
 }
 
-function statusFromEvent(deploymentId, status) {
-  const labels = {
-    pending: 'Queued',
-    building: 'Building',
-    pushing: 'Publishing',
-    deploying: 'Deploying',
-    running: 'Completed',
-    failed: 'Failed',
-    cancelled: 'Cancelled',
-    stopped: 'Stopped'
-  }
-  const activeStatuses = ['pending', 'building', 'pushing', 'deploying']
-  const outcomes = {
-    running: 'succeeded',
-    failed: 'failed',
-    cancelled: 'cancelled',
-    stopped: 'succeeded'
-  }
+function patchStatus(deploymentId, status) {
   const patch = (deployment) =>
-    deployment.id === deploymentId
-      ? {
-          ...deployment,
-          status,
-          isActive: activeStatuses.includes(status),
-          outcome: outcomes[status] || deployment.outcome,
-          outcomeLabel: labels[status] || deployment.outcomeLabel
-        }
-      : deployment
+    deployment.id === deploymentId ? { ...deployment, status } : deployment
 
+  deployments.value = deployments.value.map(patch)
   activeDeployments.value = activeDeployments.value.map(patch)
-  items.value = items.value.map(patch)
 }
 
 function connectActiveDeployments() {
-  const activeIds = new Set(activeDeployments.value.map((item) => item.id))
+  const activeIds = new Set(
+    activeDeployments.value
+      .filter((item) =>
+        ['pending', 'building', 'pushing', 'deploying'].includes(item.status)
+      )
+      .map((item) => item.id)
+  )
 
   for (const [id, source] of activeSources) {
     if (!activeIds.has(id)) {
@@ -152,8 +68,11 @@ function connectActiveDeployments() {
     }
   }
 
-  for (const deployment of activeDeployments.value) {
+  for (const deployment of activeDeployments.value.filter((item) =>
+    activeIds.has(item.id)
+  )) {
     if (activeSources.has(deployment.id)) continue
+
     const source = new EventSource(
       `/api/v1/deployments/${deployment.id}/stream`
     )
@@ -162,24 +81,18 @@ function connectActiveDeployments() {
       try {
         const data = JSON.parse(event.data)
         if (!data.status) return
-        statusFromEvent(deployment.id, data.status)
-        liveRegionMessage.value = `Deployment ${deployment.id} is ${data.status}.`
+
+        patchStatus(deployment.id, data.status)
 
         if (
           ['running', 'failed', 'cancelled', 'stopped'].includes(data.status)
         ) {
           source.close()
           activeSources.delete(deployment.id)
-          if (window.scrollY > 240) {
-            updateAvailable.value = true
-            liveRegionMessage.value =
-              'Deployment activity changed. Refresh the history when ready.'
-          } else {
-            refreshActivity()
-          }
+          refreshHistory()
         }
       } catch {
-        // Ignore malformed stream events and allow EventSource to continue.
+        // Ignore malformed events and allow EventSource to reconnect.
       }
     }
     source.onerror = () => {
@@ -192,23 +105,8 @@ function connectActiveDeployments() {
 watch(
   () => props.history,
   (history) => {
-    const nextItems = history.items || []
-    if (appendNextPage.value) {
-      const seen = new Set(items.value.map((item) => item.id))
-      items.value = [
-        ...items.value,
-        ...nextItems.filter((item) => !seen.has(item.id))
-      ]
-      appendNextPage.value = false
-    } else {
-      items.value = [...nextItems]
-    }
-
+    deployments.value = [...(history.items || [])]
     activeDeployments.value = [...(history.activeDeployments || [])]
-    selectedStatus.value = history.filters?.status || 'all'
-    selectedEnvironment.value = history.filters?.environment || ''
-    selectedApp.value = history.filters?.app || ''
-    selectedSource.value = history.filters?.source || ''
     connectActiveDeployments()
   },
   { deep: true }
@@ -222,643 +120,195 @@ watch(
   { deep: true, immediate: true }
 )
 
-onMounted(() => {
-  clockInterval = setInterval(() => {
-    clock.value = Date.now()
-  }, 1000)
-})
-
 onBeforeUnmount(() => {
-  if (clockInterval) clearInterval(clockInterval)
   for (const source of activeSources.values()) source.close()
   activeSources.clear()
 })
 
-function outcomeClasses(outcome) {
-  return {
-    current:
-      'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-950/50 dark:text-emerald-300 dark:ring-emerald-400/20',
-    succeeded:
-      'bg-emerald-50 text-emerald-700 ring-emerald-600/20 dark:bg-emerald-950/50 dark:text-emerald-300 dark:ring-emerald-400/20',
-    'in-progress':
-      'bg-blue-50 text-blue-700 ring-blue-600/20 dark:bg-blue-950/50 dark:text-blue-300 dark:ring-blue-400/20',
-    failed:
-      'bg-red-50 text-red-700 ring-red-600/20 dark:bg-red-950/50 dark:text-red-300 dark:ring-red-400/20',
-    cancelled:
-      'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-400/20',
-    neutral:
-      'bg-gray-100 text-gray-600 ring-gray-500/20 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-400/20'
-  }[outcome]
-}
-
-function healthClasses(health) {
-  if (health === 'Healthy') {
-    return 'text-emerald-700 dark:text-emerald-300'
+function statusBadge(status) {
+  const map = {
+    running: {
+      label: 'Running',
+      classes:
+        'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+    },
+    building: {
+      label: 'Building',
+      classes:
+        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    },
+    pushing: {
+      label: 'Pushing',
+      classes:
+        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    },
+    deploying: {
+      label: 'Deploying',
+      classes:
+        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    },
+    pending: {
+      label: 'Pending',
+      classes:
+        'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+    },
+    failed: {
+      label: 'Failed',
+      classes: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
+    },
+    stopped: {
+      label: 'Stopped',
+      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+    },
+    cancelled: {
+      label: 'Cancelled',
+      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+    },
+    creating: {
+      label: 'Creating',
+      classes:
+        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    }
   }
-  if (health === 'Unhealthy' || health === 'Failed') {
-    return 'text-red-700 dark:text-red-300'
+
+  return (
+    map[status] || {
+      label: status,
+      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+    }
+  )
+}
+
+function statusDotClasses(status) {
+  if (status === 'running') return 'bg-green-500'
+  if (status === 'failed') return 'bg-red-500'
+  if (['building', 'pushing', 'deploying'].includes(status)) {
+    return 'bg-blue-500'
   }
-  return 'text-gray-600 dark:text-gray-300'
+  if (['cancelled', 'stopped'].includes(status)) return 'bg-gray-400'
+  return 'bg-yellow-500'
 }
 
-function progressFor(status) {
-  return { pending: 12, building: 38, pushing: 64, deploying: 84 }[status] || 8
-}
-
-function formatDuration(seconds) {
-  if (seconds === null || seconds === undefined) return '—'
-  if (seconds < 1) return '<1s'
-  if (seconds < 60) return `${seconds}s`
-  const minutes = Math.floor(seconds / 60)
-  const remainder = seconds % 60
-  if (minutes < 60)
-    return remainder ? `${minutes}m ${remainder}s` : `${minutes}m`
-  const hours = Math.floor(minutes / 60)
-  return `${hours}h ${minutes % 60}m`
-}
-
-function displayDuration(deployment) {
-  if (deployment.isActive && deployment.startedAt) {
-    return Math.max(
-      0,
-      Math.round((clock.value - Number(deployment.startedAt)) / 1000)
-    )
-  }
-  return deployment.duration
-}
-
-function relativeTime(value) {
-  if (!value) return 'Unknown'
-  const seconds = Math.max(0, Math.floor((Date.now() - Number(value)) / 1000))
+function timeAgo(date) {
+  if (!date) return 'Never'
+  const seconds = Math.floor((new Date() - new Date(date)) / 1000)
   const intervals = [
-    ['year', 31536000],
-    ['month', 2592000],
-    ['week', 604800],
-    ['day', 86400],
-    ['hour', 3600],
-    ['minute', 60]
+    { label: 'year', seconds: 31536000 },
+    { label: 'month', seconds: 2592000 },
+    { label: 'week', seconds: 604800 },
+    { label: 'day', seconds: 86400 },
+    { label: 'hour', seconds: 3600 },
+    { label: 'minute', seconds: 60 }
   ]
-  for (const [label, size] of intervals) {
-    const count = Math.floor(seconds / size)
-    if (count >= 1) return `${count} ${label}${count === 1 ? '' : 's'} ago`
+  for (const interval of intervals) {
+    const count = Math.floor(seconds / interval.seconds)
+    if (count >= 1) {
+      return `${count} ${interval.label}${count > 1 ? 's' : ''} ago`
+    }
   }
   return 'Just now'
 }
 
-function exactTime(value) {
-  if (!value) return 'Unknown time'
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: 'medium',
-    timeStyle: 'short'
-  }).format(new Date(Number(value)))
-}
-
-function isoTime(value) {
-  if (!value) return undefined
-  return new Date(Number(value)).toISOString()
-}
-
-function targetLabel(deployment) {
-  return [deployment.environment?.name, deployment.app?.name]
-    .filter(Boolean)
-    .join(' / ')
+function deploymentTestId(deployment) {
+  if (deployment.status === 'failed') return 'failed-deployment-row'
+  if (
+    ['pending', 'building', 'pushing', 'deploying'].includes(deployment.status)
+  ) {
+    return 'active-deployment-row'
+  }
+  return 'deployment-history-row'
 }
 </script>
 
 <template>
-  <section class="space-y-8" data-testid="deployment-overview">
-    <p class="sr-only" aria-live="polite">{{ liveRegionMessage }}</p>
+  <div v-if="deployments.length > 0 || !hideWhenEmpty">
+    <h2 class="mb-4 text-sm font-medium text-gray-900 dark:text-white">
+      {{ title }}
+    </h2>
 
-    <div>
-      <div class="mb-3 flex items-center justify-between gap-4">
-        <div>
-          <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
-            {{ currentTitle }}
-          </h2>
-          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            The release currently serving application traffic.
-          </p>
-        </div>
-      </div>
-
+    <div
+      v-if="deployments.length > 0"
+      class="rounded-lg border border-gray-200 dark:border-gray-800"
+      data-testid="deployment-history"
+    >
       <div
-        v-if="history.currentReleases?.length"
-        class="grid gap-3 lg:grid-cols-2"
+        class="divide-y divide-gray-200 rounded-lg bg-white dark:divide-gray-800 dark:bg-gray-950"
       >
-        <article
-          v-for="release in history.currentReleases"
-          :key="release.id"
-          class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm shadow-gray-950/[0.02] dark:border-gray-800 dark:bg-gray-950"
-          data-testid="current-release"
-        >
-          <div
-            class="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
-          >
-            <div class="min-w-0">
-              <div class="flex flex-wrap items-center gap-2">
-                <span
-                  :class="[
-                    'inline-flex rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
-                    outcomeClasses('current')
-                  ]"
-                >
-                  Current
-                </span>
-                <span
-                  :class="[
-                    'text-xs font-medium',
-                    healthClasses(release.health)
-                  ]"
-                >
-                  {{ release.health }}
-                </span>
-              </div>
-              <h3
-                class="mt-3 truncate text-base font-semibold text-gray-950 dark:text-white"
-              >
-                {{ release.title }}
-              </h3>
-              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                {{ targetLabel(release) }}
-                <template v-if="release.gitBranch || release.gitCommit">
-                  <span aria-hidden="true"> · </span>
-                  <span v-if="release.gitBranch">{{ release.gitBranch }}</span>
-                  <code
-                    v-if="release.gitCommit"
-                    class="ml-1 font-mono text-xs"
-                    >{{ release.gitCommit.slice(0, 7) }}</code
-                  >
-                </template>
-              </p>
-            </div>
-            <div class="flex w-full shrink-0 items-center gap-2 sm:w-auto">
-              <Link
-                v-if="release.appHref"
-                :href="release.appHref"
-                class="min-h-11 inline-flex flex-1 items-center justify-center rounded-lg border border-gray-200 px-3 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-900 sm:flex-none"
-              >
-                View app
-              </Link>
-              <Link
-                :href="release.href"
-                aria-label="Open current deployment"
-                class="inline-flex h-11 w-11 items-center justify-center rounded-lg bg-gray-950 text-white hover:bg-gray-800 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100"
-              >
-                <svg
-                  class="h-4 w-4"
-                  viewBox="0 0 20 20"
-                  fill="none"
-                  stroke="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="m7 4 6 6-6 6"
-                    stroke-width="1.7"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                  />
-                </svg>
-              </Link>
-            </div>
-          </div>
-          <dl class="mt-5 grid grid-cols-2 gap-x-5 gap-y-3 sm:grid-cols-4">
-            <div>
-              <dt class="text-xs text-gray-400 dark:text-gray-500">Source</dt>
-              <dd class="mt-1 text-sm text-gray-700 dark:text-gray-200">
-                {{ release.sourceLabel }}
-              </dd>
-            </div>
-            <div>
-              <dt class="text-xs text-gray-400 dark:text-gray-500">Actor</dt>
-              <dd
-                class="mt-1 truncate text-sm text-gray-700 dark:text-gray-200"
-              >
-                {{ release.actor }}
-              </dd>
-            </div>
-            <div>
-              <dt class="text-xs text-gray-400 dark:text-gray-500">Duration</dt>
-              <dd class="mt-1 text-sm text-gray-700 dark:text-gray-200">
-                {{ formatDuration(release.duration) }}
-              </dd>
-            </div>
-            <div>
-              <dt class="text-xs text-gray-400 dark:text-gray-500">Deployed</dt>
-              <dd class="mt-1 text-sm text-gray-700 dark:text-gray-200">
-                <time
-                  :datetime="isoTime(release.deployedAt)"
-                  :title="exactTime(release.deployedAt)"
-                >
-                  {{ relativeTime(release.deployedAt) }}
-                </time>
-              </dd>
-            </div>
-          </dl>
-        </article>
-      </div>
-
-      <div
-        v-else
-        class="rounded-xl border border-dashed border-gray-300 px-5 py-6 dark:border-gray-700"
-        data-testid="no-current-release"
-      >
-        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">
-          No current release
-        </p>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          {{ currentEmpty }}
-        </p>
-      </div>
-    </div>
-
-    <div v-if="activeDeployments.length" aria-live="polite">
-      <div class="mb-3">
-        <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
-          Active work
-        </h2>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Live deployment progress. This does not change history ordering.
-        </p>
-      </div>
-      <div class="space-y-2">
         <Link
-          v-for="deployment in activeDeployments"
+          v-for="deployment in deployments"
           :key="deployment.id"
           :href="deployment.href"
-          class="block rounded-xl border border-blue-200 bg-blue-50/50 p-4 hover:border-blue-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:border-blue-900 dark:bg-blue-950/20 dark:hover:border-blue-800"
-          data-testid="active-deployment"
+          :class="[
+            'flex items-center justify-between py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50',
+            showEnvironment ? 'px-6' : 'px-4'
+          ]"
+          data-testid="deployment-row"
+          :data-test="deploymentTestId(deployment)"
         >
-          <div class="flex items-start justify-between gap-4">
-            <div class="min-w-0">
-              <div class="flex flex-wrap items-center gap-2">
-                <span
-                  :class="[
-                    'inline-flex rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
-                    outcomeClasses('in-progress')
-                  ]"
-                >
-                  {{ deployment.outcomeLabel }}
-                </span>
-                <span class="text-xs text-gray-500 dark:text-gray-400">
-                  {{ targetLabel(deployment) }}
-                </span>
-              </div>
-              <p
-                class="mt-2 truncate text-sm font-medium text-gray-900 dark:text-white"
-              >
-                {{ deployment.title }}
-              </p>
-            </div>
-            <span class="shrink-0 text-xs text-gray-500 dark:text-gray-400">
-              {{ formatDuration(displayDuration(deployment)) }}
+          <div class="flex items-center space-x-3">
+            <span
+              :class="[
+                'h-2 w-2 rounded-full',
+                statusDotClasses(deployment.status)
+              ]"
+            ></span>
+            <span
+              v-if="showEnvironment"
+              class="text-sm text-gray-900 dark:text-white"
+            >
+              {{ deployment.environment?.name || 'Unknown' }}
+            </span>
+            <span
+              v-if="showStatus"
+              :class="[
+                'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium',
+                statusBadge(deployment.status).classes
+              ]"
+            >
+              {{ statusBadge(deployment.status).label }}
+            </span>
+            <span
+              v-if="deployment.app?.name"
+              class="inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+            >
+              {{ deployment.app.name }}
+            </span>
+            <span
+              v-if="deployment.gitBranch"
+              class="text-xs text-gray-500 dark:text-gray-400"
+            >
+              {{ deployment.gitBranch }}
+            </span>
+            <span
+              v-if="showStatus && deployment.gitCommit"
+              class="font-mono text-xs text-gray-400 dark:text-gray-500"
+            >
+              {{ deployment.gitCommit.slice(0, 7) }}
             </span>
           </div>
-          <div
-            class="mt-4 h-1.5 overflow-hidden rounded-full bg-blue-100 dark:bg-blue-950"
-            aria-hidden="true"
-          >
-            <div
-              class="h-full rounded-full bg-blue-600 transition-[width] duration-500 dark:bg-blue-400"
-              :style="{ width: `${progressFor(deployment.status)}%` }"
-            ></div>
+          <div class="flex items-center space-x-4">
+            <span class="text-xs text-gray-500 dark:text-gray-400">
+              {{ deployment.actor }}
+            </span>
+            <span class="text-xs text-gray-400 dark:text-gray-500">
+              {{ timeAgo(deployment.createdAt) }}
+            </span>
           </div>
         </Link>
       </div>
     </div>
 
-    <div>
-      <div
-        class="flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between"
-      >
-        <div>
-          <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
-            Deployment history
-          </h2>
-          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Newest first, with deployment outcome separate from runtime state.
-          </p>
-        </div>
-
-        <div class="flex flex-wrap items-end gap-2">
-          <label v-if="showEnvironmentFilter" class="block">
-            <span class="sr-only">Filter by environment</span>
-            <select
-              v-model="selectedEnvironment"
-              class="min-h-11 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
-              @change="applyFilters"
-            >
-              <option value="">All environments</option>
-              <option
-                v-for="option in history.options.environments"
-                :key="option.value"
-                :value="option.value"
-              >
-                {{ option.label }}
-              </option>
-            </select>
-          </label>
-          <label v-if="showAppFilter" class="block">
-            <span class="sr-only">Filter by app</span>
-            <select
-              v-model="selectedApp"
-              class="min-h-11 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
-              @change="applyFilters"
-            >
-              <option value="">All apps</option>
-              <option
-                v-for="option in history.options.apps"
-                :key="option.value"
-                :value="option.value"
-              >
-                {{ option.label }}
-              </option>
-            </select>
-          </label>
-          <label class="block">
-            <span class="sr-only">Filter by source</span>
-            <select
-              v-model="selectedSource"
-              class="min-h-11 rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/20 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
-              @change="applyFilters"
-            >
-              <option value="">All sources</option>
-              <option
-                v-for="option in history.options.sources"
-                :key="option.value"
-                :value="option.value"
-              >
-                {{ option.label }}
-              </option>
-            </select>
-          </label>
-        </div>
-      </div>
-
-      <fieldset class="mt-4 min-w-0">
-        <legend class="sr-only">Filter deployments by outcome</legend>
-        <div
-          class="flex max-w-full gap-1 overflow-x-auto rounded-lg bg-gray-100 p-1 dark:bg-gray-900"
-          :class="hasSecondaryFilters ? 'lg:max-w-xl' : 'lg:max-w-lg'"
-        >
-          <button
-            v-for="filter in statusFilters"
-            :key="filter.value"
-            type="button"
-            :data-test="`deployment-filter-${filter.value}`"
-            :aria-pressed="selectedStatus === filter.value"
-            :class="[
-              'min-h-11 shrink-0 rounded-md px-3 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-1',
-              selectedStatus === filter.value
-                ? 'bg-white text-gray-950 shadow-sm dark:bg-gray-800 dark:text-white'
-                : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white'
-            ]"
-            @click="chooseStatus(filter.value)"
-          >
-            {{ filter.label }}
-          </button>
-        </div>
-      </fieldset>
-
-      <div
-        v-if="updateAvailable"
-        class="mt-4 flex items-center justify-between gap-4 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 dark:border-blue-900 dark:bg-blue-950/30"
-        role="status"
-      >
-        <p class="text-sm text-blue-800 dark:text-blue-200">
-          Deployment activity changed while you were reading.
-        </p>
-        <button
-          type="button"
-          class="min-h-11 shrink-0 rounded-lg bg-blue-700 px-3 text-sm font-medium text-white hover:bg-blue-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 dark:bg-blue-500 dark:text-blue-950"
-          @click="refreshActivity"
-        >
-          Refresh
-        </button>
-      </div>
-
-      <div
-        v-if="items.length"
-        class="mt-4 overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950"
-      >
-        <div class="hidden overflow-x-auto lg:block">
-          <table class="w-full table-fixed text-left">
-            <caption class="sr-only">
-              Deployment history ordered newest first
-            </caption>
-            <thead
-              class="border-b border-gray-200 bg-gray-50/80 dark:border-gray-800 dark:bg-gray-900/60"
-            >
-              <tr>
-                <th class="w-[30%] px-4 py-3 text-xs font-medium text-gray-500">
-                  Deployment
-                </th>
-                <th class="w-[15%] px-3 py-3 text-xs font-medium text-gray-500">
-                  Target
-                </th>
-                <th class="w-[12%] px-3 py-3 text-xs font-medium text-gray-500">
-                  Outcome
-                </th>
-                <th class="w-[9%] px-3 py-3 text-xs font-medium text-gray-500">
-                  Source
-                </th>
-                <th class="w-[11%] px-3 py-3 text-xs font-medium text-gray-500">
-                  Actor
-                </th>
-                <th class="w-[8%] px-3 py-3 text-xs font-medium text-gray-500">
-                  Duration
-                </th>
-                <th class="w-[15%] px-3 py-3 text-xs font-medium text-gray-500">
-                  Deployed
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-100 dark:divide-gray-900">
-              <tr
-                v-for="deployment in items"
-                :key="deployment.id"
-                class="transition-colors hover:bg-gray-50/80 dark:hover:bg-gray-900/50"
-                data-testid="deployment-row"
-              >
-                <td class="px-4 py-4 align-top">
-                  <Link
-                    :href="deployment.href"
-                    class="block truncate text-sm font-medium text-gray-950 hover:underline focus:outline-none focus-visible:rounded focus-visible:ring-2 focus-visible:ring-sky-500 dark:text-white"
-                  >
-                    {{ deployment.title }}
-                  </Link>
-                  <p
-                    class="mt-1 truncate text-xs text-gray-500 dark:text-gray-400"
-                  >
-                    <span v-if="deployment.gitBranch">{{
-                      deployment.gitBranch
-                    }}</span>
-                    <code v-if="deployment.gitCommit" class="ml-1 font-mono">{{
-                      deployment.gitCommit.slice(0, 7)
-                    }}</code>
-                    <span v-if="!deployment.gitBranch && !deployment.gitCommit"
-                      >#{{ deployment.id }}</span
-                    >
-                  </p>
-                </td>
-                <td
-                  class="px-3 py-4 align-top text-sm text-gray-600 dark:text-gray-300"
-                >
-                  <span class="block truncate">{{
-                    deployment.environment?.name || 'Unknown'
-                  }}</span>
-                  <span class="mt-1 block truncate text-xs text-gray-400">{{
-                    deployment.app?.name || 'Default app'
-                  }}</span>
-                </td>
-                <td class="px-3 py-4 align-top">
-                  <span
-                    :class="[
-                      'inline-flex rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
-                      outcomeClasses(deployment.outcome)
-                    ]"
-                  >
-                    {{ deployment.outcomeLabel }}
-                  </span>
-                </td>
-                <td
-                  class="px-3 py-4 align-top text-sm text-gray-600 dark:text-gray-300"
-                >
-                  {{ deployment.sourceLabel }}
-                </td>
-                <td
-                  class="truncate px-3 py-4 align-top text-sm text-gray-600 dark:text-gray-300"
-                >
-                  {{ deployment.actor }}
-                </td>
-                <td
-                  class="px-3 py-4 align-top font-mono text-xs text-gray-500 dark:text-gray-400"
-                >
-                  {{ formatDuration(displayDuration(deployment)) }}
-                </td>
-                <td class="px-3 py-4 align-top">
-                  <time
-                    :datetime="isoTime(deployment.deployedAt)"
-                    :title="exactTime(deployment.deployedAt)"
-                    class="block text-sm text-gray-600 dark:text-gray-300"
-                  >
-                    {{ relativeTime(deployment.deployedAt) }}
-                  </time>
-                  <span
-                    class="mt-1 block text-xs text-gray-400 dark:text-gray-500"
-                  >
-                    {{ exactTime(deployment.deployedAt) }}
-                  </span>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <div class="divide-y divide-gray-100 dark:divide-gray-900 lg:hidden">
-          <article
-            v-for="deployment in items"
-            :key="deployment.id"
-            class="p-4"
-            data-testid="deployment-card"
-          >
-            <div class="flex items-start justify-between gap-3">
-              <div class="min-w-0">
-                <Link
-                  :href="deployment.href"
-                  class="block truncate text-sm font-semibold text-gray-950 focus:outline-none focus-visible:rounded focus-visible:ring-2 focus-visible:ring-sky-500 dark:text-white"
-                >
-                  {{ deployment.title }}
-                </Link>
-                <p
-                  class="mt-1 truncate text-xs text-gray-500 dark:text-gray-400"
-                >
-                  {{ targetLabel(deployment) || 'Unknown target' }}
-                </p>
-              </div>
-              <span
-                :class="[
-                  'inline-flex shrink-0 rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset',
-                  outcomeClasses(deployment.outcome)
-                ]"
-              >
-                {{ deployment.outcomeLabel }}
-              </span>
-            </div>
-            <dl class="mt-4 grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
-              <div>
-                <dt class="text-xs text-gray-400">Source</dt>
-                <dd class="mt-1 text-gray-700 dark:text-gray-200">
-                  {{ deployment.sourceLabel }}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-xs text-gray-400">Actor</dt>
-                <dd class="mt-1 truncate text-gray-700 dark:text-gray-200">
-                  {{ deployment.actor }}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-xs text-gray-400">Duration</dt>
-                <dd
-                  class="mt-1 font-mono text-xs text-gray-700 dark:text-gray-200"
-                >
-                  {{ formatDuration(displayDuration(deployment)) }}
-                </dd>
-              </div>
-              <div>
-                <dt class="text-xs text-gray-400">Deployed</dt>
-                <dd class="mt-1 text-gray-700 dark:text-gray-200">
-                  <time
-                    :datetime="isoTime(deployment.deployedAt)"
-                    :title="exactTime(deployment.deployedAt)"
-                  >
-                    {{ relativeTime(deployment.deployedAt) }}
-                  </time>
-                </dd>
-              </div>
-            </dl>
-            <p
-              class="mt-3 truncate border-t border-gray-100 pt-3 text-xs text-gray-400 dark:border-gray-900 dark:text-gray-500"
-            >
-              <span v-if="deployment.gitBranch">{{
-                deployment.gitBranch
-              }}</span>
-              <code v-if="deployment.gitCommit" class="ml-1 font-mono">{{
-                deployment.gitCommit.slice(0, 7)
-              }}</code>
-              <span v-if="!deployment.gitBranch && !deployment.gitCommit"
-                >Deployment #{{ deployment.id }}</span
-              >
-              <span aria-hidden="true"> · </span>
-              {{ exactTime(deployment.deployedAt) }}
-            </p>
-          </article>
-        </div>
-      </div>
-
-      <div
-        v-else
-        class="mt-4 rounded-xl border border-dashed border-gray-300 px-6 py-10 text-center dark:border-gray-700"
-        data-testid="empty-deployment-history"
-      >
-        <p class="text-sm font-medium text-gray-700 dark:text-gray-200">
-          No matching deployments
-        </p>
-        <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-          Try another filter, or deploy an application to start its history.
-        </p>
-      </div>
-
-      <div v-if="history.nextCursor" class="mt-4 flex justify-center">
-        <button
-          type="button"
-          class="min-h-11 inline-flex items-center justify-center rounded-lg border border-gray-200 bg-white px-4 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 disabled:cursor-wait disabled:opacity-60 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200 dark:hover:bg-gray-900"
-          :disabled="loadingMore"
-          @click="loadMore"
-        >
-          {{ loadingMore ? 'Loading…' : 'Load more' }}
-        </button>
-      </div>
+    <div
+      v-else
+      class="rounded-lg border border-dashed border-gray-300 px-6 py-8 text-center dark:border-gray-700"
+      data-testid="empty-deployment-history"
+    >
+      <p class="text-sm text-gray-500 dark:text-gray-400">
+        {{ emptyMessage }}
+      </p>
+      <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
+        {{ emptyHelp }}
+      </p>
     </div>
-  </section>
+  </div>
 </template>

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -747,10 +747,10 @@ onUnmounted(() => {
     >
       <!-- Team Selector + Collapse -->
       <div class="flex items-center justify-between px-3 py-4">
-        <div class="relative min-w-0 flex-1">
+        <div class="relative flex-1">
           <button
             @click.stop="teamDropdownOpen = !teamDropdownOpen"
-            class="flex w-full min-w-0 items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
+            class="flex w-full items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
           >
             <img
               v-if="loggedInUser.team?.logoUrl"
@@ -1212,14 +1212,12 @@ onUnmounted(() => {
         :action="action"
         @dismiss="dismissAction"
       />
-      <template v-if="!page.props.deploymentHistory">
-        <DeploymentToast
-          v-for="deployment in activeDeployments"
-          :key="'deploy-' + deployment.id"
-          :deployment="deployment"
-          @dismiss="dismissDeployment"
-        />
-      </template>
+      <DeploymentToast
+        v-for="deployment in activeDeployments"
+        :key="'deploy-' + deployment.id"
+        :deployment="deployment"
+        @dismiss="dismissDeployment"
+      />
     </div>
 
     <!-- Command Palette (Cmd+K) -->

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -747,10 +747,10 @@ onUnmounted(() => {
     >
       <!-- Team Selector + Collapse -->
       <div class="flex items-center justify-between px-3 py-4">
-        <div class="relative flex-1">
+        <div class="relative min-w-0 flex-1">
           <button
             @click.stop="teamDropdownOpen = !teamDropdownOpen"
-            class="flex w-full items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
+            class="flex w-full min-w-0 items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
           >
             <img
               v-if="loggedInUser.team?.logoUrl"
@@ -1212,12 +1212,14 @@ onUnmounted(() => {
         :action="action"
         @dismiss="dismissAction"
       />
-      <DeploymentToast
-        v-for="deployment in activeDeployments"
-        :key="'deploy-' + deployment.id"
-        :deployment="deployment"
-        @dismiss="dismissDeployment"
-      />
+      <template v-if="!page.props.deploymentHistory">
+        <DeploymentToast
+          v-for="deployment in activeDeployments"
+          :key="'deploy-' + deployment.id"
+          :deployment="deployment"
+          @dismiss="dismissDeployment"
+        />
+      </template>
     </div>
 
     <!-- Command Palette (Cmd+K) -->

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -17,6 +17,7 @@ import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { useToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import DeploymentHistory from '@/components/DeploymentHistory.vue'
 import { highlightLogLine } from '@/lib/highlightLog'
 
 defineOptions({
@@ -29,7 +30,7 @@ const props = defineProps({
   app: Object,
   appEnvVars: Object,
   inheritedVars: Object,
-  deployments: Array,
+  deploymentHistory: Object,
   services: Array,
   backupConfigured: Boolean,
   checklist: Array,
@@ -40,56 +41,6 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const toast = useToast()
-
-// --- SSE-powered deployment tracking (replaces usePoll) ---
-const activeDeploymentSources = ref(new Map())
-
-function connectActiveDeployments() {
-  const activeStatuses = ['pending', 'building', 'deploying']
-  const active = props.deployments.filter((d) =>
-    activeStatuses.includes(d.status)
-  )
-
-  for (const dep of active) {
-    if (activeDeploymentSources.value.has(dep.id)) continue
-
-    const es = new EventSource(`/api/v1/deployments/${dep.id}/stream`)
-    es.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data)
-        if (
-          data.status &&
-          ['running', 'failed', 'cancelled'].includes(data.status)
-        ) {
-          es.close()
-          activeDeploymentSources.value.delete(dep.id)
-          router.reload()
-        }
-      } catch {
-        /* ignore */
-      }
-    }
-    es.onerror = () => {
-      /* auto-reconnects */
-    }
-    activeDeploymentSources.value.set(dep.id, es)
-  }
-}
-
-function disconnectActiveDeployments() {
-  for (const es of activeDeploymentSources.value.values()) {
-    es.close()
-  }
-  activeDeploymentSources.value.clear()
-}
-
-watch(
-  () => props.deployments,
-  () => {
-    connectActiveDeployments()
-  },
-  { immediate: true }
-)
 
 // --- Deploy ---
 const deploying = ref(false)
@@ -700,7 +651,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  disconnectActiveDeployments()
   disconnectLogs()
   document.removeEventListener('keydown', handleEscapeKey)
 })
@@ -1861,94 +1811,11 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <!-- Deployments -->
-        <div>
-          <h2 class="mb-4 text-sm font-medium text-gray-900 dark:text-white">
-            Deployments
-          </h2>
-
-          <div
-            v-if="deployments.length > 0"
-            class="rounded-lg border border-gray-200 dark:border-gray-800"
-          >
-            <div
-              class="divide-y divide-gray-200 rounded-lg bg-white dark:divide-gray-800 dark:bg-gray-950"
-            >
-              <Link
-                v-for="dep in deployments"
-                :key="dep.id"
-                :href="`/projects/${project.slug}/deployments/${dep.id}`"
-                class="flex items-center justify-between px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50"
-              >
-                <div class="flex items-center space-x-3">
-                  <span
-                    :class="[
-                      'h-2 w-2 rounded-full',
-                      dep.status === 'running'
-                        ? 'bg-green-500'
-                        : dep.status === 'failed'
-                        ? 'bg-red-500'
-                        : dep.status === 'building' ||
-                          dep.status === 'deploying'
-                        ? 'bg-blue-500'
-                        : dep.status === 'cancelled' || dep.status === 'stopped'
-                        ? 'bg-gray-400'
-                        : 'bg-yellow-500'
-                    ]"
-                  ></span>
-                  <span
-                    :class="[
-                      'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium',
-                      statusBadge(dep.status).classes
-                    ]"
-                  >
-                    {{ statusBadge(dep.status).label }}
-                  </span>
-                  <span
-                    class="inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
-                  >
-                    {{ app.name }}
-                  </span>
-                  <span
-                    v-if="dep.gitBranch"
-                    class="text-xs text-gray-500 dark:text-gray-400"
-                  >
-                    {{ dep.gitBranch }}
-                  </span>
-                  <span
-                    v-if="dep.gitCommit"
-                    class="font-mono text-xs text-gray-400 dark:text-gray-500"
-                  >
-                    {{ dep.gitCommit.slice(0, 7) }}
-                  </span>
-                </div>
-                <div class="flex items-center space-x-4">
-                  <span class="text-xs text-gray-500 dark:text-gray-400">
-                    {{
-                      dep.triggeredBy?.fullName ||
-                      (dep.triggerType === 'webhook' ? 'Git' : 'System')
-                    }}
-                  </span>
-                  <span class="text-xs text-gray-400 dark:text-gray-500">
-                    {{ timeAgo(dep.createdAt) }}
-                  </span>
-                </div>
-              </Link>
-            </div>
-          </div>
-
-          <div
-            v-else
-            class="rounded-lg border border-dashed border-gray-300 px-6 py-8 text-center dark:border-gray-700"
-          >
-            <p class="text-sm text-gray-500 dark:text-gray-400">
-              No deployments yet.
-            </p>
-            <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
-              Slide to deploy your first version.
-            </p>
-          </div>
-        </div>
+        <DeploymentHistory
+          :history="deploymentHistory"
+          :base-url="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`"
+          current-empty="Deploy this app to establish its current release."
+        />
       </div>
     </div>
 

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -1813,8 +1813,7 @@ onBeforeUnmount(() => {
 
         <DeploymentHistory
           :history="deploymentHistory"
-          :base-url="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`"
-          current-empty="Deploy this app to establish its current release."
+          empty-help="Slide to deploy your first version."
         />
       </div>
     </div>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -2511,8 +2511,7 @@ onBeforeUnmount(() => {
 
         <DeploymentHistory
           :history="deploymentHistory"
-          :base-url="`/projects/${project.slug}/environments/${environment.slug}`"
-          current-empty="Deploy an app in this environment to establish the current release."
+          empty-help="Slide to deploy your first version."
         />
       </div>
     </div>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -14,6 +14,7 @@ import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import DeploymentHistory from '@/components/DeploymentHistory.vue'
 import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
 import { useEventSource } from '@/composables/sse'
@@ -28,7 +29,7 @@ const props = defineProps({
   app: Object,
   apps: Array,
   envVars: Object,
-  deployments: Array,
+  deploymentHistory: Object,
   checklist: Array,
   backupConfigured: Boolean,
   githubConnected: Boolean,
@@ -273,56 +274,6 @@ function cancelAddApp() {
   createAppForm.reset()
   clearRepo()
 }
-
-// --- SSE-powered deployment tracking (replaces usePoll) ---
-const activeDeploymentSources = ref(new Map())
-
-function connectActiveDeployments() {
-  const activeStatuses = ['pending', 'building', 'deploying']
-  const active = props.deployments.filter((d) =>
-    activeStatuses.includes(d.status)
-  )
-
-  for (const dep of active) {
-    if (activeDeploymentSources.value.has(dep.id)) continue
-
-    const es = new EventSource(`/api/v1/deployments/${dep.id}/stream`)
-    es.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data)
-        if (
-          data.status &&
-          ['running', 'failed', 'cancelled'].includes(data.status)
-        ) {
-          es.close()
-          activeDeploymentSources.value.delete(dep.id)
-          router.reload()
-        }
-      } catch {
-        /* ignore */
-      }
-    }
-    es.onerror = () => {
-      /* auto-reconnects */
-    }
-    activeDeploymentSources.value.set(dep.id, es)
-  }
-}
-
-function disconnectActiveDeployments() {
-  for (const es of activeDeploymentSources.value.values()) {
-    es.close()
-  }
-  activeDeploymentSources.value.clear()
-}
-
-watch(
-  () => props.deployments,
-  () => {
-    connectActiveDeployments()
-  },
-  { immediate: true }
-)
 
 // --- Env vars management ---
 const localVars = reactive({ ...props.envVars })
@@ -961,7 +912,6 @@ onMounted(() => {
 })
 
 onBeforeUnmount(() => {
-  disconnectActiveDeployments()
   document.removeEventListener('keydown', handleEscapeKey)
 })
 </script>
@@ -2559,95 +2509,11 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <!-- Deployments -->
-        <div>
-          <h2 class="mb-4 text-sm font-medium text-gray-900 dark:text-white">
-            Deployments
-          </h2>
-
-          <div
-            v-if="deployments.length > 0"
-            class="rounded-lg border border-gray-200 dark:border-gray-800"
-          >
-            <div
-              class="divide-y divide-gray-200 rounded-lg bg-white dark:divide-gray-800 dark:bg-gray-950"
-            >
-              <Link
-                v-for="dep in deployments"
-                :key="dep.id"
-                :href="`/projects/${project.slug}/deployments/${dep.id}`"
-                class="flex items-center justify-between px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50"
-              >
-                <div class="flex items-center space-x-3">
-                  <span
-                    :class="[
-                      'h-2 w-2 rounded-full',
-                      dep.status === 'running'
-                        ? 'bg-green-500'
-                        : dep.status === 'failed'
-                        ? 'bg-red-500'
-                        : dep.status === 'building' ||
-                          dep.status === 'deploying'
-                        ? 'bg-blue-500'
-                        : dep.status === 'cancelled' || dep.status === 'stopped'
-                        ? 'bg-gray-400'
-                        : 'bg-yellow-500'
-                    ]"
-                  ></span>
-                  <span
-                    :class="[
-                      'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium',
-                      statusBadge(dep.status).classes
-                    ]"
-                  >
-                    {{ statusBadge(dep.status).label }}
-                  </span>
-                  <span
-                    v-if="dep.app && dep.app.name"
-                    class="inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
-                  >
-                    {{ dep.app.name }}
-                  </span>
-                  <span
-                    v-if="dep.gitBranch"
-                    class="text-xs text-gray-500 dark:text-gray-400"
-                  >
-                    {{ dep.gitBranch }}
-                  </span>
-                  <span
-                    v-if="dep.gitCommit"
-                    class="font-mono text-xs text-gray-400 dark:text-gray-500"
-                  >
-                    {{ dep.gitCommit.slice(0, 7) }}
-                  </span>
-                </div>
-                <div class="flex items-center space-x-4">
-                  <span class="text-xs text-gray-500 dark:text-gray-400">
-                    {{
-                      dep.triggeredBy?.fullName ||
-                      (dep.triggerType === 'webhook' ? 'Git' : 'System')
-                    }}
-                  </span>
-                  <span class="text-xs text-gray-400 dark:text-gray-500">
-                    {{ timeAgo(dep.createdAt) }}
-                  </span>
-                </div>
-              </Link>
-            </div>
-          </div>
-
-          <div
-            v-else
-            class="rounded-lg border border-dashed border-gray-300 px-6 py-8 text-center dark:border-gray-700"
-          >
-            <p class="text-sm text-gray-500 dark:text-gray-400">
-              No deployments yet.
-            </p>
-            <p class="mt-1 text-sm text-gray-400 dark:text-gray-500">
-              Slide to deploy your first version.
-            </p>
-          </div>
-        </div>
+        <DeploymentHistory
+          :history="deploymentHistory"
+          :base-url="`/projects/${project.slug}/environments/${environment.slug}`"
+          current-empty="Deploy an app in this environment to establish the current release."
+        />
       </div>
     </div>
 

--- a/assets/js/pages/projects/show.vue
+++ b/assets/js/pages/projects/show.vue
@@ -2,6 +2,7 @@
 import { Link, Head } from '@inertiajs/vue3'
 import { inject } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import DeploymentHistory from '@/components/DeploymentHistory.vue'
 
 defineOptions({
   layout: AppLayout
@@ -10,7 +11,7 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environments: Array,
-  recentDeployments: Array
+  deploymentHistory: Object
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -254,9 +255,9 @@ function timeAgo(date) {
             v-for="env in environments"
             :key="env.id"
             :href="`/projects/${project.slug}/environments/${env.slug}`"
-            class="flex items-center justify-between px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-900/50"
+            class="flex flex-col items-start gap-3 px-5 py-4 hover:bg-gray-50 dark:hover:bg-gray-900/50 sm:flex-row sm:items-center sm:justify-between sm:px-6"
           >
-            <div class="flex items-center space-x-3">
+            <div class="flex flex-wrap items-center gap-2 sm:gap-3">
               <span class="font-medium text-gray-900 dark:text-white">{{
                 env.name
               }}</span>
@@ -275,7 +276,9 @@ function timeAgo(date) {
                 {{ statusBadge(env).label }}
               </span>
             </div>
-            <div class="flex items-center space-x-4">
+            <div
+              class="flex w-full items-center justify-between gap-4 sm:w-auto sm:justify-end"
+            >
               <span class="text-sm text-gray-500 dark:text-gray-400">
                 {{
                   env.app?.lastDeployedAt
@@ -317,66 +320,13 @@ function timeAgo(date) {
           </p>
         </div>
 
-        <!-- Recent Deployments -->
-        <div v-if="recentDeployments.length > 0" class="mt-10">
-          <h2 class="mb-4 text-sm font-medium text-gray-900 dark:text-white">
-            Recent deployments
-          </h2>
-          <div class="rounded-lg border border-gray-200 dark:border-gray-800">
-            <div
-              class="divide-y divide-gray-200 rounded-lg bg-white dark:divide-gray-800 dark:bg-gray-950"
-            >
-              <Link
-                v-for="dep in recentDeployments"
-                :key="dep.id"
-                :href="`/projects/${project.slug}/deployments/${dep.id}`"
-                class="flex items-center justify-between px-6 py-3 hover:bg-gray-50 dark:hover:bg-gray-900/50"
-              >
-                <div class="flex items-center space-x-3">
-                  <span
-                    :class="[
-                      'h-2 w-2 rounded-full',
-                      dep.status === 'running'
-                        ? 'bg-green-500'
-                        : dep.status === 'failed'
-                        ? 'bg-red-500'
-                        : dep.status === 'building' ||
-                          dep.status === 'deploying'
-                        ? 'bg-blue-500'
-                        : 'bg-gray-400'
-                    ]"
-                  ></span>
-                  <span class="text-sm text-gray-900 dark:text-white">{{
-                    dep.environment?.name || 'Unknown'
-                  }}</span>
-                  <span
-                    v-if="dep.app && dep.app.name"
-                    class="inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
-                  >
-                    {{ dep.app.name }}
-                  </span>
-                  <span
-                    v-if="dep.gitBranch"
-                    class="text-xs text-gray-500 dark:text-gray-400"
-                  >
-                    {{ dep.gitBranch }}
-                  </span>
-                </div>
-                <div class="flex items-center space-x-4">
-                  <span class="text-xs text-gray-500 dark:text-gray-400">
-                    {{
-                      dep.triggeredBy?.fullName ||
-                      (dep.triggerType === 'webhook' ? 'Git' : 'System')
-                    }}
-                  </span>
-                  <span class="text-xs text-gray-400 dark:text-gray-500">
-                    {{ timeAgo(dep.createdAt) }}
-                  </span>
-                </div>
-              </Link>
-            </div>
-          </div>
-        </div>
+        <DeploymentHistory
+          class="mt-10"
+          :history="deploymentHistory"
+          :base-url="`/projects/${project.slug}`"
+          current-title="Current production release"
+          current-empty="Deploy an app to production to establish the current release."
+        />
       </div>
     </div>
   </div>

--- a/assets/js/pages/projects/show.vue
+++ b/assets/js/pages/projects/show.vue
@@ -255,9 +255,9 @@ function timeAgo(date) {
             v-for="env in environments"
             :key="env.id"
             :href="`/projects/${project.slug}/environments/${env.slug}`"
-            class="flex flex-col items-start gap-3 px-5 py-4 hover:bg-gray-50 dark:hover:bg-gray-900/50 sm:flex-row sm:items-center sm:justify-between sm:px-6"
+            class="flex items-center justify-between px-6 py-4 hover:bg-gray-50 dark:hover:bg-gray-900/50"
           >
-            <div class="flex flex-wrap items-center gap-2 sm:gap-3">
+            <div class="flex items-center space-x-3">
               <span class="font-medium text-gray-900 dark:text-white">{{
                 env.name
               }}</span>
@@ -276,9 +276,7 @@ function timeAgo(date) {
                 {{ statusBadge(env).label }}
               </span>
             </div>
-            <div
-              class="flex w-full items-center justify-between gap-4 sm:w-auto sm:justify-end"
-            >
+            <div class="flex items-center space-x-4">
               <span class="text-sm text-gray-500 dark:text-gray-400">
                 {{
                   env.app?.lastDeployedAt
@@ -323,9 +321,10 @@ function timeAgo(date) {
         <DeploymentHistory
           class="mt-10"
           :history="deploymentHistory"
-          :base-url="`/projects/${project.slug}`"
-          current-title="Current production release"
-          current-empty="Deploy an app to production to establish the current release."
+          title="Recent deployments"
+          show-environment
+          :show-status="false"
+          hide-when-empty
         />
       </div>
     </div>

--- a/tests/e2e/pages/projects/deployment-history.test.js
+++ b/tests/e2e/pages/projects/deployment-history.test.js
@@ -1,0 +1,110 @@
+const { test } = require('sounding')
+
+async function seedHistory({ sails, world }) {
+  const current = world.current
+  const target = {
+    environment: current.environments.production.id,
+    app: current.apps.web.id
+  }
+  const now = Date.now()
+  const currentRelease = await world.create('deployment').with({
+    ...target,
+    status: 'running',
+    triggerType: 'webhook',
+    gitBranch: 'main',
+    gitCommit: 'c0ffee123456789',
+    gitMessage: 'Ship deployment history',
+    startedAt: now - 20000,
+    finishedAt: now - 5000,
+    createdAt: now - 20000
+  })
+  await world.create('deployment').with({
+    ...target,
+    status: 'stopped',
+    triggerType: 'webhook',
+    gitMessage: 'Previous successful release',
+    startedAt: now - 80000,
+    finishedAt: now - 60000,
+    createdAt: now - 80000
+  })
+  await world.create('deployment').with({
+    ...target,
+    status: 'failed',
+    triggerType: 'cli',
+    gitMessage: 'Failed release for filtering',
+    startedAt: now - 50000,
+    finishedAt: now - 45000,
+    createdAt: now - 50000
+  })
+  await world.create('deployment').with({
+    ...target,
+    status: 'building',
+    triggerType: 'manual',
+    gitMessage: 'Build in progress',
+    startedAt: now - 3000,
+    createdAt: now - 3000
+  })
+
+  await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+    status: 'running',
+    currentDeployment: currentRelease.id,
+    lastDeployedAt: currentRelease.finishedAt
+  })
+
+  return current.projects.deploymentTarget.slug
+}
+
+function historyWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: {
+        slug,
+        name: 'Deployment History UI'
+      }
+    }
+  }
+}
+
+test(
+  'deployment history is clear and keyboard-filterable on desktop',
+  { browser: true, world: historyWorld('deployment-history-desktop') },
+  async ({ sails, world, login, page, expect }) => {
+    const slug = await seedHistory({ sails, world })
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.goto(`/projects/${slug}`)
+
+    await page.wait('@current-release')
+    await page.wait('@active-deployment')
+    await page.wait('@deployment-row')
+    await expect(page).toSee('Current production release')
+    await expect(page).toSee('Ship deployment history')
+    await expect(page).toSee('Build in progress')
+    await expect(page).toSee('Succeeded')
+
+    await page.press('@deployment-filter-failed', 'Enter')
+    await expect(page).toSee('Failed release for filtering')
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)
+
+test(
+  'deployment history prioritizes readable cards on mobile',
+  { browser: 'mobile', world: historyWorld('deployment-history-mobile') },
+  async ({ sails, world, login, page, expect }) => {
+    const slug = await seedHistory({ sails, world })
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.goto(`/projects/${slug}`)
+
+    await page.wait('@current-release')
+    await page.wait('@deployment-card')
+    await expect(page).toSee('Deployment history')
+    await expect(page).toSee('Ship deployment history')
+    await expect(page).toSee('Previous successful release')
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)

--- a/tests/e2e/pages/projects/deployment-history.test.js
+++ b/tests/e2e/pages/projects/deployment-history.test.js
@@ -51,7 +51,11 @@ async function seedHistory({ sails, world }) {
     lastDeployedAt: currentRelease.finishedAt
   })
 
-  return current.projects.deploymentTarget.slug
+  return {
+    projectSlug: current.projects.deploymentTarget.slug,
+    environmentSlug: current.environments.production.slug,
+    appSlug: current.apps.web.slug
+  }
 }
 
 function historyWorld(slug) {
@@ -67,44 +71,51 @@ function historyWorld(slug) {
 }
 
 test(
-  'deployment history is clear and keyboard-filterable on desktop',
+  'deployment history keeps the compact deployment list on desktop',
   { browser: true, world: historyWorld('deployment-history-desktop') },
   async ({ sails, world, login, page, expect }) => {
-    const slug = await seedHistory({ sails, world })
+    const target = await seedHistory({ sails, world })
     await login.withPassword('genesisUser', page, {
       password: world.current.auth.genesisUserPassword
     })
-    await page.goto(`/projects/${slug}`)
+    await page.goto(
+      `/projects/${target.projectSlug}/environments/${target.environmentSlug}/apps/${target.appSlug}`
+    )
 
-    await page.wait('@current-release')
-    await page.wait('@active-deployment')
-    await page.wait('@deployment-row')
-    await expect(page).toSee('Current production release')
-    await expect(page).toSee('Ship deployment history')
-    await expect(page).toSee('Build in progress')
-    await expect(page).toSee('Succeeded')
+    await page.wait('@deployment-history')
+    await page.wait('@active-deployment-row')
+    await page.wait('@failed-deployment-row')
+    await expect(page).toSee('Deployments')
+    await expect(page).toSee('Running')
+    await expect(page).toSee('Building')
+    await expect(page).toSee('Failed')
+    await expect(page).toSee('Stopped')
+    await expect(page).toSee('main')
+    await expect(page).toSee('c0ffee1')
 
-    await page.press('@deployment-filter-failed', 'Enter')
-    await expect(page).toSee('Failed release for filtering')
     expect(page).toHaveNoJavascriptErrors()
   }
 )
 
 test(
-  'deployment history prioritizes readable cards on mobile',
+  'deployment history keeps the compact deployment list on mobile',
   { browser: 'mobile', world: historyWorld('deployment-history-mobile') },
   async ({ sails, world, login, page, expect }) => {
-    const slug = await seedHistory({ sails, world })
+    const target = await seedHistory({ sails, world })
     await login.withPassword('genesisUser', page, {
       password: world.current.auth.genesisUserPassword
     })
-    await page.goto(`/projects/${slug}`)
+    await page.goto(
+      `/projects/${target.projectSlug}/environments/${target.environmentSlug}/apps/${target.appSlug}`
+    )
 
-    await page.wait('@current-release')
-    await page.wait('@deployment-card')
-    await expect(page).toSee('Deployment history')
-    await expect(page).toSee('Ship deployment history')
-    await expect(page).toSee('Previous successful release')
+    await page.wait('@deployment-history')
+    await page.wait('@active-deployment-row')
+    await expect(page).toSee('Deployments')
+    await expect(page).toSee('Running')
+    await expect(page).toSee('Building')
+    await expect(page).toSee('Failed')
+    await expect(page).toSee('Stopped')
     expect(page).toHaveNoJavascriptErrors()
   }
 )

--- a/tests/e2e/pages/projects/deployment-history.test.js
+++ b/tests/e2e/pages/projects/deployment-history.test.js
@@ -14,9 +14,9 @@ async function seedHistory({ sails, world }) {
     gitBranch: 'main',
     gitCommit: 'c0ffee123456789',
     gitMessage: 'Ship deployment history',
-    startedAt: now - 20000,
-    finishedAt: now - 5000,
-    createdAt: now - 20000
+    startedAt: now - 100000,
+    finishedAt: now - 90000,
+    createdAt: now - 100000
   })
   await world.create('deployment').with({
     ...target,
@@ -41,8 +41,8 @@ async function seedHistory({ sails, world }) {
     status: 'building',
     triggerType: 'manual',
     gitMessage: 'Build in progress',
-    startedAt: now - 3000,
-    createdAt: now - 3000
+    startedAt: now - 120000,
+    createdAt: now - 120000
   })
 
   await sails.models.app.updateOne({ id: current.apps.web.id }).set({
@@ -71,7 +71,7 @@ function historyWorld(slug) {
 }
 
 test(
-  'deployment history keeps the compact deployment list on desktop',
+  'deployment history prioritizes active and current compact rows on desktop',
   { browser: true, world: historyWorld('deployment-history-desktop') },
   async ({ sails, world, login, page, expect }) => {
     const target = await seedHistory({ sails, world })
@@ -92,6 +92,17 @@ test(
     await expect(page).toSee('Stopped')
     await expect(page).toSee('main')
     await expect(page).toSee('c0ffee1')
+
+    const rows = await page.script(() =>
+      [...document.querySelectorAll('[data-testid="deployment-row"]')].map(
+        (row) => row.textContent
+      )
+    )
+    expect(rows.length).toBe(4)
+    expect(rows[0].includes('Building')).toBe(true)
+    expect(rows[1].includes('Running')).toBe(true)
+    expect(rows[2].includes('Failed')).toBe(true)
+    expect(rows[3].includes('Stopped')).toBe(true)
 
     expect(page).toHaveNoJavascriptErrors()
   }

--- a/tests/functional/pages/projects.test.js
+++ b/tests/functional/pages/projects.test.js
@@ -88,3 +88,175 @@ test(
     expect(environmentPage).toHaveInertiaProp('app.slug', 'web')
   }
 )
+
+test(
+  'deployment history sorts before limiting and uses a stable cursor',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'ordered-history',
+          name: 'Ordered History'
+        }
+      }
+    }
+  },
+  async ({ sails, world, visit, expect }) => {
+    const current = world.current
+    const environment = current.environments.production
+    const app = current.apps.web
+    const baseTime = Date.now() - 100000
+
+    for (let index = 0; index < 27; index += 1) {
+      await world.create('deployment').with({
+        status: 'stopped',
+        environment: environment.id,
+        app: app.id,
+        gitMessage: `Release ${String(index).padStart(2, '0')}`,
+        createdAt: baseTime + index * 1000,
+        startedAt: baseTime + index * 1000,
+        finishedAt: baseTime + index * 1000 + 500
+      })
+    }
+
+    const tiedAt = baseTime + 200000
+    const firstTie = await world.create('deployment').with({
+      status: 'stopped',
+      environment: environment.id,
+      app: app.id,
+      gitMessage: 'Tie A',
+      createdAt: tiedAt,
+      startedAt: tiedAt,
+      finishedAt: tiedAt + 500
+    })
+    const secondTie = await world.create('deployment').with({
+      status: 'running',
+      environment: environment.id,
+      app: app.id,
+      gitMessage: 'Tie B',
+      createdAt: tiedAt,
+      startedAt: tiedAt,
+      finishedAt: tiedAt + 500
+    })
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'running',
+      currentDeployment: secondTie.id,
+      lastDeployedAt: tiedAt
+    })
+
+    const firstPage = await visit.as('genesisUser')(
+      `/projects/${current.projects.deploymentTarget.slug}`
+    )
+    expect(firstPage).toHaveStatus(200)
+    expect(firstPage).toHaveInertiaPropCount('deploymentHistory.items', 25)
+    expect(firstPage).toHaveInertiaProp(
+      'deploymentHistory.items.0.id',
+      secondTie.id
+    )
+    expect(firstPage).toHaveInertiaProp(
+      'deploymentHistory.items.1.id',
+      firstTie.id
+    )
+    expect(firstPage).toHaveInertiaProp(
+      'deploymentHistory.items.0.outcomeLabel',
+      'Current'
+    )
+    expect(firstPage).toHaveInertiaProp(
+      'deploymentHistory.items.2.outcomeLabel',
+      'Succeeded'
+    )
+    expect(firstPage).toHaveInertiaProp(
+      'deploymentHistory.currentReleases.0.id',
+      secondTie.id
+    )
+
+    const firstItems = firstPage.data.props.deploymentHistory.items
+    const cursor = firstPage.data.props.deploymentHistory.nextCursor
+    expect(Boolean(cursor)).toBe(true)
+
+    const secondPage = await visit.as('genesisUser')(
+      `/projects/${
+        current.projects.deploymentTarget.slug
+      }?deploymentCursor=${encodeURIComponent(cursor)}`
+    )
+    expect(secondPage).toHaveStatus(200)
+    expect(secondPage).toHaveInertiaPropCount('deploymentHistory.items', 4)
+    expect(secondPage).toHaveInertiaProp(
+      'deploymentHistory.items.0.title',
+      'Release 03'
+    )
+    expect(secondPage).toHaveInertiaProp(
+      'deploymentHistory.items.3.title',
+      'Release 00'
+    )
+
+    const firstIds = new Set(firstItems.map((deployment) => deployment.id))
+    const secondItems = secondPage.data.props.deploymentHistory.items
+    expect(secondItems.some((deployment) => firstIds.has(deployment.id))).toBe(
+      false
+    )
+  }
+)
+
+test(
+  'deployment history filters outcomes and sources without hiding active work',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'filtered-history',
+          name: 'Filtered History'
+        }
+      }
+    }
+  },
+  async ({ world, visit, expect }) => {
+    const current = world.current
+    const target = {
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    }
+
+    const failure = await world.create('deployment').with({
+      ...target,
+      status: 'failed',
+      triggerType: 'cli',
+      gitMessage: 'Broken CLI release',
+      finishedAt: Date.now()
+    })
+    await world.create('deployment').with({
+      ...target,
+      status: 'stopped',
+      triggerType: 'webhook',
+      gitMessage: 'Successful Git release',
+      finishedAt: Date.now()
+    })
+    const active = await world.create('deployment').with({
+      ...target,
+      status: 'pushing',
+      triggerType: 'manual',
+      gitMessage: 'Publishing release'
+    })
+
+    const page = await visit.as('genesisUser')(
+      `/projects/${current.projects.deploymentTarget.slug}?deploymentStatus=failed&deploymentSource=cli`
+    )
+
+    expect(page).toHaveStatus(200)
+    expect(page).toHaveInertiaPropCount('deploymentHistory.items', 1)
+    expect(page).toHaveInertiaProp('deploymentHistory.items.0.id', failure.id)
+    expect(page).toHaveInertiaProp('deploymentHistory.filters.status', 'failed')
+    expect(page).toHaveInertiaProp('deploymentHistory.filters.source', 'cli')
+    expect(page).toHaveInertiaProp(
+      'deploymentHistory.activeDeployments.0.id',
+      active.id
+    )
+    expect(page).toHaveInertiaProp(
+      'deploymentHistory.activeDeployments.0.outcomeLabel',
+      'Publishing'
+    )
+  }
+)


### PR DESCRIPTION
## Summary

- preserve Slipway’s existing compact deployment list on project, environment, and app pages
- keep active work first, the true App.currentDeployment release second, and remaining history newest-first
- deduplicate priority rows while leaving the underlying chronological history and cursor truthful
- order datastore history deterministically by creation time and ID before association enrichment
- keep legacy deployments attached to the correct app and refresh active rows when their status changes
- cover chronological ordering, tie-breaking, legacy data, priority ordering, and the unchanged desktop/mobile UI with Sounding

## Verification

- npm run lint
- npm test (48 unit, 23 functional, 6 browser trials)

Fixes #240