### PR TITLE
fix: make direct app ports reachable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,24 @@ curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.s
 
 This installs two containers (Slipway + Caddy proxy) and gives you a dashboard URL.
 
+Slipway publishes direct application URLs from TCP ports `1338-1500`. The
+installer adds that range to UFW or firewalld when either firewall is already
+active; it does not enable a firewall or change your SSH rules. If your VPS
+provider has a separate network firewall, allow inbound TCP `1338-1500` there
+as well. Applications reached through a configured domain only require ports
+`80` and `443`.
+
+After the first deployment, validate direct access from a different machine or
+network so the request crosses the provider firewall:
+
+```bash
+curl -I --connect-timeout 5 http://YOUR_SERVER_IP:ALLOCATED_PORT/health
+```
+
+The deployment log confirms the container health and live Docker mapping. If
+those checks pass but this external request times out, the remaining boundary
+is the VPS provider or host firewall.
+
 ### Run Slipway locally like production
 
 When you want a local run that mirrors the production installer more closely than host-side `npm run dev`, use:

--- a/api/controllers/api/v1/deploy/rollback-deployment.js
+++ b/api/controllers/api/v1/deploy/rollback-deployment.js
@@ -161,6 +161,10 @@ async function executeRollback(
 
     // 3. Generate container name
     const appSlugForName = targetApp ? targetApp.slug : undefined
+    const isPubliclyRoutable = !targetApp || targetApp.routePath !== null
+    const appBindHost = isPubliclyRoutable
+      ? sails.config.custom.slipwayPortHost || '0.0.0.0'
+      : '127.0.0.1'
     const containerName = await App.generateContainerName(
       environment.id,
       appSlugForName
@@ -208,6 +212,7 @@ async function executeRollback(
       containerName,
       port: 1337,
       hostPort,
+      host: appBindHost,
       envVars,
       deploymentId: rollbackId
     })
@@ -285,12 +290,14 @@ async function executeRollback(
     const { fullDomain, generatedDomain } = await Environment.resolveDomains(
       environment.id
     )
-    const directUrl =
-      targetApp && targetApp.routePath === null
-        ? null
-        : `http://${await sails.helpers.getServerIp()}:${
-            containerResult.hostPort
-          }`
+    const directAccess = await sails.helpers.deploy.getDirectAccess.with({
+      serverIp: await sails.helpers.getServerIp(),
+      hostPort: containerResult.hostPort,
+      routePath: targetApp ? targetApp.routePath : '/',
+      containerRunning: true,
+      portBinding: containerResult.portBinding
+    })
+    const directUrl = directAccess.url
     await Deployment.appendDeployLog(rollbackId, `Rollback complete.\n`)
     if (fullDomain) {
       await Deployment.appendDeployLog(
@@ -308,6 +315,24 @@ async function executeRollback(
       await Deployment.appendDeployLog(
         rollbackId,
         `  Direct:    ${directUrl}\n`
+      )
+      await Deployment.appendDeployLog(
+        rollbackId,
+        `  Network:   Container healthy; ${containerResult.portBinding.diagnostic}\n`
+      )
+      await Deployment.appendDeployLog(
+        rollbackId,
+        `  Firewall:  ${directAccess.firewallHint}\n`
+      )
+    } else if (!isPubliclyRoutable) {
+      await Deployment.appendDeployLog(
+        rollbackId,
+        `  Network:   Worker port is bound to 127.0.0.1 and is not publicly exposed.\n`
+      )
+    } else if (directAccess.message) {
+      await Deployment.appendDeployLog(
+        rollbackId,
+        `  Network:   ${directAccess.message}\n`
       )
     }
 

--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -74,9 +74,10 @@ module.exports = {
 
     // Check container health for this app
     let containerHealth = null
+    let containerStatus = null
     if (app.containerName) {
       try {
-        const containerStatus = await sails.helpers.docker.getContainerStatus(
+        containerStatus = await sails.helpers.docker.getContainerStatus(
           app.containerName
         )
         containerHealth = containerStatus.health
@@ -91,10 +92,36 @@ module.exports = {
     const { fullDomain, generatedDomain, domains } =
       await Environment.resolveDomains(environment.id)
     const serverIp = await sails.helpers.getServerIp()
-    const directUrl =
-      app.hostPort && app.routePath !== null
-        ? `http://${serverIp}:${app.hostPort}`
-        : null
+    let directAccess = null
+    if (app.hostPort && app.routePath !== null) {
+      let portBinding = null
+      if (app.containerName && containerStatus?.running) {
+        try {
+          portBinding = await sails.helpers.docker.getPortBinding.with({
+            containerName: app.containerName,
+            containerPort: app.port || 1337,
+            hostPort: app.hostPort,
+            host: sails.config.custom.slipwayPortHost || '0.0.0.0'
+          })
+        } catch (error) {
+          portBinding = {
+            valid: false,
+            diagnostic: error.message || String(error)
+          }
+        }
+      }
+
+      directAccess = await sails.helpers.deploy.getDirectAccess.with({
+        serverIp,
+        hostPort: app.hostPort,
+        routePath: app.routePath,
+        containerRunning: containerStatus
+          ? Boolean(containerStatus.running)
+          : app.status === 'running',
+        portBinding
+      })
+    }
+    const directUrl = directAccess?.url || null
 
     const appWithHealth = { ...app, containerHealth }
     const deploymentHistory = await sails.helpers.deployment.getHistory.with({
@@ -179,7 +206,7 @@ module.exports = {
           serverIp,
           services
         },
-        app: { ...app, containerHealth, directUrl },
+        app: { ...app, containerHealth, directUrl, directAccess },
         appEnvVars: decryptedApp.envVars || {},
         inheritedVars,
         deploymentHistory,

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -64,6 +64,10 @@ module.exports = {
           })) || (await App.findOne({ environment: environment.id }))
       }
       const appSlug = targetApp ? targetApp.slug : undefined
+      const isPubliclyRoutable = !targetApp || targetApp.routePath !== null
+      const appBindHost = isPubliclyRoutable
+        ? sails.config.custom.slipwayPortHost || '0.0.0.0'
+        : '127.0.0.1'
 
       // 3. Generate image name and container names
       const imageName = await App.generateImageName(
@@ -186,6 +190,7 @@ module.exports = {
         containerName: deployContainerName,
         port: 1337,
         hostPort: deployHostPort,
+        host: appBindHost,
         envVars,
         deploymentId,
         resourceLimits
@@ -305,10 +310,14 @@ module.exports = {
       const { fullDomain, generatedDomain } = await Environment.resolveDomains(
         environment.id
       )
-      const directUrl =
-        targetApp && targetApp.routePath === null
-          ? null
-          : `http://${await sails.helpers.getServerIp()}:${deployHostPort}`
+      const directAccess = await sails.helpers.deploy.getDirectAccess.with({
+        serverIp: await sails.helpers.getServerIp(),
+        hostPort: deployHostPort,
+        routePath: targetApp ? targetApp.routePath : '/',
+        containerRunning: true,
+        portBinding: containerResult.portBinding
+      })
+      const directUrl = directAccess.url
       await Deployment.appendDeployLog(deploymentId, `Deployment complete.\n`)
       if (fullDomain) {
         await Deployment.appendDeployLog(
@@ -326,6 +335,24 @@ module.exports = {
         await Deployment.appendDeployLog(
           deploymentId,
           `  Direct:    ${directUrl}\n`
+        )
+        await Deployment.appendDeployLog(
+          deploymentId,
+          `  Network:   Container healthy; ${containerResult.portBinding.diagnostic}\n`
+        )
+        await Deployment.appendDeployLog(
+          deploymentId,
+          `  Firewall:  ${directAccess.firewallHint}\n`
+        )
+      } else if (!isPubliclyRoutable) {
+        await Deployment.appendDeployLog(
+          deploymentId,
+          `  Network:   Worker port is bound to 127.0.0.1 and is not publicly exposed.\n`
+        )
+      } else if (directAccess.message) {
+        await Deployment.appendDeployLog(
+          deploymentId,
+          `  Network:   ${directAccess.message}\n`
         )
       }
 

--- a/api/helpers/deploy/get-direct-access.js
+++ b/api/helpers/deploy/get-direct-access.js
@@ -1,0 +1,116 @@
+module.exports = {
+  friendlyName: 'Get direct access',
+
+  description:
+    'Describe a routable app direct endpoint only when its live Docker mapping is valid.',
+
+  inputs: {
+    serverIp: {
+      type: 'string',
+      required: true
+    },
+    hostPort: {
+      type: 'number',
+      required: true
+    },
+    routePath: {
+      type: 'string',
+      allowNull: true
+    },
+    containerRunning: {
+      type: 'boolean',
+      defaultsTo: true
+    },
+    portBinding: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    serverIp,
+    hostPort,
+    routePath,
+    containerRunning,
+    portBinding
+  }) {
+    if (routePath === null) {
+      return {
+        url: null,
+        attemptedUrl: null,
+        status: 'not-routable',
+        message: null,
+        firewallHint: null
+      }
+    }
+
+    const attemptedUrl = `http://${formatHostname(serverIp)}:${hostPort}`
+    const firewallHint = `If this URL times out, allow inbound TCP ${hostPort} in both the VPS provider firewall and any active host firewall.`
+
+    if (!containerRunning) {
+      return {
+        url: null,
+        attemptedUrl,
+        status: 'unavailable',
+        message: 'Direct access is unavailable because the app is not running.',
+        firewallHint
+      }
+    }
+
+    if (!portBinding || portBinding.valid !== true) {
+      return {
+        url: null,
+        attemptedUrl,
+        status: 'unavailable',
+        message:
+          portBinding?.diagnostic ||
+          `Slipway could not verify Docker's host port ${hostPort} mapping. Redeploy the app and check the deployment logs.`,
+        firewallHint
+      }
+    }
+
+    if (isLoopback(portBinding.host)) {
+      return {
+        url: null,
+        attemptedUrl,
+        status: 'unavailable',
+        message: `Docker published host port ${hostPort} only on ${portBinding.host}, so it is intentionally private. Bind routable apps to 0.0.0.0 and redeploy before using a public direct URL.`,
+        firewallHint
+      }
+    }
+
+    return {
+      url: attemptedUrl,
+      attemptedUrl,
+      status: 'published',
+      message: null,
+      firewallHint,
+      binding: portBinding
+    }
+  }
+}
+
+function formatHostname(hostname) {
+  const normalized = String(hostname || '').trim()
+
+  return normalized.includes(':') && !normalized.startsWith('[')
+    ? `[${normalized}]`
+    : normalized
+}
+
+function isLoopback(hostname) {
+  const normalized = String(hostname || '')
+    .trim()
+    .toLowerCase()
+
+  return (
+    normalized === 'localhost' ||
+    normalized === '::1' ||
+    normalized.startsWith('127.')
+  )
+}

--- a/api/helpers/docker/format-port-binding.js
+++ b/api/helpers/docker/format-port-binding.js
@@ -1,0 +1,37 @@
+module.exports = {
+  friendlyName: 'Format port binding',
+
+  description: 'Build the Docker publish argument for an application port.',
+
+  inputs: {
+    host: {
+      type: 'string',
+      defaultsTo: '0.0.0.0',
+      description: 'Host interface that should receive the published port.'
+    },
+    hostPort: {
+      type: 'number',
+      required: true,
+      description: 'Port exposed on the host.'
+    },
+    containerPort: {
+      type: 'number',
+      required: true,
+      description: 'Port exposed by the container.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ host, hostPort, containerPort }) {
+    const bindHost = String(host || '0.0.0.0').trim() || '0.0.0.0'
+
+    return bindHost === '0.0.0.0'
+      ? `${hostPort}:${containerPort}`
+      : `${bindHost}:${hostPort}:${containerPort}`
+  }
+}

--- a/api/helpers/docker/get-port-binding.js
+++ b/api/helpers/docker/get-port-binding.js
@@ -1,0 +1,63 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Get port binding',
+
+  description:
+    'Inspect a running container and verify its published host port mapping.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    containerPort: {
+      type: 'number',
+      required: true
+    },
+    hostPort: {
+      type: 'number',
+      required: true
+    },
+    host: {
+      type: 'string',
+      defaultsTo: '0.0.0.0'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, containerPort, hostPort, host }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+
+    try {
+      const { stdout } = await execFileAsync(dockerPath, [
+        'inspect',
+        '--format',
+        '{{json .NetworkSettings.Ports}}',
+        containerName
+      ])
+      const portBindings = JSON.parse(stdout.trim() || '{}')
+
+      return sails.helpers.docker.parsePortBindings.with({
+        portBindings,
+        containerPort,
+        hostPort,
+        host
+      })
+    } catch (error) {
+      throw new Error(
+        `Could not inspect the live Docker port mapping for ${containerName}: ${
+          error.message || error
+        }`
+      )
+    }
+  }
+}

--- a/api/helpers/docker/parse-port-bindings.js
+++ b/api/helpers/docker/parse-port-bindings.js
@@ -1,0 +1,114 @@
+module.exports = {
+  friendlyName: 'Parse port bindings',
+
+  description:
+    'Compare Docker inspect port bindings with the mapping Slipway requested.',
+
+  inputs: {
+    portBindings: {
+      type: 'ref',
+      required: true,
+      description: 'Docker NetworkSettings.Ports value.'
+    },
+    containerPort: {
+      type: 'number',
+      required: true
+    },
+    hostPort: {
+      type: 'number',
+      required: true
+    },
+    host: {
+      type: 'string',
+      defaultsTo: '0.0.0.0'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ portBindings, containerPort, hostPort, host }) {
+    const key = `${containerPort}/tcp`
+    const expectedHost = normalizeHost(host)
+    const expectedPort = String(hostPort)
+    const bindings = Array.isArray(portBindings[key])
+      ? portBindings[key].map((binding) => ({
+          host: normalizeHost(binding.HostIp),
+          port: String(binding.HostPort || '')
+        }))
+      : []
+    const matchingPort = bindings.filter(
+      (binding) => binding.port === expectedPort
+    )
+    const matched = matchingPort.find((binding) =>
+      hostMatches(expectedHost, binding.host)
+    )
+
+    if (matched) {
+      return {
+        valid: true,
+        containerPort,
+        host: matched.host,
+        hostPort,
+        bindings,
+        diagnostic: `Docker published ${matched.host}:${hostPort} -> ${containerPort}/tcp.`
+      }
+    }
+
+    if (bindings.length === 0) {
+      return {
+        valid: false,
+        containerPort,
+        host: expectedHost,
+        hostPort,
+        bindings,
+        diagnostic: `Docker did not publish container port ${containerPort}/tcp.`
+      }
+    }
+
+    if (matchingPort.length === 0) {
+      return {
+        valid: false,
+        containerPort,
+        host: expectedHost,
+        hostPort,
+        bindings,
+        diagnostic: `Docker published container port ${containerPort}/tcp on ${describeBindings(
+          bindings
+        )}, not the expected host port ${hostPort}.`
+      }
+    }
+
+    return {
+      valid: false,
+      containerPort,
+      host: expectedHost,
+      hostPort,
+      bindings,
+      diagnostic: `Docker published host port ${hostPort} on ${matchingPort
+        .map((binding) => binding.host)
+        .join(', ')}, not the expected interface ${expectedHost}.`
+    }
+  }
+}
+
+function normalizeHost(host) {
+  return String(host || '0.0.0.0').trim() || '0.0.0.0'
+}
+
+function hostMatches(expected, actual) {
+  if (expected === '0.0.0.0') {
+    return actual === '0.0.0.0' || actual === '::'
+  }
+
+  return expected === actual
+}
+
+function describeBindings(bindings) {
+  return bindings
+    .map((binding) => `${binding.host}:${binding.port || 'unknown'}`)
+    .join(', ')
+}

--- a/api/helpers/docker/run-container.js
+++ b/api/helpers/docker/run-container.js
@@ -57,9 +57,6 @@ module.exports = {
     success: {
       description: 'Container is running',
       outputType: 'ref'
-    },
-    runFailed: {
-      description: 'Failed to run container'
     }
   },
 
@@ -79,6 +76,13 @@ module.exports = {
     const bindHost = normalizeHost(
       host || sails.config.custom.slipwayPortHost || '0.0.0.0'
     )
+    const portBindingArgument =
+      await sails.helpers.docker.formatPortBinding.with({
+        host: bindHost,
+        hostPort,
+        containerPort: port
+      })
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
 
     // Build docker run args array (no shell — safe from injection)
     const args = [
@@ -89,7 +93,7 @@ module.exports = {
       '--network',
       networkName,
       '-p',
-      formatPortBinding(bindHost, hostPort, port)
+      portBindingArgument
     ]
 
     // Add environment variables
@@ -123,7 +127,7 @@ module.exports = {
     }
 
     try {
-      const { stdout } = await execFileAsync('docker', args)
+      const { stdout } = await execFileAsync(dockerPath, args)
       const containerId = stdout.trim()
 
       sails.log.info(
@@ -137,33 +141,49 @@ module.exports = {
         )
       }
 
-      return {
-        containerId,
+      const portBinding = await sails.helpers.docker.getPortBinding.with({
         containerName,
+        containerPort: port,
         hostPort,
-        network: networkName
+        host: bindHost
+      })
+
+      if (!portBinding.valid) {
+        throw new Error(
+          `Host binding verification failed: ${portBinding.diagnostic}`
+        )
       }
-    } catch (error) {
-      sails.log.error(`Failed to run container: ${error.message}`)
 
       if (deploymentId) {
         await Deployment.appendDeployLog(
           deploymentId,
-          `Error starting container: ${error.message}\n`
+          `Host binding verified: ${portBinding.host}:${hostPort} -> ${port}/tcp\n`
         )
       }
 
-      throw 'runFailed'
+      return {
+        containerId,
+        containerName,
+        hostPort,
+        network: networkName,
+        portBinding
+      }
+    } catch (error) {
+      const errorMessage = error.message || String(error)
+      sails.log.error(`Failed to run container: ${errorMessage}`)
+
+      if (deploymentId) {
+        await Deployment.appendDeployLog(
+          deploymentId,
+          `Container startup or host binding failed: ${errorMessage}\n`
+        )
+      }
+
+      throw error
     }
   }
 }
 
 function normalizeHost(host) {
   return String(host || '0.0.0.0').trim() || '0.0.0.0'
-}
-
-function formatPortBinding(host, hostPort, containerPort) {
-  return host === '0.0.0.0'
-    ? `${hostPort}:${containerPort}`
-    : `${host}:${hostPort}:${containerPort}`
 }

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -181,7 +181,8 @@ const accessUrls = computed(() => {
       label: 'Direct',
       display: props.app.directUrl.replace(/^https?:\/\//, ''),
       value: props.app.directUrl,
-      href: props.app.directUrl
+      href: props.app.directUrl,
+      hint: props.app.directAccess?.firewallHint
     })
   }
   return list
@@ -817,6 +818,7 @@ onBeforeUnmount(() => {
               <div class="group flex items-center gap-2">
                 <a
                   :href="primaryAccessUrl.href"
+                  :title="primaryAccessUrl.hint"
                   target="_blank"
                   class="text-sm text-gray-500 underline decoration-gray-300 decoration-dashed underline-offset-2 hover:text-gray-900 dark:text-gray-400 dark:decoration-gray-600 dark:hover:text-white"
                 >
@@ -896,6 +898,7 @@ onBeforeUnmount(() => {
                   >
                   <a
                     :href="d.href"
+                    :title="d.hint"
                     target="_blank"
                     class="text-sm text-gray-700 underline decoration-gray-300 decoration-dashed underline-offset-2 hover:text-gray-900 dark:text-gray-300 dark:decoration-gray-600 dark:hover:text-white"
                   >
@@ -937,6 +940,13 @@ onBeforeUnmount(() => {
                 </div>
               </div>
             </div>
+            <p
+              v-if="app.directAccess?.status === 'unavailable'"
+              data-test="direct-access-diagnostic"
+              class="mt-1 max-w-2xl text-xs text-amber-700 dark:text-amber-400"
+            >
+              {{ app.directAccess.message }}
+            </p>
           </div>
           <div class="flex items-center space-x-2">
             <!-- More menu -->

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -23,7 +23,16 @@ module.exports = {
   hookTimeout: 80000,
 
   custom: {
-    baseUrl: process.env.SLIPWAY_URL
+    baseUrl: process.env.SLIPWAY_URL,
+
+    // Production app hostnames come from a configured wildcard or custom domain.
+    slipwayDomain: null,
+
+    // Keep Docker's allocator aligned with the range opened by install.sh.
+    slipwayPortRange: {
+      start: Number(process.env.SLIPWAY_APP_PORT_START) || 1338,
+      end: Number(process.env.SLIPWAY_APP_PORT_END) || 1500
+    }
   },
   /**************************************************************************
    *                                                                         *
@@ -194,7 +203,7 @@ module.exports = {
      *                                                                          *
      ***************************************************************************/
     trustProxy: true
-  },
+  }
 
   /**************************************************************************
    *                                                                         *
@@ -225,27 +234,4 @@ module.exports = {
    *                                                                         *
    **************************************************************************/
   // ssl: undefined,
-
-  /**************************************************************************
-   *                                                                         *
-   * Overrides for any custom configuration specifically for your app.       *
-   * (for example, production API keys)                                      *
-   *                                                                         *
-   ***************************************************************************/
-  custom: {
-    // Disable slipwayDomain so production requires wildcardDomain setting or custom domains
-    slipwayDomain: null
-    // mailgunApiKey: 'key-prod_fake_bd32301385130a0bafe030c',
-    // stripeSecret: 'sk_prod__fake_Nfgh82401348jaDa3lkZ0d9Hm',
-    //--------------------------------------------------------------------------
-    // /\   OR, to avoid checking them in to version control, you might opt to
-    // ||   set sensitive credentials like these using environment variables.
-    //
-    // For example:
-    // ```
-    // sails_custom__mailgunApiKey=key-prod_fake_bd32301385130a0bafe030c
-    // sails_custom__stripeSecret=sk_prod__fake_Nfgh82401348jaDa3lkZ0d9Hm
-    // ```
-    //--------------------------------------------------------------------------
-  }
 }

--- a/install.sh
+++ b/install.sh
@@ -28,6 +28,9 @@ SLIPWAY_CERTS_VOLUME="${SLIPWAY_CERTS_VOLUME:-slipway-certs}"
 SLIPWAY_PORT="${SLIPWAY_PORT:-1337}"
 SLIPWAY_HTTP_PORT="${SLIPWAY_HTTP_PORT:-80}"
 SLIPWAY_HTTPS_PORT="${SLIPWAY_HTTPS_PORT:-443}"
+SLIPWAY_APP_PORT_START="${SLIPWAY_APP_PORT_START:-1338}"
+SLIPWAY_APP_PORT_END="${SLIPWAY_APP_PORT_END:-1500}"
+SLIPWAY_CONFIGURE_FIREWALL="${SLIPWAY_CONFIGURE_FIREWALL:-true}"
 SLIPWAY_HEALTH_ATTEMPTS="${SLIPWAY_HEALTH_ATTEMPTS:-30}"
 SLIPWAY_SKIP_PULL="${SLIPWAY_SKIP_PULL:-false}"
 IS_UPDATE=false
@@ -62,6 +65,8 @@ run_slipway_container() {
         -e NODE_ENV=production \
         -e PORT=1337 \
         -e SLIPWAY_URL="$SLIPWAY_URL" \
+        -e SLIPWAY_APP_PORT_START="$SLIPWAY_APP_PORT_START" \
+        -e SLIPWAY_APP_PORT_END="$SLIPWAY_APP_PORT_END" \
         -e SESSION_SECRET="$SESSION_SECRET" \
         -e DATA_ENCRYPTION_KEY="$DATA_ENCRYPTION_KEY" \
         "$SLIPWAY_IMAGE"
@@ -154,6 +159,42 @@ replace_live_container() {
     fi
 }
 
+configure_host_firewall() {
+    if [ "$SLIPWAY_CONFIGURE_FIREWALL" != true ]; then
+        echo -e "${YELLOW}Host firewall configuration skipped (SLIPWAY_CONFIGURE_FIREWALL=$SLIPWAY_CONFIGURE_FIREWALL).${NC}"
+        return
+    fi
+
+    if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q '^Status: active'; then
+        echo "Allowing Slipway ports through UFW..."
+        if ufw allow "$SLIPWAY_PORT/tcp" comment 'Slipway dashboard' >/dev/null \
+            && ufw allow "$SLIPWAY_HTTP_PORT/tcp" comment 'Slipway HTTP' >/dev/null \
+            && ufw allow "$SLIPWAY_HTTPS_PORT/tcp" comment 'Slipway HTTPS' >/dev/null \
+            && ufw allow "$SLIPWAY_APP_PORT_START:$SLIPWAY_APP_PORT_END/tcp" comment 'Slipway direct app access' >/dev/null; then
+            echo -e "${GREEN}UFW allows the dashboard, proxy, and direct app port range${NC}"
+        else
+            echo -e "${YELLOW}Slipway could not update every UFW rule. Review 'ufw status' before using direct app URLs.${NC}"
+        fi
+        return
+    fi
+
+    if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
+        echo "Allowing Slipway ports through firewalld..."
+        if firewall-cmd --permanent --add-port="$SLIPWAY_PORT/tcp" >/dev/null \
+            && firewall-cmd --permanent --add-port="$SLIPWAY_HTTP_PORT/tcp" >/dev/null \
+            && firewall-cmd --permanent --add-port="$SLIPWAY_HTTPS_PORT/tcp" >/dev/null \
+            && firewall-cmd --permanent --add-port="$SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END/tcp" >/dev/null \
+            && firewall-cmd --reload >/dev/null; then
+            echo -e "${GREEN}firewalld allows the dashboard, proxy, and direct app port range${NC}"
+        else
+            echo -e "${YELLOW}Slipway could not update every firewalld rule. Review 'firewall-cmd --list-ports' before using direct app URLs.${NC}"
+        fi
+        return
+    fi
+
+    echo -e "${GREEN}No active UFW or firewalld host firewall detected${NC}"
+}
+
 # Check if running as root
 if [ "$EUID" -ne 0 ]; then
     echo -e "${YELLOW}Warning: Not running as root. You may need sudo for Docker commands.${NC}"
@@ -215,6 +256,8 @@ else
     cat > "$SLIPWAY_ENV_FILE" <<EOF
 SESSION_SECRET=$SESSION_SECRET
 DATA_ENCRYPTION_KEY=$DATA_ENCRYPTION_KEY
+SLIPWAY_APP_PORT_START=$SLIPWAY_APP_PORT_START
+SLIPWAY_APP_PORT_END=$SLIPWAY_APP_PORT_END
 EOF
     chmod 600 "$SLIPWAY_ENV_FILE"
     echo -e "${GREEN}Secrets generated and saved to $SLIPWAY_ENV_FILE${NC}"
@@ -300,7 +343,10 @@ validate_slipway_image
 replace_live_container
 echo -e "${GREEN}Slipway dashboard running${NC}"
 
-# 11. Show access info
+# 11. Keep host firewall rules aligned with Slipway's published ports
+configure_host_firewall
+
+# 12. Show access info
 echo ""
 echo -e "${GREEN}========================================================${NC}"
 if [ "$IS_UPDATE" = true ]; then
@@ -311,6 +357,9 @@ fi
 echo -e "${GREEN}========================================================${NC}"
 echo ""
 echo "  Dashboard: $SLIPWAY_URL"
+echo "  Direct app ports: TCP $SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END"
+echo "  If your VPS provider has a network firewall, allow inbound TCP $SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END for direct app URLs."
+echo "  Domains proxied through Caddy only require TCP $SLIPWAY_HTTP_PORT and $SLIPWAY_HTTPS_PORT."
 echo ""
 if [ "$IS_UPDATE" = false ]; then
     echo "  Next steps:"

--- a/tests/e2e/pages/projects/direct-access.test.js
+++ b/tests/e2e/pages/projects/direct-access.test.js
@@ -1,0 +1,39 @@
+const { test } = require('sounding')
+
+test(
+  'an unavailable direct endpoint is explained instead of linked',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'direct-access-diagnostic',
+          name: 'Direct Access Diagnostic'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      hostPort: 1340,
+      port: 1337,
+      containerName: null
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/apps/${current.apps.web.slug}`
+    )
+
+    await page.wait('@direct-access-diagnostic')
+    await expect(page).toSee(
+      "Slipway could not verify Docker's host port 1340 mapping."
+    )
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)

--- a/tests/unit/helpers/docker/direct-access.test.js
+++ b/tests/unit/helpers/docker/direct-access.test.js
@@ -1,0 +1,133 @@
+const { test } = require('sounding')
+
+test('routable apps publish their container port on the public host interface', async ({
+  sails,
+  expect
+}) => {
+  const argument = await sails.helpers.docker.formatPortBinding.with({
+    host: '0.0.0.0',
+    hostPort: 1340,
+    containerPort: 1337
+  })
+  const binding = await sails.helpers.docker.parsePortBindings.with({
+    portBindings: {
+      '1337/tcp': [
+        { HostIp: '0.0.0.0', HostPort: '1340' },
+        { HostIp: '::', HostPort: '1340' }
+      ]
+    },
+    containerPort: 1337,
+    hostPort: 1340,
+    host: '0.0.0.0'
+  })
+
+  expect(argument).toBe('1340:1337')
+  expect(binding.valid).toBe(true)
+  expect(binding.hostPort).toBe(1340)
+  expect(binding.diagnostic).toMatch(/0\.0\.0\.0:1340 -> 1337\/tcp/)
+})
+
+test('worker ports bind to loopback instead of the public interface', async ({
+  sails,
+  expect
+}) => {
+  const argument = await sails.helpers.docker.formatPortBinding.with({
+    host: '127.0.0.1',
+    hostPort: 1341,
+    containerPort: 1337
+  })
+
+  expect(argument).toBe('127.0.0.1:1341:1337')
+})
+
+test('direct access is advertised only for a verified live Docker mapping', async ({
+  sails,
+  expect
+}) => {
+  const directAccess = await sails.helpers.deploy.getDirectAccess.with({
+    serverIp: '46.62.235.40',
+    hostPort: 1340,
+    routePath: '/',
+    containerRunning: true,
+    portBinding: {
+      valid: true,
+      host: '0.0.0.0',
+      hostPort: 1340,
+      containerPort: 1337
+    }
+  })
+
+  expect(directAccess.status).toBe('published')
+  expect(directAccess.url).toBe('http://46.62.235.40:1340')
+  expect(directAccess.firewallHint).toMatch(/allow inbound TCP 1340/)
+})
+
+test('a missing or incorrect Docker mapping becomes a diagnostic, not a link', async ({
+  sails,
+  expect
+}) => {
+  const binding = await sails.helpers.docker.parsePortBindings.with({
+    portBindings: {
+      '1337/tcp': [{ HostIp: '127.0.0.1', HostPort: '1400' }]
+    },
+    containerPort: 1337,
+    hostPort: 1340,
+    host: '0.0.0.0'
+  })
+  const directAccess = await sails.helpers.deploy.getDirectAccess.with({
+    serverIp: '46.62.235.40',
+    hostPort: 1340,
+    routePath: '/',
+    containerRunning: true,
+    portBinding: binding
+  })
+
+  expect(binding.valid).toBe(false)
+  expect(directAccess.status).toBe('unavailable')
+  expect(directAccess.url).toBe(null)
+  expect(directAccess.attemptedUrl).toBe('http://46.62.235.40:1340')
+  expect(directAccess.message).toMatch(/not the expected host port 1340/)
+})
+
+test('workers never receive a direct HTTP endpoint', async ({
+  sails,
+  expect
+}) => {
+  const directAccess = await sails.helpers.deploy.getDirectAccess.with({
+    serverIp: '46.62.235.40',
+    hostPort: 1342,
+    routePath: null,
+    containerRunning: true,
+    portBinding: {
+      valid: true,
+      host: '127.0.0.1',
+      hostPort: 1342,
+      containerPort: 1337
+    }
+  })
+
+  expect(directAccess.status).toBe('not-routable')
+  expect(directAccess.url).toBe(null)
+})
+
+test('an intentionally private loopback binding is explained instead of advertised', async ({
+  sails,
+  expect
+}) => {
+  const directAccess = await sails.helpers.deploy.getDirectAccess.with({
+    serverIp: '46.62.235.40',
+    hostPort: 1343,
+    routePath: '/',
+    containerRunning: true,
+    portBinding: {
+      valid: true,
+      host: '127.0.0.1',
+      hostPort: 1343,
+      containerPort: 1337
+    }
+  })
+
+  expect(directAccess.status).toBe('unavailable')
+  expect(directAccess.url).toBe(null)
+  expect(directAccess.message).toMatch(/intentionally private/)
+})

--- a/tests/unit/helpers/system/install-config.test.js
+++ b/tests/unit/helpers/system/install-config.test.js
@@ -119,4 +119,32 @@ test('installer keeps production defaults overridable for isolated rehearsals', 
   expect(script.includes('-v "$SLIPWAY_DB_VOLUME:/app/db"')).toBe(true)
   expect(script.includes('-p "$SLIPWAY_HTTP_PORT:80"')).toBe(true)
   expect(script.includes('-p "$SLIPWAY_HTTPS_PORT:443"')).toBe(true)
+  expect(
+    script.includes('SLIPWAY_APP_PORT_START="${SLIPWAY_APP_PORT_START:-1338}"')
+  ).toBe(true)
+  expect(
+    script.includes('SLIPWAY_APP_PORT_END="${SLIPWAY_APP_PORT_END:-1500}"')
+  ).toBe(true)
+  expect(
+    script.includes('SLIPWAY_APP_PORT_START=$SLIPWAY_APP_PORT_START')
+  ).toBe(true)
+  expect(script.includes('SLIPWAY_APP_PORT_END=$SLIPWAY_APP_PORT_END')).toBe(
+    true
+  )
+  expect(script.includes('configure_host_firewall()')).toBe(true)
+  expect(
+    script.includes(
+      'ufw allow "$SLIPWAY_APP_PORT_START:$SLIPWAY_APP_PORT_END/tcp"'
+    )
+  ).toBe(true)
+  expect(
+    script.includes(
+      'firewall-cmd --permanent --add-port="$SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END/tcp"'
+    )
+  ).toBe(true)
+  expect(
+    script.includes(
+      'If your VPS provider has a network firewall, allow inbound TCP'
+    )
+  ).toBe(true)
 })


### PR DESCRIPTION
## Summary
- verify each live Docker host-port mapping before advertising a direct URL
- align install and update flows with the configured app port range and active host firewalls
- keep worker bindings private and replace invalid direct links with a focused diagnostic
- document provider-firewall configuration and an external reachability smoke test

## Verification
- `npm test` (54 unit, 23 functional, 7 browser trials)
- `npm run lint`
- external smoke test: ports 1338, 1339, 1340, and 1341 all return HTTP 200

Fixes #241