### PR TITLE
fix: keep Helm editor visible with large output

### DIFF
--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -268,27 +268,31 @@ onUnmounted(() => {
       >
         <!-- Header with Team Selector -->
         <div class="flex items-center justify-between px-3 py-4">
-          <div class="relative flex-1">
+          <div class="relative min-w-0 flex-1">
             <button
+              data-test="mobile-team-selector"
               @click.stop="teamDropdownOpen = !teamDropdownOpen"
-              class="flex w-full items-center justify-between rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
+              class="flex w-full min-w-0 items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
             >
-              <div class="flex items-center space-x-2">
+              <div class="flex min-w-0 flex-1 items-center space-x-2">
                 <img
                   v-if="loggedInUser.team?.logoUrl"
                   :src="loggedInUser.team.logoUrl"
                   alt=""
-                  class="h-6 w-6 rounded object-cover"
+                  class="h-6 w-6 shrink-0 rounded object-cover"
                 />
                 <span
                   v-else
-                  class="bg-brand flex h-6 w-6 items-center justify-center rounded text-xs font-medium text-white"
+                  class="bg-brand flex h-6 w-6 shrink-0 items-center justify-center rounded text-xs font-medium text-white"
                 >
                   {{ loggedInUser.team?.name?.charAt(0)?.toUpperCase() || 'T' }}
                 </span>
-                <span class="truncate font-medium">{{
-                  loggedInUser.team?.name || 'Team'
-                }}</span>
+                <span
+                  data-test="mobile-team-name"
+                  class="truncate font-medium"
+                  :title="loggedInUser.team?.name || 'Team'"
+                  >{{ loggedInUser.team?.name || 'Team' }}</span
+                >
               </div>
               <svg
                 :class="[
@@ -391,6 +395,7 @@ onUnmounted(() => {
             </Transition>
           </div>
           <button
+            data-test="mobile-menu-close"
             @click="closeMobileMenu"
             class="ml-2 rounded-md p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-200"
           >
@@ -747,26 +752,28 @@ onUnmounted(() => {
     >
       <!-- Team Selector + Collapse -->
       <div class="flex items-center justify-between px-3 py-4">
-        <div class="relative flex-1">
+        <div class="relative min-w-0 flex-1">
           <button
             @click.stop="teamDropdownOpen = !teamDropdownOpen"
-            class="flex w-full items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
+            class="flex w-full min-w-0 items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
           >
             <img
               v-if="loggedInUser.team?.logoUrl"
               :src="loggedInUser.team.logoUrl"
               alt=""
-              class="h-6 w-6 rounded object-cover"
+              class="h-6 w-6 shrink-0 rounded object-cover"
             />
             <span
               v-else
-              class="bg-brand flex h-6 w-6 items-center justify-center rounded text-xs font-medium text-white"
+              class="bg-brand flex h-6 w-6 shrink-0 items-center justify-center rounded text-xs font-medium text-white"
             >
               {{ loggedInUser.team?.name?.charAt(0)?.toUpperCase() || 'T' }}
             </span>
-            <span class="flex-1 truncate text-left font-medium">{{
-              loggedInUser.team?.name || 'Team'
-            }}</span>
+            <span
+              class="min-w-0 flex-1 truncate text-left font-medium"
+              :title="loggedInUser.team?.name || 'Team'"
+              >{{ loggedInUser.team?.name || 'Team' }}</span
+            >
             <svg
               :class="[
                 'h-4 w-4 shrink-0 text-gray-400 transition-transform dark:text-gray-500',

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -228,6 +228,7 @@ function highlightJSON(str) {
       <div class="flex items-center space-x-3">
         <!-- Mobile menu toggle -->
         <button
+          data-test="helm-mobile-menu"
           @click="toggleMobileMenu"
           class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
         >

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -217,10 +217,13 @@ function highlightJSON(str) {
   <Head
     :title="`Helm - ${project.name} / ${environment.name} | Slipway`"
   ></Head>
-  <div class="flex h-full flex-col">
+  <div
+    data-test="helm-page"
+    class="flex h-full min-h-0 flex-col overflow-hidden"
+  >
     <!-- Header -->
     <div
-      class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-8 sm:py-4"
+      class="flex shrink-0 items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-8 sm:py-4"
     >
       <div class="flex items-center space-x-3">
         <!-- Mobile menu toggle -->
@@ -368,6 +371,7 @@ function highlightJSON(str) {
 
         <!-- Run button -->
         <button
+          data-test="helm-run"
           @click="execute"
           :disabled="running || !isRunning"
           class="flex items-center space-x-1.5 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 sm:px-3"
@@ -411,13 +415,19 @@ function highlightJSON(str) {
     </div>
 
     <!-- Main content - Tinkerwell style -->
-    <div class="flex flex-1 flex-col overflow-hidden lg:flex-row">
+    <div
+      data-test="helm-workspace"
+      class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden lg:flex-row"
+    >
       <!-- Editor panel -->
       <div
-        class="flex flex-1 flex-col border-b border-gray-100 dark:border-gray-800 lg:border-b-0 lg:border-r"
+        data-test="helm-editor-panel"
+        class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden border-b border-gray-100 dark:border-gray-800 lg:border-b-0 lg:border-r"
       >
         <!-- Code editor with syntax highlighting -->
-        <div class="relative flex-1 overflow-hidden bg-white dark:bg-gray-950">
+        <div
+          class="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-white dark:bg-gray-950"
+        >
           <!-- Editor area -->
           <div class="relative h-full overflow-auto">
             <!-- Highlighted layer -->
@@ -428,6 +438,7 @@ function highlightJSON(str) {
             ></pre>
             <!-- Textarea -->
             <textarea
+              data-test="helm-editor"
               v-model="code"
               @keydown="handleKeydown"
               :disabled="!isRunning"
@@ -440,13 +451,18 @@ function highlightJSON(str) {
       </div>
 
       <!-- Output panel -->
-      <div class="flex flex-1 flex-col bg-white dark:bg-gray-950">
+      <div
+        data-test="helm-output-panel"
+        class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-gray-950"
+      >
         <div
-          class="relative flex-1 overflow-y-auto p-4 font-mono text-sm leading-6"
+          data-test="helm-output-scroll"
+          class="relative min-h-0 min-w-0 flex-1 overflow-auto p-4 font-mono text-sm leading-6"
         >
           <!-- Output -->
           <pre
             v-if="output"
+            data-test="helm-output"
             class="whitespace-pre-wrap"
             v-html="highlightedOutput"
           ></pre>
@@ -477,7 +493,7 @@ function highlightJSON(str) {
         <!-- History (collapsible at bottom) -->
         <div
           v-if="history.length > 0"
-          class="border-t border-gray-100 dark:border-gray-800"
+          class="shrink-0 border-t border-gray-100 dark:border-gray-800"
         >
           <div class="max-h-32 overflow-y-auto">
             <button

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -1,0 +1,154 @@
+const { test } = require('sounding')
+
+function helmWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: {
+        slug,
+        name: 'Helm Layout'
+      }
+    }
+  }
+}
+
+function oversizedOutput() {
+  return JSON.stringify(
+    Array.from({ length: 180 }, (_, index) => ({
+      id: index + 1,
+      name: `creator-${index + 1}`,
+      value: 'x'.repeat(160)
+    })),
+    null,
+    2
+  )
+}
+
+async function openHelmWithMockedExecution({ sails, world, login, page }) {
+  const current = world.current
+  const projectSlug = current.projects.deploymentTarget.slug
+  const environmentSlug = current.environments.production.slug
+  let executionCount = 0
+
+  await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+    status: 'running',
+    containerName: 'sounding-helm-app'
+  })
+
+  await login.withPassword('genesisUser', page, {
+    password: current.auth.genesisUserPassword
+  })
+
+  await page.raw.route(
+    `**/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`,
+    async (route) => {
+      executionCount += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          output:
+            executionCount === 1
+              ? oversizedOutput()
+              : JSON.stringify({ ready: true }, null, 2)
+        })
+      })
+    }
+  )
+
+  await page.goto(
+    `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+  )
+  await page.fill('@helm-editor', 'await Creator.find()')
+  await page.click('@helm-run')
+  await page.wait('@helm-output')
+}
+
+async function measureHelm(page) {
+  return page.script(() => {
+    const rect = (selector) => {
+      const box = document.querySelector(selector).getBoundingClientRect()
+      return {
+        height: box.height,
+        width: box.width,
+        left: box.left,
+        top: box.top
+      }
+    }
+    const outputScroll = document.querySelector(
+      '[data-test="helm-output-scroll"]'
+    )
+
+    return {
+      viewportHeight: window.innerHeight,
+      page: rect('[data-test="helm-page"]'),
+      workspace: rect('[data-test="helm-workspace"]'),
+      editor: rect('[data-test="helm-editor-panel"]'),
+      output: rect('[data-test="helm-output-panel"]'),
+      outputClientHeight: outputScroll.clientHeight,
+      outputScrollHeight: outputScroll.scrollHeight
+    }
+  })
+}
+
+async function proveOutputScrollsAndEditorStillRuns({ page, expect }) {
+  const outputScroll = page.raw.locator('[data-test="helm-output-scroll"]')
+  await outputScroll.evaluate((element) => {
+    element.scrollTop = element.scrollHeight
+  })
+  expect(
+    (await outputScroll.evaluate((element) => element.scrollTop)) > 0
+  ).toBe(true)
+
+  await page.fill('@helm-editor', 'return { ready: true }')
+  expect(
+    await page.script(
+      () =>
+        document.activeElement?.matches('[data-test="helm-editor"]') === true
+    )
+  ).toBe(true)
+  await page.click('@helm-run')
+  await page.raw
+    .locator('[data-test="helm-output"]')
+    .filter({ hasText: 'ready' })
+    .waitFor()
+  expect(
+    (
+      await page.raw.locator('[data-test="helm-output"]').textContent()
+    ).includes('"ready": true')
+  ).toBe(true)
+  expect(page).toHaveNoSmoke()
+}
+
+test(
+  'Helm keeps its editor visible while oversized output scrolls on desktop',
+  { browser: true, world: helmWorld('helm-layout-desktop') },
+  async ({ sails, world, login, page, expect }) => {
+    await openHelmWithMockedExecution({ sails, world, login, page })
+
+    const layout = await measureHelm(page)
+    expect(layout.page.height <= layout.viewportHeight).toBe(true)
+    expect(layout.editor.width > layout.workspace.width * 0.35).toBe(true)
+    expect(layout.output.width > layout.workspace.width * 0.35).toBe(true)
+    expect(layout.outputScrollHeight > layout.outputClientHeight).toBe(true)
+
+    await proveOutputScrollsAndEditorStillRuns({ page, expect })
+  }
+)
+
+test(
+  'Helm keeps both panes usable with oversized output on mobile',
+  { browser: 'mobile', world: helmWorld('helm-layout-mobile') },
+  async ({ sails, world, login, page, expect }) => {
+    await openHelmWithMockedExecution({ sails, world, login, page })
+
+    const layout = await measureHelm(page)
+    expect(layout.page.height <= layout.viewportHeight).toBe(true)
+    expect(layout.editor.height > layout.workspace.height * 0.25).toBe(true)
+    expect(layout.output.height > layout.workspace.height * 0.25).toBe(true)
+    expect(layout.outputScrollHeight > layout.outputClientHeight).toBe(true)
+
+    await proveOutputScrollsAndEditorStillRuns({ page, expect })
+  }
+)

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -150,5 +150,33 @@ test(
     expect(layout.outputScrollHeight > layout.outputClientHeight).toBe(true)
 
     await proveOutputScrollsAndEditorStillRuns({ page, expect })
+
+    await page.click('@helm-mobile-menu')
+    await page.wait('@mobile-team-name')
+    await page.wait(350)
+    const teamSelector = await page.script(() => {
+      const label = document.querySelector('[data-test="mobile-team-name"]')
+      const closeButton = document.querySelector(
+        '[data-test="mobile-menu-close"]'
+      )
+      const labelBox = label.getBoundingClientRect()
+      const closeButtonBox = closeButton.getBoundingClientRect()
+
+      return {
+        clientWidth: label.clientWidth,
+        scrollWidth: label.scrollWidth,
+        textOverflow: getComputedStyle(label).textOverflow,
+        labelRight: labelBox.right,
+        closeButtonLeft: closeButtonBox.left,
+        title: label.title,
+        text: label.textContent.trim()
+      }
+    })
+
+    expect(teamSelector.scrollWidth > teamSelector.clientWidth).toBe(true)
+    expect(teamSelector.textOverflow).toBe('ellipsis')
+    expect(teamSelector.labelRight <= teamSelector.closeButtonLeft).toBe(true)
+    expect(teamSelector.title).toBe(teamSelector.text)
+    expect(page).toHaveNoSmoke()
   }
 )

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -38,6 +38,7 @@ async function openHelmWithMockedExecution({ sails, world, login, page }) {
   await login.withPassword('genesisUser', page, {
     password: current.auth.genesisUserPassword
   })
+  await page.wait('text=Helm Layout')
 
   await page.raw.route(
     `**/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`,


### PR DESCRIPTION
## Summary
- constrain the existing Helm split panes on both flex axes
- keep oversized output inside its own scroll container
- preserve the editor, header, history, and existing desktop/mobile layout without adding UI
- truncate long team names inside the existing mobile and desktop selectors instead of letting them overlap adjacent controls
- retain the full team name in the native title tooltip
- add Sounding browser regressions for the Helm layout and mobile team selector

## Verification
- `npm run lint`
- `npm test` — 54 unit, 23 functional, 9 browser trials
- desktop and mobile oversized-output screenshots captured
- mobile long-team-name screenshot captured

Fixes #229