### PR TITLE
fix: reconcile managed container status from Docker

### DIFF
--- a/api/helpers/docker/get-container-stats.js
+++ b/api/helpers/docker/get-container-stats.js
@@ -56,12 +56,13 @@ module.exports = {
     } catch (err) {
       if (err.code === 'ENOENT') {
         sails.log.warn('Lookout: Docker binary not found at', dockerPath)
-        return []
+      } else {
+        sails.log.verbose('Lookout: docker stats error:', err.message)
       }
-      // No running containers returns exit code 0 with empty output,
-      // but some Docker versions may error — treat gracefully
-      sails.log.verbose('Lookout: docker stats error:', err.message)
-      return []
+
+      // A command failure is not an authoritative empty sample. Let the caller
+      // skip this metrics cycle without changing lifecycle state.
+      throw err
     }
   }
 }

--- a/api/helpers/docker/list-container-states.js
+++ b/api/helpers/docker/list-container-states.js
@@ -1,0 +1,67 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'List container states',
+
+  description:
+    'List authoritative lifecycle states for all Docker containers, including stopped containers.',
+
+  inputs: {},
+
+  exits: {
+    success: {
+      description: 'Container lifecycle states retrieved.',
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function () {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const { stdout } = await execFileAsync(
+      dockerPath,
+      ['container', 'ls', '--all', '--format', '{{json .}}'],
+      { maxBuffer: 10 * 1024 * 1024 }
+    )
+
+    return parseContainerStates(stdout)
+  }
+}
+
+function parseContainerStates(stdout) {
+  if (!stdout || !stdout.trim()) return []
+
+  return stdout
+    .trim()
+    .split('\n')
+    .map((line) => {
+      let raw
+      try {
+        raw = JSON.parse(line)
+      } catch (error) {
+        throw new Error(`Could not parse Docker container state: ${line}`, {
+          cause: error
+        })
+      }
+
+      const name = raw.Names || raw.Name
+      const state = String(raw.State || '').toLowerCase()
+      if (!name || !state) {
+        throw new Error(
+          `Docker container state is missing a name or state: ${line}`
+        )
+      }
+
+      return {
+        id: raw.ID || null,
+        name,
+        state,
+        running: state === 'running',
+        status: raw.Status || null
+      }
+    })
+}
+
+module.exports._private = { parseContainerStates }

--- a/api/helpers/lookout/reconcile-container-statuses.js
+++ b/api/helpers/lookout/reconcile-container-statuses.js
@@ -1,0 +1,105 @@
+module.exports = {
+  friendlyName: 'Reconcile container statuses',
+
+  description:
+    'Converge stable app and service statuses with an authoritative Docker lifecycle snapshot.',
+
+  inputs: {
+    containerStates: {
+      type: 'ref',
+      description:
+        'Optional complete lifecycle snapshot. When omitted, Docker is queried directly.'
+    }
+  },
+
+  exits: {
+    success: {
+      description: 'Status transitions that were persisted.',
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerStates }) {
+    if (containerStates === undefined) {
+      containerStates = await sails.helpers.docker.listContainerStates()
+    }
+
+    if (!Array.isArray(containerStates)) {
+      throw new Error('containerStates must be a complete array snapshot.')
+    }
+
+    const statesByName = new Map(
+      containerStates.map((state) => [state.name, state])
+    )
+    const [apps, services] = await Promise.all([
+      sails.models.app.find().select(['id', 'status', 'containerName']),
+      sails.models.service.find().select(['id', 'status', 'containerName'])
+    ])
+
+    const appTransitions = await reconcileRecords({
+      model: sails.models.app,
+      records: apps,
+      resourceType: 'app',
+      statesByName
+    })
+    const serviceTransitions = await reconcileRecords({
+      model: sails.models.service,
+      records: services,
+      resourceType: 'service',
+      statesByName
+    })
+
+    return [...appTransitions, ...serviceTransitions]
+  }
+}
+
+async function reconcileRecords({
+  model,
+  records,
+  resourceType,
+  statesByName
+}) {
+  const transitions = []
+
+  for (const record of records) {
+    if (!record.containerName) continue
+    if (!['running', 'stopped'].includes(record.status)) continue
+
+    const nextStatus = getStableStatus(statesByName.get(record.containerName))
+    if (!nextStatus || nextStatus === record.status) continue
+
+    const updated = await model
+      .updateOne({
+        id: record.id,
+        status: record.status,
+        containerName: record.containerName
+      })
+      .set({ status: nextStatus })
+
+    if (!updated) continue
+
+    transitions.push({
+      resourceType,
+      id: record.id,
+      containerName: record.containerName,
+      from: record.status,
+      to: nextStatus
+    })
+  }
+
+  return transitions
+}
+
+function getStableStatus(containerState) {
+  if (!containerState) return 'stopped'
+
+  const state = String(containerState.state || '').toLowerCase()
+  if (containerState.running === true || state === 'running') return 'running'
+  if (['exited', 'dead', 'stopped'].includes(state)) return 'stopped'
+
+  // Restarting, paused, created, and removing are transitional Docker states.
+  // Preserve Slipway's last stable status until Docker converges.
+  return null
+}
+
+module.exports._private = { getStableStatus, reconcileRecords }

--- a/api/hooks/lookout/index.js
+++ b/api/hooks/lookout/index.js
@@ -6,7 +6,7 @@
  * Triggers resource alerts when CPU or memory exceeds 90% for 3 consecutive samples (~90s).
  *
  * Also:
- * - Health checks: detects containers that should be running but aren't
+ * - Lifecycle reconciliation: converges app/service status with Docker state
  * - Log persistence: collects container logs every 5 minutes, prunes after 7 days
  */
 
@@ -26,9 +26,9 @@ module.exports = function defineLookoutHook(sails) {
       sails.log.info('Initializing hook (`lookout`)')
 
       sails.after('hook:orm:loaded', () => {
-        // Main 30-second interval: metrics + health checks + backup schedule check
-        pollInterval = setInterval(collectMetrics, 30000)
-        collectMetrics()
+        // Main 30-second interval: lifecycle reconciliation + metrics.
+        pollInterval = setInterval(runLookoutCycle, 30000)
+        runLookoutCycle()
 
         // Separate 5-minute interval for log collection
         logInterval = setInterval(collectLogs, 5 * 60 * 1000)
@@ -42,20 +42,67 @@ module.exports = function defineLookoutHook(sails) {
     }
   }
 
+  async function runLookoutCycle() {
+    await reconcileLifecycleStatuses()
+    await collectMetrics()
+  }
+
+  async function reconcileLifecycleStatuses() {
+    try {
+      const transitions =
+        await sails.helpers.lookout.reconcileContainerStatuses()
+
+      for (const transition of transitions) {
+        const cooldownKey = `down:${transition.containerName}`
+
+        if (transition.to === 'running') {
+          alertCooldowns.delete(cooldownKey)
+          sails.log.info(
+            `Lookout: Container recovered: ${transition.containerName} (${transition.resourceType})`
+          )
+          continue
+        }
+
+        sails.log.warn(
+          `Lookout: Container down: ${transition.containerName} (${transition.resourceType})`
+        )
+
+        const now = Date.now()
+        const lastAlert = alertCooldowns.get(cooldownKey)
+        if (lastAlert && now - lastAlert < ALERT_COOLDOWN_MS) continue
+        alertCooldowns.set(cooldownKey, now)
+
+        try {
+          await sails.helpers.notification.sendContainerDownAlert.with({
+            containerName: transition.containerName,
+            resourceType: transition.resourceType
+          })
+        } catch (alertErr) {
+          sails.log.verbose(
+            'Lookout: Failed to send container down alert:',
+            alertErr.message
+          )
+        }
+      }
+    } catch (err) {
+      sails.log.warn(
+        'Lookout: Could not reconcile container lifecycle state:',
+        err.message
+      )
+    }
+  }
+
   async function collectMetrics() {
     try {
       const stats = await sails.helpers.docker.getContainerStats()
 
-      // Pre-fetch all running apps and services for matching
+      // Pre-fetch currently running apps and services for metric matching.
+      // Lifecycle truth is reconciled separately from this stats sample.
       const apps = await App.find({ status: 'running' }).populate('environment')
       const services = await Service.find({ status: 'running' }).populate(
         'environment'
       )
       const now = Date.now()
-
-      // Health check: detect containers that are in DB as 'running' but missing from docker stats
-      const runningContainerNames = new Set((stats || []).map((s) => s.name))
-      await checkHealth(apps, services, runningContainerNames, now)
 
       if (!stats || stats.length === 0) {
         return
@@ -167,73 +214,6 @@ module.exports = function defineLookoutHook(sails) {
       await checkDiskSpace(now)
     } catch (err) {
       sails.log.warn('Lookout: Error collecting metrics:', err.message)
-    }
-  }
-
-  /**
-   * Health check: compare DB 'running' state against actual docker stats.
-   * Any app/service marked running but not in docker stats is down.
-   */
-  async function checkHealth(apps, services, runningContainerNames, now) {
-    try {
-      for (const app of apps) {
-        if (!app.containerName || runningContainerNames.has(app.containerName))
-          continue
-
-        // Container is not in docker stats — it's down
-        sails.log.warn(`Lookout: Container down: ${app.containerName} (app)`)
-        await App.updateOne({ id: app.id }).set({ status: 'stopped' })
-
-        // Check cooldown before alerting
-        const cooldownKey = `down:${app.containerName}`
-        const lastAlert = alertCooldowns.get(cooldownKey)
-        if (lastAlert && now - lastAlert < ALERT_COOLDOWN_MS) continue
-        alertCooldowns.set(cooldownKey, now)
-
-        try {
-          await sails.helpers.notification.sendContainerDownAlert.with({
-            containerName: app.containerName,
-            resourceType: 'app'
-          })
-        } catch (alertErr) {
-          sails.log.verbose(
-            'Lookout: Failed to send container down alert:',
-            alertErr.message
-          )
-        }
-      }
-
-      for (const service of services) {
-        if (
-          !service.containerName ||
-          runningContainerNames.has(service.containerName)
-        )
-          continue
-
-        sails.log.warn(
-          `Lookout: Container down: ${service.containerName} (service)`
-        )
-        await Service.updateOne({ id: service.id }).set({ status: 'stopped' })
-
-        const cooldownKey = `down:${service.containerName}`
-        const lastAlert = alertCooldowns.get(cooldownKey)
-        if (lastAlert && now - lastAlert < ALERT_COOLDOWN_MS) continue
-        alertCooldowns.set(cooldownKey, now)
-
-        try {
-          await sails.helpers.notification.sendContainerDownAlert.with({
-            containerName: service.containerName,
-            resourceType: 'service'
-          })
-        } catch (alertErr) {
-          sails.log.verbose(
-            'Lookout: Failed to send container down alert:',
-            alertErr.message
-          )
-        }
-      }
-    } catch (err) {
-      sails.log.verbose('Lookout: Health check error:', err.message)
     }
   }
 

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -1226,38 +1226,60 @@ onBeforeUnmount(() => {
           </div>
         </div>
 
-        <!-- Slide to Deploy -->
-        <div class="mb-10 flex justify-end">
-          <div class="w-full max-w-md sm:w-auto sm:max-w-none">
-            <div
-              v-if="!sourceIsReady"
-              role="alert"
-              class="mb-3 rounded-lg border border-amber-200 bg-amber-50 p-3 text-left dark:border-amber-900/60 dark:bg-amber-950/30"
+        <section
+          v-if="!sourceIsReady"
+          role="alert"
+          aria-labelledby="deployment-source-warning-title"
+          data-test="deployment-source-warning"
+          class="mb-4 rounded-lg border border-amber-200 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-950/20"
+        >
+          <div class="flex items-start gap-3 px-4 py-3">
+            <svg
+              class="mt-0.5 h-4 w-4 shrink-0 text-amber-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
             >
-              <p class="text-sm font-medium text-amber-900 dark:text-amber-200">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+              />
+            </svg>
+            <div class="min-w-0">
+              <h2
+                id="deployment-source-warning-title"
+                class="text-sm font-medium text-amber-800 dark:text-amber-300"
+              >
                 Deployment source required
-              </p>
+              </h2>
               <p
-                class="mt-1 text-xs leading-5 text-amber-800 dark:text-amber-300"
+                class="mt-1 text-xs leading-5 text-gray-600 dark:text-gray-400"
               >
                 {{ sourceReadiness?.message }}
               </p>
               <Link
                 :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/settings`"
-                class="min-h-11 mt-2 inline-flex items-center text-xs font-medium text-amber-900 underline underline-offset-2 dark:text-amber-200"
+                class="min-h-11 mt-2 inline-flex items-center text-xs font-medium text-amber-700 underline underline-offset-2 dark:text-amber-400"
               >
                 Connect or repair repository settings
               </Link>
             </div>
-            <div class="ml-auto w-56">
-              <SlideToDeploy
-                ref="slideRef"
-                :is-production="environment.isProduction"
-                :environment-name="environment.name"
-                :disabled="deploying || !checklistAllGood || !sourceIsReady"
-                @deploy="triggerDeploy"
-              />
-            </div>
+          </div>
+        </section>
+
+        <!-- Slide to Deploy -->
+        <div class="mb-10 flex justify-end">
+          <div class="w-56">
+            <SlideToDeploy
+              ref="slideRef"
+              :is-production="environment.isProduction"
+              :environment-name="environment.name"
+              :disabled="deploying || !checklistAllGood || !sourceIsReady"
+              @deploy="triggerDeploy"
+            />
           </div>
         </div>
 

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -1233,40 +1233,42 @@ onBeforeUnmount(() => {
           data-test="deployment-source-warning"
           class="mb-4 rounded-lg border border-amber-200 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-950/20"
         >
-          <div class="flex items-start gap-3 px-4 py-3">
-            <svg
-              class="mt-0.5 h-4 w-4 shrink-0 text-amber-500"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
-              />
-            </svg>
-            <div class="min-w-0">
-              <h2
-                id="deployment-source-warning-title"
-                class="text-sm font-medium text-amber-800 dark:text-amber-300"
+          <div class="flex items-start justify-between gap-3 px-4 py-3">
+            <div class="flex min-w-0 items-start gap-3">
+              <svg
+                class="mt-0.5 h-4 w-4 shrink-0 text-amber-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
               >
-                Deployment source required
-              </h2>
-              <p
-                class="mt-1 text-xs leading-5 text-gray-600 dark:text-gray-400"
-              >
-                {{ sourceReadiness?.message }}
-              </p>
-              <Link
-                :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/settings`"
-                class="min-h-11 mt-2 inline-flex items-center text-xs font-medium text-amber-700 underline underline-offset-2 dark:text-amber-400"
-              >
-                Connect or repair repository settings
-              </Link>
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+                />
+              </svg>
+              <div class="min-w-0">
+                <h2
+                  id="deployment-source-warning-title"
+                  class="text-sm font-medium text-amber-800 dark:text-amber-300"
+                >
+                  Deployment source required
+                </h2>
+                <p
+                  class="mt-1 text-xs leading-5 text-gray-600 dark:text-gray-400"
+                >
+                  {{ sourceReadiness?.message }}
+                </p>
+              </div>
             </div>
+            <Link
+              :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/settings`"
+              class="shrink-0 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
+            >
+              Configure source
+            </Link>
           </div>
         </section>
 

--- a/tests/e2e/pages/projects/status-reconciliation.test.js
+++ b/tests/e2e/pages/projects/status-reconciliation.test.js
@@ -1,0 +1,64 @@
+const { test } = require('sounding')
+
+test(
+  'a Docker-recovered app returns to Running in the existing app UI',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'status-reconciliation',
+          name: 'Status Reconciliation'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const containerName = `slipway-${current.key}-web`
+    const originalGetContainerStatus = sails.helpers.docker.getContainerStatus
+
+    sails.helpers.docker.getContainerStatus = async () => ({
+      running: true,
+      health: 'healthy'
+    })
+
+    try {
+      const app = await sails.models.app
+        .updateOne({ id: current.apps.web.id })
+        .set({ status: 'stopped', containerName })
+
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await page.goto(
+        `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/apps/${current.apps.web.slug}`
+      )
+
+      await expect(page).toSee('Stopped')
+      await page.screenshot('.tmp/status-recovery-before.png', {
+        fullPage: true
+      })
+
+      await sails.helpers.lookout.reconcileContainerStatuses.with({
+        containerStates: [
+          { name: containerName, state: 'running', running: true }
+        ]
+      })
+
+      expect((await sails.models.app.findOne({ id: app.id })).status).toBe(
+        'running'
+      )
+
+      await page.reload()
+      await expect(page).toSee('Running')
+      await page.screenshot('.tmp/status-recovery-running.png', {
+        fullPage: true
+      })
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.helpers.docker.getContainerStatus = originalGetContainerStatus
+    }
+  }
+)

--- a/tests/e2e/pages/projects/status-reconciliation.test.js
+++ b/tests/e2e/pages/projects/status-reconciliation.test.js
@@ -36,6 +36,20 @@ test(
         `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/apps/${current.apps.web.slug}`
       )
 
+      await page.wait('@deployment-source-warning')
+      const warningWidths = await page.script(() => {
+        const warning = document.querySelector(
+          '[data-test="deployment-source-warning"]'
+        )
+        return {
+          warning: Math.round(warning.getBoundingClientRect().width),
+          content: Math.round(
+            warning.parentElement.getBoundingClientRect().width
+          )
+        }
+      })
+
+      expect(warningWidths.warning).toBe(warningWidths.content)
       await expect(page).toSee('Stopped')
       await page.screenshot('.tmp/status-recovery-before.png', {
         fullPage: true

--- a/tests/e2e/pages/projects/status-reconciliation.test.js
+++ b/tests/e2e/pages/projects/status-reconciliation.test.js
@@ -37,6 +37,7 @@ test(
       )
 
       await page.wait('@deployment-source-warning')
+      await expect(page).toSee('Configure source')
       const warningWidths = await page.script(() => {
         const warning = document.querySelector(
           '[data-test="deployment-source-warning"]'

--- a/tests/factories/service.js
+++ b/tests/factories/service.js
@@ -1,0 +1,6 @@
+module.exports = ({ defineFactory }) =>
+  defineFactory('service', ({ sequence }) => ({
+    name: sequence('service-name', (number) => `database-${number}`),
+    type: 'postgresql',
+    version: '16'
+  }))

--- a/tests/unit/helpers/lookout/reconcile-container-statuses.test.js
+++ b/tests/unit/helpers/lookout/reconcile-container-statuses.test.js
@@ -1,0 +1,301 @@
+const { test } = require('sounding')
+const listContainerStates = require('../../../../api/helpers/docker/list-container-states')
+
+const { parseContainerStates } = listContainerStates._private
+
+function managedContainersWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: {
+        slug,
+        name: 'Managed Containers'
+      }
+    }
+  }
+}
+
+async function createManagedRecords({ sails, world, status = 'stopped' }) {
+  const current = world.current
+  const app = await sails.models.app
+    .updateOne({ id: current.apps.web.id })
+    .set({
+      status,
+      containerName: `slipway-${current.key}-web`
+    })
+  const service = await world.create('service').with({
+    environment: current.environments.production.id,
+    status,
+    containerName: `slipway-${current.key}-database`
+  })
+
+  return { app, service }
+}
+
+function transitionsFor(transitions, records) {
+  const targetIds = new Set(records.map((record) => record.id))
+  return transitions.filter((transition) => targetIds.has(transition.id))
+}
+
+test(
+  'status reconciliation restores managed apps and services observed running',
+  { world: managedContainersWorld('container-status-recovery') },
+  async ({ sails, world, expect }) => {
+    const { app, service } = await createManagedRecords({ sails, world })
+
+    const transitions =
+      await sails.helpers.lookout.reconcileContainerStatuses.with({
+        containerStates: [
+          { name: app.containerName, state: 'running', running: true },
+          { name: service.containerName, state: 'running', running: true }
+        ]
+      })
+
+    const updatedApp = await sails.models.app.findOne({ id: app.id })
+    const updatedService = await sails.models.service.findOne({
+      id: service.id
+    })
+
+    expect(updatedApp.status).toBe('running')
+    expect(updatedService.status).toBe('running')
+    expect(transitionsFor(transitions, [app, service])).toEqual([
+      {
+        resourceType: 'app',
+        id: app.id,
+        containerName: app.containerName,
+        from: 'stopped',
+        to: 'running'
+      },
+      {
+        resourceType: 'service',
+        id: service.id,
+        containerName: service.containerName,
+        from: 'stopped',
+        to: 'running'
+      }
+    ])
+  }
+)
+
+test(
+  'status reconciliation converges after a missing container returns',
+  { world: managedContainersWorld('container-status-missed-sample') },
+  async ({ sails, world, expect }) => {
+    const { app, service } = await createManagedRecords({
+      sails,
+      world,
+      status: 'running'
+    })
+
+    const stoppedTransitions =
+      await sails.helpers.lookout.reconcileContainerStatuses.with({
+        containerStates: []
+      })
+
+    expect((await sails.models.app.findOne({ id: app.id })).status).toBe(
+      'stopped'
+    )
+    expect(
+      (await sails.models.service.findOne({ id: service.id })).status
+    ).toBe('stopped')
+    expect(
+      transitionsFor(stoppedTransitions, [app, service]).map(
+        (transition) => transition.to
+      )
+    ).toEqual(['stopped', 'stopped'])
+
+    const recoveredTransitions =
+      await sails.helpers.lookout.reconcileContainerStatuses.with({
+        containerStates: [
+          { name: app.containerName, state: 'running', running: true },
+          { name: service.containerName, state: 'running', running: true }
+        ]
+      })
+
+    expect((await sails.models.app.findOne({ id: app.id })).status).toBe(
+      'running'
+    )
+    expect(
+      (await sails.models.service.findOne({ id: service.id })).status
+    ).toBe('running')
+    expect(
+      transitionsFor(recoveredTransitions, [app, service]).map(
+        (transition) => transition.to
+      )
+    ).toEqual(['running', 'running'])
+  }
+)
+
+test(
+  'status reconciliation preserves transitional and intentional states',
+  { world: managedContainersWorld('container-status-transitions') },
+  async ({ sails, world, expect }) => {
+    const { app, service } = await createManagedRecords({
+      sails,
+      world,
+      status: 'running'
+    })
+    await sails.models.service.updateOne({ id: service.id }).set({
+      status: 'stopped'
+    })
+
+    const transitions =
+      await sails.helpers.lookout.reconcileContainerStatuses.with({
+        containerStates: [
+          { name: app.containerName, state: 'restarting', running: false },
+          { name: service.containerName, state: 'exited', running: false }
+        ]
+      })
+
+    expect((await sails.models.app.findOne({ id: app.id })).status).toBe(
+      'running'
+    )
+    expect(
+      (await sails.models.service.findOne({ id: service.id })).status
+    ).toBe('stopped')
+    expect(transitionsFor(transitions, [app, service])).toEqual([])
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'deploying'
+    })
+    const deploymentTransitions =
+      await sails.helpers.lookout.reconcileContainerStatuses.with({
+        containerStates: [
+          { name: app.containerName, state: 'running', running: true },
+          { name: service.containerName, state: 'exited', running: false }
+        ]
+      })
+
+    expect((await sails.models.app.findOne({ id: app.id })).status).toBe(
+      'deploying'
+    )
+    expect(transitionsFor(deploymentTransitions, [app, service])).toEqual([])
+  }
+)
+
+test('docker stats failures remain errors instead of empty samples', async ({
+  sails,
+  expect
+}) => {
+  const originalDockerConfig = sails.config.docker
+  sails.config.docker = {
+    ...(originalDockerConfig || {}),
+    binaryPath: '/definitely-missing-slipway-docker'
+  }
+
+  try {
+    let error
+    try {
+      await sails.helpers.docker.getContainerStats()
+    } catch (err) {
+      error = err
+    }
+
+    expect(error).toBeDefined()
+    expect(error.code).toBe('ENOENT')
+  } finally {
+    sails.config.docker = originalDockerConfig
+  }
+})
+
+test(
+  'Docker lifecycle observation failures leave persisted status untouched',
+  { world: managedContainersWorld('container-status-observation-failure') },
+  async ({ sails, world, expect }) => {
+    const originalDockerConfig = sails.config.docker
+    const app = await sails.models.app
+      .updateOne({ id: world.current.apps.web.id })
+      .set({
+        status: 'running',
+        containerName: `slipway-${world.current.key}-unobserved`
+      })
+    sails.config.docker = {
+      ...(originalDockerConfig || {}),
+      binaryPath: '/definitely-missing-slipway-docker'
+    }
+
+    try {
+      let error
+      try {
+        await sails.helpers.lookout.reconcileContainerStatuses()
+      } catch (err) {
+        error = err
+      }
+
+      expect(error).toBeDefined()
+      expect(error.code).toBe('ENOENT')
+      expect((await sails.models.app.findOne({ id: app.id })).status).toBe(
+        'running'
+      )
+    } finally {
+      sails.config.docker = originalDockerConfig
+    }
+  }
+)
+
+test('Docker lifecycle output is normalized as a complete snapshot', async ({
+  expect
+}) => {
+  const states = parseContainerStates(
+    [
+      JSON.stringify({
+        ID: 'abc123',
+        Names: 'slipway-web',
+        State: 'running',
+        Status: 'Up 2 minutes'
+      }),
+      JSON.stringify({
+        ID: 'def456',
+        Names: 'slipway-db',
+        State: 'exited',
+        Status: 'Exited (0) 1 minute ago'
+      }),
+      JSON.stringify({
+        ID: 'ghi789',
+        Names: 'slipway-worker',
+        State: 'restarting',
+        Status: 'Restarting (1) 2 seconds ago'
+      })
+    ].join('\n')
+  )
+
+  expect(states).toEqual([
+    {
+      id: 'abc123',
+      name: 'slipway-web',
+      state: 'running',
+      running: true,
+      status: 'Up 2 minutes'
+    },
+    {
+      id: 'def456',
+      name: 'slipway-db',
+      state: 'exited',
+      running: false,
+      status: 'Exited (0) 1 minute ago'
+    },
+    {
+      id: 'ghi789',
+      name: 'slipway-worker',
+      state: 'restarting',
+      running: false,
+      status: 'Restarting (1) 2 seconds ago'
+    }
+  ])
+})
+
+test('malformed Docker lifecycle output rejects the whole snapshot', async ({
+  expect
+}) => {
+  let error
+  try {
+    parseContainerStates(
+      `${JSON.stringify({ Names: 'slipway-web', State: 'running' })}\nnot-json`
+    )
+  } catch (err) {
+    error = err
+  }
+
+  expect(error).toBeDefined()
+  expect(error.message).toMatch(/Could not parse Docker container state/)
+})


### PR DESCRIPTION
## Summary
- reconcile all managed app and service lifecycle statuses from one complete Docker container snapshot
- restore stopped records when Docker auto-recovers containers while preserving active deployment and transitional states
- keep Docker stats failures from being interpreted as stopped containers
- retain down-alert cooldown behavior and clear it after recovery
- prove the existing app UI moves from Stopped to Running after reconciliation

## Verification
- npm run lint
- npm test (61 unit, 23 functional, 10 browser; 94 total)
- verified the Docker container-list command against the local engine
- captured before/after screenshots from the Sounding browser trial

Closes #228