### PR TITLE
Make Caddy traffic cutover transactional

### DIFF
--- a/api/controllers/api/v1/deploy/rollback-deployment.js
+++ b/api/controllers/api/v1/deploy/rollback-deployment.js
@@ -43,53 +43,33 @@ module.exports = {
 
   fn: async function ({ projectSlug, environmentSlug, deploymentId, appSlug }) {
     const user = await User.findOne({ id: this.req.session.userId })
-
     const project = await Project.findOne({ slug: projectSlug }).populate(
       'team'
     )
 
-    if (!project) {
-      throw 'notFound'
-    }
-
-    if (project.team.id !== user.team) {
-      throw 'forbidden'
-    }
+    if (!project) throw 'notFound'
+    if (project.team.id !== user.team) throw 'forbidden'
 
     const environment = await Environment.findOne({
       project: project.id,
       slug: environmentSlug
     })
+    if (!environment) throw 'notFound'
 
-    if (!environment) {
-      throw 'notFound'
-    }
+    const targetApp = appSlug
+      ? await App.findOne({ environment: environment.id, slug: appSlug })
+      : (await App.findOne({
+          environment: environment.id,
+          isDefault: true
+        })) || (await App.findOne({ environment: environment.id }))
 
-    // Resolve target app
-    let targetApp
-    if (appSlug) {
-      targetApp = await App.findOne({
-        environment: environment.id,
-        slug: appSlug
-      })
-    } else {
-      targetApp =
-        (await App.findOne({ environment: environment.id, isDefault: true })) ||
-        (await App.findOne({ environment: environment.id }))
-    }
-
-    // Find the target deployment to roll back to
     const targetDeployment = await Deployment.findOne({
       id: deploymentId,
       environment: environment.id,
       status: 'running'
     })
+    if (!targetDeployment?.imageName) throw 'badRequest'
 
-    if (!targetDeployment || !targetDeployment.imageName) {
-      throw 'badRequest'
-    }
-
-    // Create a new deployment record for the rollback
     const rollback = await Deployment.create({
       status: 'pending',
       gitCommit: targetDeployment.gitCommit,
@@ -98,7 +78,7 @@ module.exports = {
       triggeredBy: user.id,
       triggerType: 'api',
       environment: environment.id,
-      app: targetApp ? targetApp.id : undefined,
+      app: targetApp?.id,
       startedAt: Date.now()
     }).fetch()
 
@@ -106,15 +86,19 @@ module.exports = {
       `Rollback ${rollback.id} triggered for ${project.slug}/${environment.slug} → deployment ${deploymentId}`
     )
 
-    // Kick off the async rollback pipeline
-    process.nextTick(() => {
-      executeRollback(
-        rollback.id,
-        targetDeployment,
-        project,
-        environment,
-        targetApp
-      )
+    process.nextTick(async () => {
+      try {
+        await sails.helpers.deploy.executeRollback.with({
+          rollbackId: rollback.id,
+          targetDeployment,
+          environment,
+          app: targetApp
+        })
+      } catch (error) {
+        sails.log.error(
+          `Rollback ${rollback.id} failed: ${error.message || error}`
+        )
+      }
     })
 
     return {
@@ -124,248 +108,5 @@ module.exports = {
         message: 'Rollback started'
       }
     }
-  }
-}
-
-/**
- * Async rollback pipeline. Skips the build step — reuses an existing image.
- */
-async function executeRollback(
-  rollbackId,
-  targetDeployment,
-  project,
-  environment,
-  targetApp
-) {
-  let hostPort = null
-  let hostPortReserved = false
-
-  try {
-    // 1. Set status to deploying (no build needed)
-    await Deployment.updateOne({ id: rollbackId }).set({
-      status: 'deploying',
-      imageName: targetDeployment.imageName
-    })
-
-    await Deployment.appendBuildLog(
-      rollbackId,
-      `Rolling back to deployment ${targetDeployment.id}\n`
-    )
-    await Deployment.appendBuildLog(
-      rollbackId,
-      `Reusing image: ${targetDeployment.imageName}\n`
-    )
-
-    // 2. Ensure Docker network exists
-    await sails.helpers.docker.ensureNetwork()
-
-    // 3. Generate container name
-    const appSlugForName = targetApp ? targetApp.slug : undefined
-    const isPubliclyRoutable = !targetApp || targetApp.routePath !== null
-    const appBindHost = isPubliclyRoutable
-      ? sails.config.custom.slipwayPortHost || '0.0.0.0'
-      : '127.0.0.1'
-    const containerName = await App.generateContainerName(
-      environment.id,
-      appSlugForName
-    )
-
-    // 4. Allocate a host port
-    hostPort = await sails.helpers.docker.allocatePort.with({
-      ownerType: 'deployment',
-      ownerId: String(rollbackId)
-    })
-    hostPortReserved = true
-
-    // 5. Get env vars (3-tier merge: global < environment < app)
-    let globalEnvVars = {}
-    try {
-      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
-      globalEnvVars = JSON.parse(globalJson)
-    } catch {
-      /* ignore */
-    }
-
-    const envRecord = await Environment.findOne({
-      id: environment.id
-    }).decrypt()
-    const appEnvVars = (targetApp && targetApp.envVars) || {}
-    const envVars = {
-      ...globalEnvVars,
-      ...(envRecord.envVars || {}),
-      ...appEnvVars
-    }
-
-    // 6. Check for existing app
-    const existingApp =
-      targetApp ||
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    const healthPath = App.normalizeHealthPath(
-      (targetApp && targetApp.healthPath) ||
-        (existingApp && existingApp.healthPath)
-    )
-
-    // 7. Run the container with the existing image
-    const containerResult = await sails.helpers.docker.runContainer.with({
-      imageName: targetDeployment.imageName,
-      containerName,
-      port: 1337,
-      hostPort,
-      host: appBindHost,
-      envVars,
-      deploymentId: rollbackId
-    })
-
-    // 8. HTTP health check before switching traffic to the rollback image
-    await sails.helpers.docker.healthCheck.with({
-      containerName: containerResult.containerName,
-      port: 1337,
-      hostPort: containerResult.hostPort,
-      path: healthPath,
-      deploymentId: rollbackId
-    })
-
-    // 9. Create or update the App record
-    if (existingApp) {
-      await App.updateOne({ id: existingApp.id }).set({
-        status: 'running',
-        containerId: containerResult.containerId,
-        containerName: containerResult.containerName,
-        imageId: null,
-        imageName: targetDeployment.imageName,
-        port: 1337,
-        hostPort: containerResult.hostPort,
-        lastDeployedAt: Date.now(),
-        currentDeployment: rollbackId
-      })
-    } else {
-      await App.create({
-        status: 'running',
-        containerId: containerResult.containerId,
-        containerName: containerResult.containerName,
-        imageName: targetDeployment.imageName,
-        port: 1337,
-        hostPort: containerResult.hostPort,
-        lastDeployedAt: Date.now(),
-        environment: environment.id,
-        currentDeployment: rollbackId,
-        slug: appSlugForName || 'app',
-        name: appSlugForName || 'app',
-        healthPath,
-        isDefault: true
-      })
-    }
-    await releaseDeployPort({ hostPort, deploymentId: rollbackId })
-    hostPortReserved = false
-
-    // 10. Update Caddy reverse proxy route
-    try {
-      await sails.helpers.caddy.updateRoute(environment.id)
-    } catch (caddyErr) {
-      sails.log.warn(
-        `Caddy route update failed (non-fatal): ${caddyErr.message}`
-      )
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `Warning: Caddy route update failed: ${caddyErr.message}\n`
-      )
-    }
-
-    // 11. Mark previous running deployments as stopped (scoped to app)
-    const stopCriteria = {
-      environment: environment.id,
-      status: 'running',
-      id: { '!=': rollbackId }
-    }
-    if (existingApp) stopCriteria.app = existingApp.id
-    await Deployment.update(stopCriteria).set({ status: 'stopped' })
-
-    // 12. Mark deployment as running
-    await Deployment.updateOne({ id: rollbackId }).set({
-      status: 'running',
-      finishedAt: Date.now()
-    })
-
-    const { fullDomain, generatedDomain } = await Environment.resolveDomains(
-      environment.id
-    )
-    const directAccess = await sails.helpers.deploy.getDirectAccess.with({
-      serverIp: await sails.helpers.getServerIp(),
-      hostPort: containerResult.hostPort,
-      routePath: targetApp ? targetApp.routePath : '/',
-      containerRunning: true,
-      portBinding: containerResult.portBinding
-    })
-    const directUrl = directAccess.url
-    await Deployment.appendDeployLog(rollbackId, `Rollback complete.\n`)
-    if (fullDomain) {
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `  URL:       https://${fullDomain}\n`
-      )
-    }
-    if (generatedDomain && generatedDomain !== fullDomain) {
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `  Fallback:  https://${generatedDomain}\n`
-      )
-    }
-    if (directUrl) {
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `  Direct:    ${directUrl}\n`
-      )
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `  Network:   Container healthy; ${containerResult.portBinding.diagnostic}\n`
-      )
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `  Firewall:  ${directAccess.firewallHint}\n`
-      )
-    } else if (!isPubliclyRoutable) {
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `  Network:   Worker port is bound to 127.0.0.1 and is not publicly exposed.\n`
-      )
-    } else if (directAccess.message) {
-      await Deployment.appendDeployLog(
-        rollbackId,
-        `  Network:   ${directAccess.message}\n`
-      )
-    }
-
-    sails.log.info(`Rollback ${rollbackId} completed successfully`)
-  } catch (err) {
-    sails.log.error(`Rollback ${rollbackId} failed: ${err.message}`)
-
-    if (hostPortReserved && hostPort) {
-      await releaseDeployPort({ hostPort, deploymentId: rollbackId })
-      hostPortReserved = false
-    }
-
-    const current = await Deployment.findOne({ id: rollbackId })
-    if (current && current.status !== 'failed') {
-      await Deployment.updateOne({ id: rollbackId }).set({
-        status: 'failed',
-        errorMessage: err.message,
-        finishedAt: Date.now()
-      })
-    }
-  }
-}
-
-async function releaseDeployPort({ hostPort, deploymentId }) {
-  try {
-    await sails.helpers.docker.releasePort.with({
-      hostPort,
-      ownerType: 'deployment',
-      ownerId: String(deploymentId)
-    })
-  } catch (err) {
-    sails.log.warn(
-      `Could not release port reservation ${hostPort}: ${err.message || err}`
-    )
   }
 }

--- a/api/helpers/caddy/finish-route-update.js
+++ b/api/helpers/caddy/finish-route-update.js
@@ -1,0 +1,167 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Finish route update',
+
+  description:
+    'Commit or roll back a verified Caddy route candidate without discarding the previous route prematurely.',
+
+  inputs: {
+    action: {
+      type: 'string',
+      required: true,
+      isIn: ['commit', 'rollback']
+    },
+    transaction: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ action, transaction }) {
+    if (action === 'rollback') {
+      await rollbackRoute(transaction)
+      return { action: 'rolled_back', routeId: transaction.routeId }
+    }
+
+    try {
+      await commitRoute(transaction)
+      return { action: 'committed', routeId: transaction.routeId }
+    } catch (error) {
+      try {
+        await rollbackRoute(transaction)
+      } catch (rollbackError) {
+        error.rollbackError = rollbackError
+      }
+      throw error
+    }
+  }
+}
+
+async function commitRoute(transaction) {
+  const dockerPath = sails.config.docker?.binaryPath || 'docker'
+  const retiredUpstreams = difference(
+    transaction.previousUpstreams,
+    transaction.candidateUpstreams
+  )
+
+  if (transaction.previousExists) {
+    if (transaction.previousWasRunning) {
+      await execFileAsync(dockerPath, ['stop', transaction.routeId])
+      await sails.helpers.caddy.verifyRoute.with({
+        expectedUpstreams: transaction.candidateUpstreams,
+        excludedUpstreams: retiredUpstreams
+      })
+    }
+    await execFileAsync(dockerPath, [
+      'rename',
+      transaction.routeId,
+      transaction.previousRouteId
+    ])
+  }
+
+  await execFileAsync(dockerPath, [
+    'rename',
+    transaction.candidateRouteId,
+    transaction.routeId
+  ])
+
+  if (transaction.previousExists) {
+    await tolerateDockerError(dockerPath, [
+      'rm',
+      '-f',
+      transaction.previousRouteId
+    ])
+  }
+}
+
+async function rollbackRoute(transaction) {
+  const dockerPath = sails.config.docker?.binaryPath || 'docker'
+  const candidateOnlyUpstreams = difference(
+    transaction.candidateUpstreams,
+    transaction.previousUpstreams
+  )
+  const previousState = await getContainerState(
+    dockerPath,
+    transaction.previousRouteId
+  )
+
+  if (previousState.exists) {
+    await tolerateDockerError(dockerPath, ['rm', '-f', transaction.routeId])
+    await tolerateDockerError(dockerPath, [
+      'rm',
+      '-f',
+      transaction.candidateRouteId
+    ])
+    await execFileAsync(dockerPath, [
+      'rename',
+      transaction.previousRouteId,
+      transaction.routeId
+    ])
+  } else {
+    await tolerateDockerError(dockerPath, [
+      'rm',
+      '-f',
+      transaction.candidateRouteId
+    ])
+    if (!transaction.previousExists) {
+      await tolerateDockerError(dockerPath, ['rm', '-f', transaction.routeId])
+    }
+  }
+
+  if (transaction.previousExists && transaction.previousWasRunning) {
+    const routeState = await getContainerState(dockerPath, transaction.routeId)
+    if (!routeState.running) {
+      await execFileAsync(dockerPath, ['start', transaction.routeId])
+    }
+    if (transaction.previousUpstreams.length > 0) {
+      await sails.helpers.caddy.verifyRoute.with({
+        expectedUpstreams: transaction.previousUpstreams,
+        excludedUpstreams: candidateOnlyUpstreams
+      })
+    }
+  } else if (!transaction.previousExists) {
+    await sails.helpers.caddy.verifyRoute.with({
+      expectedUpstreams: [],
+      excludedUpstreams: candidateOnlyUpstreams
+    })
+  }
+}
+
+function difference(values, excludedValues) {
+  const excluded = new Set(excludedValues)
+  return values.filter((value) => !excluded.has(value))
+}
+
+async function getContainerState(dockerPath, containerName) {
+  try {
+    const { stdout } = await execFileAsync(dockerPath, [
+      'inspect',
+      '--format',
+      '{{.State.Running}}',
+      containerName
+    ])
+    return { exists: true, running: stdout.trim() === 'true' }
+  } catch {
+    return { exists: false, running: false }
+  }
+}
+
+async function tolerateDockerError(dockerPath, args) {
+  try {
+    await execFileAsync(dockerPath, args)
+  } catch {
+    // Cleanup is intentionally idempotent.
+  }
+}
+
+module.exports._private = { commitRoute, difference, rollbackRoute }

--- a/api/helpers/caddy/generate-route-config.js
+++ b/api/helpers/caddy/generate-route-config.js
@@ -9,6 +9,11 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'Environment ID'
+    },
+    apps: {
+      type: 'ref',
+      description:
+        'Optional app snapshot to render instead of reading the current App records.'
     }
   },
 
@@ -22,7 +27,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ environmentId }) {
+  fn: async function ({ environmentId, apps }) {
     const environment = await Environment.findOne({
       id: environmentId
     }).populate('project')
@@ -32,10 +37,12 @@ module.exports = {
     }
 
     // Fetch all apps in this environment
-    const apps = await App.find({ environment: environmentId })
+    const environmentApps = Array.isArray(apps)
+      ? apps
+      : await App.find({ environment: environmentId })
 
     // Filter to apps with a hostPort (deployed) and a routePath (not workers)
-    const routableApps = apps.filter(
+    const routableApps = environmentApps.filter(
       (app) => app.hostPort && app.routePath !== null
     )
 

--- a/api/helpers/caddy/update-route.js
+++ b/api/helpers/caddy/update-route.js
@@ -1,49 +1,91 @@
-const { execFile } = require('child_process')
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
 
 module.exports = {
   friendlyName: 'Update route',
 
   description:
-    'Update or create a Caddy route for an environment ' +
-    'using a Docker label container picked up by caddy-docker-proxy.',
+    'Replace an environment route through a verified caddy-docker-proxy label container.',
 
   inputs: {
     environmentId: {
       type: 'string',
       required: true,
       description: 'Environment ID to update route for'
+    },
+    apps: {
+      type: 'ref',
+      description:
+        'Optional complete app snapshot used to stage a route before committing App state.'
+    },
+    routeVersion: {
+      type: 'string',
+      description:
+        'Unique deployment or operation identifier for the candidate route.'
+    },
+    deferCommit: {
+      type: 'boolean',
+      defaultsTo: false,
+      description:
+        'Keep the previous route active after candidate verification so the caller can commit or roll back the staged route.'
     }
   },
 
   exits: {
     success: {
-      description: 'Route updated successfully'
+      description: 'Route updated successfully',
+      outputType: 'ref'
     },
     noApp: {
       description: 'No app deployed in this environment'
-    },
-    caddyError: {
-      description: 'Failed to update Caddy config'
     }
   },
 
-  fn: async function ({ environmentId }) {
-    const config = await sails.helpers.caddy.generateRouteConfig(environmentId)
+  fn: async function ({ environmentId, apps, routeVersion, deferCommit }) {
+    const environmentApps = Array.isArray(apps)
+      ? apps
+      : await App.find({ environment: environmentId })
+    const previousApps = Array.isArray(apps)
+      ? await App.find({ environment: environmentId })
+      : environmentApps
+    const config = await sails.helpers.caddy.generateRouteConfig.with({
+      environmentId,
+      apps: environmentApps
+    })
 
     if (!config) {
-      throw 'noApp'
+      const environment = await Environment.findOne({
+        id: environmentId
+      }).populate('project')
+      if (!environment) {
+        throw 'noApp'
+      }
+
+      const emptyRouteContainerName = `slipway-route-${environment.project.slug}-${environment.slug}`
+      const dockerPath = sails.config.docker?.binaryPath || 'docker'
+      await tolerateDockerError(dockerPath, [
+        'rm',
+        '-f',
+        emptyRouteContainerName
+      ])
+      sails.log.info(
+        `Removed the empty Caddy route for environment ${environmentId}`
+      )
+      return {
+        domains: [],
+        routeId: emptyRouteContainerName,
+        action: 'removed'
+      }
     }
 
     const dockerPath = sails.config.docker?.binaryPath || 'docker'
     const network = sails.config.custom.slipwayNetwork || 'slipway'
     const routeContainerName = `slipway-route-${config.projectSlug}-${config.environmentSlug}`
 
-    // Remove existing route container
-    await new Promise((resolve) => {
-      execFile(dockerPath, ['rm', '-f', routeContainerName], () => resolve())
-    })
-
     if (!config.domains || config.domains.length === 0 || !config.route) {
+      await tolerateDockerError(dockerPath, ['rm', '-f', routeContainerName])
       sails.log.info(
         `No hostname route configured for environment ${environmentId}; direct IP access remains available`
       )
@@ -54,83 +96,178 @@ module.exports = {
       }
     }
 
-    // Get routable apps for this environment
-    const apps = await App.find({ environment: environmentId })
-    const routableApps = apps.filter(
+    const routableApps = environmentApps.filter(
       (app) => app.hostPort && app.routePath !== null
     )
+    const expectedUpstreams = routableApps.map(
+      (app) => `${app.containerName}:${app.port}`
+    )
+    const previousUpstreams = previousApps
+      .filter((app) => app.hostPort && app.routePath !== null)
+      .map((app) => `${app.containerName}:${app.port}`)
+    const suffix = normalizeContainerSuffix(routeVersion || String(Date.now()))
+    const candidateName = `${routeContainerName}-candidate-${suffix}`
+    const previousName = `${routeContainerName}-previous-${suffix}`
+    const oldState = await getContainerState(dockerPath, routeContainerName)
+    const oldExists = oldState.exists
+    const oldWasRunning = oldState.running
 
-    // Build docker run args with caddy labels
-    const args = [
-      'run',
-      '-d',
-      '--name',
-      routeContainerName,
-      '--network',
+    await tolerateDockerError(dockerPath, ['rm', '-f', candidateName])
+    await tolerateDockerError(dockerPath, ['rm', '-f', previousName])
+
+    const args = await buildCreateArgs({
+      candidateName,
       network,
-      '--restart',
-      'unless-stopped',
-      '--label',
-      `caddy=${config.domains.join(',')}`
-    ]
-
-    if (routableApps.length === 1) {
-      // Single app — straightforward reverse proxy using container name
-      const app = routableApps[0]
-      args.push(
-        '--label',
-        `caddy.reverse_proxy=${app.containerName}:${app.port}`
-      )
-    } else {
-      // Multi-app — sort by path specificity, root last
-      const sorted = [...routableApps].sort((a, b) => {
-        if (a.routePath === '/') return 1
-        if (b.routePath === '/') return -1
-        return b.routePath.length - a.routePath.length
-      })
-
-      sorted.forEach((app, i) => {
-        if (app.routePath === '/') {
-          args.push(
-            '--label',
-            `caddy.reverse_proxy=${app.containerName}:${app.port}`
-          )
-        } else {
-          args.push('--label', `caddy.handle_path_${i}=${app.routePath}*`)
-          args.push(
-            '--label',
-            `caddy.handle_path_${i}.reverse_proxy=${app.containerName}:${app.port}`
-          )
-        }
-      })
-    }
-
-    // Add TLS email if configured
-    const acmeEmail = await sails.helpers.setting.get('acmeEmail')
-    if (acmeEmail) {
-      args.push('--label', `caddy.tls=${acmeEmail}`)
-    }
-
-    args.push('alpine', 'sleep', 'infinity')
-
-    return new Promise((resolve, reject) => {
-      execFile(dockerPath, args, (err) => {
-        if (err) {
-          sails.log.error(
-            `Route container creation failed for ${config.domains.join(
-              ', '
-            )}: ${err.message}`
-          )
-          throw 'caddyError'
-        }
-        sails.log.info(`Caddy route created for ${config.domains.join(', ')}`)
-        resolve({
-          domain: config.domain,
-          domains: config.domains,
-          routeId: routeContainerName,
-          action: 'created'
-        })
-      })
+      config,
+      routableApps
     })
+
+    try {
+      await execFileAsync(dockerPath, args)
+      await execFileAsync(dockerPath, ['start', candidateName])
+
+      // Keep the previous route active while Caddy accepts the candidate.
+      // This lets the deployment commit App state before retiring anything.
+      await sails.helpers.caddy.verifyRoute.with({ expectedUpstreams })
+
+      const transaction = {
+        routeId: routeContainerName,
+        candidateRouteId: candidateName,
+        previousRouteId: previousName,
+        previousExists: oldExists,
+        previousWasRunning: oldWasRunning,
+        previousUpstreams,
+        candidateUpstreams: expectedUpstreams
+      }
+      const result = {
+        domain: config.domain,
+        domains: config.domains,
+        routeId: routeContainerName,
+        action: oldExists ? 'replaced' : 'created',
+        expectedUpstreams,
+        transaction
+      }
+
+      if (deferCommit) {
+        sails.log.info(
+          `Caddy candidate route verified for ${config.domains.join(', ')}`
+        )
+        return result
+      }
+
+      await sails.helpers.caddy.finishRouteUpdate.with({
+        action: 'commit',
+        transaction
+      })
+      sails.log.info(`Caddy route verified for ${config.domains.join(', ')}`)
+      return result
+    } catch (error) {
+      await tolerateDockerError(dockerPath, ['rm', '-f', candidateName])
+
+      try {
+        if (oldWasRunning && previousUpstreams.length > 0) {
+          await sails.helpers.caddy.verifyRoute.with({
+            expectedUpstreams: previousUpstreams,
+            excludedUpstreams: expectedUpstreams.filter(
+              (upstream) => !previousUpstreams.includes(upstream)
+            )
+          })
+        }
+      } catch (rollbackError) {
+        error.rollbackError = rollbackError
+      }
+
+      sails.log.error(
+        `Caddy route replacement failed for ${config.domains.join(', ')}: ${
+          error.message || error
+        }`
+      )
+      throw error
+    }
   }
 }
+
+async function buildCreateArgs({
+  candidateName,
+  network,
+  config,
+  routableApps
+}) {
+  const args = [
+    'create',
+    '--name',
+    candidateName,
+    '--network',
+    network,
+    '--restart',
+    'unless-stopped',
+    '--label',
+    `caddy=${config.domains.join(',')}`
+  ]
+
+  if (routableApps.length === 1) {
+    const app = routableApps[0]
+    args.push('--label', `caddy.reverse_proxy=${app.containerName}:${app.port}`)
+  } else {
+    const sorted = [...routableApps].sort((a, b) => {
+      if (a.routePath === '/') return 1
+      if (b.routePath === '/') return -1
+      return b.routePath.length - a.routePath.length
+    })
+
+    sorted.forEach((app, index) => {
+      if (app.routePath === '/') {
+        args.push(
+          '--label',
+          `caddy.reverse_proxy=${app.containerName}:${app.port}`
+        )
+      } else {
+        args.push('--label', `caddy.handle_path_${index}=${app.routePath}*`)
+        args.push(
+          '--label',
+          `caddy.handle_path_${index}.reverse_proxy=${app.containerName}:${app.port}`
+        )
+      }
+    })
+  }
+
+  const acmeEmail = await sails.helpers.setting.get('acmeEmail')
+  if (acmeEmail) {
+    args.push('--label', `caddy.tls=${acmeEmail}`)
+  }
+
+  args.push('alpine', 'sleep', 'infinity')
+  return args
+}
+
+async function getContainerState(dockerPath, containerName) {
+  try {
+    const { stdout } = await execFileAsync(dockerPath, [
+      'inspect',
+      '--format',
+      '{{.State.Running}}',
+      containerName
+    ])
+    return { exists: true, running: stdout.trim() === 'true' }
+  } catch {
+    return { exists: false, running: false }
+  }
+}
+
+async function tolerateDockerError(dockerPath, args) {
+  try {
+    await execFileAsync(dockerPath, args)
+  } catch {
+    // Cleanup is intentionally idempotent.
+  }
+}
+
+function normalizeContainerSuffix(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+}
+
+module.exports._private = { buildCreateArgs, normalizeContainerSuffix }

--- a/api/helpers/caddy/verify-route.js
+++ b/api/helpers/caddy/verify-route.js
@@ -1,0 +1,133 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Verify route',
+
+  description:
+    'Wait for the expected generated route, then require Caddy to accept it as active configuration.',
+
+  inputs: {
+    expectedUpstreams: {
+      type: 'ref',
+      required: true,
+      description:
+        'Container upstreams that must appear as host:port values. May be empty when verifying removal.'
+    },
+    excludedUpstreams: {
+      type: 'ref',
+      defaultsTo: [],
+      description: 'Container upstreams that must no longer appear.'
+    },
+    timeoutMs: {
+      type: 'number',
+      defaultsTo: 10000,
+      description: 'Maximum time to wait for caddy-docker-proxy to reload.'
+    }
+  },
+
+  exits: {
+    success: {
+      description: 'The expected route is present in Caddy.',
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ expectedUpstreams, excludedUpstreams, timeoutMs }) {
+    excludedUpstreams = Array.isArray(excludedUpstreams)
+      ? excludedUpstreams
+      : []
+    if (
+      !Array.isArray(expectedUpstreams) ||
+      (expectedUpstreams.length === 0 && excludedUpstreams.length === 0)
+    ) {
+      throw createVerificationError('No Caddy route assertions were provided.')
+    }
+
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const proxyContainer =
+      sails.config.custom.slipwayProxyContainer || 'slipway-proxy'
+    const deadline = Date.now() + timeoutMs
+    let lastError
+
+    while (Date.now() <= deadline) {
+      try {
+        const configPath = '/config/caddy/Caddyfile.autosave'
+        const { stdout } = await execFileAsync(
+          dockerPath,
+          caddyCommand(proxyContainer, 'adapt', configPath)
+        )
+
+        const missingUpstreams = expectedUpstreams.filter(
+          (upstream) => !stdout.includes(upstream)
+        )
+        const staleUpstreams = excludedUpstreams.filter((upstream) =>
+          stdout.includes(upstream)
+        )
+
+        if (missingUpstreams.length > 0 || staleUpstreams.length > 0) {
+          lastError = new Error(
+            [
+              missingUpstreams.length > 0
+                ? `missing ${missingUpstreams.join(', ')}`
+                : null,
+              staleUpstreams.length > 0
+                ? `still includes ${staleUpstreams.join(', ')}`
+                : null
+            ]
+              .filter(Boolean)
+              .join('; ')
+          )
+        } else {
+          // `adapt` proves caddy-docker-proxy rendered the intended route.
+          // `reload` talks to Caddy's admin API and blocks until that exact
+          // Caddyfile is accepted; Caddy keeps the previous active config if
+          // the reload fails.
+          await execFileAsync(
+            dockerPath,
+            caddyCommand(proxyContainer, 'reload', configPath)
+          )
+          return { expectedUpstreams }
+        }
+      } catch (error) {
+        lastError = error
+      }
+
+      await wait(100)
+    }
+
+    throw createVerificationError(
+      `Caddy did not load the expected route within ${timeoutMs}ms: ${
+        lastError?.message || 'unknown verification failure'
+      }`,
+      lastError
+    )
+  }
+}
+
+function createVerificationError(message, cause) {
+  const error = new Error(message, cause ? { cause } : undefined)
+  error.code = 'CADDY_ROUTE_VERIFICATION_FAILED'
+  return error
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function caddyCommand(proxyContainer, command, configPath) {
+  return [
+    'exec',
+    proxyContainer,
+    'caddy',
+    command,
+    '--config',
+    configPath,
+    '--adapter',
+    'caddyfile'
+  ]
+}
+
+module.exports._private = { caddyCommand, createVerificationError }

--- a/api/helpers/deploy/cutover-traffic.js
+++ b/api/helpers/deploy/cutover-traffic.js
@@ -1,0 +1,323 @@
+module.exports = {
+  friendlyName: 'Cut over traffic',
+
+  description:
+    'Verify a candidate Caddy route before committing App state, with deterministic route restoration on failure.',
+
+  inputs: {
+    deploymentId: {
+      type: 'string',
+      required: true,
+      description: 'Deployment that owns this cutover.'
+    },
+    environmentId: {
+      type: 'string',
+      required: true,
+      description: 'Environment whose route is being changed.'
+    },
+    appId: {
+      type: 'string',
+      description: 'Existing App record to replace.'
+    },
+    candidate: {
+      type: 'ref',
+      required: true,
+      description: 'Candidate App fields after health checks have passed.'
+    }
+  },
+
+  exits: {
+    success: {
+      description: 'Traffic and App state now point at the candidate.',
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ deploymentId, environmentId, appId, candidate }) {
+    const previousApp = appId ? await App.findOne({ id: appId }) : null
+    if (appId && !previousApp) {
+      throw new Error(`Cannot cut over missing app ${appId}.`)
+    }
+
+    const currentApps = await App.find({ environment: environmentId })
+    const candidateApp = {
+      ...(previousApp || {}),
+      ...candidate,
+      id: previousApp?.id,
+      environment: environmentId,
+      status: 'running',
+      imageId: null,
+      lastDeployedAt: Date.now(),
+      currentDeployment: deploymentId,
+      slug: candidate.slug || previousApp?.slug || 'app',
+      name:
+        candidate.name ||
+        previousApp?.name ||
+        candidate.slug ||
+        previousApp?.slug ||
+        'app',
+      healthPath: App.normalizeHealthPath(
+        candidate.healthPath || previousApp?.healthPath
+      ),
+      routePath:
+        candidate.routePath === undefined
+          ? previousApp?.routePath ?? '/'
+          : candidate.routePath,
+      isDefault:
+        candidate.isDefault === undefined
+          ? previousApp?.isDefault ?? true
+          : candidate.isDefault
+    }
+    const routeApps = previousApp
+      ? currentApps.map((app) =>
+          app.id === previousApp.id ? candidateApp : app
+        )
+      : [...currentApps, candidateApp]
+    const auditContext = await getAuditContext(deploymentId, environmentId)
+    const requiresRouteCutover = candidateApp.routePath !== null
+    let candidateRouteApplied = false
+    let stagedRoute = null
+    let appStateCommitted = false
+    let committedApp = null
+
+    await appendDeployLog(
+      deploymentId,
+      `Cutover: applying route to ${candidateApp.containerName}:${candidateApp.port}\n`
+    )
+    await audit('deployment.cutover.started', {
+      ...auditContext,
+      deploymentId,
+      environmentId,
+      fromContainer: previousApp?.containerName || null,
+      toContainer: candidateApp.containerName
+    })
+
+    try {
+      const route = requiresRouteCutover
+        ? await sails.helpers.caddy.updateRoute.with({
+            environmentId,
+            apps: routeApps,
+            routeVersion: deploymentId,
+            deferCommit: true
+          })
+        : { action: 'unchanged', reason: 'worker' }
+      candidateRouteApplied = requiresRouteCutover
+      stagedRoute = route.transaction || null
+
+      committedApp = previousApp
+        ? await App.updateOne({ id: previousApp.id }).set(
+            appValues(candidateApp)
+          )
+        : await App.create(appValues(candidateApp)).fetch()
+
+      if (!committedApp) {
+        throw new Error(
+          'The candidate route loaded, but App state was not updated.'
+        )
+      }
+      appStateCommitted = true
+
+      if (stagedRoute) {
+        await sails.helpers.caddy.finishRouteUpdate.with({
+          action: 'commit',
+          transaction: stagedRoute
+        })
+      }
+
+      await appendDeployLog(
+        deploymentId,
+        `Cutover: route verified and App state committed.\n`
+      )
+      await audit('deployment.cutover.succeeded', {
+        ...auditContext,
+        deploymentId,
+        environmentId,
+        fromContainer: previousApp?.containerName || null,
+        toContainer: candidateApp.containerName
+      })
+
+      return { app: committedApp, previousApp, route }
+    } catch (cutoverError) {
+      // A staged route can be retried here even if the lower-level commit's
+      // first restoration attempt failed. Only report rollback failure when
+      // this final recovery attempt also fails.
+      let rollbackError = stagedRoute
+        ? null
+        : cutoverError.rollbackError || null
+
+      if (stagedRoute) {
+        try {
+          await sails.helpers.caddy.finishRouteUpdate.with({
+            action: 'rollback',
+            transaction: stagedRoute
+          })
+        } catch (error) {
+          rollbackError = combineErrors(
+            rollbackError,
+            error.rollbackError || error
+          )
+        }
+      } else if (candidateRouteApplied) {
+        try {
+          await sails.helpers.caddy.updateRoute.with({
+            environmentId,
+            routeVersion: `${deploymentId}-rollback`
+          })
+        } catch (error) {
+          rollbackError = combineErrors(
+            rollbackError,
+            error.rollbackError || error
+          )
+        }
+      }
+
+      if (appStateCommitted) {
+        try {
+          if (previousApp) {
+            await App.updateOne({ id: previousApp.id }).set(
+              appValues(previousApp)
+            )
+          } else if (committedApp) {
+            await App.destroyOne({ id: committedApp.id })
+          }
+        } catch (error) {
+          rollbackError = combineErrors(rollbackError, error)
+        }
+      }
+
+      await appendDeployLog(
+        deploymentId,
+        `Cutover failed: ${cutoverError.message || cutoverError}\n`
+      )
+      await audit('deployment.cutover.failed', {
+        ...auditContext,
+        deploymentId,
+        environmentId,
+        fromContainer: previousApp?.containerName || null,
+        toContainer: candidateApp.containerName,
+        error: cutoverError.message || String(cutoverError)
+      })
+
+      if (rollbackError) {
+        await appendDeployLog(
+          deploymentId,
+          `Cutover rollback failed: ${rollbackError.message || rollbackError}\n`
+        )
+        await audit('deployment.cutover.rollback_failed', {
+          ...auditContext,
+          deploymentId,
+          environmentId,
+          restoredContainer: previousApp?.containerName || null,
+          error: rollbackError.message || String(rollbackError)
+        })
+
+        const error = new Error(
+          `Traffic cutover failed: ${
+            cutoverError.message || cutoverError
+          }. Cutover rollback also failed: ${
+            rollbackError.message || rollbackError
+          }`,
+          { cause: cutoverError }
+        )
+        error.code = 'TRAFFIC_CUTOVER_ROLLBACK_FAILED'
+        error.rollbackError = rollbackError
+        throw error
+      }
+
+      await appendDeployLog(
+        deploymentId,
+        previousApp
+          ? `Cutover rolled back; the previous route and container remain active.\n`
+          : `Cutover rolled back; the candidate route was removed and no partial App state remains.\n`
+      )
+      await audit('deployment.cutover.rolled_back', {
+        ...auditContext,
+        deploymentId,
+        environmentId,
+        restoredContainer: previousApp?.containerName || null
+      })
+
+      const error = new Error(
+        `Traffic cutover failed and was rolled back: ${
+          cutoverError.message || cutoverError
+        }`,
+        { cause: cutoverError }
+      )
+      error.code = cutoverError.code || 'TRAFFIC_CUTOVER_FAILED'
+      throw error
+    }
+  }
+}
+
+function appValues(app) {
+  return {
+    status: 'running',
+    containerId: app.containerId,
+    containerName: app.containerName,
+    imageId: app.imageId ?? null,
+    imageName: app.imageName,
+    port: app.port,
+    hostPort: app.hostPort,
+    lastDeployedAt: app.lastDeployedAt,
+    environment: app.environment,
+    currentDeployment: app.currentDeployment,
+    slug: app.slug || 'app',
+    name: app.name || app.slug || 'app',
+    healthPath: app.healthPath,
+    routePath: app.routePath === undefined ? '/' : app.routePath,
+    isDefault: app.isDefault === undefined ? true : app.isDefault
+  }
+}
+
+function combineErrors(first, second) {
+  if (!first) return second
+  if (!second) return first
+  return new Error(`${first.message || first}; ${second.message || second}`, {
+    cause: first
+  })
+}
+
+async function appendDeployLog(deploymentId, message) {
+  try {
+    await Deployment.appendDeployLog(deploymentId, message)
+  } catch {
+    // The cutover result must not depend on best-effort logging.
+  }
+}
+
+async function getAuditContext(deploymentId, environmentId) {
+  const [deployment, environment] = await Promise.all([
+    Deployment.findOne({ id: deploymentId }),
+    Environment.findOne({ id: environmentId }).populate('project')
+  ])
+
+  return {
+    userId:
+      typeof deployment?.triggeredBy === 'object'
+        ? deployment.triggeredBy.id
+        : deployment?.triggeredBy,
+    teamId:
+      typeof environment?.project?.team === 'object'
+        ? environment.project.team.id
+        : environment?.project?.team
+  }
+}
+
+async function audit(action, details) {
+  await sails.helpers.audit.log.with({
+    action,
+    resourceType: 'deployment',
+    resourceId: details.deploymentId,
+    details: {
+      environmentId: details.environmentId,
+      fromContainer: details.fromContainer,
+      toContainer: details.toContainer,
+      restoredContainer: details.restoredContainer,
+      error: details.error
+    },
+    userId: details.userId,
+    teamId: details.teamId
+  })
+}
+
+module.exports._private = { appValues, combineErrors }

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -1,7 +1,3 @@
-const { execFile } = require('child_process')
-const util = require('util')
-const execFileAsync = util.promisify(execFile)
-
 module.exports = {
   friendlyName: 'Execute deployment pipeline',
 
@@ -73,10 +69,6 @@ module.exports = {
       const imageName = await App.generateImageName(
         environment.id,
         deploymentId,
-        appSlug
-      )
-      const canonicalName = await App.generateContainerName(
-        environment.id,
         appSlug
       )
       deployContainerName = await App.generateDeployContainerName(
@@ -208,56 +200,36 @@ module.exports = {
 
       // === Health check passed — switch traffic ===
 
-      // 11. Update App record (Caddy reads from this, so traffic switches after updateRoute)
+      // 11. Verify the candidate route before committing App state.
       currentStage = 'traffic cutover'
-      if (existingApp) {
-        await App.updateOne({ id: existingApp.id }).set({
-          status: 'running',
+      await sails.helpers.deploy.cutoverTraffic.with({
+        deploymentId,
+        environmentId: environment.id,
+        appId: existingApp?.id,
+        candidate: {
           containerId: containerResult.containerId,
-          containerName: canonicalName,
-          imageId: null,
+          containerName: deployContainerName,
           imageName,
           port: 1337,
           hostPort: deployHostPort,
-          lastDeployedAt: Date.now(),
-          currentDeployment: deploymentId
-        })
-      } else {
-        await App.create({
-          status: 'running',
-          containerId: containerResult.containerId,
-          containerName: canonicalName,
-          imageName,
-          port: 1337,
-          hostPort: deployHostPort,
-          lastDeployedAt: Date.now(),
-          environment: environment.id,
-          currentDeployment: deploymentId,
           slug: appSlug || 'app',
-          name: appSlug || 'app',
+          name: existingApp?.name || appSlug || 'app',
           healthPath,
-          isDefault: true
-        })
-      }
+          routePath: existingApp?.routePath,
+          isDefault: existingApp?.isDefault
+        }
+      })
       await releaseDeployPort({ hostPort: deployHostPort, deploymentId })
       deployHostPortReserved = false
+      deployContainerName = null
 
-      // 12. Update Caddy reverse proxy route — traffic now goes to new container
-      try {
-        await sails.helpers.caddy.updateRoute(environment.id)
-      } catch (caddyErr) {
-        sails.log.warn(
-          `Caddy route update failed (non-fatal): ${caddyErr.message}`
-        )
-        await Deployment.appendDeployLog(
-          deploymentId,
-          `Warning: Caddy route update failed: ${caddyErr.message}\n`
-        )
-      }
-
-      // 13. Stop old container (the one with the previous App.containerName)
+      // 12. Only retire the previous container after route verification and
+      // App state commit have both succeeded.
       currentStage = 'cleanup'
-      if (oldContainerName && oldContainerName !== deployContainerName) {
+      if (
+        oldContainerName &&
+        oldContainerName !== containerResult.containerName
+      ) {
         try {
           await sails.helpers.docker.stopContainer.with({
             containerName: oldContainerName
@@ -276,21 +248,7 @@ module.exports = {
         }
       }
 
-      // 14. Rename deploy-scoped container to canonical name
-      if (deployContainerName !== canonicalName) {
-        try {
-          await execFileAsync('docker', [
-            'rename',
-            deployContainerName,
-            canonicalName
-          ])
-          deployContainerName = null // Renamed, no longer needs cleanup
-        } catch (renameErr) {
-          sails.log.warn(`Could not rename container: ${renameErr.message}`)
-        }
-      }
-
-      // 15. Mark previous running deployments as stopped (scoped to this app)
+      // 13. Mark previous running deployments as stopped (scoped to this app)
       const stopCriteria = {
         environment: environment.id,
         status: 'running',
@@ -301,7 +259,7 @@ module.exports = {
       }
       await Deployment.update(stopCriteria).set({ status: 'stopped' })
 
-      // 16. Mark this deployment as running
+      // 14. Mark this deployment as running
       await Deployment.updateOne({ id: deploymentId }).set({
         status: 'running',
         finishedAt: Date.now()

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -1,0 +1,284 @@
+module.exports = {
+  friendlyName: 'Execute rollback',
+
+  description:
+    'Run a rollback deployment from an existing image through the shared transactional cutover.',
+
+  inputs: {
+    rollbackId: {
+      type: 'string',
+      required: true
+    },
+    targetDeployment: {
+      type: 'ref',
+      required: true
+    },
+    environment: {
+      type: 'ref',
+      required: true
+    },
+    app: {
+      type: 'ref'
+    }
+  },
+
+  fn: async function ({
+    rollbackId,
+    targetDeployment,
+    environment,
+    app: appInput
+  }) {
+    let candidateContainerName = null
+    let hostPort = null
+    let hostPortReserved = false
+    let currentStage = 'initialization'
+
+    try {
+      await Deployment.updateOne({ id: rollbackId }).set({
+        status: 'deploying',
+        imageName: targetDeployment.imageName
+      })
+
+      await Deployment.appendBuildLog(
+        rollbackId,
+        `Rolling back to deployment ${targetDeployment.id}\n`
+      )
+      await Deployment.appendBuildLog(
+        rollbackId,
+        `Reusing image: ${targetDeployment.imageName}\n`
+      )
+
+      await sails.helpers.docker.ensureNetwork()
+
+      const existingApp =
+        appInput ||
+        (await App.findOne({
+          environment: environment.id,
+          isDefault: true
+        })) ||
+        (await App.findOne({ environment: environment.id }))
+      const appSlug = existingApp?.slug
+      const isPubliclyRoutable = !existingApp || existingApp.routePath !== null
+      const appBindHost = isPubliclyRoutable
+        ? sails.config.custom.slipwayPortHost || '0.0.0.0'
+        : '127.0.0.1'
+      const healthPath = App.normalizeHealthPath(existingApp?.healthPath)
+      const oldContainerName = existingApp?.containerName
+      candidateContainerName = await App.generateDeployContainerName(
+        environment.id,
+        rollbackId,
+        appSlug
+      )
+
+      hostPort = await sails.helpers.docker.allocatePort.with({
+        ownerType: 'deployment',
+        ownerId: String(rollbackId)
+      })
+      hostPortReserved = true
+
+      let globalEnvVars = {}
+      try {
+        const globalJson = await sails.helpers.setting.get(
+          'globalEnvVars',
+          '{}'
+        )
+        globalEnvVars = JSON.parse(globalJson)
+      } catch {
+        /* ignore invalid legacy settings */
+      }
+
+      const envRecord = await Environment.findOne({
+        id: environment.id
+      }).decrypt()
+      const envVars = {
+        ...globalEnvVars,
+        ...(envRecord.envVars || {}),
+        ...(existingApp?.envVars || {})
+      }
+
+      currentStage = 'container startup'
+      const containerResult = await sails.helpers.docker.runContainer.with({
+        imageName: targetDeployment.imageName,
+        containerName: candidateContainerName,
+        port: 1337,
+        hostPort,
+        host: appBindHost,
+        envVars,
+        deploymentId: rollbackId,
+        resourceLimits: existingApp?.resourceLimits
+      })
+
+      currentStage = 'health check'
+      await sails.helpers.docker.healthCheck.with({
+        containerName: candidateContainerName,
+        port: 1337,
+        hostPort,
+        path: healthPath,
+        deploymentId: rollbackId
+      })
+
+      currentStage = 'traffic cutover'
+      await sails.helpers.deploy.cutoverTraffic.with({
+        deploymentId: rollbackId,
+        environmentId: environment.id,
+        appId: existingApp?.id,
+        candidate: {
+          containerId: containerResult.containerId,
+          containerName: candidateContainerName,
+          imageName: targetDeployment.imageName,
+          port: 1337,
+          hostPort,
+          slug: appSlug || 'app',
+          name: existingApp?.name || appSlug || 'app',
+          healthPath,
+          routePath: existingApp?.routePath,
+          isDefault: existingApp?.isDefault
+        }
+      })
+
+      await releaseDeployPort({ hostPort, deploymentId: rollbackId })
+      hostPortReserved = false
+      candidateContainerName = null
+
+      currentStage = 'cleanup'
+      if (
+        oldContainerName &&
+        oldContainerName !== containerResult.containerName
+      ) {
+        try {
+          await sails.helpers.docker.stopContainer.with({
+            containerName: oldContainerName
+          })
+          await Deployment.appendDeployLog(
+            rollbackId,
+            `Stopped old container: ${oldContainerName}\n`
+          )
+        } catch (error) {
+          sails.log.verbose(
+            `Could not stop old container ${oldContainerName}: ${
+              error.message || error
+            }`
+          )
+        }
+      }
+
+      const stopCriteria = {
+        environment: environment.id,
+        status: 'running',
+        id: { '!=': rollbackId }
+      }
+      if (existingApp) stopCriteria.app = existingApp.id
+      await Deployment.update(stopCriteria).set({ status: 'stopped' })
+
+      await Deployment.updateOne({ id: rollbackId }).set({
+        status: 'running',
+        finishedAt: Date.now()
+      })
+
+      const { fullDomain, generatedDomain } = await Environment.resolveDomains(
+        environment.id
+      )
+      const directAccess = await sails.helpers.deploy.getDirectAccess.with({
+        serverIp: await sails.helpers.getServerIp(),
+        hostPort,
+        routePath: existingApp ? existingApp.routePath : '/',
+        containerRunning: true,
+        portBinding: containerResult.portBinding
+      })
+      await Deployment.appendDeployLog(rollbackId, `Rollback complete.\n`)
+      if (fullDomain) {
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `  URL:       https://${fullDomain}\n`
+        )
+      }
+      if (generatedDomain && generatedDomain !== fullDomain) {
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `  Fallback:  https://${generatedDomain}\n`
+        )
+      }
+      if (directAccess.url) {
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `  Direct:    ${directAccess.url}\n`
+        )
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `  Network:   Container healthy; ${containerResult.portBinding.diagnostic}\n`
+        )
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `  Firewall:  ${directAccess.firewallHint}\n`
+        )
+      } else if (!isPubliclyRoutable) {
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `  Network:   Worker port is bound to 127.0.0.1 and is not publicly exposed.\n`
+        )
+      } else if (directAccess.message) {
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `  Network:   ${directAccess.message}\n`
+        )
+      }
+
+      sails.log.info(`Rollback ${rollbackId} completed successfully`)
+    } catch (error) {
+      const errorMessage = error.message || String(error)
+      sails.log.error(
+        `Rollback ${rollbackId} failed during ${currentStage}: ${errorMessage}`
+      )
+
+      try {
+        await Deployment.appendDeployLog(
+          rollbackId,
+          `\nERROR [${currentStage}]: ${errorMessage}\n`
+        )
+      } catch {
+        /* preserve the original failure */
+      }
+
+      if (candidateContainerName) {
+        try {
+          await sails.helpers.docker.stopContainer.with({
+            containerName: candidateContainerName
+          })
+        } catch {
+          /* the candidate may not have started */
+        }
+      }
+
+      if (hostPortReserved && hostPort) {
+        await releaseDeployPort({ hostPort, deploymentId: rollbackId })
+      }
+
+      const current = await Deployment.findOne({ id: rollbackId })
+      if (current && current.status !== 'failed') {
+        await Deployment.updateOne({ id: rollbackId }).set({
+          status: 'failed',
+          errorMessage,
+          finishedAt: Date.now()
+        })
+      }
+
+      throw error
+    }
+  }
+}
+
+async function releaseDeployPort({ hostPort, deploymentId }) {
+  try {
+    await sails.helpers.docker.releasePort.with({
+      hostPort,
+      ownerType: 'deployment',
+      ownerId: String(deploymentId)
+    })
+  } catch (error) {
+    sails.log.warn(
+      `Could not release port reservation ${hostPort}: ${
+        error.message || error
+      }`
+    )
+  }
+}

--- a/tests/unit/helpers/caddy/finish-route-update.test.js
+++ b/tests/unit/helpers/caddy/finish-route-update.test.js
@@ -1,0 +1,228 @@
+const childProcess = require('node:child_process')
+const path = require('node:path')
+const { promisify } = require('node:util')
+
+const { test } = require('sounding')
+
+const helperPath = path.resolve(
+  __dirname,
+  '../../../../api/helpers/caddy/finish-route-update.js'
+)
+
+test('route commit failure restores and verifies the previous route', async ({
+  sails,
+  expect
+}) => {
+  const transaction = routeTransaction()
+  const docker = fakeDocker({
+    [transaction.routeId]: true,
+    [transaction.candidateRouteId]: true
+  })
+  const helper = loadHelperWithExec(docker.exec)
+  const originalVerifyRoute = sails.helpers.caddy.verifyRoute
+  const verified = []
+  sails.helpers.caddy.verifyRoute = machineStub(
+    async ({ expectedUpstreams, excludedUpstreams }) => {
+      verified.push({ expectedUpstreams, excludedUpstreams })
+      if (verified.length === 1) {
+        throw new Error('Candidate-only route was rejected')
+      }
+      return { expectedUpstreams }
+    }
+  )
+
+  try {
+    const error = await captureError(
+      helper.fn({ action: 'commit', transaction })
+    )
+
+    expect(error.message).toContain('Candidate-only route was rejected')
+    expect(docker.state(transaction.routeId)).toEqual({
+      exists: true,
+      running: true
+    })
+    expect(docker.state(transaction.candidateRouteId).exists).toBe(false)
+    expect(verified).toEqual([
+      {
+        expectedUpstreams: transaction.candidateUpstreams,
+        excludedUpstreams: ['slipway-web-previous:1337']
+      },
+      {
+        expectedUpstreams: transaction.previousUpstreams,
+        excludedUpstreams: ['slipway-web-candidate:1337']
+      }
+    ])
+  } finally {
+    sails.helpers.caddy.verifyRoute = originalVerifyRoute
+  }
+})
+
+test('cancelling a staged route keeps the previous route running', async ({
+  sails,
+  expect
+}) => {
+  const transaction = routeTransaction()
+  const docker = fakeDocker({
+    [transaction.routeId]: true,
+    [transaction.candidateRouteId]: true
+  })
+  const helper = loadHelperWithExec(docker.exec)
+  const originalVerifyRoute = sails.helpers.caddy.verifyRoute
+  const verified = []
+  sails.helpers.caddy.verifyRoute = machineStub(
+    async ({ expectedUpstreams, excludedUpstreams }) => {
+      verified.push({ expectedUpstreams, excludedUpstreams })
+      return { expectedUpstreams }
+    }
+  )
+
+  try {
+    const result = await helper.fn({ action: 'rollback', transaction })
+
+    expect(result.action).toBe('rolled_back')
+    expect(docker.state(transaction.routeId)).toEqual({
+      exists: true,
+      running: true
+    })
+    expect(docker.state(transaction.candidateRouteId).exists).toBe(false)
+    expect(verified).toEqual([
+      {
+        expectedUpstreams: transaction.previousUpstreams,
+        excludedUpstreams: ['slipway-web-candidate:1337']
+      }
+    ])
+  } finally {
+    sails.helpers.caddy.verifyRoute = originalVerifyRoute
+  }
+})
+
+test('cancelling a first route verifies that the candidate was removed', async ({
+  sails,
+  expect
+}) => {
+  const transaction = {
+    ...routeTransaction(),
+    previousExists: false,
+    previousWasRunning: false,
+    previousUpstreams: []
+  }
+  const docker = fakeDocker({
+    [transaction.candidateRouteId]: true
+  })
+  const helper = loadHelperWithExec(docker.exec)
+  const originalVerifyRoute = sails.helpers.caddy.verifyRoute
+  const verified = []
+  sails.helpers.caddy.verifyRoute = machineStub(async (inputs) => {
+    verified.push(inputs)
+    return { expectedUpstreams: inputs.expectedUpstreams }
+  })
+
+  try {
+    await helper.fn({ action: 'rollback', transaction })
+
+    expect(docker.state(transaction.routeId).exists).toBe(false)
+    expect(docker.state(transaction.candidateRouteId).exists).toBe(false)
+    expect(verified).toEqual([
+      {
+        expectedUpstreams: [],
+        excludedUpstreams: transaction.candidateUpstreams
+      }
+    ])
+  } finally {
+    sails.helpers.caddy.verifyRoute = originalVerifyRoute
+  }
+})
+
+function routeTransaction() {
+  return {
+    routeId: 'slipway-route-project-production',
+    candidateRouteId: 'slipway-route-project-production-candidate-123',
+    previousRouteId: 'slipway-route-project-production-previous-123',
+    previousExists: true,
+    previousWasRunning: true,
+    previousUpstreams: [
+      'slipway-web-previous:1337',
+      'slipway-api-unchanged:1337'
+    ],
+    candidateUpstreams: [
+      'slipway-web-candidate:1337',
+      'slipway-api-unchanged:1337'
+    ]
+  }
+}
+
+function fakeDocker(initialContainers) {
+  const containers = new Map(
+    Object.entries(initialContainers).map(([name, running]) => [
+      name,
+      { running }
+    ])
+  )
+
+  return {
+    exec: async (dockerPath, args) => {
+      const [command, ...rest] = args
+
+      if (command === 'inspect') {
+        const container = containers.get(rest.at(-1))
+        if (!container) throw new Error('No such container')
+        return { stdout: `${container.running}\n`, stderr: '' }
+      }
+
+      if (command === 'stop' || command === 'start') {
+        const container = containers.get(rest[0])
+        if (!container) throw new Error('No such container')
+        container.running = command === 'start'
+      } else if (command === 'rename') {
+        const [from, to] = rest
+        const container = containers.get(from)
+        if (!container || containers.has(to)) {
+          throw new Error('Container rename failed')
+        }
+        containers.delete(from)
+        containers.set(to, container)
+      } else if (command === 'rm') {
+        containers.delete(rest.at(-1))
+      }
+
+      return { stdout: '', stderr: '' }
+    },
+    state: (name) => {
+      const container = containers.get(name)
+      return container
+        ? { exists: true, running: container.running }
+        : { exists: false, running: false }
+    }
+  }
+}
+
+function loadHelperWithExec(fakeExecFile) {
+  const originalExecFile = childProcess.execFile
+  const stubExecFile = () => {}
+  stubExecFile[promisify.custom] = fakeExecFile
+
+  childProcess.execFile = stubExecFile
+  delete require.cache[require.resolve(helperPath)]
+
+  try {
+    return require(helperPath)
+  } finally {
+    childProcess.execFile = originalExecFile
+    delete require.cache[require.resolve(helperPath)]
+  }
+}
+
+function machineStub(fn) {
+  fn.with = fn
+  return fn
+}
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}

--- a/tests/unit/helpers/caddy/update-route.test.js
+++ b/tests/unit/helpers/caddy/update-route.test.js
@@ -1,0 +1,159 @@
+const childProcess = require('node:child_process')
+const path = require('node:path')
+const { promisify } = require('node:util')
+
+const { test } = require('sounding')
+
+const helperPath = path.resolve(
+  __dirname,
+  '../../../../api/helpers/caddy/update-route.js'
+)
+
+function routeWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: {
+        slug,
+        name: 'Transactional Route'
+      }
+    }
+  }
+}
+
+test(
+  'an empty app snapshot removes the environment route',
+  { world: routeWorld('empty-route-removal') },
+  async ({ world, expect }) => {
+    const calls = []
+    const helper = loadHelperWithExec(async (dockerPath, args) => {
+      calls.push({ dockerPath, args })
+      return { stdout: '', stderr: '' }
+    })
+
+    const result = await helper.fn({
+      environmentId: world.current.environments.production.id,
+      apps: []
+    })
+
+    expect(result.action).toBe('removed')
+    expect(calls.map(({ args }) => args)).toEqual([
+      ['rm', '-f', result.routeId]
+    ])
+  }
+)
+
+test(
+  'candidate route verification failure removes the candidate and verifies the still-active previous route',
+  { world: routeWorld('route-restoration') },
+  async ({ sails, world, expect }) => {
+    const environment = world.current.environments.production
+    const currentApp = await sails.models.app
+      .updateOne({ id: world.current.apps.web.id })
+      .set({
+        status: 'running',
+        containerId: 'previous-container-id',
+        containerName: 'slipway-route-restoration-previous',
+        port: 1337,
+        hostPort: 1410,
+        routePath: '/'
+      })
+    const routeContainerName = `slipway-route-${world.current.projects.deploymentTarget.slug}-${environment.slug}`
+    const candidateName = `${routeContainerName}-candidate-deployment-123`
+    const calls = []
+    const oldRunning = true
+    const helper = loadHelperWithExec(async (dockerPath, args) => {
+      calls.push({ dockerPath, args })
+
+      if (args[0] === 'inspect') {
+        return { stdout: `${oldRunning}\n`, stderr: '' }
+      }
+      return { stdout: '', stderr: '' }
+    })
+    const originalVerifyRoute = sails.helpers.caddy.verifyRoute
+    const originalLogError = sails.log.error
+    let verificationCount = 0
+    sails.log.error = () => {}
+    sails.helpers.caddy.verifyRoute = machineStub(async () => {
+      verificationCount += 1
+      if (verificationCount === 1) {
+        const error = new Error('Candidate-only route was rejected')
+        error.code = 'CADDY_ROUTE_VERIFICATION_FAILED'
+        throw error
+      }
+      return { expectedUpstreams: [] }
+    })
+
+    try {
+      const error = await captureError(
+        helper.fn({
+          environmentId: environment.id,
+          routeVersion: 'deployment-123',
+          deferCommit: true,
+          apps: [
+            {
+              ...currentApp,
+              containerId: 'candidate-container-id',
+              containerName: 'slipway-route-restoration-candidate',
+              hostPort: 1411
+            }
+          ]
+        })
+      )
+      const commands = calls.map(({ args }) => args)
+      const removeCandidateAfterFailure = commands.findLastIndex(
+        (args) => args[0] === 'rm' && args[2] === candidateName
+      )
+      const persistedApp = await sails.models.app.findOne({ id: currentApp.id })
+
+      expect(error.message).toContain('Candidate-only route was rejected')
+      expect(verificationCount).toBe(2)
+      expect(oldRunning).toBe(true)
+      expect(removeCandidateAfterFailure > -1).toBe(true)
+      expect(
+        commands.some(
+          (args) =>
+            args[0] === 'stop' ||
+            (args[0] === 'start' && args[1] === routeContainerName)
+        )
+      ).toBe(false)
+      expect(persistedApp.containerName).toBe(
+        'slipway-route-restoration-previous'
+      )
+    } finally {
+      sails.helpers.caddy.verifyRoute = originalVerifyRoute
+      sails.log.error = originalLogError
+    }
+  }
+)
+
+function loadHelperWithExec(fakeExecFile) {
+  const originalExecFile = childProcess.execFile
+  const stubExecFile = () => {}
+  stubExecFile[promisify.custom] = fakeExecFile
+
+  childProcess.execFile = stubExecFile
+  delete require.cache[require.resolve(helperPath)]
+
+  try {
+    return require(helperPath)
+  } finally {
+    childProcess.execFile = originalExecFile
+    delete require.cache[require.resolve(helperPath)]
+  }
+}
+
+function machineStub(fn) {
+  fn.with = fn
+  return fn
+}
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}

--- a/tests/unit/helpers/caddy/verify-route.test.js
+++ b/tests/unit/helpers/caddy/verify-route.test.js
@@ -1,0 +1,134 @@
+const childProcess = require('node:child_process')
+const path = require('node:path')
+const { promisify } = require('node:util')
+
+const { test } = require('sounding')
+
+const helperPath = path.resolve(
+  __dirname,
+  '../../../../api/helpers/caddy/verify-route.js'
+)
+
+test('route verification requires Caddy to accept the generated configuration', async ({
+  expect
+}) => {
+  const calls = []
+  const helper = loadHelperWithExec(async (dockerPath, args) => {
+    calls.push({ dockerPath, args })
+    return {
+      stdout: args.includes('adapt')
+        ? '{"dial":"slipway-web-candidate:1337"}'
+        : '',
+      stderr: ''
+    }
+  })
+
+  const result = await helper.fn({
+    expectedUpstreams: ['slipway-web-candidate:1337'],
+    timeoutMs: 100
+  })
+
+  expect(result.expectedUpstreams).toEqual(['slipway-web-candidate:1337'])
+  expect(calls.map(({ args }) => args[3])).toEqual(['adapt', 'reload'])
+  expect(calls[1].args).toEqual([
+    'exec',
+    'slipway-proxy',
+    'caddy',
+    'reload',
+    '--config',
+    '/config/caddy/Caddyfile.autosave',
+    '--adapter',
+    'caddyfile'
+  ])
+})
+
+test('Caddy admin API failure fails route verification explicitly', async ({
+  expect
+}) => {
+  const helper = loadHelperWithExec(async (dockerPath, args) => {
+    if (args.includes('adapt')) {
+      return {
+        stdout: '{"dial":"slipway-web-candidate:1337"}',
+        stderr: ''
+      }
+    }
+
+    throw new Error('Caddy admin endpoint unavailable')
+  })
+
+  const error = await captureError(
+    helper.fn({
+      expectedUpstreams: ['slipway-web-candidate:1337'],
+      timeoutMs: 1
+    })
+  )
+
+  expect(error.code).toBe('CADDY_ROUTE_VERIFICATION_FAILED')
+  expect(error.message).toContain('Caddy admin endpoint unavailable')
+})
+
+test('route verification rejects stale upstreams after cutover', async ({
+  expect
+}) => {
+  const helper = loadHelperWithExec(async () => ({
+    stdout:
+      '{"dial":"slipway-web-candidate:1337"}{"dial":"slipway-web-previous:1337"}',
+    stderr: ''
+  }))
+
+  const error = await captureError(
+    helper.fn({
+      expectedUpstreams: ['slipway-web-candidate:1337'],
+      excludedUpstreams: ['slipway-web-previous:1337'],
+      timeoutMs: 1
+    })
+  )
+
+  expect(error.code).toBe('CADDY_ROUTE_VERIFICATION_FAILED')
+  expect(error.message).toContain('still includes slipway-web-previous:1337')
+})
+
+test('route verification can confirm that a first candidate was removed', async ({
+  expect
+}) => {
+  const calls = []
+  const helper = loadHelperWithExec(async (dockerPath, args) => {
+    calls.push(args)
+    return { stdout: '{"dial":"unrelated-app:1337"}', stderr: '' }
+  })
+
+  const result = await helper.fn({
+    expectedUpstreams: [],
+    excludedUpstreams: ['slipway-web-candidate:1337'],
+    timeoutMs: 100
+  })
+
+  expect(result.expectedUpstreams).toEqual([])
+  expect(calls.map((args) => args[3])).toEqual(['adapt', 'reload'])
+})
+
+function loadHelperWithExec(fakeExecFile) {
+  const originalExecFile = childProcess.execFile
+  const stubExecFile = () => {}
+  stubExecFile[promisify.custom] = fakeExecFile
+
+  childProcess.execFile = stubExecFile
+  delete require.cache[require.resolve(helperPath)]
+
+  try {
+    return require(helperPath)
+  } finally {
+    childProcess.execFile = originalExecFile
+    delete require.cache[require.resolve(helperPath)]
+  }
+}
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}

--- a/tests/unit/helpers/deploy/cutover-traffic.test.js
+++ b/tests/unit/helpers/deploy/cutover-traffic.test.js
@@ -1,0 +1,656 @@
+const { test } = require('sounding')
+
+function cutoverWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: {
+        slug,
+        name: 'Transactional Cutover'
+      }
+    }
+  }
+}
+
+async function prepareCutover({ sails, world }) {
+  const current = world.current
+  const app = current.apps.web
+  const previousDeployment = await world.create('deployment').with({
+    status: 'running',
+    imageName: 'slipway/web:previous',
+    environment: current.environments.production.id,
+    app: app.id,
+    triggeredBy: current.users.genesisUser.id
+  })
+  const previousApp = await sails.models.app.updateOne({ id: app.id }).set({
+    status: 'running',
+    containerId: 'previous-container-id',
+    containerName: 'slipway-web-previous',
+    imageName: previousDeployment.imageName,
+    port: 1337,
+    hostPort: 1401,
+    currentDeployment: previousDeployment.id
+  })
+  const deployment = await world.create('deployment').with({
+    status: 'deploying',
+    imageName: 'slipway/web:candidate',
+    environment: current.environments.production.id,
+    app: app.id,
+    triggeredBy: current.users.genesisUser.id
+  })
+
+  return {
+    app: previousApp,
+    candidate: {
+      containerId: 'candidate-container-id',
+      containerName: 'slipway-web-candidate',
+      imageName: deployment.imageName,
+      port: 1337,
+      hostPort: 1402,
+      slug: previousApp.slug,
+      name: previousApp.name,
+      healthPath: previousApp.healthPath,
+      routePath: previousApp.routePath,
+      isDefault: previousApp.isDefault
+    },
+    deployment,
+    environment: current.environments.production
+  }
+}
+
+function machineStub(fn) {
+  fn.with = fn
+  return fn
+}
+
+function stagedRoute(action = 'replaced') {
+  return {
+    action,
+    transaction: {
+      routeId: 'slipway-route-test',
+      candidateRouteId: 'slipway-route-test-candidate',
+      previousRouteId: 'slipway-route-test-previous'
+    }
+  }
+}
+
+test(
+  'traffic cutover verifies the candidate route before committing App state',
+  { world: cutoverWorld('cutover-success') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const originalFinishRouteUpdate = sails.helpers.caddy.finishRouteUpdate
+    const calls = []
+    const finishCalls = []
+
+    sails.helpers.caddy.updateRoute = machineStub(async (inputs) => {
+      calls.push(inputs)
+      const persisted = await sails.models.app.findOne({ id: setup.app.id })
+      expect(persisted.containerName).toBe('slipway-web-previous')
+      expect(
+        inputs.apps.find((app) => app.id === setup.app.id).containerName
+      ).toBe('slipway-web-candidate')
+      return stagedRoute()
+    })
+    sails.helpers.caddy.finishRouteUpdate = machineStub(async (inputs) => {
+      finishCalls.push(inputs)
+      const persisted = await sails.models.app.findOne({ id: setup.app.id })
+      expect(persisted.containerName).toBe('slipway-web-candidate')
+      return { action: 'committed' }
+    })
+
+    try {
+      const result = await sails.helpers.deploy.cutoverTraffic.with({
+        deploymentId: setup.deployment.id,
+        environmentId: setup.environment.id,
+        appId: setup.app.id,
+        candidate: setup.candidate
+      })
+
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+      const actions = (
+        await sails.models.auditlog.find({ resourceId: setup.deployment.id })
+      ).map((event) => event.action)
+
+      expect(calls.length).toBe(1)
+      expect(calls[0].deferCommit).toBe(true)
+      expect(finishCalls.map(({ action }) => action)).toEqual(['commit'])
+      expect(result.previousApp.containerName).toBe('slipway-web-previous')
+      expect(app.containerName).toBe('slipway-web-candidate')
+      expect(app.hostPort).toBe(1402)
+      expect(app.currentDeployment).toBe(setup.deployment.id)
+      expect(actions).toEqual([
+        'deployment.cutover.started',
+        'deployment.cutover.succeeded'
+      ])
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+      sails.helpers.caddy.finishRouteUpdate = originalFinishRouteUpdate
+    }
+  }
+)
+
+test(
+  'first deployment stages a root route before creating its App record',
+  { world: cutoverWorld('cutover-first-deployment') },
+  async ({ sails, world, expect }) => {
+    const environment = world.current.environments.production
+    await sails.models.app.destroy({ environment: environment.id })
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      imageName: 'slipway/web:first',
+      environment: environment.id,
+      triggeredBy: world.current.users.genesisUser.id
+    })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const originalFinishRouteUpdate = sails.helpers.caddy.finishRouteUpdate
+    let stagedApp
+
+    sails.helpers.caddy.updateRoute = machineStub(async ({ apps }) => {
+      stagedApp = apps[0]
+      const persistedApps = await sails.models.app.find({
+        environment: environment.id
+      })
+      expect(persistedApps.length).toBe(0)
+      return stagedRoute('created')
+    })
+    sails.helpers.caddy.finishRouteUpdate = machineStub(async () => ({
+      action: 'committed'
+    }))
+
+    try {
+      const result = await sails.helpers.deploy.cutoverTraffic.with({
+        deploymentId: deployment.id,
+        environmentId: environment.id,
+        candidate: {
+          containerId: 'first-container-id',
+          containerName: 'slipway-web-first',
+          imageName: deployment.imageName,
+          port: 1337,
+          hostPort: 1400
+        }
+      })
+
+      expect(stagedApp.routePath).toBe('/')
+      expect(stagedApp.healthPath).toBe('/health')
+      expect(result.app.containerName).toBe('slipway-web-first')
+      expect(result.app.routePath).toBe('/')
+      expect(result.app.isDefault).toBe(true)
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+      sails.helpers.caddy.finishRouteUpdate = originalFinishRouteUpdate
+    }
+  }
+)
+
+test(
+  'failed first App commit removes the candidate route and leaves no partial App state',
+  { world: cutoverWorld('cutover-first-deployment-failure') },
+  async ({ sails, world, expect }) => {
+    const environment = world.current.environments.production
+    await sails.models.app.destroy({ environment: environment.id })
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      imageName: 'slipway/web:first-failure',
+      environment: environment.id,
+      triggeredBy: world.current.users.genesisUser.id
+    })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const originalFinishRouteUpdate = sails.helpers.caddy.finishRouteUpdate
+    const routeCalls = []
+    const finishActions = []
+
+    sails.helpers.caddy.updateRoute = machineStub(async (inputs) => {
+      routeCalls.push(inputs)
+      return stagedRoute('created')
+    })
+    sails.helpers.caddy.finishRouteUpdate = machineStub(async ({ action }) => {
+      finishActions.push(action)
+      return { action: 'rolled_back' }
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.cutoverTraffic.with({
+          deploymentId: deployment.id,
+          environmentId: environment.id,
+          candidate: {
+            containerId: 'first-failed-container-id',
+            containerName: 'slipway-web-first-failure',
+            imageName: deployment.imageName,
+            port: 1337,
+            hostPort: 'not-a-port'
+          }
+        })
+      )
+      const apps = await sails.models.app.find({ environment: environment.id })
+      const actions = (
+        await sails.models.auditlog.find({ resourceId: deployment.id })
+      ).map((event) => event.action)
+
+      expect(error.message).toContain('was rolled back')
+      expect(apps.length).toBe(0)
+      expect(routeCalls.length).toBe(1)
+      expect(routeCalls[0].apps[0].containerName).toBe(
+        'slipway-web-first-failure'
+      )
+      expect(finishActions).toEqual(['rollback'])
+      expect(actions).toEqual([
+        'deployment.cutover.started',
+        'deployment.cutover.failed',
+        'deployment.cutover.rolled_back'
+      ])
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+      sails.helpers.caddy.finishRouteUpdate = originalFinishRouteUpdate
+    }
+  }
+)
+
+test(
+  'Caddy update failure preserves the previous App and records a rollback',
+  { world: cutoverWorld('cutover-caddy-failure') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const failure = new Error('Caddy route container could not be created')
+    failure.code = 'CADDY_ROUTE_APPLY_FAILED'
+    sails.helpers.caddy.updateRoute = machineStub(async () => {
+      throw failure
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.cutoverTraffic.with({
+          deploymentId: setup.deployment.id,
+          environmentId: setup.environment.id,
+          appId: setup.app.id,
+          candidate: setup.candidate
+        })
+      )
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+      const actions = (
+        await sails.models.auditlog.find({ resourceId: setup.deployment.id })
+      ).map((event) => event.action)
+
+      expect(error.message).toContain('was rolled back')
+      expect(app.containerName).toBe('slipway-web-previous')
+      expect(app.hostPort).toBe(1401)
+      expect(actions).toEqual([
+        'deployment.cutover.started',
+        'deployment.cutover.failed',
+        'deployment.cutover.rolled_back'
+      ])
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+    }
+  }
+)
+
+test(
+  'route verification failure never commits the candidate App state',
+  { world: cutoverWorld('cutover-verification-failure') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const failure = new Error('Candidate upstream never appeared in Caddy')
+    failure.code = 'CADDY_ROUTE_VERIFICATION_FAILED'
+    sails.helpers.caddy.updateRoute = machineStub(async () => {
+      throw failure
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.cutoverTraffic.with({
+          deploymentId: setup.deployment.id,
+          environmentId: setup.environment.id,
+          appId: setup.app.id,
+          candidate: setup.candidate
+        })
+      )
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+      const deployment = await sails.models.deployment.findOne({
+        id: setup.deployment.id
+      })
+
+      expect(error.message).toContain('Candidate upstream never appeared')
+      expect(app.containerName).toBe('slipway-web-previous')
+      expect(deployment.deployLogs).toContain(
+        'the previous route and container remain active'
+      )
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+    }
+  }
+)
+
+test(
+  'route restoration failure is explicit and leaves previous App state intact',
+  { world: cutoverWorld('cutover-rollback-failure') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const originalFinishRouteUpdate = sails.helpers.caddy.finishRouteUpdate
+    let routeCalls = 0
+    sails.helpers.caddy.updateRoute = machineStub(async () => {
+      routeCalls += 1
+      return stagedRoute()
+    })
+    sails.helpers.caddy.finishRouteUpdate = machineStub(async ({ action }) => {
+      if (action === 'rollback') {
+        throw new Error('Previous route could not be restored')
+      }
+      return { action: 'committed' }
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.cutoverTraffic.with({
+          deploymentId: setup.deployment.id,
+          environmentId: setup.environment.id,
+          appId: setup.app.id,
+          candidate: {
+            ...setup.candidate,
+            hostPort: 'not-a-port'
+          }
+        })
+      )
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+      const actions = (
+        await sails.models.auditlog.find({ resourceId: setup.deployment.id })
+      ).map((event) => event.action)
+
+      expect(routeCalls).toBe(1)
+      expect(error.message).toContain('Cutover rollback also failed')
+      expect(error.message).toContain('Previous route could not be restored')
+      expect(app.containerName).toBe('slipway-web-previous')
+      expect(app.hostPort).toBe(1401)
+      expect(actions).toContain('deployment.cutover.rollback_failed')
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+      sails.helpers.caddy.finishRouteUpdate = originalFinishRouteUpdate
+    }
+  }
+)
+
+test(
+  'route finalization failure restores the App record committed during cutover',
+  { world: cutoverWorld('cutover-finalization-failure') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const originalFinishRouteUpdate = sails.helpers.caddy.finishRouteUpdate
+    const finishActions = []
+    sails.helpers.caddy.updateRoute = machineStub(async () => stagedRoute())
+    sails.helpers.caddy.finishRouteUpdate = machineStub(async ({ action }) => {
+      finishActions.push(action)
+      if (action === 'commit') {
+        const persisted = await sails.models.app.findOne({ id: setup.app.id })
+        expect(persisted.containerName).toBe('slipway-web-candidate')
+        throw new Error('Candidate-only route could not be finalized')
+      }
+      return { action: 'rolled_back' }
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.cutoverTraffic.with({
+          deploymentId: setup.deployment.id,
+          environmentId: setup.environment.id,
+          appId: setup.app.id,
+          candidate: setup.candidate
+        })
+      )
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+
+      expect(error.message).toContain('was rolled back')
+      expect(finishActions).toEqual(['commit', 'rollback'])
+      expect(app.containerName).toBe('slipway-web-previous')
+      expect(app.hostPort).toBe(1401)
+      expect(app.currentDeployment).toBe(setup.app.currentDeployment)
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+      sails.helpers.caddy.finishRouteUpdate = originalFinishRouteUpdate
+    }
+  }
+)
+
+test(
+  'worker cutover commits state without mutating Caddy routes',
+  { world: cutoverWorld('cutover-worker') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    let routeCalls = 0
+    sails.helpers.caddy.updateRoute = machineStub(async () => {
+      routeCalls += 1
+      throw new Error('Worker cutover must not touch Caddy')
+    })
+
+    try {
+      const result = await sails.helpers.deploy.cutoverTraffic.with({
+        deploymentId: setup.deployment.id,
+        environmentId: setup.environment.id,
+        appId: setup.app.id,
+        candidate: { ...setup.candidate, routePath: null }
+      })
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+
+      expect(routeCalls).toBe(0)
+      expect(result.route).toEqual({ action: 'unchanged', reason: 'worker' })
+      expect(app.containerName).toBe('slipway-web-candidate')
+      expect(app.routePath).toBe(null)
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+    }
+  }
+)
+
+test(
+  'rollback uses a deployment-scoped candidate and retires the old container only after cutover',
+  { world: cutoverWorld('transactional-rollback') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const previousDeployment = await sails.models.deployment.findOne({
+      id: setup.app.currentDeployment
+    })
+    const originals = {
+      ensureNetwork: sails.helpers.docker.ensureNetwork,
+      allocatePort: sails.helpers.docker.allocatePort,
+      runContainer: sails.helpers.docker.runContainer,
+      healthCheck: sails.helpers.docker.healthCheck,
+      releasePort: sails.helpers.docker.releasePort,
+      stopContainer: sails.helpers.docker.stopContainer,
+      getServerIp: sails.helpers.getServerIp,
+      getDirectAccess: sails.helpers.deploy.getDirectAccess,
+      updateRoute: sails.helpers.caddy.updateRoute,
+      finishRouteUpdate: sails.helpers.caddy.finishRouteUpdate
+    }
+    const sequence = []
+    let candidateName
+
+    sails.helpers.docker.ensureNetwork = machineStub(async () => {})
+    sails.helpers.docker.allocatePort = machineStub(async () => 1403)
+    sails.helpers.docker.runContainer = machineStub(async (inputs) => {
+      sequence.push('candidate-started')
+      candidateName = inputs.containerName
+      return {
+        containerId: 'rollback-container-id',
+        containerName: inputs.containerName,
+        hostPort: inputs.hostPort,
+        portBinding: { diagnostic: 'verified' }
+      }
+    })
+    sails.helpers.docker.healthCheck = machineStub(async () => {
+      sequence.push('candidate-healthy')
+    })
+    sails.helpers.caddy.updateRoute = machineStub(async (inputs) => {
+      sequence.push('route-verified')
+      const persisted = await sails.models.app.findOne({ id: setup.app.id })
+      expect(persisted.containerName).toBe('slipway-web-previous')
+      expect(
+        inputs.apps.find((app) => app.id === setup.app.id).containerName
+      ).toBe(candidateName)
+      return stagedRoute()
+    })
+    sails.helpers.caddy.finishRouteUpdate = machineStub(async ({ action }) => {
+      sequence.push('route-finalized')
+      const persisted = await sails.models.app.findOne({ id: setup.app.id })
+      expect(action).toBe('commit')
+      expect(persisted.containerName).toBe(candidateName)
+      return { action: 'committed' }
+    })
+    sails.helpers.docker.releasePort = machineStub(async () => {
+      sequence.push('port-released')
+      return { released: 1 }
+    })
+    sails.helpers.docker.stopContainer = machineStub(async (inputs) => {
+      sequence.push(`stopped:${inputs.containerName}`)
+    })
+    sails.helpers.getServerIp = machineStub(async () => '127.0.0.1')
+    sails.helpers.deploy.getDirectAccess = machineStub(async () => ({
+      url: null,
+      message: null
+    }))
+
+    try {
+      await sails.helpers.deploy.executeRollback.with({
+        rollbackId: setup.deployment.id,
+        targetDeployment: previousDeployment,
+        environment: setup.environment,
+        app: setup.app
+      })
+
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+      const rollback = await sails.models.deployment.findOne({
+        id: setup.deployment.id
+      })
+
+      expect(candidateName).toContain(String(setup.deployment.id))
+      expect(candidateName === 'slipway-web-previous').toBe(false)
+      expect(app.containerName).toBe(candidateName)
+      expect(rollback.status).toBe('running')
+      expect(sequence).toEqual([
+        'candidate-started',
+        'candidate-healthy',
+        'route-verified',
+        'route-finalized',
+        'port-released',
+        'stopped:slipway-web-previous'
+      ])
+    } finally {
+      sails.helpers.docker.ensureNetwork = originals.ensureNetwork
+      sails.helpers.docker.allocatePort = originals.allocatePort
+      sails.helpers.docker.runContainer = originals.runContainer
+      sails.helpers.docker.healthCheck = originals.healthCheck
+      sails.helpers.docker.releasePort = originals.releasePort
+      sails.helpers.docker.stopContainer = originals.stopContainer
+      sails.helpers.getServerIp = originals.getServerIp
+      sails.helpers.deploy.getDirectAccess = originals.getDirectAccess
+      sails.helpers.caddy.updateRoute = originals.updateRoute
+      sails.helpers.caddy.finishRouteUpdate = originals.finishRouteUpdate
+    }
+  }
+)
+
+test(
+  'rollback failure removes only the candidate and keeps the previous app live',
+  { world: cutoverWorld('transactional-rollback-failure') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const previousDeployment = await sails.models.deployment.findOne({
+      id: setup.app.currentDeployment
+    })
+    const originals = {
+      ensureNetwork: sails.helpers.docker.ensureNetwork,
+      allocatePort: sails.helpers.docker.allocatePort,
+      runContainer: sails.helpers.docker.runContainer,
+      healthCheck: sails.helpers.docker.healthCheck,
+      releasePort: sails.helpers.docker.releasePort,
+      stopContainer: sails.helpers.docker.stopContainer,
+      updateRoute: sails.helpers.caddy.updateRoute
+    }
+    const sequence = []
+    let candidateName
+    const originalLogError = sails.log.error
+    sails.log.error = () => {}
+
+    sails.helpers.docker.ensureNetwork = machineStub(async () => {})
+    sails.helpers.docker.allocatePort = machineStub(async () => 1404)
+    sails.helpers.docker.runContainer = machineStub(async (inputs) => {
+      candidateName = inputs.containerName
+      sequence.push(`started:${candidateName}`)
+      return {
+        containerId: 'failed-rollback-container-id',
+        containerName: candidateName,
+        hostPort: inputs.hostPort,
+        portBinding: { diagnostic: 'verified' }
+      }
+    })
+    sails.helpers.docker.healthCheck = machineStub(async () => {
+      sequence.push('candidate-healthy')
+    })
+    sails.helpers.caddy.updateRoute = machineStub(async () => {
+      sequence.push('route-rejected')
+      const failure = new Error('Caddy rejected the rollback route')
+      failure.code = 'CADDY_ROUTE_VERIFICATION_FAILED'
+      throw failure
+    })
+    sails.helpers.docker.stopContainer = machineStub(async (inputs) => {
+      sequence.push(`stopped:${inputs.containerName}`)
+    })
+    sails.helpers.docker.releasePort = machineStub(async () => {
+      sequence.push('port-released')
+      return { released: 1 }
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.executeRollback.with({
+          rollbackId: setup.deployment.id,
+          targetDeployment: previousDeployment,
+          environment: setup.environment,
+          app: setup.app
+        })
+      )
+      const app = await sails.models.app.findOne({ id: setup.app.id })
+      const rollback = await sails.models.deployment.findOne({
+        id: setup.deployment.id
+      })
+
+      expect(error.message).toContain('Caddy rejected the rollback route')
+      expect(app.containerName).toBe('slipway-web-previous')
+      expect(app.hostPort).toBe(1401)
+      expect(rollback.status).toBe('failed')
+      expect(rollback.deployLogs).toContain('ERROR [traffic cutover]')
+      expect(sequence).toEqual([
+        `started:${candidateName}`,
+        'candidate-healthy',
+        'route-rejected',
+        `stopped:${candidateName}`,
+        'port-released'
+      ])
+      expect(sequence.includes('stopped:slipway-web-previous')).toBe(false)
+    } finally {
+      sails.helpers.docker.ensureNetwork = originals.ensureNetwork
+      sails.helpers.docker.allocatePort = originals.allocatePort
+      sails.helpers.docker.runContainer = originals.runContainer
+      sails.helpers.docker.healthCheck = originals.healthCheck
+      sails.helpers.docker.releasePort = originals.releasePort
+      sails.helpers.docker.stopContainer = originals.stopContainer
+      sails.helpers.caddy.updateRoute = originals.updateRoute
+      sails.log.error = originalLogError
+    }
+  }
+)
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}

--- a/tests/unit/helpers/deploy/health-path.test.js
+++ b/tests/unit/helpers/deploy/health-path.test.js
@@ -18,22 +18,22 @@ test('deploy pipeline probes the app readiness path before switching traffic', a
   const healthCheckIndex = source.indexOf(
     'await sails.helpers.docker.healthCheck.with({'
   )
-  const appRecordIndex = source.indexOf('// 11. Update App record')
-  const routeIndex = source.indexOf('// 12. Update Caddy reverse proxy route')
+  const cutoverIndex = source.indexOf(
+    'await sails.helpers.deploy.cutoverTraffic.with({'
+  )
 
   expect(healthPathIndex > -1).toBe(true)
   expect(source.includes('path: healthPath')).toBe(true)
   expect(source.includes('healthPath,')).toBe(true)
   expect(healthPathIndex < healthCheckIndex).toBe(true)
-  expect(healthCheckIndex < appRecordIndex).toBe(true)
-  expect(appRecordIndex < routeIndex).toBe(true)
+  expect(healthCheckIndex < cutoverIndex).toBe(true)
 })
 
 test('rollback probes the app readiness path before switching traffic', async ({
   expect
 }) => {
   const source = fs.readFileSync(
-    path.join(appRoot, 'api/controllers/api/v1/deploy/rollback-deployment.js'),
+    path.join(appRoot, 'api/helpers/deploy/execute-rollback.js'),
     'utf8'
   )
   const healthPathIndex = source.indexOf(
@@ -42,13 +42,13 @@ test('rollback probes the app readiness path before switching traffic', async ({
   const healthCheckIndex = source.indexOf(
     'await sails.helpers.docker.healthCheck.with({'
   )
-  const appRecordIndex = source.indexOf('// 9. Create or update the App record')
-  const routeIndex = source.indexOf('// 10. Update Caddy reverse proxy route')
+  const cutoverIndex = source.indexOf(
+    'await sails.helpers.deploy.cutoverTraffic.with({'
+  )
 
   expect(healthPathIndex > -1).toBe(true)
   expect(source.includes('path: healthPath')).toBe(true)
   expect(source.includes('healthPath,')).toBe(true)
   expect(healthPathIndex < healthCheckIndex).toBe(true)
-  expect(healthCheckIndex < appRecordIndex).toBe(true)
-  expect(appRecordIndex < routeIndex).toBe(true)
+  expect(healthCheckIndex < cutoverIndex).toBe(true)
 })


### PR DESCRIPTION
## Summary

- stage and verify candidate Caddy routes while the previous route remains active
- commit App state before retiring the previous route and container
- restore route and App state on cutover failure, with explicit deployment logs and audit events
- run manual rollbacks through the same transactional cutover helper
- keep deployment-scoped container names so rollback candidates cannot collide with the live app

## Verification

- npm run lint
- npm run test:unit (80 passed)
- npm run test:functional (23 passed)
- npm run test:e2e (10 passed)
- isolated real caddy-docker-proxy promotion and rollback rehearsal

Closes #232