### PR TITLE
fix(deploy): serialize and recover deployment pipelines

### DIFF
--- a/api/controllers/api/v1/deploy/cancel-deployment.js
+++ b/api/controllers/api/v1/deploy/cancel-deployment.js
@@ -56,11 +56,17 @@ module.exports = {
       }
     }
 
-    // Mark as cancelled
+    const lease = await DeploymentLease.findOne({ deployment: deploymentId })
+
+    // Mark as cancelled. An active worker keeps the lease while it unwinds so
+    // the next queued deployment cannot overlap its resource cleanup.
     await Deployment.updateOne({ id: deploymentId }).set({
       status: 'cancelled',
       errorMessage: `Cancelled by ${user.fullName || user.email}`,
       finishedAt: Date.now()
+    })
+    await DeploymentJob.updateOne({ deployment: deploymentId }).set({
+      stage: lease ? 'cancel_requested' : 'cancelled'
     })
 
     await Deployment.appendBuildLog(

--- a/api/controllers/api/v1/deploy/get-active-deployments.js
+++ b/api/controllers/api/v1/deploy/get-active-deployments.js
@@ -39,6 +39,13 @@ module.exports = {
       environment: environmentIds,
       status: ['pending', 'building', 'pushing', 'deploying']
     }).sort('createdAt DESC')
+    activeDeployments.sort(
+      (left, right) =>
+        Number(left.status === 'pending') -
+          Number(right.status === 'pending') ||
+        Number(right.createdAt) - Number(left.createdAt) ||
+        Number(right.id) - Number(left.id)
+    )
 
     // Get all apps for these environments (for app name enrichment)
     const apps = await App.find({ environment: environmentIds })
@@ -68,6 +75,7 @@ module.exports = {
             ? deployment.gitCommit.slice(0, 7)
             : null,
           startedAt: deployment.startedAt,
+          queuePosition: await DeploymentJob.getQueuePosition(deployment.id),
           project: {
             id: proj.id,
             name: proj.name,

--- a/api/controllers/api/v1/deploy/get-deployment-status.js
+++ b/api/controllers/api/v1/deploy/get-deployment-status.js
@@ -48,6 +48,7 @@ module.exports = {
     }
 
     const duration = Deployment.getDuration(deployment)
+    const queuePosition = await DeploymentJob.getQueuePosition(deployment.id)
 
     return {
       deployment: {
@@ -66,6 +67,7 @@ module.exports = {
         startedAt: deployment.startedAt,
         finishedAt: deployment.finishedAt,
         duration,
+        queuePosition,
         errorMessage: deployment.errorMessage,
         environment: {
           id: deployment.environment.id,

--- a/api/controllers/api/v1/deploy/rollback-deployment.js
+++ b/api/controllers/api/v1/deploy/rollback-deployment.js
@@ -70,42 +70,31 @@ module.exports = {
     })
     if (!targetDeployment?.imageName) throw 'badRequest'
 
-    const rollback = await Deployment.create({
-      status: 'pending',
-      gitCommit: targetDeployment.gitCommit,
-      gitBranch: targetDeployment.gitBranch,
-      gitMessage: `Rollback to deployment ${targetDeployment.id}`,
-      triggeredBy: user.id,
-      triggerType: 'api',
-      environment: environment.id,
-      app: targetApp?.id,
-      startedAt: Date.now()
-    }).fetch()
+    const queued = await sails.helpers.deploy.queueDeployment.with({
+      values: {
+        gitCommit: targetDeployment.gitCommit,
+        gitBranch: targetDeployment.gitBranch,
+        gitMessage: `Rollback to deployment ${targetDeployment.id}`,
+        triggeredBy: user.id,
+        triggerType: 'api',
+        environment: environment.id
+      },
+      app: targetApp,
+      kind: 'rollback',
+      targetDeploymentId: targetDeployment.id
+    })
+    const rollback = queued.deployment
 
     sails.log.info(
       `Rollback ${rollback.id} triggered for ${project.slug}/${environment.slug} → deployment ${deploymentId}`
     )
 
-    process.nextTick(async () => {
-      try {
-        await sails.helpers.deploy.executeRollback.with({
-          rollbackId: rollback.id,
-          targetDeployment,
-          environment,
-          app: targetApp
-        })
-      } catch (error) {
-        sails.log.error(
-          `Rollback ${rollback.id} failed: ${error.message || error}`
-        )
-      }
-    })
-
     return {
       deployment: {
         id: rollback.id,
         status: 'pending',
-        message: 'Rollback started'
+        message: 'Rollback queued',
+        queuePosition: queued.queuePosition
       }
     }
   }

--- a/api/controllers/api/v1/deploy/stream-active-deployments.js
+++ b/api/controllers/api/v1/deploy/stream-active-deployments.js
@@ -80,6 +80,12 @@ async function fetchActiveDeployments(teamId) {
     environment: environmentIds,
     status: ['pending', 'building', 'pushing', 'deploying']
   }).sort('createdAt DESC')
+  activeDeployments.sort(
+    (left, right) =>
+      Number(left.status === 'pending') - Number(right.status === 'pending') ||
+      Number(right.createdAt) - Number(left.createdAt) ||
+      Number(right.id) - Number(left.id)
+  )
 
   if (activeDeployments.length === 0) return []
 

--- a/api/controllers/api/v1/deploy/trigger-deployment.js
+++ b/api/controllers/api/v1/deploy/trigger-deployment.js
@@ -143,18 +143,18 @@ module.exports = {
       }
     }
 
-    // Create deployment record
-    const deployment = await Deployment.create({
-      status: 'pending',
-      gitCommit: finalGitCommit,
-      gitBranch: finalGitBranch,
-      gitMessage: finalGitMessage,
-      triggeredBy: user.id,
-      triggerType: 'api',
-      environment: environment.id,
-      app: targetApp ? targetApp.id : undefined,
-      startedAt: Date.now()
-    }).fetch()
+    const queued = await sails.helpers.deploy.queueDeployment.with({
+      values: {
+        gitCommit: finalGitCommit,
+        gitBranch: finalGitBranch,
+        gitMessage: finalGitMessage,
+        triggeredBy: user.id,
+        triggerType: 'api',
+        environment: environment.id
+      },
+      app: targetApp
+    })
+    const deployment = queued.deployment
 
     sails.log.info(
       `Deployment ${deployment.id} triggered for ${project.slug}/${environment.slug}`
@@ -173,27 +173,12 @@ module.exports = {
       })
       .exec(() => {})
 
-    // Kick off the async deployment pipeline after returning the response
-    process.nextTick(async () => {
-      try {
-        await sails.helpers.deploy.executePipeline.with({
-          deploymentId: deployment.id,
-          project,
-          environment,
-          app: targetApp
-        })
-      } catch (err) {
-        sails.log.error(
-          `Deployment ${deployment.id} failed: ${err.message || err}`
-        )
-      }
-    })
-
     return {
       deployment: {
         id: deployment.id,
         status: 'pending',
-        message: 'Deployment started'
+        message: 'Deployment queued',
+        queuePosition: queued.queuePosition
       }
     }
   }

--- a/api/controllers/api/v1/webhook/github.js
+++ b/api/controllers/api/v1/webhook/github.js
@@ -167,38 +167,24 @@ module.exports = {
     const deploymentIds = []
 
     for (const app of apps.length > 0 ? apps : [null]) {
-      const deployment = await Deployment.create({
-        status: 'pending',
-        gitCommit: body.after || body.head_commit?.id,
-        gitBranch: branch,
-        gitMessage: body.head_commit?.message,
-        triggeredBy: owner ? owner.id : null,
-        triggerType: 'webhook',
-        environment: environment.id,
-        app: app ? app.id : undefined,
-        startedAt: Date.now()
-      }).fetch()
+      const queued = await sails.helpers.deploy.queueDeployment.with({
+        values: {
+          gitCommit: body.after || body.head_commit?.id,
+          gitBranch: branch,
+          gitMessage: body.head_commit?.message,
+          triggeredBy: owner ? owner.id : null,
+          triggerType: 'webhook',
+          environment: environment.id
+        },
+        app
+      })
+      const deployment = queued.deployment
 
       deploymentIds.push(deployment.id)
 
       sails.log.info(
         `Webhook auto-deploy triggered for ${projectSlug}: ${deployment.id}`
       )
-
-      process.nextTick(async () => {
-        try {
-          await sails.helpers.deploy.executePipeline.with({
-            deploymentId: deployment.id,
-            project,
-            environment,
-            app
-          })
-        } catch (err) {
-          sails.log.error(
-            `Webhook deploy ${deployment.id} failed: ${err.message || err}`
-          )
-        }
-      })
     }
 
     return {
@@ -292,36 +278,21 @@ async function handlePullRequest(project, body) {
     // Get owner for deployer
     const owner = await User.findOne({ id: project.createdBy })
 
-    // Create deployment
-    const deployment = await Deployment.create({
-      status: 'pending',
-      gitCommit: pr.head.sha,
-      gitBranch: branch,
-      gitMessage: pr.title,
-      triggeredBy: owner ? owner.id : null,
-      triggerType: 'webhook',
-      environment: environment.id,
-      startedAt: Date.now()
-    }).fetch()
+    const queued = await sails.helpers.deploy.queueDeployment.with({
+      values: {
+        gitCommit: pr.head.sha,
+        gitBranch: branch,
+        gitMessage: pr.title,
+        triggeredBy: owner ? owner.id : null,
+        triggerType: 'webhook',
+        environment: environment.id
+      }
+    })
+    const deployment = queued.deployment
 
     sails.log.info(
       `Preview deploy triggered for ${project.slug}/pr-${prNumber}: ${deployment.id}`
     )
-
-    // Kick off async deployment via shared pipeline
-    process.nextTick(async () => {
-      try {
-        await sails.helpers.deploy.executePipeline.with({
-          deploymentId: deployment.id,
-          project,
-          environment
-        })
-      } catch (err) {
-        sails.log.error(
-          `Preview deploy ${deployment.id} failed: ${err.message || err}`
-        )
-      }
-    })
 
     return {
       message: `Preview deployment triggered for PR #${prNumber}`,

--- a/api/controllers/project/content-update.js
+++ b/api/controllers/project/content-update.js
@@ -131,27 +131,25 @@ module.exports = {
 
     // Trigger deploy if requested
     if (deploy) {
-      const deployment = await Deployment.create({
-        status: 'pending',
-        gitMessage: `Content update: ${collection}/${file}`,
-        triggeredBy: user.id,
-        triggerType: 'manual',
-        environment: environment.id,
-        startedAt: Date.now()
-      }).fetch()
+      const app =
+        (await App.findOne({
+          environment: environment.id,
+          isDefault: true
+        })) || (await App.findOne({ environment: environment.id }))
+      const queued = await sails.helpers.deploy.queueDeployment.with({
+        values: {
+          gitMessage: `Content update: ${collection}/${file}`,
+          triggeredBy: user.id,
+          triggerType: 'manual',
+          environment: environment.id
+        },
+        app
+      })
+      const deployment = queued.deployment
 
       sails.log.info(
         `[content] Deployment ${deployment.id} triggered for content change`
       )
-
-      // Kick off the async deployment pipeline
-      process.nextTick(async () => {
-        try {
-          await sails.helpers.deploy.execute(deployment.id)
-        } catch (err) {
-          sails.log.error(`Content deploy failed: ${err.message}`)
-        }
-      })
 
       // Redirect to deployment page
       return `/projects/${slug}/deployments/${deployment.id}`

--- a/api/controllers/project/view-deployment.js
+++ b/api/controllers/project/view-deployment.js
@@ -53,6 +53,7 @@ module.exports = {
     }
 
     const duration = Deployment.getDuration(deployment)
+    const queuePosition = await DeploymentJob.getQueuePosition(deployment.id)
 
     // Check if this is the currently active deployment
     const app =
@@ -70,6 +71,7 @@ module.exports = {
         deployment: {
           ...deployment,
           duration,
+          queuePosition,
           isCurrentDeployment,
           triggeredBy: deployment.triggeredBy
             ? {

--- a/api/controllers/webhook/github.js
+++ b/api/controllers/webhook/github.js
@@ -170,35 +170,19 @@ async function handlePush(repo, payload) {
     const deploymentIds = []
 
     for (const app of apps.length > 0 ? apps : [null]) {
-      const deployment = await Deployment.create({
-        status: 'pending',
-        triggerType: 'webhook',
-        gitCommit: commit,
-        gitMessage: payload.head_commit?.message?.substring(0, 200),
-        gitBranch: branch,
-        environment: environment.id,
-        app: app ? app.id : undefined,
-        startedAt: Date.now()
-      }).fetch()
+      const queued = await sails.helpers.deploy.queueDeployment.with({
+        values: {
+          triggerType: 'webhook',
+          gitCommit: commit,
+          gitMessage: payload.head_commit?.message?.substring(0, 200),
+          gitBranch: branch,
+          environment: environment.id
+        },
+        app
+      })
+      const deployment = queued.deployment
 
       deploymentIds.push(deployment.id)
-
-      process.nextTick(async () => {
-        try {
-          await sails.helpers.deploy.executePipeline.with({
-            deploymentId: deployment.id,
-            project,
-            environment,
-            app
-          })
-        } catch (err) {
-          sails.log.error(
-            `[webhook] Deployment ${deployment.id} failed: ${
-              err.message || err
-            }`
-          )
-        }
-      })
     }
 
     return {

--- a/api/helpers/caddy/cleanup-route-transaction.js
+++ b/api/helpers/caddy/cleanup-route-transaction.js
@@ -1,0 +1,64 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Cleanup route transaction',
+
+  description:
+    'Remove deployment-scoped Caddy route containers left by an interrupted cutover.',
+
+  inputs: {
+    environmentId: {
+      type: 'string',
+      required: true
+    },
+    routeVersion: {
+      type: 'string',
+      required: true
+    },
+    phase: {
+      type: 'string',
+      isIn: ['before-repair', 'after-repair'],
+      required: true
+    }
+  },
+
+  fn: async function ({ environmentId, routeVersion, phase }) {
+    const environment = await Environment.findOne({
+      id: environmentId
+    }).populate('project')
+    if (!environment?.project) return { removed: [] }
+
+    const routeId = `slipway-route-${environment.project.slug}-${environment.slug}`
+    const suffix = normalizeContainerSuffix(routeVersion)
+    const candidates = [`${routeId}-candidate-${suffix}`]
+    if (phase === 'after-repair') {
+      candidates.push(`${routeId}-previous-${suffix}`)
+    }
+
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const removed = []
+    for (const containerName of candidates) {
+      try {
+        await execFileAsync(dockerPath, ['rm', '-f', containerName])
+        removed.push(containerName)
+      } catch {
+        // Cleanup is idempotent; the named transaction container may not exist.
+      }
+    }
+
+    return { removed }
+  }
+}
+
+function normalizeContainerSuffix(value) {
+  return String(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9_.-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 64)
+}
+
+module.exports._private = { normalizeContainerSuffix }

--- a/api/helpers/deploy/assert-deployment-lease.js
+++ b/api/helpers/deploy/assert-deployment-lease.js
@@ -1,0 +1,53 @@
+module.exports = {
+  friendlyName: 'Assert deployment lease',
+
+  description:
+    'Fence a deployment mutation so an expired or cancelled worker cannot change environment traffic or App state.',
+
+  inputs: {
+    deploymentId: {
+      type: 'string',
+      required: true
+    },
+    leaseToken: {
+      type: 'string'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ deploymentId, leaseToken }) {
+    if (!leaseToken) return { valid: true }
+
+    const [lease, deployment] = await Promise.all([
+      DeploymentLease.findOne({
+        deployment: deploymentId,
+        token: leaseToken,
+        expiresAt: { '>': Date.now() }
+      }),
+      Deployment.findOne({ id: deploymentId })
+    ])
+
+    if (!lease) {
+      return {
+        valid: false,
+        code: 'DEPLOYMENT_LEASE_LOST',
+        message: `Deployment ${deploymentId} no longer owns its pipeline lease.`
+      }
+    }
+
+    if (deployment?.status === 'cancelled') {
+      return {
+        valid: false,
+        code: 'DEPLOYMENT_CANCELLED',
+        message: `Deployment ${deploymentId} was cancelled.`
+      }
+    }
+
+    return { valid: true }
+  }
+}

--- a/api/helpers/deploy/cutover-traffic.js
+++ b/api/helpers/deploy/cutover-traffic.js
@@ -10,6 +10,10 @@ module.exports = {
       required: true,
       description: 'Deployment that owns this cutover.'
     },
+    leaseToken: {
+      type: 'string',
+      description: 'Fencing token held by the durable deployment worker.'
+    },
     environmentId: {
       type: 'string',
       required: true,
@@ -33,7 +37,13 @@ module.exports = {
     }
   },
 
-  fn: async function ({ deploymentId, environmentId, appId, candidate }) {
+  fn: async function ({
+    deploymentId,
+    leaseToken,
+    environmentId,
+    appId,
+    candidate
+  }) {
     const previousApp = appId ? await App.findOne({ id: appId }) : null
     if (appId && !previousApp) {
       throw new Error(`Cannot cut over missing app ${appId}.`)
@@ -93,6 +103,7 @@ module.exports = {
     })
 
     try {
+      await assertLease(deploymentId, leaseToken)
       const route = requiresRouteCutover
         ? await sails.helpers.caddy.updateRoute.with({
             environmentId,
@@ -104,6 +115,9 @@ module.exports = {
       candidateRouteApplied = requiresRouteCutover
       stagedRoute = route.transaction || null
 
+      // The route has been staged but App state has not changed yet. Recheck
+      // ownership so a newer worker can never inherit this candidate.
+      await assertLease(deploymentId, leaseToken)
       committedApp = previousApp
         ? await App.updateOne({ id: previousApp.id }).set(
             appValues(candidateApp)
@@ -117,6 +131,9 @@ module.exports = {
       }
       appStateCommitted = true
 
+      // Fence the final route commit independently from the App write. If the
+      // lease was lost, the catch path restores both pieces of state.
+      await assertLease(deploymentId, leaseToken)
       if (stagedRoute) {
         await sails.helpers.caddy.finishRouteUpdate.with({
           action: 'commit',
@@ -249,6 +266,18 @@ module.exports = {
   }
 }
 
+async function assertLease(deploymentId, leaseToken) {
+  const result = await sails.helpers.deploy.assertDeploymentLease.with({
+    deploymentId,
+    leaseToken
+  })
+  if (result?.valid === false) {
+    const error = new Error(result.message)
+    error.code = result.code
+    throw error
+  }
+}
+
 function appValues(app) {
   return {
     status: 'running',
@@ -291,15 +320,18 @@ async function getAuditContext(deploymentId, environmentId) {
     Environment.findOne({ id: environmentId }).populate('project')
   ])
 
+  const triggeredBy =
+    deployment?.triggeredBy && typeof deployment.triggeredBy === 'object'
+      ? deployment.triggeredBy.id
+      : deployment?.triggeredBy
+  const team =
+    environment?.project?.team && typeof environment.project.team === 'object'
+      ? environment.project.team.id
+      : environment?.project?.team
+
   return {
-    userId:
-      typeof deployment?.triggeredBy === 'object'
-        ? deployment.triggeredBy.id
-        : deployment?.triggeredBy,
-    teamId:
-      typeof environment?.project?.team === 'object'
-        ? environment.project.team.id
-        : environment?.project?.team
+    userId: triggeredBy || undefined,
+    teamId: team || undefined
   }
 }
 

--- a/api/helpers/deploy/ensure-queue-schema.js
+++ b/api/helpers/deploy/ensure-queue-schema.js
@@ -1,0 +1,57 @@
+module.exports = {
+  friendlyName: 'Ensure deployment queue schema',
+
+  description:
+    'Create the durable deployment coordinator tables on existing production SQLite databases.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore()
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS deployment_jobs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        deployment_id INTEGER NOT NULL UNIQUE,
+        target_key TEXT NOT NULL,
+        app_slug TEXT NOT NULL DEFAULT 'app',
+        kind TEXT NOT NULL DEFAULT 'deploy',
+        target_deployment_id INTEGER,
+        stage TEXT NOT NULL DEFAULT 'queued',
+        attempt INTEGER NOT NULL DEFAULT 0,
+        candidate_container_name TEXT,
+        previous_container_name TEXT,
+        image_name TEXT,
+        host_port INTEGER,
+        build_context_path TEXT,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS deployment_jobs_target_stage
+      ON deployment_jobs (target_key, stage, created_at, id)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS deployment_leases (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        target_key TEXT NOT NULL UNIQUE,
+        deployment_id INTEGER NOT NULL UNIQUE,
+        token TEXT NOT NULL UNIQUE,
+        owner TEXT NOT NULL,
+        stage TEXT NOT NULL DEFAULT 'claimed',
+        heartbeat_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS deployment_leases_expiry
+      ON deployment_leases (expires_at)
+    `)
+  }
+}

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -24,6 +24,10 @@ module.exports = {
       type: 'ref',
       description:
         'Target App record (if omitted, resolves default app in environment)'
+    },
+    leaseToken: {
+      type: 'string',
+      description: 'Fencing token held by the durable deployment worker.'
     }
   },
 
@@ -33,19 +37,54 @@ module.exports = {
     }
   },
 
-  fn: async function ({ deploymentId, project, environment, app: appInput }) {
+  fn: async function ({
+    deploymentId,
+    project,
+    environment,
+    app: appInput,
+    leaseToken
+  }) {
     let deployContainerName = null
+    let deployImageName = null
     let deployHostPort = null
     let deployHostPortReserved = false
     let currentStage = 'initialization'
+
+    const recordStage = async (stage, resources = {}) => {
+      currentStage = stage.replace(/_/g, ' ')
+      const result = await sails.helpers.deploy.recordDeploymentStage.with({
+        deploymentId,
+        leaseToken,
+        stage,
+        ...resources
+      })
+      requireValidCoordinatorResult(result)
+    }
+
+    const assertLease = async () => {
+      const result = await sails.helpers.deploy.assertDeploymentLease.with({
+        deploymentId,
+        leaseToken
+      })
+      requireValidCoordinatorResult(result)
+    }
+
+    const updateDeployment = async (values) => {
+      const result = await sails.helpers.deploy.updateDeploymentForLease.with({
+        deploymentId,
+        leaseToken,
+        values
+      })
+      requireValidCoordinatorResult(result)
+      return result.deployment
+    }
 
     try {
       const deployment = await Deployment.findOne({ id: deploymentId })
 
       // 1. Set status to building
-      await Deployment.updateOne({ id: deploymentId }).set({
-        status: 'building'
-      })
+      await recordStage('initialization')
+      await updateDeployment({ status: 'building' })
 
       // 2. Ensure Docker network exists
       await sails.helpers.docker.ensureNetwork()
@@ -71,13 +110,17 @@ module.exports = {
         deploymentId,
         appSlug
       )
+      deployImageName = imageName
       deployContainerName = await App.generateDeployContainerName(
         environment.id,
         deploymentId,
         appSlug
       )
 
-      currentStage = 'source preparation'
+      await recordStage('source_preparation', {
+        candidateContainerName: deployContainerName,
+        imageName
+      })
       const { contextPath } =
         await sails.helpers.deploy.ensureBuildContext.with({
           project,
@@ -93,7 +136,7 @@ module.exports = {
         (targetApp && targetApp.dockerfilePath) ||
         project.dockerfilePath ||
         'Dockerfile'
-      currentStage = 'image build'
+      await recordStage('image_build', { buildContextPath: contextPath })
       await sails.helpers.docker.buildImage.with({
         contextPath,
         imageName,
@@ -102,6 +145,7 @@ module.exports = {
       })
 
       // 4b. Detect Sails features (sails-content, sails-quest, etc.)
+      await assertLease()
       const detectedFeatures = await sails.helpers.sails.detectFeatures(
         contextPath
       )
@@ -116,10 +160,8 @@ module.exports = {
       }
 
       // 5. Set status to deploying
-      await Deployment.updateOne({ id: deploymentId }).set({
-        imageName,
-        status: 'deploying'
-      })
+      await recordStage('container_startup')
+      await updateDeployment({ imageName, status: 'deploying' })
 
       // 6. Allocate a host port
       deployHostPort = await sails.helpers.docker.allocatePort.with({
@@ -127,6 +169,7 @@ module.exports = {
         ownerId: String(deploymentId)
       })
       deployHostPortReserved = true
+      await recordStage('container_startup', { hostPort: deployHostPort })
 
       // 7. 3-tier env var merge: global < environment < app-specific
       let globalEnvVars = {}
@@ -174,9 +217,11 @@ module.exports = {
         memory: '1.5g'
       }
       const oldContainerName = existingApp ? existingApp.containerName : null
+      await recordStage('container_startup', {
+        previousContainerName: oldContainerName || undefined
+      })
 
       // 9. Run the new container with deploy-scoped name (old container still running)
-      currentStage = 'container startup'
       const containerResult = await sails.helpers.docker.runContainer.with({
         imageName,
         containerName: deployContainerName,
@@ -189,7 +234,7 @@ module.exports = {
       })
 
       // 10. HTTP health check on the new container (Docker DNS, with localhost fallback for local dev)
-      currentStage = 'health check'
+      await recordStage('health_check')
       await sails.helpers.docker.healthCheck.with({
         containerName: deployContainerName,
         port: 1337,
@@ -201,9 +246,10 @@ module.exports = {
       // === Health check passed — switch traffic ===
 
       // 11. Verify the candidate route before committing App state.
-      currentStage = 'traffic cutover'
+      await recordStage('traffic_cutover')
       await sails.helpers.deploy.cutoverTraffic.with({
         deploymentId,
+        leaseToken,
         environmentId: environment.id,
         appId: existingApp?.id,
         candidate: {
@@ -219,13 +265,16 @@ module.exports = {
           isDefault: existingApp?.isDefault
         }
       })
+      // The candidate is now canonical. Never remove it from the generic
+      // failure cleanup if this worker loses its lease after cutover.
+      deployContainerName = null
+
+      await recordStage('cleanup')
       await releaseDeployPort({ hostPort: deployHostPort, deploymentId })
       deployHostPortReserved = false
-      deployContainerName = null
 
       // 12. Only retire the previous container after route verification and
       // App state commit have both succeeded.
-      currentStage = 'cleanup'
       if (
         oldContainerName &&
         oldContainerName !== containerResult.containerName
@@ -249,10 +298,11 @@ module.exports = {
       }
 
       // 13. Mark previous running deployments as stopped (scoped to this app)
+      await assertLease()
       const stopCriteria = {
         environment: environment.id,
         status: 'running',
-        id: { '!=': deploymentId }
+        id: { '<': deploymentId }
       }
       if (existingApp) {
         stopCriteria.app = existingApp.id
@@ -260,10 +310,8 @@ module.exports = {
       await Deployment.update(stopCriteria).set({ status: 'stopped' })
 
       // 14. Mark this deployment as running
-      await Deployment.updateOne({ id: deploymentId }).set({
-        status: 'running',
-        finishedAt: Date.now()
-      })
+      await updateDeployment({ status: 'running', finishedAt: Date.now() })
+      await recordStage('complete')
 
       const { fullDomain, generatedDomain } = await Environment.resolveDomains(
         environment.id
@@ -394,10 +442,35 @@ module.exports = {
         deployHostPortReserved = false
       }
 
-      // Mark deployment as failed (only if not already marked by build-image)
+      if (deployImageName && deployContainerName) {
+        try {
+          await sails.helpers.docker.removeImage.with({
+            imageName: deployImageName
+          })
+        } catch (cleanupError) {
+          sails.log.verbose(
+            `Could not remove failed image ${deployImageName}: ${
+              cleanupError.message || cleanupError
+            }`
+          )
+        }
+      }
+
+      // Mark deployment as failed only while this worker still owns the
+      // fenced lease. A stale worker must not overwrite recovery state.
       const current = await Deployment.findOne({ id: deploymentId })
-      if (current && current.status !== 'failed') {
-        await Deployment.updateOne({ id: deploymentId }).set({
+      let ownsLease = true
+      try {
+        await assertLease()
+      } catch {
+        ownsLease = false
+      }
+      if (
+        current &&
+        ownsLease &&
+        !['running', 'failed', 'cancelled'].includes(current.status)
+      ) {
+        await updateDeployment({
           status: 'failed',
           errorMessage,
           finishedAt: Date.now()
@@ -422,6 +495,13 @@ module.exports = {
       throw err
     }
   }
+}
+
+function requireValidCoordinatorResult(result) {
+  if (!result || result.valid !== false) return
+  const error = new Error(result.message)
+  error.code = result.code
+  throw error
 }
 
 async function releaseDeployPort({ hostPort, deploymentId }) {

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -19,6 +19,10 @@ module.exports = {
     },
     app: {
       type: 'ref'
+    },
+    leaseToken: {
+      type: 'string',
+      description: 'Fencing token held by the durable deployment worker.'
     }
   },
 
@@ -26,15 +30,48 @@ module.exports = {
     rollbackId,
     targetDeployment,
     environment,
-    app: appInput
+    app: appInput,
+    leaseToken
   }) {
     let candidateContainerName = null
     let hostPort = null
     let hostPortReserved = false
     let currentStage = 'initialization'
 
+    const recordStage = async (stage, resources = {}) => {
+      currentStage = stage.replace(/_/g, ' ')
+      const result = await sails.helpers.deploy.recordDeploymentStage.with({
+        deploymentId: rollbackId,
+        leaseToken,
+        stage,
+        ...resources
+      })
+      requireValidCoordinatorResult(result)
+    }
+
+    const assertLease = async () => {
+      const result = await sails.helpers.deploy.assertDeploymentLease.with({
+        deploymentId: rollbackId,
+        leaseToken
+      })
+      requireValidCoordinatorResult(result)
+    }
+
+    const updateDeployment = async (values) => {
+      const result = await sails.helpers.deploy.updateDeploymentForLease.with({
+        deploymentId: rollbackId,
+        leaseToken,
+        values
+      })
+      requireValidCoordinatorResult(result)
+      return result.deployment
+    }
+
     try {
-      await Deployment.updateOne({ id: rollbackId }).set({
+      await recordStage('initialization', {
+        imageName: targetDeployment.imageName
+      })
+      await updateDeployment({
         status: 'deploying',
         imageName: targetDeployment.imageName
       })
@@ -69,12 +106,17 @@ module.exports = {
         rollbackId,
         appSlug
       )
+      await recordStage('container_startup', {
+        candidateContainerName,
+        previousContainerName: oldContainerName || undefined
+      })
 
       hostPort = await sails.helpers.docker.allocatePort.with({
         ownerType: 'deployment',
         ownerId: String(rollbackId)
       })
       hostPortReserved = true
+      await recordStage('container_startup', { hostPort })
 
       let globalEnvVars = {}
       try {
@@ -96,7 +138,6 @@ module.exports = {
         ...(existingApp?.envVars || {})
       }
 
-      currentStage = 'container startup'
       const containerResult = await sails.helpers.docker.runContainer.with({
         imageName: targetDeployment.imageName,
         containerName: candidateContainerName,
@@ -108,7 +149,7 @@ module.exports = {
         resourceLimits: existingApp?.resourceLimits
       })
 
-      currentStage = 'health check'
+      await recordStage('health_check')
       await sails.helpers.docker.healthCheck.with({
         containerName: candidateContainerName,
         port: 1337,
@@ -117,9 +158,10 @@ module.exports = {
         deploymentId: rollbackId
       })
 
-      currentStage = 'traffic cutover'
+      await recordStage('traffic_cutover')
       await sails.helpers.deploy.cutoverTraffic.with({
         deploymentId: rollbackId,
+        leaseToken,
         environmentId: environment.id,
         appId: existingApp?.id,
         candidate: {
@@ -136,11 +178,11 @@ module.exports = {
         }
       })
 
+      candidateContainerName = null
+      await recordStage('cleanup')
       await releaseDeployPort({ hostPort, deploymentId: rollbackId })
       hostPortReserved = false
-      candidateContainerName = null
 
-      currentStage = 'cleanup'
       if (
         oldContainerName &&
         oldContainerName !== containerResult.containerName
@@ -162,18 +204,17 @@ module.exports = {
         }
       }
 
+      await assertLease()
       const stopCriteria = {
         environment: environment.id,
         status: 'running',
-        id: { '!=': rollbackId }
+        id: { '<': rollbackId }
       }
       if (existingApp) stopCriteria.app = existingApp.id
       await Deployment.update(stopCriteria).set({ status: 'stopped' })
 
-      await Deployment.updateOne({ id: rollbackId }).set({
-        status: 'running',
-        finishedAt: Date.now()
-      })
+      await updateDeployment({ status: 'running', finishedAt: Date.now() })
+      await recordStage('complete')
 
       const { fullDomain, generatedDomain } = await Environment.resolveDomains(
         environment.id
@@ -254,8 +295,18 @@ module.exports = {
       }
 
       const current = await Deployment.findOne({ id: rollbackId })
-      if (current && current.status !== 'failed') {
-        await Deployment.updateOne({ id: rollbackId }).set({
+      let ownsLease = true
+      try {
+        await assertLease()
+      } catch {
+        ownsLease = false
+      }
+      if (
+        current &&
+        ownsLease &&
+        !['running', 'failed', 'cancelled'].includes(current.status)
+      ) {
+        await updateDeployment({
           status: 'failed',
           errorMessage,
           finishedAt: Date.now()
@@ -265,6 +316,13 @@ module.exports = {
       throw error
     }
   }
+}
+
+function requireValidCoordinatorResult(result) {
+  if (!result || result.valid !== false) return
+  const error = new Error(result.message)
+  error.code = result.code
+  throw error
 }
 
 async function releaseDeployPort({ hostPort, deploymentId }) {

--- a/api/helpers/deploy/queue-deployment.js
+++ b/api/helpers/deploy/queue-deployment.js
@@ -1,0 +1,113 @@
+const withDatastoreTransaction = require('../../lib/with-datastore-transaction')
+
+module.exports = {
+  friendlyName: 'Queue deployment',
+
+  description:
+    'Create a deployment and its durable pipeline job atomically, then ask the coordinator to run it.',
+
+  inputs: {
+    values: {
+      type: 'ref',
+      required: true,
+      description: 'Values for the Deployment record.'
+    },
+    app: {
+      type: 'ref',
+      description: 'Target App record, when one already exists.'
+    },
+    kind: {
+      type: 'string',
+      isIn: ['deploy', 'rollback'],
+      defaultsTo: 'deploy'
+    },
+    targetDeploymentId: {
+      type: 'number',
+      description: 'Existing deployment whose image a rollback will reuse.'
+    },
+    dispatch: {
+      type: 'boolean',
+      defaultsTo: true,
+      description: 'Whether to wake the in-process coordinator immediately.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ values, app, kind, targetDeploymentId, dispatch }) {
+    const environmentId = normalizeId(values.environment)
+    if (!environmentId) {
+      throw new Error('A queued deployment requires an environment.')
+    }
+
+    const appSlug = app?.slug || 'app'
+    // The source cache and Caddy route are environment-wide resources. Keep
+    // all app pipelines in the same environment queue so they cannot race at
+    // those shared mutation boundaries.
+    const targetKey = `environment:${environmentId}`
+    let deployment
+    let job
+
+    await withDatastoreTransaction(async (db) => {
+      deployment = await Deployment.create({
+        ...values,
+        status: 'pending',
+        startedAt: null,
+        app: app?.id || values.app || null
+      })
+        .fetch()
+        .usingConnection(db)
+
+      job = await DeploymentJob.create({
+        deployment: deployment.id,
+        targetKey,
+        appSlug,
+        kind,
+        targetDeploymentId: targetDeploymentId || null,
+        stage: 'queued'
+      })
+        .fetch()
+        .usingConnection(db)
+    })
+
+    const queuePosition = await getQueuePosition(job)
+
+    if (dispatch) {
+      process.nextTick(() => {
+        sails.helpers.deploy.runQueuedDeployments
+          .with({ targetKey })
+          .catch((error) => {
+            sails.log.error(
+              `Deployment queue ${targetKey} failed: ${error.message || error}`
+            )
+          })
+      })
+    }
+
+    return {
+      deployment,
+      job,
+      state: 'queued',
+      queuePosition
+    }
+  }
+}
+
+function normalizeId(value) {
+  if (value && typeof value === 'object') return value.id
+  return value
+}
+
+async function getQueuePosition(job) {
+  const jobs = await DeploymentJob.find({
+    targetKey: job.targetKey,
+    stage: { in: ['queued', 'claimed'] }
+  }).sort(['createdAt ASC', 'id ASC'])
+
+  const index = jobs.findIndex((candidate) => candidate.id === job.id)
+  return index === -1 ? 1 : index + 1
+}

--- a/api/helpers/deploy/reconcile-deployments.js
+++ b/api/helpers/deploy/reconcile-deployments.js
@@ -1,0 +1,381 @@
+const crypto = require('node:crypto')
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const RECOVERY_LEASE_TTL = 30 * 1000
+const ACTIVE_STATUSES = ['pending', 'building', 'pushing', 'deploying']
+const ACTIVE_JOB_STAGES = [
+  'claimed',
+  'initialization',
+  'source_preparation',
+  'image_build',
+  'container_startup',
+  'health_check',
+  'traffic_cutover',
+  'cleanup',
+  'cancel_requested'
+]
+
+module.exports = {
+  friendlyName: 'Reconcile deployments',
+
+  description:
+    'Recover stale durable jobs and deterministically clean deployment resources left by an interrupted Slipway process.',
+
+  inputs: {},
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function () {
+    const recovered = []
+    const now = Date.now()
+
+    await PortReservation.destroy({ expiresAt: { '<': now } })
+
+    const staleLeases = await DeploymentLease.find({
+      expiresAt: { '<=': now }
+    })
+    for (const lease of staleLeases) {
+      const claimed = await claimForRecovery(lease)
+      if (!claimed) continue
+      try {
+        recovered.push(await recoverLease(claimed))
+      } catch (error) {
+        sails.log.warn(
+          `Deployment recovery ${claimed.deployment} will retry: ${
+            error.message || error
+          }`
+        )
+      }
+    }
+
+    const activeJobs = await DeploymentJob.find({
+      stage: { in: ACTIVE_JOB_STAGES }
+    })
+    for (const job of activeJobs) {
+      const existingLease = await DeploymentLease.findOne({
+        deployment: job.deployment
+      })
+      if (existingLease) continue
+
+      const claimed = await createRecoveryLease(job)
+      if (!claimed) continue
+      try {
+        recovered.push(await recoverLease(claimed))
+      } catch (error) {
+        sails.log.warn(
+          `Deployment recovery ${claimed.deployment} will retry: ${
+            error.message || error
+          }`
+        )
+      }
+    }
+
+    const activeDeployments = await Deployment.find({
+      status: { in: ACTIVE_STATUSES }
+    })
+    for (const deployment of activeDeployments) {
+      const job = await DeploymentJob.findOne({ deployment: deployment.id })
+      if (job) continue
+      try {
+        recovered.push(await recoverLegacyDeployment(deployment))
+      } catch (error) {
+        sails.log.warn(
+          `Legacy deployment recovery ${deployment.id} will retry: ${
+            error.message || error
+          }`
+        )
+      }
+    }
+
+    return { recovered }
+  }
+}
+
+async function claimForRecovery(lease) {
+  const now = Date.now()
+  const token = crypto.randomUUID()
+  return DeploymentLease.updateOne({
+    id: lease.id,
+    token: lease.token,
+    expiresAt: { '<=': now }
+  }).set({
+    token,
+    owner: `recovery:${os.hostname()}:${process.pid}`,
+    stage: 'recovering',
+    heartbeatAt: now,
+    expiresAt: now + RECOVERY_LEASE_TTL
+  })
+}
+
+async function createRecoveryLease(job) {
+  const now = Date.now()
+  try {
+    return await DeploymentLease.create({
+      targetKey: job.targetKey,
+      deployment: job.deployment,
+      token: crypto.randomUUID(),
+      owner: `recovery:${os.hostname()}:${process.pid}`,
+      stage: 'recovering',
+      heartbeatAt: now,
+      expiresAt: now + RECOVERY_LEASE_TTL
+    }).fetch()
+  } catch (error) {
+    if (/unique|constraint/i.test(error.message || '')) return null
+    throw error
+  }
+}
+
+async function recoverLease(lease) {
+  const [job, deployment] = await Promise.all([
+    DeploymentJob.findOne({ deployment: lease.deployment }),
+    Deployment.findOne({ id: lease.deployment })
+  ])
+
+  if (!job || !deployment) {
+    await DeploymentLease.destroyOne({ id: lease.id, token: lease.token })
+    return { deploymentId: lease.deployment, action: 'discarded' }
+  }
+
+  await DeploymentJob.updateOne({ id: job.id }).set({ stage: 'recovering' })
+
+  const app = deployment.app
+    ? await App.findOne({ id: deployment.app })
+    : await App.findOne({
+        environment: deployment.environment,
+        slug: job.appSlug
+      })
+  const candidateIsCurrent = Boolean(
+    app &&
+      app.currentDeployment === deployment.id &&
+      (!job.candidateContainerName ||
+        app.containerName === job.candidateContainerName)
+  )
+
+  if (candidateIsCurrent) {
+    await restoreRouteFromAppState(deployment.environment, deployment.id, {
+      candidateIsCurrent: true
+    })
+    await stopContainer(job.previousContainerName, app.containerName)
+    await markOtherDeploymentsStopped(deployment, app)
+    await releasePort(deployment.id, job.hostPort)
+
+    await Deployment.updateOne({ id: deployment.id }).set({
+      status: 'running',
+      finishedAt: deployment.finishedAt || Date.now(),
+      errorMessage: null
+    })
+    await DeploymentJob.updateOne({ id: job.id }).set({ stage: 'complete' })
+    await DeploymentLease.destroyOne({ id: lease.id, token: lease.token })
+
+    await Deployment.appendDeployLog(
+      deployment.id,
+      'Recovery: the committed release was verified and finalized after Slipway restarted.\n'
+    )
+
+    return { deploymentId: deployment.id, action: 'finalized' }
+  }
+
+  await restoreRouteFromAppState(deployment.environment, deployment.id)
+  await stopContainer(job.candidateContainerName)
+  await releasePort(deployment.id, job.hostPort)
+  if (job.kind === 'deploy') {
+    await removeImage(job.imageName || deployment.imageName)
+  }
+  cleanupTemporaryBuildContext(job.buildContextPath, deployment.id)
+
+  const wasCancelled = deployment.status === 'cancelled'
+  const errorMessage = `Slipway restarted during ${humanizeStage(
+    job.stage
+  )}. The incomplete candidate was rolled back safely.`
+
+  if (!wasCancelled) {
+    await Deployment.updateOne({ id: deployment.id }).set({
+      status: 'failed',
+      errorMessage,
+      finishedAt: Date.now()
+    })
+    await Deployment.appendDeployLog(
+      deployment.id,
+      `Recovery: ${errorMessage}\n`
+    )
+  }
+
+  await DeploymentJob.updateOne({ id: job.id }).set({
+    stage: wasCancelled ? 'cancelled' : 'failed'
+  })
+  await DeploymentLease.destroyOne({ id: lease.id, token: lease.token })
+
+  return {
+    deploymentId: deployment.id,
+    action: wasCancelled ? 'cancelled' : 'rolled_back'
+  }
+}
+
+async function recoverLegacyDeployment(deployment) {
+  const app = deployment.app
+    ? await App.findOne({ id: deployment.app })
+    : await App.findOne({
+        environment: deployment.environment,
+        isDefault: true
+      })
+  const candidateContainerName = await App.generateDeployContainerName(
+    deployment.environment,
+    deployment.id,
+    app?.slug
+  )
+  const candidateIsCurrent = Boolean(
+    app &&
+      app.currentDeployment === deployment.id &&
+      app.containerName === candidateContainerName
+  )
+
+  if (candidateIsCurrent) {
+    await restoreRouteFromAppState(deployment.environment, deployment.id, {
+      candidateIsCurrent: true
+    })
+    await markOtherDeploymentsStopped(deployment, app)
+    await releasePort(deployment.id)
+    await Deployment.updateOne({ id: deployment.id }).set({
+      status: 'running',
+      finishedAt: deployment.finishedAt || Date.now(),
+      errorMessage: null
+    })
+    await Deployment.appendDeployLog(
+      deployment.id,
+      'Recovery: the committed legacy release was verified and finalized after Slipway restarted.\n'
+    )
+    return { deploymentId: deployment.id, action: 'legacy_finalized' }
+  }
+
+  await restoreRouteFromAppState(deployment.environment, deployment.id)
+  await stopContainer(candidateContainerName, app?.containerName)
+  await releasePort(deployment.id)
+  if (deployment.imageName?.endsWith(`:${deployment.id}`)) {
+    await removeImage(deployment.imageName)
+  }
+
+  const errorMessage =
+    'Slipway restarted before this legacy deployment had durable recovery state. Its candidate resources were rolled back safely.'
+  await Deployment.updateOne({ id: deployment.id }).set({
+    status: 'failed',
+    errorMessage,
+    finishedAt: Date.now()
+  })
+  await Deployment.appendDeployLog(deployment.id, `Recovery: ${errorMessage}\n`)
+
+  return { deploymentId: deployment.id, action: 'legacy_rolled_back' }
+}
+
+async function restoreRouteFromAppState(
+  environmentId,
+  deploymentId,
+  { candidateIsCurrent = false } = {}
+) {
+  if (!candidateIsCurrent) {
+    await sails.helpers.caddy.cleanupRouteTransaction.with({
+      environmentId,
+      routeVersion: deploymentId,
+      phase: 'before-repair'
+    })
+  }
+
+  try {
+    await sails.helpers.caddy.updateRoute.with({ environmentId })
+  } catch (error) {
+    sails.log.warn(
+      `Could not reconcile Caddy route for environment ${environmentId}: ${
+        error.message || error
+      }`
+    )
+    throw error
+  }
+
+  await sails.helpers.caddy.cleanupRouteTransaction.with({
+    environmentId,
+    routeVersion: deploymentId,
+    phase: 'after-repair'
+  })
+}
+
+async function stopContainer(containerName, currentContainerName) {
+  if (!containerName || containerName === currentContainerName) return
+  try {
+    await sails.helpers.docker.stopContainer.with({ containerName })
+  } catch (error) {
+    if (error !== 'notFound' && error?.code !== 'notFound') {
+      sails.log.warn(
+        `Could not clean deployment container ${containerName}: ${
+          error.message || error
+        }`
+      )
+    }
+  }
+}
+
+async function releasePort(deploymentId, hostPort) {
+  if (hostPort) {
+    await sails.helpers.docker.releasePort.with({
+      hostPort,
+      ownerType: 'deployment',
+      ownerId: String(deploymentId)
+    })
+    return
+  }
+
+  await PortReservation.destroy({
+    ownerType: 'deployment',
+    ownerId: String(deploymentId)
+  })
+}
+
+async function removeImage(imageName) {
+  if (!imageName) return
+  try {
+    await sails.helpers.docker.removeImage.with({ imageName })
+  } catch (error) {
+    sails.log.warn(
+      `Could not clean deployment image ${imageName}: ${error.message || error}`
+    )
+  }
+}
+
+async function markOtherDeploymentsStopped(deployment, app) {
+  const criteria = {
+    environment: deployment.environment,
+    status: 'running',
+    id: { '<': deployment.id }
+  }
+  if (app) criteria.app = app.id
+  await Deployment.update(criteria).set({ status: 'stopped' })
+}
+
+function cleanupTemporaryBuildContext(contextPath, deploymentId) {
+  if (!contextPath) return
+  const ownedRoot = path.join(
+    os.tmpdir(),
+    'slipway',
+    'deployments',
+    String(deploymentId)
+  )
+  const resolved = path.resolve(contextPath)
+  if (resolved !== ownedRoot && !resolved.startsWith(`${ownedRoot}${path.sep}`))
+    return
+  fs.rmSync(resolved, { recursive: true, force: true })
+}
+
+function humanizeStage(stage) {
+  return String(stage || 'an unknown deployment stage').replace(/_/g, ' ')
+}
+
+module.exports._private = {
+  claimForRecovery,
+  createRecoveryLease,
+  recoverLease,
+  cleanupTemporaryBuildContext
+}

--- a/api/helpers/deploy/record-deployment-stage.js
+++ b/api/helpers/deploy/record-deployment-stage.js
@@ -1,0 +1,91 @@
+const LEASE_TTL = 30 * 1000
+
+module.exports = {
+  friendlyName: 'Record deployment stage',
+
+  description:
+    'Persist pipeline progress and renew the matching fenced deployment lease.',
+
+  inputs: {
+    deploymentId: {
+      type: 'string',
+      required: true
+    },
+    leaseToken: {
+      type: 'string'
+    },
+    stage: {
+      type: 'string',
+      required: true
+    },
+    candidateContainerName: {
+      type: 'string'
+    },
+    previousContainerName: {
+      type: 'string'
+    },
+    imageName: {
+      type: 'string'
+    },
+    hostPort: {
+      type: 'number'
+    },
+    buildContextPath: {
+      type: 'string'
+    }
+  },
+
+  fn: async function ({
+    deploymentId,
+    leaseToken,
+    stage,
+    candidateContainerName,
+    previousContainerName,
+    imageName,
+    hostPort,
+    buildContextPath
+  }) {
+    if (leaseToken) {
+      const now = Date.now()
+      const lease = await DeploymentLease.updateOne({
+        deployment: deploymentId,
+        token: leaseToken,
+        expiresAt: { '>': now }
+      }).set({
+        stage,
+        heartbeatAt: now,
+        expiresAt: now + LEASE_TTL
+      })
+
+      if (!lease) {
+        return {
+          valid: false,
+          code: 'DEPLOYMENT_LEASE_LOST',
+          message: `Deployment ${deploymentId} no longer owns its pipeline lease.`
+        }
+      }
+
+      const deployment = await Deployment.findOne({ id: deploymentId })
+      if (deployment?.status === 'cancelled') {
+        return {
+          valid: false,
+          code: 'DEPLOYMENT_CANCELLED',
+          message: `Deployment ${deploymentId} was cancelled.`
+        }
+      }
+    }
+
+    const updates = { stage }
+    if (candidateContainerName !== undefined)
+      updates.candidateContainerName = candidateContainerName
+    if (previousContainerName !== undefined)
+      updates.previousContainerName = previousContainerName
+    if (imageName !== undefined) updates.imageName = imageName
+    if (hostPort !== undefined) updates.hostPort = hostPort
+    if (buildContextPath !== undefined)
+      updates.buildContextPath = buildContextPath
+
+    await DeploymentJob.updateOne({ deployment: deploymentId }).set(updates)
+    return { valid: true }
+  }
+}

--- a/api/helpers/deploy/run-queued-deployments.js
+++ b/api/helpers/deploy/run-queued-deployments.js
@@ -1,0 +1,255 @@
+const crypto = require('node:crypto')
+const os = require('node:os')
+
+const LEASE_TTL = 30 * 1000
+const HEARTBEAT_INTERVAL = 10 * 1000
+
+module.exports = {
+  friendlyName: 'Run queued deployments',
+
+  description:
+    'Claim and run the oldest queued deployment for each available environment.',
+
+  inputs: {
+    targetKey: {
+      type: 'string',
+      description: 'Optional environment queue to drain.'
+    }
+  },
+
+  fn: async function ({ targetKey }) {
+    const criteria = { stage: 'queued' }
+    if (targetKey) criteria.targetKey = targetKey
+
+    const queuedJobs = await DeploymentJob.find(criteria).sort([
+      'createdAt ASC',
+      'id ASC'
+    ])
+    const targetKeys = [...new Set(queuedJobs.map((job) => job.targetKey))]
+
+    await Promise.all(targetKeys.map((key) => drainTarget(key)))
+
+    return { targets: targetKeys.length }
+  }
+}
+
+async function drainTarget(targetKey) {
+  while (true) {
+    const claimed = await claimNextJob(targetKey)
+    if (!claimed) return
+
+    await runClaimedJob(claimed)
+  }
+}
+
+async function claimNextJob(targetKey) {
+  const jobs = await DeploymentJob.find({ targetKey, stage: 'queued' }).sort([
+    'createdAt ASC',
+    'id ASC'
+  ])
+
+  for (const job of jobs) {
+    const deployment = await Deployment.findOne({ id: job.deployment })
+    if (!deployment || deployment.status === 'cancelled') {
+      await DeploymentJob.updateOne({ id: job.id, stage: 'queued' }).set({
+        stage: 'cancelled'
+      })
+      continue
+    }
+
+    if (deployment.status !== 'pending') {
+      await DeploymentJob.updateOne({ id: job.id, stage: 'queued' }).set({
+        stage: isSuccessfulStatus(deployment.status) ? 'complete' : 'failed'
+      })
+      continue
+    }
+
+    const now = Date.now()
+    const token = crypto.randomUUID()
+    let lease
+
+    try {
+      lease = await DeploymentLease.create({
+        targetKey,
+        deployment: deployment.id,
+        token,
+        owner: `${os.hostname()}:${process.pid}`,
+        stage: 'claimed',
+        heartbeatAt: now,
+        expiresAt: now + LEASE_TTL
+      }).fetch()
+    } catch (error) {
+      if (isUniqueConflict(error)) return null
+      throw error
+    }
+
+    const claimedJob = await DeploymentJob.updateOne({
+      id: job.id,
+      stage: 'queued'
+    }).set({
+      stage: 'claimed',
+      attempt: job.attempt + 1
+    })
+
+    if (!claimedJob) {
+      await DeploymentLease.destroyOne({ id: lease.id, token })
+      continue
+    }
+
+    await Deployment.updateOne({ id: deployment.id, status: 'pending' }).set({
+      startedAt: deployment.startedAt || now
+    })
+
+    return { job: claimedJob, deployment, lease }
+  }
+
+  return null
+}
+
+async function runClaimedJob({ job, deployment, lease }) {
+  const heartbeat = setInterval(async () => {
+    try {
+      const now = Date.now()
+      const renewed = await DeploymentLease.updateOne({
+        id: lease.id,
+        token: lease.token
+      }).set({
+        heartbeatAt: now,
+        expiresAt: now + LEASE_TTL
+      })
+      if (!renewed) clearInterval(heartbeat)
+    } catch (error) {
+      sails.log.warn(
+        `Could not heartbeat deployment ${deployment.id}: ${
+          error.message || error
+        }`
+      )
+    }
+  }, HEARTBEAT_INTERVAL)
+
+  if (typeof heartbeat.unref === 'function') heartbeat.unref()
+
+  try {
+    const environment = await Environment.findOne({
+      id: deployment.environment
+    }).populate('project')
+    if (!environment?.project) {
+      throw new Error(
+        `Deployment ${deployment.id} has no deployable environment.`
+      )
+    }
+
+    const app = deployment.app
+      ? await App.findOne({ id: deployment.app })
+      : await App.findOne({
+          environment: environment.id,
+          slug: job.appSlug
+        })
+
+    await DeploymentJob.updateOne({ id: job.id }).set({
+      previousContainerName: app?.containerName || null
+    })
+
+    if (job.kind === 'rollback') {
+      const targetDeployment = await Deployment.findOne({
+        id: job.targetDeploymentId
+      })
+      if (!targetDeployment?.imageName) {
+        throw new Error(
+          `Rollback source deployment ${job.targetDeploymentId} is unavailable.`
+        )
+      }
+
+      await sails.helpers.deploy.executeRollback.with({
+        rollbackId: deployment.id,
+        targetDeployment,
+        environment,
+        app,
+        leaseToken: lease.token
+      })
+    } else {
+      await sails.helpers.deploy.executePipeline.with({
+        deploymentId: deployment.id,
+        project: environment.project,
+        environment,
+        app,
+        leaseToken: lease.token
+      })
+    }
+  } catch (error) {
+    const errorMessage = error.message || String(error)
+    sails.log.error(
+      `Deployment worker ${deployment.id} stopped: ${errorMessage}`
+    )
+
+    // Pipeline helpers persist their own failures, but coordinator preflight
+    // can also fail (for example, a deleted environment or rollback source).
+    // Never leave that durable job failed while its Deployment still appears
+    // pending forever.
+    const current = await Deployment.findOne({ id: deployment.id })
+    if (
+      current &&
+      !['running', 'stopped', 'failed', 'cancelled'].includes(current.status)
+    ) {
+      const failed = await sails.helpers.deploy.updateDeploymentForLease.with({
+        deploymentId: deployment.id,
+        leaseToken: lease.token,
+        values: {
+          status: 'failed',
+          errorMessage,
+          finishedAt: Date.now()
+        }
+      })
+      if (failed.valid) {
+        try {
+          await Deployment.appendDeployLog(
+            deployment.id,
+            `\nERROR [coordinator]: ${errorMessage}\n`
+          )
+        } catch {
+          // Failure state is authoritative; diagnostics are best-effort.
+        }
+      }
+    }
+  } finally {
+    clearInterval(heartbeat)
+
+    const ownedLease = await DeploymentLease.findOne({
+      id: lease.id,
+      token: lease.token
+    })
+
+    if (!ownedLease) return
+
+    const current = await Deployment.findOne({ id: deployment.id })
+    const stage =
+      current?.status === 'running'
+        ? 'complete'
+        : current?.status === 'cancelled'
+        ? 'cancelled'
+        : 'failed'
+
+    await DeploymentJob.updateOne({ id: job.id }).set({ stage })
+    await DeploymentLease.destroyOne({ id: lease.id, token: lease.token })
+  }
+}
+
+function isSuccessfulStatus(status) {
+  return ['running', 'stopped'].includes(status)
+}
+
+function isUniqueConflict(error) {
+  const code = error?.code || error?.raw?.code || error?.cause?.code
+  return (
+    code === 'E_UNIQUE' ||
+    code === 'SQLITE_CONSTRAINT' ||
+    /unique|constraint/i.test(error?.message || '')
+  )
+}
+
+module.exports._private = {
+  claimNextJob,
+  drainTarget,
+  runClaimedJob,
+  isUniqueConflict
+}

--- a/api/helpers/deploy/update-deployment-for-lease.js
+++ b/api/helpers/deploy/update-deployment-for-lease.js
@@ -1,0 +1,78 @@
+const withDatastoreTransaction = require('../../lib/with-datastore-transaction')
+
+module.exports = {
+  friendlyName: 'Update deployment for lease',
+
+  description:
+    'Atomically fence a Deployment update with its current durable lease.',
+
+  inputs: {
+    deploymentId: {
+      type: 'string',
+      required: true
+    },
+    leaseToken: {
+      type: 'string'
+    },
+    values: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ deploymentId, leaseToken, values }) {
+    if (!leaseToken) {
+      return {
+        valid: true,
+        deployment: await Deployment.updateOne({ id: deploymentId }).set(values)
+      }
+    }
+
+    let updated
+    await withDatastoreTransaction(async (db) => {
+      const [lease, deployment] = await Promise.all([
+        DeploymentLease.findOne({
+          deployment: deploymentId,
+          token: leaseToken,
+          expiresAt: { '>': Date.now() }
+        }).usingConnection(db),
+        Deployment.findOne({ id: deploymentId }).usingConnection(db)
+      ])
+
+      if (!lease) {
+        return
+      }
+
+      if (deployment?.status === 'cancelled') {
+        return
+      }
+
+      updated = await Deployment.updateOne({ id: deploymentId })
+        .set(values)
+        .usingConnection(db)
+    })
+
+    if (!updated) {
+      const deployment = await Deployment.findOne({ id: deploymentId })
+      return deployment?.status === 'cancelled'
+        ? {
+            valid: false,
+            code: 'DEPLOYMENT_CANCELLED',
+            message: `Deployment ${deploymentId} was cancelled.`
+          }
+        : {
+            valid: false,
+            code: 'DEPLOYMENT_LEASE_LOST',
+            message: `Deployment ${deploymentId} no longer owns its pipeline lease.`
+          }
+    }
+
+    return { valid: true, deployment: updated }
+  }
+}

--- a/api/helpers/docker/build-image.js
+++ b/api/helpers/docker/build-image.js
@@ -115,11 +115,6 @@ module.exports = {
 
         if (deploymentId) {
           await Deployment.appendBuildLog(deploymentId, `\n⚠️ ${errorMsg}\n`)
-          await Deployment.updateOne({ id: deploymentId }).set({
-            status: 'failed',
-            errorMessage: errorMsg,
-            finishedAt: Date.now()
-          })
         }
         reject(new Error(errorMsg))
       }, timeout)
@@ -160,13 +155,6 @@ module.exports = {
           })
         } else {
           sails.log.error(`Docker build failed with code ${code}`)
-          if (deploymentId) {
-            await Deployment.updateOne({ id: deploymentId }).set({
-              status: 'failed',
-              errorMessage: `Build failed with exit code ${code}`,
-              finishedAt: Date.now()
-            })
-          }
           reject(
             new Error(`Docker build failed with exit code ${code}\n${stderr}`)
           )
@@ -179,13 +167,6 @@ module.exports = {
         if (killed) return // Already handled by timeout
 
         sails.log.error(`Docker build error: ${error.message}`)
-        if (deploymentId) {
-          await Deployment.updateOne({ id: deploymentId }).set({
-            status: 'failed',
-            errorMessage: error.message,
-            finishedAt: Date.now()
-          })
-        }
         reject(error)
       })
     })

--- a/api/helpers/docker/remove-image.js
+++ b/api/helpers/docker/remove-image.js
@@ -1,0 +1,31 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Remove image',
+
+  description: 'Remove a deployment-scoped Docker image when it is orphaned.',
+
+  inputs: {
+    imageName: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ imageName }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+
+    try {
+      await execFileAsync(dockerPath, ['image', 'rm', imageName])
+      return { removed: true }
+    } catch (error) {
+      if (/no such image/i.test(error.message || '')) {
+        return { removed: false }
+      }
+      throw error
+    }
+  }
+}

--- a/api/lib/with-datastore-transaction.js
+++ b/api/lib/with-datastore-transaction.js
@@ -1,0 +1,31 @@
+const MAX_ATTEMPTS = 20
+
+module.exports = async function withDatastoreTransaction(work) {
+  let lastError
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await sails.getDatastore().transaction(work)
+    } catch (error) {
+      lastError = error
+      if (!isRetryableLock(error) || attempt === MAX_ATTEMPTS) throw error
+      await new Promise((resolve) =>
+        setTimeout(resolve, Math.min(attempt * 10, 100))
+      )
+    }
+  }
+
+  throw lastError
+}
+
+function isRetryableLock(error) {
+  const message = [error?.message, error?.raw?.message, error?.cause?.message]
+    .filter(Boolean)
+    .join(' ')
+
+  return /transaction is already active|sqlite_busy|database is locked/i.test(
+    message
+  )
+}
+
+module.exports._private = { isRetryableLock }

--- a/api/models/DeploymentJob.js
+++ b/api/models/DeploymentJob.js
@@ -1,0 +1,96 @@
+/**
+ * DeploymentJob.js
+ *
+ * Durable execution state for a deployment or rollback pipeline.
+ */
+
+module.exports = {
+  tableName: 'deployment_jobs',
+
+  attributes: {
+    deployment: {
+      model: 'deployment',
+      required: true,
+      unique: true,
+      columnName: 'deployment_id'
+    },
+
+    targetKey: {
+      type: 'string',
+      required: true,
+      description: 'Environment key whose pipelines must be serialized.',
+      columnName: 'target_key'
+    },
+
+    appSlug: {
+      type: 'string',
+      defaultsTo: 'app',
+      columnName: 'app_slug'
+    },
+
+    kind: {
+      type: 'string',
+      isIn: ['deploy', 'rollback'],
+      defaultsTo: 'deploy'
+    },
+
+    targetDeploymentId: {
+      type: 'number',
+      allowNull: true,
+      description: 'Existing deployment image used by a rollback job.',
+      columnName: 'target_deployment_id'
+    },
+
+    stage: {
+      type: 'string',
+      defaultsTo: 'queued'
+    },
+
+    attempt: {
+      type: 'number',
+      defaultsTo: 0
+    },
+
+    candidateContainerName: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'candidate_container_name'
+    },
+
+    previousContainerName: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'previous_container_name'
+    },
+
+    imageName: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'image_name'
+    },
+
+    hostPort: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'host_port'
+    },
+
+    buildContextPath: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'build_context_path'
+    }
+  },
+
+  getQueuePosition: async function (deploymentId) {
+    const job = await DeploymentJob.findOne({ deployment: deploymentId })
+    if (!job || !['queued', 'claimed'].includes(job.stage)) return null
+
+    const jobs = await DeploymentJob.find({
+      targetKey: job.targetKey,
+      stage: { in: ['queued', 'claimed'] }
+    }).sort(['createdAt ASC', 'id ASC'])
+    const index = jobs.findIndex((candidate) => candidate.id === job.id)
+    return index === -1 ? null : index + 1
+  }
+}

--- a/api/models/DeploymentLease.js
+++ b/api/models/DeploymentLease.js
@@ -1,0 +1,53 @@
+/**
+ * DeploymentLease.js
+ *
+ * Renewable, fenced ownership of one environment deployment target.
+ */
+
+module.exports = {
+  tableName: 'deployment_leases',
+
+  attributes: {
+    targetKey: {
+      type: 'string',
+      required: true,
+      unique: true,
+      columnName: 'target_key'
+    },
+
+    deployment: {
+      model: 'deployment',
+      required: true,
+      unique: true,
+      columnName: 'deployment_id'
+    },
+
+    token: {
+      type: 'string',
+      required: true,
+      unique: true
+    },
+
+    owner: {
+      type: 'string',
+      required: true
+    },
+
+    stage: {
+      type: 'string',
+      defaultsTo: 'claimed'
+    },
+
+    heartbeatAt: {
+      type: 'number',
+      required: true,
+      columnName: 'heartbeat_at'
+    },
+
+    expiresAt: {
+      type: 'number',
+      required: true,
+      columnName: 'expires_at'
+    }
+  }
+}

--- a/assets/js/components/DeploymentHistory.vue
+++ b/assets/js/components/DeploymentHistory.vue
@@ -39,13 +39,20 @@ function orderedDeployments(history) {
   const newestFirst = (left, right) =>
     Number(right.createdAt) - Number(left.createdAt) ||
     Number(right.id) - Number(left.id)
+  const oldestFirst = (left, right) =>
+    Number(left.createdAt) - Number(right.createdAt) ||
+    Number(left.id) - Number(right.id)
+  const active = history.activeDeployments || []
+  const executing = active.filter((item) => item.status !== 'pending')
+  const queued = active.filter((item) => item.status === 'pending')
 
-  for (const group of [
-    history.activeDeployments || [],
-    history.currentReleases || [],
-    history.items || []
+  for (const [group, sort] of [
+    [executing, newestFirst],
+    [history.currentReleases || [], newestFirst],
+    [queued, oldestFirst],
+    [history.items || [], newestFirst]
   ]) {
-    for (const deployment of [...group].sort(newestFirst)) {
+    for (const deployment of [...group].sort(sort)) {
       if (seen.has(deployment.id)) continue
       seen.add(deployment.id)
       ordered.push(deployment)
@@ -170,7 +177,7 @@ function statusBadge(status) {
         'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
     },
     pending: {
-      label: 'Pending',
+      label: 'Queued',
       classes:
         'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
     },

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -178,7 +178,7 @@ function statusBadge(status) {
         'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
     },
     pending: {
-      label: 'Pending',
+      label: 'Queued',
       classes:
         'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
     },

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -10,6 +10,10 @@
  */
 
 module.exports.bootstrap = async function () {
+  // Production uses `migrate: safe`; create coordinator tables before any
+  // deployment job queries run on an existing installation.
+  await sails.helpers.deploy.ensureQueueSchema()
+
   // Initialize CLI tokens map for Bearer token authentication
   sails.cliTokens = new Map()
 
@@ -26,6 +30,7 @@ module.exports.bootstrap = async function () {
   }
 
   const skipInfraBootstrap = sails.config.environment === 'test'
+  const isQuestWorker = sails.config.environment === 'console'
 
   // One-time migration: backfill multi-app fields on existing App/Deployment records
   const migrationDone = await sails.helpers.setting.get('multiAppMigrationDone')
@@ -98,6 +103,25 @@ module.exports.bootstrap = async function () {
       sails.log.verbose(
         'Could not configure Caddy dashboard route:',
         error.message
+      )
+    }
+  }
+
+  // Quest child processes run the same bootstrap. Only the long-lived web
+  // process performs startup recovery; the watchdog script handles console.
+  if (!isQuestWorker) {
+    try {
+      await sails.helpers.deploy.reconcileDeployments()
+      process.nextTick(() => {
+        sails.helpers.deploy.runQueuedDeployments().catch((error) => {
+          sails.log.error(
+            `Could not dispatch queued deployments: ${error.message || error}`
+          )
+        })
+      })
+    } catch (error) {
+      sails.log.warn(
+        `Could not reconcile deployment pipelines: ${error.message || error}`
       )
     }
   }

--- a/scripts/reconcile-deployments.js
+++ b/scripts/reconcile-deployments.js
@@ -1,0 +1,17 @@
+module.exports = {
+  friendlyName: 'Reconcile deployments',
+
+  description:
+    'Recover interrupted deployment pipelines and dispatch durable queued work.',
+
+  quest: {
+    interval: '1 minute',
+    withoutOverlapping: true
+  },
+
+  fn: async function () {
+    await sails.helpers.deploy.ensureQueueSchema()
+    await sails.helpers.deploy.reconcileDeployments()
+    await sails.helpers.deploy.runQueuedDeployments()
+  }
+}

--- a/tests/e2e/pages/projects/deployment-history.test.js
+++ b/tests/e2e/pages/projects/deployment-history.test.js
@@ -44,6 +44,14 @@ async function seedHistory({ sails, world }) {
     startedAt: now - 120000,
     createdAt: now - 120000
   })
+  await world.create('deployment').with({
+    ...target,
+    status: 'pending',
+    triggerType: 'manual',
+    gitMessage: 'Queued behind active build',
+    startedAt: null,
+    createdAt: now - 1000
+  })
 
   await sails.models.app.updateOne({ id: current.apps.web.id }).set({
     status: 'running',
@@ -88,6 +96,7 @@ test(
     await expect(page).toSee('Deployments')
     await expect(page).toSee('Running')
     await expect(page).toSee('Building')
+    await expect(page).toSee('Queued')
     await expect(page).toSee('Failed')
     await expect(page).toSee('Stopped')
     await expect(page).toSee('main')
@@ -98,12 +107,23 @@ test(
         (row) => row.textContent
       )
     )
-    expect(rows.length).toBe(4)
+    expect(rows.length).toBe(5)
     expect(rows[0].includes('Building')).toBe(true)
     expect(rows[1].includes('Running')).toBe(true)
-    expect(rows[2].includes('Failed')).toBe(true)
-    expect(rows[3].includes('Stopped')).toBe(true)
+    expect(rows[2].includes('Queued')).toBe(true)
+    expect(rows[3].includes('Failed')).toBe(true)
+    expect(rows[4].includes('Stopped')).toBe(true)
 
+    const deploymentToasts = await page.raw
+      .locator('.pointer-events-none.fixed.bottom-4.right-4')
+      .textContent()
+    expect(
+      deploymentToasts.indexOf('Building') < deploymentToasts.indexOf('Queued')
+    ).toBe(true)
+
+    await page.screenshot('.tmp/deployment-queue-order.png', {
+      fullPage: true
+    })
     expect(page).toHaveNoJavascriptErrors()
   }
 )
@@ -125,6 +145,7 @@ test(
     await expect(page).toSee('Deployments')
     await expect(page).toSee('Running')
     await expect(page).toSee('Building')
+    await expect(page).toSee('Queued')
     await expect(page).toSee('Failed')
     await expect(page).toSee('Stopped')
     expect(page).toHaveNoJavascriptErrors()

--- a/tests/factories/deploymentjob.js
+++ b/tests/factories/deploymentjob.js
@@ -1,0 +1,7 @@
+module.exports = ({ defineFactory }) =>
+  defineFactory('deploymentjob', {
+    targetKey: 'environment:1',
+    appSlug: 'web',
+    kind: 'deploy',
+    stage: 'queued'
+  })

--- a/tests/factories/deploymentlease.js
+++ b/tests/factories/deploymentlease.js
@@ -1,0 +1,9 @@
+module.exports = ({ defineFactory }) =>
+  defineFactory('deploymentlease', {
+    targetKey: 'environment:1',
+    token: 'lease-token',
+    owner: 'sounding',
+    stage: 'claimed',
+    heartbeatAt: 1,
+    expiresAt: 2
+  })

--- a/tests/functional/api/deploy.test.js
+++ b/tests/functional/api/deploy.test.js
@@ -80,7 +80,12 @@ test(
       }
     }
     sails.helpers.deploy.executePipeline = {
-      with: async (options) => pipelineCalls.push(options)
+      with: async (options) => {
+        pipelineCalls.push(options)
+        await sails.models.deployment
+          .updateOne({ id: options.deploymentId })
+          .set({ status: 'running', finishedAt: Date.now() })
+      }
     }
 
     try {
@@ -129,15 +134,17 @@ test(
       const response = await request
         .as('genesisUser')
         .post(deployPath(current.projects.deploymentTarget.slug), {})
-      await new Promise((resolve) => setImmediate(resolve))
+      await waitFor(() => pipelineCalls.length === 1)
 
       expect(response).toHaveStatus(202)
       expect(Boolean(response.data?.deployment?.id)).toBe(true)
+      expect(response.data.deployment.message).toBe('Deployment queued')
+      expect(response.data.deployment.queuePosition).toBe(1)
       expect(pipelineCalls.length).toBe(1)
       const deployment = await sails.models.deployment.findOne({
         id: response.data.deployment.id
       })
-      expect(deployment.status).toBe('pending')
+      expect(deployment.status).toBe('running')
       expect(deployment.gitCommit).toBe(null)
       expect(deployment.gitBranch).toBe(null)
       expect(deployment.gitMessage).toBe(null)
@@ -150,3 +157,11 @@ test(
     }
   }
 )
+
+async function waitFor(predicate, timeout = 2000) {
+  const deadline = Date.now() + timeout
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for state.')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}

--- a/tests/functional/api/deploy.test.js
+++ b/tests/functional/api/deploy.test.js
@@ -148,6 +148,21 @@ test(
       expect(deployment.gitCommit).toBe(null)
       expect(deployment.gitBranch).toBe(null)
       expect(deployment.gitMessage).toBe(null)
+
+      // The HTTP response intentionally returns before the durable worker
+      // finishes its bookkeeping. Wait for that boundary so test teardown
+      // cannot lower Sails while the coordinator is releasing its lease.
+      await waitFor(async () => {
+        const [job, leaseCount] = await Promise.all([
+          sails.models.deploymentjob.findOne({
+            deployment: deployment.id
+          }),
+          sails.models.deploymentlease.count({
+            deployment: deployment.id
+          })
+        ])
+        return job?.stage === 'complete' && leaseCount === 0
+      })
     } finally {
       sails.helpers.deploy.executePipeline = originalExecutePipeline
       sails.helpers.deploy.ensureBuildContext = originalEnsureBuildContext
@@ -160,7 +175,7 @@ test(
 
 async function waitFor(predicate, timeout = 2000) {
   const deadline = Date.now() + timeout
-  while (!predicate()) {
+  while (!(await predicate())) {
     if (Date.now() >= deadline) throw new Error('Timed out waiting for state.')
     await new Promise((resolve) => setTimeout(resolve, 10))
   }

--- a/tests/unit/helpers/deploy/deployment-coordinator.test.js
+++ b/tests/unit/helpers/deploy/deployment-coordinator.test.js
@@ -1,0 +1,427 @@
+const { test } = require('sounding')
+
+function deploymentWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: { slug }
+    }
+  }
+}
+
+test(
+  'two deployments for the same app run one at a time in queue order',
+  { world: deploymentWorld('serialized-deployments') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const originalExecutePipeline = sails.helpers.deploy.executePipeline
+    const pipelineCalls = []
+    let releaseFirst
+    const firstPipelineCanFinish = new Promise((resolve) => {
+      releaseFirst = resolve
+    })
+
+    sails.helpers.deploy.executePipeline = {
+      with: async ({ deploymentId, leaseToken }) => {
+        pipelineCalls.push(deploymentId)
+        const stage = await sails.helpers.deploy.recordDeploymentStage.with({
+          deploymentId,
+          leaseToken,
+          stage: 'image_build'
+        })
+        expect(stage.valid).toBe(true)
+        const building =
+          await sails.helpers.deploy.updateDeploymentForLease.with({
+            deploymentId,
+            leaseToken,
+            values: { status: 'building' }
+          })
+        expect(building.valid).toBe(true)
+        if (pipelineCalls.length === 1) await firstPipelineCanFinish
+        const running =
+          await sails.helpers.deploy.updateDeploymentForLease.with({
+            deploymentId,
+            leaseToken,
+            values: { status: 'running', finishedAt: Date.now() }
+          })
+        expect(running.valid).toBe(true)
+      }
+    }
+
+    try {
+      const values = {
+        triggerType: 'api',
+        environment: current.environments.production.id
+      }
+      const queued = await Promise.all([
+        sails.helpers.deploy.queueDeployment.with({
+          values: { ...values },
+          app: current.apps.web,
+          dispatch: false
+        }),
+        sails.helpers.deploy.queueDeployment.with({
+          values: { ...values },
+          app: current.apps.web,
+          dispatch: false
+        })
+      ])
+      const jobsInOrder = await sails.models.deploymentjob
+        .find({ id: { in: queued.map(({ job }) => job.id) } })
+        .sort(['createdAt ASC', 'id ASC'])
+      const first = queued.find(({ job }) => job.id === jobsInOrder[0].id)
+      const second = queued.find(({ job }) => job.id === jobsInOrder[1].id)
+
+      expect(queued.map((item) => item.queuePosition).sort()).toEqual([1, 2])
+
+      const drain = sails.helpers.deploy.runQueuedDeployments
+        .with({ targetKey: first.job.targetKey })
+        .then((result) => result)
+
+      await waitFor(() => pipelineCalls.length === 1)
+
+      const queuedSecond = await sails.models.deploymentjob.findOne({
+        deployment: second.deployment.id
+      })
+      const activeLease = await sails.models.deploymentlease.findOne({
+        targetKey: first.job.targetKey
+      })
+      expect(queuedSecond.stage).toBe('queued')
+      expect(activeLease.deployment).toBe(first.deployment.id)
+
+      releaseFirst()
+      await drain
+
+      expect(pipelineCalls).toEqual([first.deployment.id, second.deployment.id])
+      const completedJobs = await sails.models.deploymentjob.find({
+        deployment: { in: [first.deployment.id, second.deployment.id] }
+      })
+      expect(completedJobs.every((job) => job.stage === 'complete')).toBe(true)
+      expect(
+        await sails.models.deploymentlease.count({
+          targetKey: first.job.targetKey
+        })
+      ).toBe(0)
+    } finally {
+      releaseFirst()
+      sails.helpers.deploy.executePipeline = originalExecutePipeline
+    }
+  }
+)
+
+test(
+  'coordinator preflight failures become visible terminal deployments',
+  { world: deploymentWorld('coordinator-preflight-failure') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const queued = await sails.helpers.deploy.queueDeployment.with({
+      values: {
+        triggerType: 'manual',
+        environment: current.environments.production.id
+      },
+      app: current.apps.web,
+      kind: 'rollback',
+      targetDeploymentId: 999999,
+      dispatch: false
+    })
+
+    await sails.helpers.deploy.runQueuedDeployments.with({
+      targetKey: queued.job.targetKey
+    })
+
+    const [deployment, job, leaseCount] = await Promise.all([
+      sails.models.deployment.findOne({ id: queued.deployment.id }),
+      sails.models.deploymentjob.findOne({ id: queued.job.id }),
+      sails.models.deploymentlease.count({ targetKey: queued.job.targetKey })
+    ])
+
+    expect(deployment.status).toBe('failed')
+    expect(deployment.errorMessage).toContain('is unavailable')
+    expect(job.stage).toBe('failed')
+    expect(leaseCount).toBe(0)
+  }
+)
+
+test(
+  'restart before App commit restores the old route and removes the candidate',
+  { world: deploymentWorld('recover-before-cutover') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      imageName: 'slipway/recover-before:2'
+    })
+    const targetKey = `environment:${current.environments.production.id}`
+    const job = await world.create('deploymentjob').with({
+      deployment: deployment.id,
+      targetKey,
+      stage: 'traffic_cutover',
+      candidateContainerName: 'candidate-before',
+      previousContainerName: 'stable-before',
+      imageName: deployment.imageName,
+      hostPort: 1441
+    })
+    await world.create('deploymentlease').with({
+      deployment: deployment.id,
+      targetKey,
+      token: `stale-before-${deployment.id}`,
+      expiresAt: Date.now() - 1000
+    })
+
+    const doubles = installRecoveryDoubles(sails)
+    try {
+      const result = await sails.helpers.deploy.reconcileDeployments()
+
+      expect(result.recovered).toEqual([
+        { deploymentId: deployment.id, action: 'rolled_back' }
+      ])
+      const recoveredDeployment = await sails.models.deployment.findOne({
+        id: deployment.id
+      })
+      const recoveredJob = await sails.models.deploymentjob.findOne({
+        id: job.id
+      })
+      expect(recoveredDeployment.status).toBe('failed')
+      expect(recoveredJob.stage).toBe('failed')
+      expect(doubles.stopped).toEqual(['candidate-before'])
+      expect(doubles.routes).toEqual([current.environments.production.id])
+      expect(doubles.routeCleanups).toEqual(['before-repair', 'after-repair'])
+      expect(doubles.removedImages).toEqual([deployment.imageName])
+    } finally {
+      doubles.restore()
+    }
+  }
+)
+
+test(
+  'restart after App commit finalizes the candidate and retires the old release',
+  { world: deploymentWorld('recover-after-cutover') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const previous = await world.create('deployment').with({
+      status: 'running',
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      imageName: 'slipway/recover-after:1'
+    })
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      imageName: 'slipway/recover-after:2'
+    })
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'candidate-after',
+      currentDeployment: deployment.id,
+      hostPort: 1442
+    })
+
+    const targetKey = `environment:${current.environments.production.id}`
+    const job = await world.create('deploymentjob').with({
+      deployment: deployment.id,
+      targetKey,
+      stage: 'traffic_cutover',
+      candidateContainerName: 'candidate-after',
+      previousContainerName: 'stable-after',
+      imageName: deployment.imageName,
+      hostPort: 1442
+    })
+    await world.create('deploymentlease').with({
+      deployment: deployment.id,
+      targetKey,
+      token: `stale-after-${deployment.id}`,
+      expiresAt: Date.now() - 1000
+    })
+
+    const doubles = installRecoveryDoubles(sails)
+    try {
+      const result = await sails.helpers.deploy.reconcileDeployments()
+
+      expect(result.recovered).toEqual([
+        { deploymentId: deployment.id, action: 'finalized' }
+      ])
+      const [recoveredDeployment, recoveredJob, previousDeployment] =
+        await Promise.all([
+          sails.models.deployment.findOne({ id: deployment.id }),
+          sails.models.deploymentjob.findOne({ id: job.id }),
+          sails.models.deployment.findOne({ id: previous.id })
+        ])
+      expect(recoveredDeployment.status).toBe('running')
+      expect(recoveredJob.stage).toBe('complete')
+      expect(previousDeployment.status).toBe('stopped')
+      expect(doubles.stopped).toEqual(['stable-after'])
+      expect(doubles.removedImages).toEqual([])
+      expect(doubles.routes).toEqual([current.environments.production.id])
+      expect(doubles.routeCleanups).toEqual(['after-repair'])
+    } finally {
+      doubles.restore()
+    }
+  }
+)
+
+test(
+  'a worker that loses its lease rolls back a staged route before App commit',
+  { world: deploymentWorld('fenced-cutover') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const previous = await world.create('deployment').with({
+      status: 'running',
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      imageName: 'slipway/fenced:1'
+    })
+    const app = await sails.models.app
+      .updateOne({ id: current.apps.web.id })
+      .set({
+        status: 'running',
+        containerName: 'stable-fenced',
+        imageName: previous.imageName,
+        port: 1337,
+        hostPort: 1443,
+        currentDeployment: previous.id
+      })
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      environment: current.environments.production.id,
+      app: app.id,
+      imageName: 'slipway/fenced:2'
+    })
+    const targetKey = `environment:${current.environments.production.id}`
+    const token = `fenced-${deployment.id}`
+    await world.create('deploymentlease').with({
+      deployment: deployment.id,
+      targetKey,
+      token,
+      heartbeatAt: Date.now(),
+      expiresAt: Date.now() + 30_000
+    })
+
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const originalFinishRouteUpdate = sails.helpers.caddy.finishRouteUpdate
+    const originalAssertLease = sails.helpers.deploy.assertDeploymentLease
+    const finishActions = []
+    let leaseChecks = 0
+    sails.helpers.deploy.assertDeploymentLease = {
+      with: async () => {
+        leaseChecks += 1
+        return leaseChecks === 1
+          ? { valid: true }
+          : {
+              valid: false,
+              code: 'DEPLOYMENT_LEASE_LOST',
+              message: `Deployment ${deployment.id} no longer owns its pipeline lease.`
+            }
+      }
+    }
+    sails.helpers.caddy.updateRoute = {
+      with: async () => ({
+        action: 'replaced',
+        transaction: {
+          routeId: 'fenced-route',
+          candidateRouteId: 'fenced-route-candidate',
+          previousRouteId: 'fenced-route-previous'
+        }
+      })
+    }
+    sails.helpers.caddy.finishRouteUpdate = {
+      with: async ({ action }) => finishActions.push(action)
+    }
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.cutoverTraffic.with({
+          deploymentId: deployment.id,
+          leaseToken: token,
+          environmentId: current.environments.production.id,
+          appId: app.id,
+          candidate: {
+            containerId: 'candidate-fenced-id',
+            containerName: 'candidate-fenced',
+            imageName: deployment.imageName,
+            port: 1337,
+            hostPort: 1444,
+            slug: app.slug,
+            name: app.name,
+            routePath: app.routePath,
+            healthPath: app.healthPath,
+            isDefault: app.isDefault
+          }
+        })
+      )
+      const persistedApp = await sails.models.app.findOne({ id: app.id })
+
+      expect(Boolean(error)).toBe(true)
+      expect(leaseChecks).toBe(2)
+      expect(finishActions).toEqual(['rollback'])
+      expect(persistedApp.containerName).toBe('stable-fenced')
+      expect(persistedApp.currentDeployment).toBe(previous.id)
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+      sails.helpers.caddy.finishRouteUpdate = originalFinishRouteUpdate
+      sails.helpers.deploy.assertDeploymentLease = originalAssertLease
+    }
+  }
+)
+
+function installRecoveryDoubles(sails) {
+  const originals = {
+    updateRoute: sails.helpers.caddy.updateRoute,
+    stopContainer: sails.helpers.docker.stopContainer,
+    releasePort: sails.helpers.docker.releasePort,
+    removeImage: sails.helpers.docker.removeImage,
+    cleanupRouteTransaction: sails.helpers.caddy.cleanupRouteTransaction
+  }
+  const routes = []
+  const stopped = []
+  const removedImages = []
+  const routeCleanups = []
+
+  sails.helpers.caddy.updateRoute = {
+    with: async ({ environmentId }) => routes.push(environmentId)
+  }
+  sails.helpers.caddy.cleanupRouteTransaction = {
+    with: async ({ phase }) => routeCleanups.push(phase)
+  }
+  sails.helpers.docker.stopContainer = {
+    with: async ({ containerName }) => stopped.push(containerName)
+  }
+  sails.helpers.docker.releasePort = { with: async () => ({ released: 1 }) }
+  sails.helpers.docker.removeImage = {
+    with: async ({ imageName }) => removedImages.push(imageName)
+  }
+
+  return {
+    routes,
+    stopped,
+    removedImages,
+    routeCleanups,
+    restore() {
+      sails.helpers.caddy.updateRoute = originals.updateRoute
+      sails.helpers.caddy.cleanupRouteTransaction =
+        originals.cleanupRouteTransaction
+      sails.helpers.docker.stopContainer = originals.stopContainer
+      sails.helpers.docker.releasePort = originals.releasePort
+      sails.helpers.docker.removeImage = originals.removeImage
+    }
+  }
+}
+
+async function waitFor(predicate, timeout = 2000) {
+  const deadline = Date.now() + timeout
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for state.')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}


### PR DESCRIPTION
## Summary
- serialize deployment and rollback work with durable environment queues and renewable fenced leases
- recover interrupted builds, containers, ports, images, and Caddy cutovers on startup and through the Quest watchdog
- preserve the existing deployment UI while ordering Building, Running, and Queued releases correctly and exposing queue position and preflight errors
- route every manual, webhook, preview, content, and rollback trigger through the same coordinator

## Verification
- 85 unit tests
- 23 functional tests
- 10 end-to-end browser tests
- Prettier and diff checks

Closes #233