### PR TITLE
fix(backup): stream database transfers safely

### DIFF
--- a/api/controllers/api/v1/dock/import-sql.js
+++ b/api/controllers/api/v1/dock/import-sql.js
@@ -1,4 +1,4 @@
-const fs = require('fs')
+const fs = require('node:fs/promises')
 
 module.exports = {
   friendlyName: 'Import SQL',
@@ -79,33 +79,22 @@ module.exports = {
     const { service } = dbResult
 
     // Check for binary dump file upload
+    const maxImportBytes =
+      sails.config.custom.databaseOperations.sqlImportMaxBytes
     const uploadedFiles = await new Promise((resolve, reject) => {
       this.req
         .file('dump')
-        .upload({ maxBytes: 500 * 1024 * 1024 }, (err, files) => {
+        .upload({ maxBytes: maxImportBytes }, (err, files) => {
           if (err) reject(err)
           else resolve(files)
         })
     })
 
     if (uploadedFiles.length > 0) {
-      // Binary dump import
-      const dumpBuffer = fs.readFileSync(uploadedFiles[0].fd)
-      // Clean up temp file
-      try {
-        fs.unlinkSync(uploadedFiles[0].fd)
-      } catch {
-        /* ignore */
-      }
-
-      if (dumpBuffer.length === 0) {
-        throw { badRequest: 'Uploaded dump file is empty.' }
-      }
-
       try {
         const result = await sails.helpers.dock.importSql.with({
           service,
-          dump: dumpBuffer
+          dumpPath: uploadedFiles[0].fd
         })
         sails.log.info(
           `[dock] Binary dump restored into ${project.slug}/${environmentSlug} by ${user.fullName}`
@@ -116,6 +105,14 @@ module.exports = {
           return { success: false, error: error.importFailed.message }
         }
         throw error
+      } finally {
+        try {
+          await fs.rm(uploadedFiles[0].fd, { force: true })
+        } catch (error) {
+          sails.log.warn(
+            `[dock] Could not remove temporary import file: ${error.message}`
+          )
+        }
       }
     }
 

--- a/api/helpers/backup/delete-backup-object.js
+++ b/api/helpers/backup/delete-backup-object.js
@@ -1,3 +1,5 @@
+const createBackupStorageAdapter = require('../../lib/backup-storage-adapter')
+
 module.exports = {
   friendlyName: 'Delete S3 object',
 
@@ -11,55 +13,12 @@ module.exports = {
   },
 
   fn: async function ({ s3Key }) {
-    let globalEnvVars = {}
-    try {
-      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
-      globalEnvVars = JSON.parse(globalJson)
-    } catch {
-      /* ignore */
-    }
-
-    const uploadsConfig = {
-      key:
-        globalEnvVars.R2_ACCESS_KEY ||
-        globalEnvVars.S3_ACCESS_KEY ||
-        globalEnvVars.SPACES_ACCESS_KEY ||
-        (sails.config.uploads || {}).key,
-      secret:
-        globalEnvVars.R2_SECRET_KEY ||
-        globalEnvVars.S3_SECRET_KEY ||
-        globalEnvVars.SPACES_SECRET_KEY ||
-        (sails.config.uploads || {}).secret,
-      bucket:
-        globalEnvVars.R2_BUCKET ||
-        globalEnvVars.S3_BUCKET ||
-        globalEnvVars.SPACES_BUCKET ||
-        (sails.config.uploads || {}).bucket,
-      endpoint:
-        globalEnvVars.R2_ENDPOINT ||
-        globalEnvVars.S3_ENDPOINT ||
-        globalEnvVars.SPACES_ENDPOINT ||
-        (sails.config.uploads || {}).endpoint,
-      region:
-        globalEnvVars.S3_REGION ||
-        globalEnvVars.SPACES_REGION ||
-        (sails.config.uploads || {}).region
-    }
-
-    const skipperS3 = require('skipper-s3')
-    const adapterOpts = {
-      key: uploadsConfig.key,
-      secret: uploadsConfig.secret,
-      bucket: uploadsConfig.bucket,
-      s3ForcePathStyle: true
-    }
-    if (uploadsConfig.endpoint) adapterOpts.endpoint = uploadsConfig.endpoint
-    if (uploadsConfig.region) adapterOpts.region = uploadsConfig.region
-    const adapter = skipperS3(adapterOpts)
+    const storageConfig = await sails.helpers.backup.getStorageConfig()
+    const adapter = createBackupStorageAdapter(storageConfig)
 
     await new Promise((resolve, reject) => {
-      adapter.rm(s3Key, (err) => {
-        if (err) return reject(err)
+      adapter.rm(s3Key, (error) => {
+        if (error) return reject(error)
         resolve()
       })
     })

--- a/api/helpers/backup/download-object.js
+++ b/api/helpers/backup/download-object.js
@@ -1,0 +1,70 @@
+const fs = require('node:fs')
+
+const createBackupStorageAdapter = require('../../lib/backup-storage-adapter')
+
+module.exports = {
+  friendlyName: 'Download backup object',
+
+  description:
+    'Stream an S3-compatible backup object to disk with a byte limit.',
+
+  inputs: {
+    s3Key: {
+      type: 'string',
+      required: true
+    },
+    destinationPath: {
+      type: 'string',
+      required: true
+    },
+    storageConfig: {
+      type: 'ref',
+      required: true
+    },
+    maxBytes: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal.'
+    },
+    timeoutMs: {
+      type: 'number',
+      required: true,
+      min: 1
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    s3Key,
+    destinationPath,
+    storageConfig,
+    maxBytes,
+    signal,
+    timeoutMs
+  }) {
+    const adapter = createBackupStorageAdapter(storageConfig)
+
+    try {
+      return await sails.helpers.streams.copy.with({
+        input: adapter.read(s3Key),
+        output: fs.createWriteStream(destinationPath, { flags: 'wx' }),
+        maxBytes,
+        label: 'Downloaded backup',
+        signal,
+        timeoutMs
+      })
+    } catch (error) {
+      error.message = `Backup download failed: ${error.message}`
+      throw error
+    }
+  }
+}

--- a/api/helpers/backup/get-storage-config.js
+++ b/api/helpers/backup/get-storage-config.js
@@ -1,0 +1,60 @@
+module.exports = {
+  friendlyName: 'Get backup storage config',
+
+  description:
+    'Resolve the configured S3-compatible backup storage credentials.',
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function () {
+    let globalEnvVars = {}
+
+    try {
+      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
+      const parsed = JSON.parse(globalJson)
+      if (parsed && typeof parsed === 'object') globalEnvVars = parsed
+    } catch {
+      // A malformed optional setting must not hide valid config/uploads values.
+    }
+
+    const uploads = sails.config.uploads || {}
+    const config = {
+      key:
+        globalEnvVars.R2_ACCESS_KEY ||
+        globalEnvVars.S3_ACCESS_KEY ||
+        globalEnvVars.SPACES_ACCESS_KEY ||
+        uploads.key,
+      secret:
+        globalEnvVars.R2_SECRET_KEY ||
+        globalEnvVars.S3_SECRET_KEY ||
+        globalEnvVars.SPACES_SECRET_KEY ||
+        uploads.secret,
+      bucket:
+        globalEnvVars.R2_BUCKET ||
+        globalEnvVars.S3_BUCKET ||
+        globalEnvVars.SPACES_BUCKET ||
+        uploads.bucket,
+      endpoint:
+        globalEnvVars.R2_ENDPOINT ||
+        globalEnvVars.S3_ENDPOINT ||
+        globalEnvVars.SPACES_ENDPOINT ||
+        uploads.endpoint,
+      region:
+        globalEnvVars.S3_REGION || globalEnvVars.SPACES_REGION || uploads.region
+    }
+
+    if (!config.key || !config.secret || !config.bucket) {
+      const error = new Error(
+        'Backup storage not configured. Go to Settings > Global Environment and set the credentials, bucket, and endpoint for R2, S3, or Spaces.'
+      )
+      error.code = 'BACKUP_STORAGE_NOT_CONFIGURED'
+      throw error
+    }
+
+    return config
+  }
+}

--- a/api/helpers/backup/restore-backup.js
+++ b/api/helpers/backup/restore-backup.js
@@ -1,18 +1,24 @@
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
-const { spawn } = require('child_process')
+const fs = require('node:fs')
+const fsPromises = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+
+const verifyDatabaseDump = require('../../lib/verify-database-dump')
 
 module.exports = {
   friendlyName: 'Restore backup',
 
   description:
-    'Download a backup from S3 and restore it into the database service.',
+    'Download a backup and stream it into a database after a verified safety snapshot.',
 
   inputs: {
     backupId: {
       type: 'string',
       required: true
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal.'
     }
   },
 
@@ -22,183 +28,78 @@ module.exports = {
     }
   },
 
-  fn: async function ({ backupId }) {
+  fn: async function ({ backupId, signal }) {
     const backup = await Backup.findOne({ id: backupId })
     if (!backup || !backup.service) {
       throw new Error('Backup or service not found')
     }
 
-    if (!backup.s3Key) {
-      throw new Error('Backup has no S3 key — cannot restore')
+    if (backup.status !== 'completed' || !backup.s3Key) {
+      throw new Error(
+        'Only a completed backup with a storage key can be restored'
+      )
     }
 
     const service = await Service.findOne({ id: backup.service }).decrypt()
+    if (!service) throw new Error('Backup service not found')
 
-    // Create a safety snapshot before restoring so the current state is recoverable
-    try {
-      sails.log.info(
-        `Creating pre-restore snapshot for service ${service.name}`
-      )
-      const snapshot = await Backup.create({
-        status: 'pending',
-        type: 'manual',
-        service: service.id
-      }).fetch()
-      await sails.helpers.backup.runBackup(snapshot.id)
-      sails.log.info(`Pre-restore snapshot completed: ${snapshot.id}`)
-    } catch (err) {
-      sails.log.warn(
-        `Pre-restore snapshot failed (proceeding with restore): ${err.message}`
-      )
+    const storageConfig = await sails.helpers.backup.getStorageConfig()
+    const limits = sails.config.custom.databaseOperations
+    const restoreArgs = getRestoreArgs(service)
+    const capacityInputs = {
+      directory: os.tmpdir(),
+      maxBytes: limits.restoreMaxBytes,
+      reserveBytes: limits.minFreeDiskBytes
     }
+    if (backup.sizeBytes) capacityInputs.expectedBytes = backup.sizeBytes
 
-    // Read S3 config (same pattern as run-backup.js)
-    let globalEnvVars = {}
-    try {
-      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
-      globalEnvVars = JSON.parse(globalJson)
-    } catch {
-      /* ignore */
-    }
+    const capacity = await sails.helpers.streams.getDiskCapacity.with(
+      capacityInputs
+    )
+    await createVerifiedSafetySnapshot({ service, signal })
 
-    const uploadsConfig = {
-      key:
-        globalEnvVars.R2_ACCESS_KEY ||
-        globalEnvVars.S3_ACCESS_KEY ||
-        globalEnvVars.SPACES_ACCESS_KEY ||
-        (sails.config.uploads || {}).key,
-      secret:
-        globalEnvVars.R2_SECRET_KEY ||
-        globalEnvVars.S3_SECRET_KEY ||
-        globalEnvVars.SPACES_SECRET_KEY ||
-        (sails.config.uploads || {}).secret,
-      bucket:
-        globalEnvVars.R2_BUCKET ||
-        globalEnvVars.S3_BUCKET ||
-        globalEnvVars.SPACES_BUCKET ||
-        (sails.config.uploads || {}).bucket,
-      endpoint:
-        globalEnvVars.R2_ENDPOINT ||
-        globalEnvVars.S3_ENDPOINT ||
-        globalEnvVars.SPACES_ENDPOINT ||
-        (sails.config.uploads || {}).endpoint,
-      region:
-        globalEnvVars.S3_REGION ||
-        globalEnvVars.SPACES_REGION ||
-        (sails.config.uploads || {}).region
-    }
-
-    if (!uploadsConfig.key || !uploadsConfig.secret || !uploadsConfig.bucket) {
-      throw new Error('Backup storage not configured')
-    }
-
-    const ext =
-      { postgresql: 'dmp', mysql: 'sql', mongodb: 'gz' }[service.type] || 'sql'
-    const tmpFile = path.join(os.tmpdir(), `slipway-restore-${backupId}.${ext}`)
+    const extension = getExtension(service.type)
+    const tmpDirectory = await fsPromises.mkdtemp(
+      path.join(os.tmpdir(), 'slipway-restore-')
+    )
+    const tmpFile = path.join(tmpDirectory, `database.${extension}`)
 
     try {
-      // 1. Download from S3 using skipper-s3's read() method
       sails.log.info(
         `Restoring backup ${backupId}: downloading ${backup.s3Key}`
       )
-
-      const skipperS3 = require('skipper-s3')
-      const adapterOpts = {
-        key: uploadsConfig.key,
-        secret: uploadsConfig.secret,
-        bucket: uploadsConfig.bucket,
-        s3ForcePathStyle: true
-      }
-      if (uploadsConfig.endpoint) adapterOpts.endpoint = uploadsConfig.endpoint
-      if (uploadsConfig.region) adapterOpts.region = uploadsConfig.region
-      const adapter = skipperS3(adapterOpts)
-
-      await new Promise((resolve, reject) => {
-        const readable = adapter.read(backup.s3Key)
-        const writable = fs.createWriteStream(tmpFile)
-
-        readable.on('error', (err) =>
-          reject(new Error(`S3 download failed: ${err.message}`))
-        )
-        writable.on('error', (err) =>
-          reject(new Error(`File write failed: ${err.message}`))
-        )
-        writable.on('finish', resolve)
-
-        readable.pipe(writable)
+      const transfer = await sails.helpers.backup.downloadObject.with({
+        s3Key: backup.s3Key,
+        destinationPath: tmpFile,
+        storageConfig,
+        maxBytes: capacity.allowedBytes,
+        signal,
+        timeoutMs: limits.restoreTimeoutMs
       })
 
-      const stats = fs.statSync(tmpFile)
-      if (stats.size === 0) {
+      if (transfer.bytes === 0) {
         throw new Error('Downloaded backup file is empty')
       }
-
-      sails.log.info(`Backup downloaded: ${stats.size} bytes`)
-
-      // 2. Restore into database container
-      const dockerPath = sails.config.docker?.binaryPath || 'docker'
-      const fileContent = fs.readFileSync(tmpFile)
-
-      if (service.type === 'mongodb') {
-        // MongoDB: pipe gzip archive through mongorestore via docker exec
-        const mongoUri = `mongodb://${service.username}:${service.password}@localhost:27017/${service.database}?authSource=admin`
-        await execRestore(
-          dockerPath,
-          [
-            'exec',
-            '-i',
-            service.containerName,
-            'mongorestore',
-            '--uri',
-            mongoUri,
-            '--archive',
-            '--gzip',
-            '--drop'
-          ],
-          fileContent
-        )
-      } else if (service.type === 'postgresql') {
-        // PostgreSQL: pipe custom-format dump through pg_restore
-        await execRestore(
-          dockerPath,
-          [
-            'exec',
-            '-i',
-            '-e',
-            `PGPASSWORD=${service.password}`,
-            service.containerName,
-            'pg_restore',
-            '-U',
-            service.username,
-            '-d',
-            service.database,
-            '--no-owner',
-            '--clean',
-            '--if-exists'
-          ],
-          fileContent
-        )
-      } else if (service.type === 'mysql') {
-        // MySQL: pipe SQL through mysql
-        await execRestore(
-          dockerPath,
-          [
-            'exec',
-            '-i',
-            service.containerName,
-            'mysql',
-            '-u',
-            service.username,
-            `-p${service.password}`,
-            service.database
-          ],
-          fileContent
-        )
-      } else {
+      if (backup.sizeBytes && transfer.bytes !== backup.sizeBytes) {
         throw new Error(
-          `Restore not supported for service type: ${service.type}`
+          `Downloaded backup size does not match its recorded size (${transfer.bytes} of ${backup.sizeBytes} bytes).`
         )
       }
+
+      await verifyDatabaseDump(tmpFile, service.type)
+      sails.log.info(`Backup downloaded: ${transfer.bytes} bytes`)
+
+      await sails.helpers.streams.runProcess.with({
+        command: sails.config.docker?.binaryPath || 'docker',
+        args: restoreArgs,
+        input: fs.createReadStream(tmpFile),
+        timeoutMs: limits.restoreTimeoutMs,
+        maxInputBytes: limits.restoreMaxBytes,
+        maxOutputBytes: limits.maxProcessOutputBytes,
+        maxStderrBytes: limits.maxProcessStderrBytes,
+        signal,
+        killGraceMs: limits.killGraceMs
+      })
 
       sails.log.info(
         `Backup ${backupId} restored successfully to ${service.containerName}`
@@ -206,41 +107,112 @@ module.exports = {
 
       return { success: true, backupId, serviceName: service.name }
     } finally {
-      // Clean up temp file
       try {
-        fs.unlinkSync(tmpFile)
-      } catch {
-        /* ignore */
+        await fsPromises.rm(tmpDirectory, { recursive: true, force: true })
+      } catch (error) {
+        sails.log.warn(
+          `Could not remove restore temporary directory: ${error.message}`
+        )
       }
     }
   }
 }
 
-/**
- * Execute a docker restore command, piping file content to stdin.
- */
-function execRestore(dockerPath, args, inputBuffer) {
-  return new Promise((resolve, reject) => {
-    const proc = spawn(dockerPath, args, { timeout: 300000 })
+async function createVerifiedSafetySnapshot({ service, signal }) {
+  sails.log.info(`Creating pre-restore snapshot for service ${service.name}`)
 
-    let stderr = ''
-    proc.stderr.on('data', (data) => {
-      stderr += data.toString()
+  let snapshot
+  try {
+    snapshot = await Backup.create({
+      status: 'pending',
+      type: 'manual',
+      service: service.id
+    }).fetch()
+
+    await sails.helpers.backup.runBackup.with({
+      backupId: snapshot.id,
+      signal
     })
+  } catch (cause) {
+    throw createSafetySnapshotError(cause.message, snapshot?.id, cause)
+  }
 
-    proc.on('close', (code) => {
-      if (code !== 0) {
-        reject(new Error(`Restore failed (exit ${code}): ${stderr.trim()}`))
-      } else {
-        resolve()
-      }
-    })
+  const verified = await Backup.findOne({ id: snapshot.id })
+  if (
+    verified?.status !== 'completed' ||
+    !verified.s3Key ||
+    !verified.sizeBytes
+  ) {
+    const reason = verified?.errorMessage || 'snapshot was not verified'
+    throw createSafetySnapshotError(reason, snapshot.id)
+  }
 
-    proc.on('error', (err) => {
-      reject(new Error(`Restore process error: ${err.message}`))
-    })
+  sails.log.info(`Pre-restore snapshot verified: ${snapshot.id}`)
+  return verified
+}
 
-    proc.stdin.write(inputBuffer)
-    proc.stdin.end()
-  })
+function createSafetySnapshotError(reason, snapshotId, cause) {
+  const error = new Error(
+    `Restore stopped because the pre-restore safety snapshot failed: ${reason}`,
+    cause ? { cause } : undefined
+  )
+  error.code = 'SAFETY_SNAPSHOT_FAILED'
+  if (snapshotId) error.snapshotId = snapshotId
+  return error
+}
+
+function getRestoreArgs(service) {
+  if (service.type === 'mongodb') {
+    const mongoUri = `mongodb://${service.username}:${service.password}@localhost:27017/${service.database}?authSource=admin`
+    return [
+      'exec',
+      '-i',
+      service.containerName,
+      'mongorestore',
+      '--uri',
+      mongoUri,
+      '--archive',
+      '--gzip',
+      '--drop'
+    ]
+  }
+
+  if (service.type === 'postgresql') {
+    return [
+      'exec',
+      '-i',
+      '-e',
+      `PGPASSWORD=${service.password}`,
+      service.containerName,
+      'pg_restore',
+      '-U',
+      service.username,
+      '-d',
+      service.database,
+      '--no-owner',
+      '--clean',
+      '--if-exists'
+    ]
+  }
+
+  if (service.type === 'mysql') {
+    return [
+      'exec',
+      '-i',
+      service.containerName,
+      'mysql',
+      '-u',
+      service.username,
+      `-p${service.password}`,
+      service.database
+    ]
+  }
+
+  throw new Error(`Restore not supported for service type: ${service.type}`)
+}
+
+function getExtension(serviceType) {
+  return (
+    { postgresql: 'dmp', mysql: 'sql', mongodb: 'gz' }[serviceType] || 'sql'
+  )
 }

--- a/api/helpers/backup/run-backup.js
+++ b/api/helpers/backup/run-backup.js
@@ -1,7 +1,9 @@
-const { execFile } = require('child_process')
-const fs = require('fs')
-const path = require('path')
-const os = require('os')
+const fs = require('node:fs')
+const fsPromises = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+
+const verifyDatabaseDump = require('../../lib/verify-database-dump')
 
 module.exports = {
   friendlyName: 'Run backup',
@@ -12,6 +14,10 @@ module.exports = {
     backupId: {
       type: 'string',
       required: true
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal.'
     }
   },
 
@@ -21,223 +27,151 @@ module.exports = {
     }
   },
 
-  fn: async function ({ backupId }) {
+  fn: async function ({ backupId, signal }) {
     const backup = await Backup.findOne({ id: backupId })
     if (!backup || !backup.service) {
       throw new Error('Backup or service not found')
     }
 
-    const service = await Service.findOne({ id: backup.service }).decrypt()
     const startedAt = Date.now()
+    let service
+    let tmpDirectory
+    let s3Key
+    let uploadAttempted = false
 
     await Backup.updateOne({ id: backupId }).set({
       status: 'running',
+      errorMessage: null,
       startedAt
     })
     sails.sse.publish(`backup:${backupId}`, { status: 'running' })
 
-    // Read S3 config from global env vars (stored in Settings), fall back to sails.config.uploads
-    let globalEnvVars = {}
     try {
-      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
-      globalEnvVars = JSON.parse(globalJson)
-    } catch {
-      /* ignore */
-    }
+      service = await Service.findOne({ id: backup.service }).decrypt()
+      if (!service) throw new Error('Backup service not found')
 
-    const uploadsConfig = {
-      key:
-        globalEnvVars.R2_ACCESS_KEY ||
-        globalEnvVars.S3_ACCESS_KEY ||
-        globalEnvVars.SPACES_ACCESS_KEY ||
-        (sails.config.uploads || {}).key,
-      secret:
-        globalEnvVars.R2_SECRET_KEY ||
-        globalEnvVars.S3_SECRET_KEY ||
-        globalEnvVars.SPACES_SECRET_KEY ||
-        (sails.config.uploads || {}).secret,
-      bucket:
-        globalEnvVars.R2_BUCKET ||
-        globalEnvVars.S3_BUCKET ||
-        globalEnvVars.SPACES_BUCKET ||
-        (sails.config.uploads || {}).bucket,
-      endpoint:
-        globalEnvVars.R2_ENDPOINT ||
-        globalEnvVars.S3_ENDPOINT ||
-        globalEnvVars.SPACES_ENDPOINT ||
-        (sails.config.uploads || {}).endpoint,
-      region:
-        globalEnvVars.S3_REGION ||
-        globalEnvVars.SPACES_REGION ||
-        (sails.config.uploads || {}).region
-    }
+      const storageConfig = await sails.helpers.backup.getStorageConfig()
+      const dumpArgs = getDumpArgs(service)
+      if (!dumpArgs) {
+        throw new Error(
+          `Backup not supported for service type: ${service.type}`
+        )
+      }
 
-    if (!uploadsConfig.key || !uploadsConfig.secret || !uploadsConfig.bucket) {
-      await Backup.updateOne({ id: backupId }).set({
-        status: 'failed',
-        errorMessage:
-          'Backup storage not configured. Go to Settings > Global Environment and set R2_ACCESS_KEY, R2_SECRET_KEY, R2_BUCKET, and R2_ENDPOINT.',
-        completedAt: Date.now(),
-        durationMs: Date.now() - startedAt
+      const environment = await Environment.findOne({
+        id: service.environment
+      }).populate('project')
+      if (!environment?.project) {
+        throw new Error('Backup environment or project not found')
+      }
+
+      const extension = getExtension(service.type)
+      const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
+      s3Key = `backups/${environment.project.slug}/${environment.slug}/${service.name}/${timestamp}.${extension}`
+
+      const limits = sails.config.custom.databaseOperations
+      const capacity = await sails.helpers.streams.getDiskCapacity.with({
+        directory: os.tmpdir(),
+        maxBytes: limits.backupMaxBytes,
+        reserveBytes: limits.minFreeDiskBytes
       })
-      sails.sse.publish(`backup:${backupId}`, { status: 'failed' })
-      return backup
-    }
 
-    // Build the dump command args per service type
-    const dumpArgs = getDumpArgs(service)
-    if (!dumpArgs) {
-      await Backup.updateOne({ id: backupId }).set({
-        status: 'failed',
-        errorMessage: `Backup not supported for service type: ${service.type}`,
-        completedAt: Date.now(),
-        durationMs: Date.now() - startedAt
-      })
-      sails.sse.publish(`backup:${backupId}`, { status: 'failed' })
-      return backup
-    }
-
-    // Generate S3 key path
-    const env = await Environment.findOne({ id: service.environment }).populate(
-      'project'
-    )
-    const timestamp = new Date().toISOString().replace(/[:.]/g, '-')
-    const ext =
-      { postgresql: 'dmp', mysql: 'sql', mongodb: 'gz' }[service.type] || 'sql'
-    const s3Key = `backups/${env.project.slug}/${env.slug}/${service.name}/${timestamp}.${ext}`
-
-    // Temp file for the dump
-    const tmpFile = path.join(os.tmpdir(), `slipway-backup-${backupId}.${ext}`)
-
-    try {
-      // Run docker exec to dump database, stream stdout to temp file
+      tmpDirectory = await fsPromises.mkdtemp(
+        path.join(os.tmpdir(), 'slipway-backup-')
+      )
+      const tmpFile = path.join(tmpDirectory, `database.${extension}`)
       const dockerBinary = sails.config.docker?.binaryPath || 'docker'
-      const dockerArgs = ['exec', service.containerName, ...dumpArgs]
 
-      await new Promise((resolve, reject) => {
-        const child = execFile(
-          dockerBinary,
-          dockerArgs,
-          {
-            maxBuffer: 1024 * 1024 * 512,
-            encoding: 'buffer'
-          },
-          (err, stdout, stderr) => {
-            if (err)
-              return reject(
-                new Error(
-                  `Dump failed: ${stderr ? stderr.toString() : err.message}`
-                )
-              )
-            try {
-              fs.writeFileSync(tmpFile, stdout)
-              resolve()
-            } catch (writeErr) {
-              reject(writeErr)
-            }
-          }
-        )
+      await sails.helpers.streams.runProcess.with({
+        command: dockerBinary,
+        args: ['exec', service.containerName, ...dumpArgs],
+        output: fs.createWriteStream(tmpFile, { flags: 'wx' }),
+        timeoutMs: limits.backupTimeoutMs,
+        maxOutputBytes: capacity.allowedBytes,
+        maxStderrBytes: limits.maxProcessStderrBytes,
+        signal,
+        killGraceMs: limits.killGraceMs
       })
 
-      // Get file size
-      const stats = fs.statSync(tmpFile)
-      const sizeBytes = stats.size
+      const stats = await fsPromises.stat(tmpFile)
+      if (stats.size === 0) throw new Error('Dump produced an empty file')
+      await verifyDatabaseDump(tmpFile, service.type)
 
-      if (sizeBytes === 0) {
-        throw new Error('Dump produced an empty file')
-      }
+      uploadAttempted = true
 
-      // Verify dump file integrity by checking format-specific headers
-      const header = Buffer.alloc(5)
-      const fd = fs.openSync(tmpFile, 'r')
-      fs.readSync(fd, header, 0, 5, 0)
-      fs.closeSync(fd)
-      if (
-        service.type === 'postgresql' &&
-        header.toString('ascii', 0, 5) !== 'PGDMP'
-      ) {
-        throw new Error(
-          'PostgreSQL dump has invalid header — expected PGDMP format'
-        )
-      }
-      if (
-        service.type === 'mongodb' &&
-        (header[0] !== 0x1f || header[1] !== 0x8b)
-      ) {
-        throw new Error(
-          'MongoDB dump has invalid header — expected gzip format'
-        )
-      }
-
-      // Upload to S3 via sails-hook-uploads (uses skipper-s3 under the hood)
-      const readStream = fs.createReadStream(tmpFile)
-      readStream.filename = path.basename(s3Key)
-
-      await sails.uploadOne(readStream, {
-        adapter: require('skipper-s3'),
-        key: uploadsConfig.key,
-        secret: uploadsConfig.secret,
-        bucket: uploadsConfig.bucket,
-        endpoint: uploadsConfig.endpoint,
-        region: uploadsConfig.region,
-        s3ForcePathStyle: true,
-        saveAs: s3Key
+      await sails.helpers.backup.uploadObject.with({
+        sourcePath: tmpFile,
+        s3Key,
+        sizeBytes: stats.size,
+        storageConfig,
+        maxBytes: capacity.allowedBytes,
+        timeoutMs: limits.backupTimeoutMs,
+        signal
       })
 
-      // Update backup record
       const completedAt = Date.now()
       await Backup.updateOne({ id: backupId }).set({
         status: 'completed',
         s3Key,
-        sizeBytes,
+        sizeBytes: stats.size,
         completedAt,
         durationMs: completedAt - startedAt
       })
 
       sails.log.info(
-        `Backup completed: ${s3Key} (${formatBytes(sizeBytes)} in ${
+        `Backup completed: ${s3Key} (${formatBytes(stats.size)} in ${
           completedAt - startedAt
         }ms)`
       )
       sails.sse.publish(`backup:${backupId}`, { status: 'completed' })
+    } catch (error) {
+      if (uploadAttempted && s3Key) {
+        try {
+          await sails.helpers.backup.deleteBackupObject(s3Key)
+        } catch (cleanupError) {
+          sails.log.warn(
+            `Could not clean up partial backup ${s3Key}: ${cleanupError.message}`
+          )
+        }
+      }
 
-      // Send backup success notification
-      await sails.helpers.notification.sendBackupNotification
-        .with({
-          backup: await Backup.findOne({ id: backupId }),
-          service
-        })
-        .tolerate('error')
-    } catch (err) {
       const completedAt = Date.now()
       await Backup.updateOne({ id: backupId }).set({
         status: 'failed',
-        errorMessage: err.message,
+        s3Key: null,
+        sizeBytes: null,
+        errorMessage: error.message,
         completedAt,
         durationMs: completedAt - startedAt
       })
       sails.log.error(
-        `Backup failed for service ${service.name}: ${err.message}`
+        `Backup failed for service ${service?.name || backup.service}: ${
+          error.message
+        }`
       )
       sails.sse.publish(`backup:${backupId}`, { status: 'failed' })
-
-      // Send backup failure notification
-      await sails.helpers.notification.sendBackupNotification
-        .with({
-          backup: await Backup.findOne({ id: backupId }),
-          service
-        })
-        .tolerate('error')
     } finally {
-      // Clean up temp file
-      try {
-        fs.unlinkSync(tmpFile)
-      } catch {
-        /* ignore */
+      if (tmpDirectory) {
+        try {
+          await fsPromises.rm(tmpDirectory, { recursive: true, force: true })
+        } catch (error) {
+          sails.log.warn(
+            `Could not remove backup temporary directory: ${error.message}`
+          )
+        }
+      }
+
+      if (service) {
+        await sails.helpers.notification.sendBackupNotification
+          .with({
+            backup: await Backup.findOne({ id: backupId }),
+            service
+          })
+          .tolerate('error')
       }
     }
 
-    return await Backup.findOne({ id: backupId })
+    return Backup.findOne({ id: backupId })
   }
 }
 
@@ -280,8 +214,21 @@ function getDumpArgs(service) {
   }
 }
 
+function getExtension(serviceType) {
+  return (
+    { postgresql: 'dmp', mysql: 'sql', mongodb: 'gz' }[serviceType] || 'sql'
+  )
+}
+
 function formatBytes(bytes) {
-  if (bytes < 1024) return `${bytes} B`
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
 }

--- a/api/helpers/backup/upload-object.js
+++ b/api/helpers/backup/upload-object.js
@@ -1,0 +1,129 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const createBackupStorageAdapter = require('../../lib/backup-storage-adapter')
+
+module.exports = {
+  friendlyName: 'Upload backup object',
+
+  description:
+    'Stream a backup file into S3-compatible storage with bounded size and duration.',
+
+  inputs: {
+    sourcePath: {
+      type: 'string',
+      required: true
+    },
+    s3Key: {
+      type: 'string',
+      required: true
+    },
+    sizeBytes: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    storageConfig: {
+      type: 'ref',
+      required: true
+    },
+    maxBytes: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    timeoutMs: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    sourcePath,
+    s3Key,
+    sizeBytes,
+    storageConfig,
+    maxBytes,
+    timeoutMs,
+    signal
+  }) {
+    if (sizeBytes > maxBytes) {
+      throw new Error(`Backup upload exceeds its ${maxBytes}-byte limit.`)
+    }
+
+    const adapter = createBackupStorageAdapter(storageConfig)
+    const receiver = adapter.receive({
+      dirname: '',
+      saveAs: s3Key,
+      maxBytes,
+      maxBytesPerFile: maxBytes
+    })
+    const input = fs.createReadStream(sourcePath)
+
+    input.skipperFd = s3Key
+    input.filename = path.basename(s3Key)
+    input.headers = { 'content-type': 'application/octet-stream' }
+    input.byteCount = sizeBytes
+
+    return new Promise((resolve, reject) => {
+      let settled = false
+      const finish = (error) => {
+        if (settled) return
+        settled = true
+        clearTimeout(timeout)
+        if (signal) signal.removeEventListener('abort', onAbort)
+
+        if (error) {
+          error.message = `Backup upload failed: ${error.message}`
+          reject(error)
+        } else {
+          resolve({ bytes: sizeBytes })
+        }
+      }
+      const stop = (error) => {
+        input.destroy()
+        receiver.destroy()
+        finish(error)
+      }
+      const onAbort = () => {
+        const error = new Error('Backup upload was cancelled.')
+        error.code = 'STREAM_ABORTED'
+        stop(error)
+      }
+      const timeout = setTimeout(() => {
+        const error = new Error(`Backup upload timed out after ${timeoutMs}ms.`)
+        error.code = 'STREAM_TIMEOUT'
+        stop(error)
+      }, timeoutMs)
+      timeout.unref()
+
+      receiver.once('error', (error) => {
+        input.destroy()
+        finish(error)
+      })
+      receiver.once('finish', () => finish())
+      input.once('error', (error) => {
+        receiver.destroy()
+        finish(error)
+      })
+
+      if (signal) {
+        if (signal.aborted) return onAbort()
+        signal.addEventListener('abort', onAbort, { once: true })
+      }
+
+      receiver.end(input)
+    })
+  }
+}

--- a/api/helpers/dock/import-sql.js
+++ b/api/helpers/dock/import-sql.js
@@ -1,273 +1,225 @@
-const { execFile } = require('child_process')
-const util = require('util')
-const execFileAsync = util.promisify(execFile)
+const fs = require('node:fs')
+const fsPromises = require('node:fs/promises')
+const { Readable } = require('node:stream')
+
+const verifyDatabaseDump = require('../../lib/verify-database-dump')
 
 module.exports = {
   friendlyName: 'Import SQL',
 
-  description: 'Import SQL statements into the database.',
+  description: 'Stream SQL statements or a dump file into the database.',
 
   inputs: {
     service: {
       type: 'ref',
       required: true,
-      description: 'Database service object'
+      description: 'Database service object.'
     },
     sql: {
       type: 'string',
-      description: 'SQL statements to import (text mode)'
+      description: 'SQL statements to import in text mode.'
     },
-    dump: {
+    dumpPath: {
+      type: 'string',
+      description: 'Path to a binary dump file.'
+    },
+    signal: {
       type: 'ref',
-      description: 'Binary dump buffer for pg_restore (binary mode)'
+      description: 'Optional AbortSignal.'
     }
   },
 
   exits: {
     success: {
-      description: 'Import completed successfully',
+      description: 'Import completed successfully.',
       outputType: 'ref'
     },
     importFailed: {
-      description: 'Import failed'
+      description: 'Import failed.'
     }
   },
 
-  fn: async function ({ service, sql, dump }) {
-    if (!sql && !dump) {
-      throw new Error('Either sql or dump must be provided')
+  fn: async function ({ service, sql, dumpPath, signal }) {
+    if (!sql && !dumpPath) {
+      throw new Error('Either sql or dumpPath must be provided')
     }
 
-    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const limits = sails.config.custom.databaseOperations
     const startTime = Date.now()
 
-    // Binary dump import (.dmp for PostgreSQL, .gz for MongoDB)
-    if (dump) {
-      const { spawn } = require('child_process')
-      let args
-      let tool
-
-      if (service.type === 'postgresql') {
-        tool = 'pg_restore'
-        args = [
-          'exec',
-          '-i',
-          '-e',
-          `PGPASSWORD=${service.password}`,
-          service.containerName,
-          'pg_restore',
-          '-U',
-          service.username,
-          '-d',
-          service.database,
-          '--no-owner',
-          '--clean',
-          '--if-exists'
-        ]
-      } else if (service.type === 'mongodb') {
-        tool = 'mongorestore'
-        const mongoUri = `mongodb://${service.username}:${service.password}@localhost:27017/${service.database}?authSource=admin`
-        args = [
-          'exec',
-          '-i',
-          service.containerName,
-          'mongorestore',
-          '--uri',
-          mongoUri,
-          '--archive',
-          '--gzip',
-          '--drop'
-        ]
-      } else {
-        throw new Error(
-          `Binary dump import is not supported for ${service.type}`
-        )
-      }
-
-      return new Promise((resolve, reject) => {
-        const proc = spawn(dockerPath, args, { timeout: 300000 })
-        let stderr = ''
-        proc.stderr.on('data', (data) => {
-          stderr += data.toString()
-        })
-        proc.on('close', (code) => {
-          const duration = Date.now() - startTime
-          if (code !== 0) {
-            sails.log.error(
-              `[dock] ${tool} failed with code ${code}: ${stderr}`
-            )
-            reject({
-              importFailed: {
-                message:
-                  stderr.trim() || `${tool} failed with exit code ${code}`
-              }
-            })
-          } else {
-            resolve({
-              success: true,
-              message: 'Dump restored successfully',
-              statementCount: 1,
-              duration
-            })
-          }
-        })
-        proc.on('error', (err) => {
-          reject({ importFailed: { message: err.message } })
-        })
-        proc.stdin.write(dump)
-        proc.stdin.end()
-      })
-    }
-
-    let args
-    let env = { ...process.env }
-
-    if (service.type === 'postgresql') {
-      // PostgreSQL: pipe SQL to psql
-      env.PGPASSWORD = service.password
-
-      args = [
-        'exec',
-        '-i',
-        service.containerName,
-        'psql',
-        '-U',
-        service.username,
-        '-d',
-        service.database,
-        '--no-psqlrc',
-        '-v',
-        'ON_ERROR_STOP=1'
-      ]
-    } else if (service.type === 'mysql') {
-      // MySQL: pipe SQL to mysql
-      args = [
-        'exec',
-        '-i',
-        service.containerName,
-        'mysql',
-        '-u',
-        service.username,
-        `-p${service.password}`,
-        service.database
-      ]
-    } else if (service.type === 'mongodb') {
-      // MongoDB: use mongoimport for JSON or mongorestore for archive
-      const mongoUri = `mongodb://${service.username}:${service.password}@localhost:27017/${service.database}?authSource=admin`
-
-      // Detect if input is JSON array (mongoexport format) or binary (mongodump archive)
-      const trimmedSql = sql.trim()
-      const isJsonArray =
-        trimmedSql.startsWith('[') || trimmedSql.startsWith('{')
-
-      if (isJsonArray) {
-        // JSON import - need collection name from input or default
-        // Look for collection hint in first line comment: // collection: users
-        const collectionMatch = sql.match(/\/\/\s*collection:\s*(\w+)/)
-        const collection = collectionMatch ? collectionMatch[1] : 'imported'
-
-        args = [
-          'exec',
-          '-i',
-          service.containerName,
-          'mongoimport',
-          '--uri',
-          mongoUri,
-          '--collection',
-          collection,
-          '--jsonArray',
-          '--drop' // Replace existing collection
-        ]
-      } else {
-        // Assume mongodump archive format
-        args = [
-          'exec',
-          '-i',
-          service.containerName,
-          'mongorestore',
-          '--uri',
-          mongoUri,
-          '--archive',
-          '--gzip',
-          '--drop'
-        ]
-      }
-    } else {
-      throw new Error(`Unsupported database type: ${service.type}`)
-    }
-
     try {
-      sails.log.verbose(`[dock] Importing SQL into ${service.containerName}`)
+      let input
+      let args
+      let statementCount
 
-      // Use spawn with stdin pipe for large SQL imports
-      const { spawn } = require('child_process')
-
-      return new Promise((resolve, reject) => {
-        const proc = spawn(dockerPath, args, {
-          timeout: 300000, // 5 minute timeout
-          env
-        })
-
-        let stdout = ''
-        let stderr = ''
-
-        proc.stdout.on('data', (data) => {
-          stdout += data.toString()
-        })
-
-        proc.stderr.on('data', (data) => {
-          stderr += data.toString()
-        })
-
-        proc.on('close', (code) => {
-          const duration = Date.now() - startTime
-
-          if (code !== 0) {
-            sails.log.error(
-              `[dock] SQL import failed with code ${code}: ${stderr}`
-            )
-            reject({
-              importFailed: {
-                message: stderr.trim() || `Import failed with exit code ${code}`
-              }
-            })
-          } else {
-            // Count statements executed (rough estimate)
-            const statementCount = (sql.match(/;\s*$/gm) || []).length
-
-            resolve({
-              success: true,
-              message: stdout.trim() || 'Import completed successfully',
-              statementCount,
-              duration
-            })
-          }
-        })
-
-        proc.on('error', (error) => {
-          reject({
-            importFailed: {
-              message: error.message
-            }
-          })
-        })
-
-        // Write SQL to stdin and close
-        proc.stdin.write(sql)
-        proc.stdin.end()
-      })
-    } catch (error) {
-      sails.log.error(`[dock] SQL import failed: ${error.message}`)
-
-      if (error.importFailed) {
-        throw error
-      }
-
-      throw {
-        importFailed: {
-          message: error.message
+      if (dumpPath) {
+        const stats = await fsPromises.stat(dumpPath)
+        if (stats.size === 0) throw new Error('Uploaded dump file is empty.')
+        if (stats.size > limits.sqlImportMaxBytes) {
+          throw new Error(
+            `Uploaded dump exceeds the ${formatBytes(
+              limits.sqlImportMaxBytes
+            )} import limit.`
+          )
         }
+
+        await verifyDatabaseDump(dumpPath, service.type)
+        input = fs.createReadStream(dumpPath)
+        args = getBinaryImportArgs(service)
+        statementCount = 1
+      } else {
+        const inputBytes = Buffer.byteLength(sql)
+        if (inputBytes > limits.sqlImportMaxBytes) {
+          throw new Error(
+            `Data exceeds the ${formatBytes(
+              limits.sqlImportMaxBytes
+            )} import limit.`
+          )
+        }
+
+        input = Readable.from([sql])
+        args = getTextImportArgs(service, sql)
+        statementCount = (sql.match(/;\s*$/gm) || []).length
       }
+
+      sails.log.verbose(`[dock] Importing data into ${service.containerName}`)
+      const result = await sails.helpers.streams.runProcess.with({
+        command: sails.config.docker?.binaryPath || 'docker',
+        args,
+        input,
+        timeoutMs: limits.sqlImportTimeoutMs,
+        maxInputBytes: limits.sqlImportMaxBytes,
+        maxOutputBytes: limits.maxProcessOutputBytes,
+        maxStdoutBytes: limits.maxProcessOutputBytes,
+        maxStderrBytes: limits.maxProcessStderrBytes,
+        captureStdout: true,
+        signal,
+        killGraceMs: limits.killGraceMs
+      })
+
+      return {
+        success: true,
+        message:
+          result.stdout.trim() ||
+          (dumpPath
+            ? 'Dump restored successfully'
+            : 'Import completed successfully'),
+        statementCount,
+        duration: Date.now() - startTime
+      }
+    } catch (error) {
+      const message = error.stderr?.trim() || error.message
+      sails.log.error(`[dock] Database import failed: ${message}`)
+      throw { importFailed: { message } }
     }
   }
+}
+
+function getBinaryImportArgs(service) {
+  if (service.type === 'postgresql') {
+    return [
+      'exec',
+      '-i',
+      '-e',
+      `PGPASSWORD=${service.password}`,
+      service.containerName,
+      'pg_restore',
+      '-U',
+      service.username,
+      '-d',
+      service.database,
+      '--no-owner',
+      '--clean',
+      '--if-exists'
+    ]
+  }
+
+  if (service.type === 'mongodb') {
+    const mongoUri = `mongodb://${service.username}:${service.password}@localhost:27017/${service.database}?authSource=admin`
+    return [
+      'exec',
+      '-i',
+      service.containerName,
+      'mongorestore',
+      '--uri',
+      mongoUri,
+      '--archive',
+      '--gzip',
+      '--drop'
+    ]
+  }
+
+  throw new Error(`Binary dump import is not supported for ${service.type}`)
+}
+
+function getTextImportArgs(service, sql) {
+  if (service.type === 'postgresql') {
+    return [
+      'exec',
+      '-i',
+      '-e',
+      `PGPASSWORD=${service.password}`,
+      service.containerName,
+      'psql',
+      '-U',
+      service.username,
+      '-d',
+      service.database,
+      '--no-psqlrc',
+      '-v',
+      'ON_ERROR_STOP=1'
+    ]
+  }
+
+  if (service.type === 'mysql') {
+    return [
+      'exec',
+      '-i',
+      service.containerName,
+      'mysql',
+      '-u',
+      service.username,
+      `-p${service.password}`,
+      service.database
+    ]
+  }
+
+  if (service.type === 'mongodb') {
+    const mongoUri = `mongodb://${service.username}:${service.password}@localhost:27017/${service.database}?authSource=admin`
+    const trimmed = sql.trim()
+
+    if (trimmed.startsWith('[') || trimmed.startsWith('{')) {
+      const collectionMatch = sql.match(/\/\/\s*collection:\s*(\w+)/)
+      return [
+        'exec',
+        '-i',
+        service.containerName,
+        'mongoimport',
+        '--uri',
+        mongoUri,
+        '--collection',
+        collectionMatch ? collectionMatch[1] : 'imported',
+        '--jsonArray',
+        '--drop'
+      ]
+    }
+
+    return [
+      'exec',
+      '-i',
+      service.containerName,
+      'mongorestore',
+      '--uri',
+      mongoUri,
+      '--archive',
+      '--gzip',
+      '--drop'
+    ]
+  }
+
+  throw new Error(`Unsupported database type: ${service.type}`)
+}
+
+function formatBytes(bytes) {
+  return `${Math.round(bytes / (1024 * 1024))} MB`
 }

--- a/api/helpers/streams/copy.js
+++ b/api/helpers/streams/copy.js
@@ -1,0 +1,83 @@
+const { pipeline } = require('node:stream/promises')
+
+const createByteLimitTransform = require('../../lib/byte-limit-transform')
+
+module.exports = {
+  friendlyName: 'Copy stream',
+
+  description:
+    'Copy one stream to another with backpressure and an explicit byte limit.',
+
+  inputs: {
+    input: {
+      type: 'ref',
+      required: true,
+      description: 'Readable stream.'
+    },
+    output: {
+      type: 'ref',
+      required: true,
+      description: 'Writable stream.'
+    },
+    maxBytes: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    label: {
+      type: 'string',
+      defaultsTo: 'Stream'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal.'
+    },
+    timeoutMs: {
+      type: 'number',
+      min: 1,
+      description: 'Optional transfer deadline.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ input, output, maxBytes, label, signal, timeoutMs }) {
+    const limiter = createByteLimitTransform({ maxBytes, label })
+    const controller = new AbortController()
+    let timedOut = false
+    const onAbort = () => controller.abort()
+    const timeout = timeoutMs
+      ? setTimeout(() => {
+          timedOut = true
+          controller.abort()
+        }, timeoutMs)
+      : null
+
+    if (signal) {
+      if (signal.aborted) controller.abort()
+      else signal.addEventListener('abort', onAbort, { once: true })
+    }
+
+    try {
+      await pipeline(input, limiter, output, { signal: controller.signal })
+    } catch (error) {
+      if (timedOut) {
+        const timeoutError = new Error(
+          `${label} timed out after ${timeoutMs}ms.`
+        )
+        timeoutError.code = 'STREAM_TIMEOUT'
+        throw timeoutError
+      }
+      throw error
+    } finally {
+      if (timeout) clearTimeout(timeout)
+      if (signal) signal.removeEventListener('abort', onAbort)
+    }
+
+    return { bytes: limiter.getBytes() }
+  }
+}

--- a/api/helpers/streams/get-disk-capacity.js
+++ b/api/helpers/streams/get-disk-capacity.js
@@ -1,0 +1,81 @@
+const fs = require('node:fs/promises')
+
+module.exports = {
+  friendlyName: 'Get disk capacity',
+
+  description:
+    'Calculate how many bytes a bounded temporary operation may safely write.',
+
+  inputs: {
+    directory: {
+      type: 'string',
+      required: true
+    },
+    maxBytes: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    reserveBytes: {
+      type: 'number',
+      required: true,
+      min: 0
+    },
+    expectedBytes: {
+      type: 'number',
+      min: 0
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ directory, maxBytes, reserveBytes, expectedBytes }) {
+    const stats = await fs.statfs(directory)
+    const availableBytes = Number(stats.bavail) * Number(stats.bsize)
+    const writableBytes = Math.max(0, availableBytes - reserveBytes)
+    const allowedBytes = Math.min(maxBytes, writableBytes)
+
+    if (allowedBytes < 1) {
+      const error = new Error(
+        `Not enough temporary disk space. Slipway keeps ${formatBytes(
+          reserveBytes
+        )} free for the host.`
+      )
+      error.code = 'INSUFFICIENT_DISK_SPACE'
+      throw error
+    }
+
+    if (expectedBytes !== undefined && expectedBytes > allowedBytes) {
+      const error = new Error(
+        `This operation needs ${formatBytes(
+          expectedBytes
+        )} of temporary disk space, but only ${formatBytes(
+          allowedBytes
+        )} is safely available.`
+      )
+      error.code = 'INSUFFICIENT_DISK_SPACE'
+      error.expectedBytes = expectedBytes
+      error.allowedBytes = allowedBytes
+      throw error
+    }
+
+    return { availableBytes, allowedBytes, reserveBytes }
+  }
+}
+
+function formatBytes(bytes) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
+}

--- a/api/helpers/streams/run-process.js
+++ b/api/helpers/streams/run-process.js
@@ -1,0 +1,289 @@
+const { spawn } = require('node:child_process')
+const { Writable } = require('node:stream')
+const { pipeline } = require('node:stream/promises')
+
+const createByteLimitTransform = require('../../lib/byte-limit-transform')
+
+module.exports = {
+  friendlyName: 'Run process',
+
+  description:
+    'Run a subprocess with bounded streaming input, output, stderr, and duration.',
+
+  inputs: {
+    command: {
+      type: 'string',
+      required: true
+    },
+    args: {
+      type: 'ref',
+      defaultsTo: []
+    },
+    input: {
+      type: 'ref',
+      description: 'Optional readable stream for stdin.'
+    },
+    output: {
+      type: 'ref',
+      description: 'Optional writable stream for stdout.'
+    },
+    env: {
+      type: 'ref',
+      description: 'Optional process environment.'
+    },
+    timeoutMs: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    maxInputBytes: {
+      type: 'number',
+      defaultsTo: Number.MAX_SAFE_INTEGER,
+      min: 1
+    },
+    maxOutputBytes: {
+      type: 'number',
+      defaultsTo: Number.MAX_SAFE_INTEGER,
+      min: 1
+    },
+    maxStderrBytes: {
+      type: 'number',
+      required: true,
+      min: 1
+    },
+    maxStdoutBytes: {
+      type: 'number',
+      defaultsTo: 64 * 1024,
+      min: 1
+    },
+    captureStdout: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal.'
+    },
+    killGraceMs: {
+      type: 'number',
+      defaultsTo: 5000,
+      min: 1
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    command,
+    args,
+    input,
+    output,
+    env,
+    timeoutMs,
+    maxInputBytes,
+    maxOutputBytes,
+    maxStderrBytes,
+    maxStdoutBytes,
+    captureStdout,
+    signal,
+    killGraceMs
+  }) {
+    const startedAt = Date.now()
+    const child = spawn(command, args, {
+      env: env || process.env,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    const stderr = createBoundedCapture(maxStderrBytes)
+    const stdout = createBoundedCapture(maxStdoutBytes)
+    child.stderr.on('data', stderr.add)
+
+    const closePromise = new Promise((resolve, reject) => {
+      child.once('error', reject)
+      child.once('close', (code, processSignal) => {
+        resolve({ code, signal: processSignal })
+      })
+    })
+
+    const inputLimiter = createByteLimitTransform({
+      maxBytes: maxInputBytes,
+      label: 'Process input'
+    })
+    const outputLimiter = createByteLimitTransform({
+      maxBytes: maxOutputBytes,
+      label: 'Process output'
+    })
+
+    let pipelineFailure
+    const rawInputPromise = input
+      ? pipeline(input, inputLimiter, child.stdin)
+      : Promise.resolve(child.stdin.end())
+
+    const outputTarget =
+      output ||
+      new Writable({
+        write(chunk, encoding, callback) {
+          if (captureStdout) stdout.add(chunk)
+          callback()
+        }
+      })
+    const rawOutputPromise = pipeline(child.stdout, outputLimiter, outputTarget)
+    const stopOnPipelineFailure = (promise) =>
+      promise.catch((error) => {
+        pipelineFailure ||= error
+        if (!isExpectedPipeClosure(error)) terminate(child, killGraceMs)
+        throw error
+      })
+    const inputPromise = stopOnPipelineFailure(rawInputPromise)
+    const outputPromise = stopOnPipelineFailure(rawOutputPromise)
+
+    const interruption = createInterruption({
+      signal,
+      timeoutMs,
+      onInterrupt: () => terminate(child, killGraceMs)
+    })
+
+    try {
+      const [closeResult, inputResult, outputResult] = await Promise.race([
+        Promise.allSettled([closePromise, inputPromise, outputPromise]),
+        interruption.promise
+      ])
+
+      if (closeResult.status === 'rejected') throw closeResult.reason
+
+      const { code, signal: processSignal } = closeResult.value
+      const inputError =
+        inputResult.status === 'rejected' ? inputResult.reason : null
+      const outputError =
+        outputResult.status === 'rejected' ? outputResult.reason : null
+      const streamError = outputError || inputError || pipelineFailure
+
+      if (streamError && isPrimaryStreamError(streamError, code)) {
+        throw streamError
+      }
+
+      if (code !== 0) {
+        const detail = stderr.value().trim()
+        const error = new Error(
+          `Process exited with code ${code}${
+            processSignal ? ` (${processSignal})` : ''
+          }${detail ? `: ${detail}` : ''}`
+        )
+        error.code = 'PROCESS_FAILED'
+        error.exitCode = code
+        error.stderr = stderr.value()
+        error.stderrTruncated = stderr.truncated()
+        throw error
+      }
+
+      if (streamError) throw streamError
+
+      return {
+        durationMs: Date.now() - startedAt,
+        inputBytes: input ? inputLimiter.getBytes() : 0,
+        outputBytes: outputLimiter.getBytes(),
+        stdout: stdout.value(),
+        stdoutTruncated: stdout.truncated(),
+        stderr: stderr.value(),
+        stderrTruncated: stderr.truncated()
+      }
+    } catch (error) {
+      terminate(child, killGraceMs)
+      await Promise.allSettled([closePromise, inputPromise, outputPromise])
+      throw error
+    } finally {
+      interruption.cleanup()
+      child.stderr.off('data', stderr.add)
+    }
+  }
+}
+
+function createBoundedCapture(maxBytes) {
+  const chunks = []
+  let capturedBytes = 0
+  let totalBytes = 0
+
+  return {
+    add(chunk) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      totalBytes += buffer.length
+
+      if (capturedBytes >= maxBytes) return
+
+      const slice = buffer.subarray(0, maxBytes - capturedBytes)
+      chunks.push(slice)
+      capturedBytes += slice.length
+    },
+    value() {
+      return Buffer.concat(chunks, capturedBytes).toString('utf8')
+    },
+    truncated() {
+      return totalBytes > capturedBytes
+    }
+  }
+}
+
+function createInterruption({ signal, timeoutMs, onInterrupt }) {
+  let rejectPromise
+  const promise = new Promise((resolve, reject) => {
+    rejectPromise = reject
+  })
+
+  const interrupt = (error) => {
+    onInterrupt(error)
+    rejectPromise(error)
+  }
+
+  const timeout = setTimeout(() => {
+    const error = new Error(`Process timed out after ${timeoutMs}ms.`)
+    error.code = 'PROCESS_TIMEOUT'
+    interrupt(error)
+  }, timeoutMs)
+  timeout.unref()
+
+  const onAbort = () => {
+    const error = new Error('Process was cancelled.')
+    error.code = 'PROCESS_ABORTED'
+    interrupt(error)
+  }
+
+  if (signal) {
+    if (signal.aborted) onAbort()
+    else signal.addEventListener('abort', onAbort, { once: true })
+  }
+
+  return {
+    promise,
+    cleanup() {
+      clearTimeout(timeout)
+      if (signal) signal.removeEventListener('abort', onAbort)
+    }
+  }
+}
+
+function terminate(child, killGraceMs) {
+  if (child.exitCode !== null || child.signalCode !== null) return
+
+  child.kill('SIGTERM')
+  const forceKill = setTimeout(() => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL')
+    }
+  }, killGraceMs)
+  forceKill.unref()
+
+  child.stdin.destroy()
+  child.stdout.destroy()
+}
+
+function isPrimaryStreamError(error, processExitCode) {
+  if (processExitCode === 0 || processExitCode === null) return true
+  return !isExpectedPipeClosure(error)
+}
+
+function isExpectedPipeClosure(error) {
+  return ['EPIPE', 'ERR_STREAM_PREMATURE_CLOSE'].includes(error.code)
+}

--- a/api/lib/backup-storage-adapter.js
+++ b/api/lib/backup-storage-adapter.js
@@ -1,0 +1,12 @@
+module.exports = function createBackupStorageAdapter(config) {
+  const options = {
+    key: config.key,
+    secret: config.secret,
+    bucket: config.bucket,
+    s3ForcePathStyle: true
+  }
+  if (config.endpoint) options.endpoint = config.endpoint
+  if (config.region) options.region = config.region
+
+  return require('skipper-s3')(options)
+}

--- a/api/lib/byte-limit-transform.js
+++ b/api/lib/byte-limit-transform.js
@@ -1,0 +1,40 @@
+const { Transform } = require('node:stream')
+
+module.exports = function createByteLimitTransform({ maxBytes, label }) {
+  let bytes = 0
+
+  const transform = new Transform({
+    transform(chunk, encoding, callback) {
+      bytes += chunk.length
+
+      if (bytes > maxBytes) {
+        const error = new Error(
+          `${label} exceeded the ${formatBytes(maxBytes)} limit.`
+        )
+        error.code = 'STREAM_SIZE_LIMIT'
+        error.maxBytes = maxBytes
+        error.bytes = bytes
+        callback(error)
+        return
+      }
+
+      callback(null, chunk)
+    }
+  })
+
+  transform.getBytes = () => bytes
+  return transform
+}
+
+function formatBytes(bytes) {
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let value = bytes
+  let unit = 0
+
+  while (value >= 1024 && unit < units.length - 1) {
+    value /= 1024
+    unit += 1
+  }
+
+  return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`
+}

--- a/api/lib/verify-database-dump.js
+++ b/api/lib/verify-database-dump.js
@@ -1,0 +1,22 @@
+const fs = require('node:fs/promises')
+
+module.exports = async function verifyDatabaseDump(filePath, serviceType) {
+  const file = await fs.open(filePath, 'r')
+  const header = Buffer.alloc(5)
+
+  try {
+    await file.read(header, 0, header.length, 0)
+  } finally {
+    await file.close()
+  }
+
+  if (serviceType === 'postgresql' && header.toString('ascii') !== 'PGDMP') {
+    throw new Error(
+      'PostgreSQL dump has invalid header — expected PGDMP format'
+    )
+  }
+
+  if (serviceType === 'mongodb' && (header[0] !== 0x1f || header[1] !== 0x8b)) {
+    throw new Error('MongoDB dump has invalid header — expected gzip format')
+  }
+}

--- a/config/custom.js
+++ b/config/custom.js
@@ -63,6 +63,20 @@ module.exports.custom = {
   // Host interface used when checking and reserving app container ports
   slipwayPortHost: '0.0.0.0',
 
+  // Keep database transfers bounded on memory-constrained VPS hosts.
+  databaseOperations: {
+    backupMaxBytes: 50 * 1024 * 1024 * 1024,
+    restoreMaxBytes: 50 * 1024 * 1024 * 1024,
+    sqlImportMaxBytes: 500 * 1024 * 1024,
+    minFreeDiskBytes: 512 * 1024 * 1024,
+    backupTimeoutMs: 60 * 60 * 1000,
+    restoreTimeoutMs: 60 * 60 * 1000,
+    sqlImportTimeoutMs: 30 * 60 * 1000,
+    maxProcessOutputBytes: 64 * 1024,
+    maxProcessStderrBytes: 64 * 1024,
+    killGraceMs: 5000
+  },
+
   // API version (used for building API URLs)
   apiVersion: 'v1',
 

--- a/tests/factories/backup.js
+++ b/tests/factories/backup.js
@@ -1,0 +1,5 @@
+module.exports = ({ defineFactory }) =>
+  defineFactory('backup', {
+    status: 'pending',
+    type: 'manual'
+  })

--- a/tests/unit/helpers/backup/restore-backup.test.js
+++ b/tests/unit/helpers/backup/restore-backup.test.js
@@ -1,0 +1,87 @@
+const { test } = require('sounding')
+
+test(
+  'restore never reaches the database when its safety snapshot fails',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'restore-safety', name: 'Restore Safety' }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'main-db',
+      status: 'running',
+      containerName: 'slipway-restore-safety-main-db',
+      database: 'restore_safety',
+      username: 'postgres',
+      password: 'secret'
+    })
+    const sourceBackup = await world.create('backup').with({
+      service: service.id,
+      status: 'completed',
+      s3Key: 'backups/restore-safety/source.dmp',
+      sizeBytes: 1024
+    })
+
+    const originalRunBackup = sails.helpers.backup.runBackup
+    const originalDownload = sails.helpers.backup.downloadObject
+    const originalStorageConfig = sails.helpers.backup.getStorageConfig
+    const originalDiskCapacity = sails.helpers.streams.getDiskCapacity
+    let downloadStarted = false
+
+    sails.helpers.backup.getStorageConfig = async () => ({
+      key: 'test',
+      secret: 'test',
+      bucket: 'test'
+    })
+    const allowRestoreFile = async () => ({ allowedBytes: 2048 })
+    allowRestoreFile.with = allowRestoreFile
+    sails.helpers.streams.getDiskCapacity = allowRestoreFile
+
+    const failSafetySnapshot = async ({ backupId }) => {
+      return sails.models.backup.updateOne({ id: backupId }).set({
+        status: 'failed',
+        errorMessage: 'Object storage is unavailable',
+        completedAt: Date.now()
+      })
+    }
+    failSafetySnapshot.with = failSafetySnapshot
+    sails.helpers.backup.runBackup = failSafetySnapshot
+
+    const rejectDownload = async () => {
+      downloadStarted = true
+      throw new Error('The destructive restore path should not run')
+    }
+    rejectDownload.with = rejectDownload
+    sails.helpers.backup.downloadObject = rejectDownload
+
+    try {
+      const error = await captureError(
+        sails.helpers.backup.restoreBackup(sourceBackup.id)
+      )
+
+      expect(error.code).toBe('SAFETY_SNAPSHOT_FAILED')
+      expect(error.message).toContain('Object storage is unavailable')
+      expect(downloadStarted).toBe(false)
+    } finally {
+      sails.helpers.backup.runBackup = originalRunBackup
+      sails.helpers.backup.downloadObject = originalDownload
+      sails.helpers.backup.getStorageConfig = originalStorageConfig
+      sails.helpers.streams.getDiskCapacity = originalDiskCapacity
+    }
+  }
+)
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}

--- a/tests/unit/helpers/backup/run-backup.test.js
+++ b/tests/unit/helpers/backup/run-backup.test.js
@@ -1,0 +1,75 @@
+const fsPromises = require('node:fs/promises')
+const os = require('node:os')
+
+const { test } = require('sounding')
+
+test(
+  'backup records fail consistently and temporary files are removed on disk errors',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'backup-stream', name: 'Backup Stream' }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'main-db',
+      status: 'running',
+      containerName: 'slipway-backup-stream-main-db',
+      database: 'backup_stream',
+      username: 'postgres',
+      password: 'secret'
+    })
+    const backup = await world.create('backup').with({ service: service.id })
+    const tempBefore = await backupTempDirectories()
+
+    const originalStorageConfig = sails.helpers.backup.getStorageConfig
+    const originalRunProcess = sails.helpers.streams.runProcess
+    const originalNotification =
+      sails.helpers.notification.sendBackupNotification
+
+    sails.helpers.backup.getStorageConfig = async () => ({
+      key: 'test',
+      secret: 'test',
+      bucket: 'test'
+    })
+
+    const failDumpWrite = async ({ output }) => {
+      output.destroy()
+      const error = new Error('No space left on device')
+      error.code = 'ENOSPC'
+      throw error
+    }
+    failDumpWrite.with = failDumpWrite
+    sails.helpers.streams.runProcess = failDumpWrite
+
+    const ignoreNotification = async () => {}
+    ignoreNotification.with = () => ({
+      tolerate: async () => {}
+    })
+    sails.helpers.notification.sendBackupNotification = ignoreNotification
+
+    try {
+      const result = await sails.helpers.backup.runBackup(backup.id)
+      const tempAfter = await backupTempDirectories()
+
+      expect(result.status).toBe('failed')
+      expect(result.errorMessage).toContain('No space left on device')
+      expect(result.completedAt >= result.startedAt).toBe(true)
+      expect(result.s3Key).toBe(null)
+      expect(tempAfter).toEqual(tempBefore)
+    } finally {
+      sails.helpers.backup.getStorageConfig = originalStorageConfig
+      sails.helpers.streams.runProcess = originalRunProcess
+      sails.helpers.notification.sendBackupNotification = originalNotification
+    }
+  }
+)
+
+async function backupTempDirectories() {
+  const names = await fsPromises.readdir(os.tmpdir())
+  return names.filter((name) => name.startsWith('slipway-backup-')).sort()
+}

--- a/tests/unit/helpers/dock/import-sql-stream.test.js
+++ b/tests/unit/helpers/dock/import-sql-stream.test.js
@@ -1,0 +1,70 @@
+const fs = require('node:fs')
+const fsPromises = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+test('a dump import passes a bounded file stream to the database process', async ({
+  sails,
+  expect
+}) => {
+  const tmpDirectory = await fsPromises.mkdtemp(
+    path.join(os.tmpdir(), 'slipway-import-test-')
+  )
+  const dumpPath = path.join(tmpDirectory, 'database.dmp')
+  const dumpBytes = 2 * 1024 * 1024
+  await writePostgresDump(dumpPath, dumpBytes)
+
+  const originalRunProcess = sails.helpers.streams.runProcess
+  const originalLimit = sails.config.custom.databaseOperations.sqlImportMaxBytes
+  let streamedBytes = 0
+
+  const consumeProcessInput = async ({ input, maxInputBytes }) => {
+    expect(maxInputBytes).toBe(4 * 1024 * 1024)
+    expect(Buffer.isBuffer(input)).toBe(false)
+    for await (const chunk of input) streamedBytes += chunk.length
+    return { stdout: '', stderr: '' }
+  }
+  consumeProcessInput.with = consumeProcessInput
+  sails.helpers.streams.runProcess = consumeProcessInput
+  sails.config.custom.databaseOperations.sqlImportMaxBytes = 4 * 1024 * 1024
+
+  try {
+    const result = await sails.helpers.dock.importSql.with({
+      service: {
+        type: 'postgresql',
+        containerName: 'slipway-test-postgres',
+        database: 'app',
+        username: 'postgres',
+        password: 'secret'
+      },
+      dumpPath
+    })
+
+    expect(streamedBytes).toBe(dumpBytes)
+    expect(result.success).toBe(true)
+  } finally {
+    sails.helpers.streams.runProcess = originalRunProcess
+    sails.config.custom.databaseOperations.sqlImportMaxBytes = originalLimit
+    await fsPromises.rm(tmpDirectory, { recursive: true, force: true })
+  }
+})
+
+async function writePostgresDump(filePath, bytes) {
+  await new Promise((resolve, reject) => {
+    const output = fs.createWriteStream(filePath, { flags: 'wx' })
+    output.once('error', reject)
+    output.once('finish', resolve)
+    output.write('PGDMP')
+
+    const chunk = Buffer.alloc(64 * 1024)
+    let remaining = bytes - 5
+    while (remaining > 0) {
+      const size = Math.min(remaining, chunk.length)
+      output.write(chunk.subarray(0, size))
+      remaining -= size
+    }
+    output.end()
+  })
+}

--- a/tests/unit/helpers/streams/run-process.test.js
+++ b/tests/unit/helpers/streams/run-process.test.js
@@ -1,0 +1,203 @@
+const { Readable, Writable } = require('node:stream')
+
+const { test } = require('sounding')
+
+test('process output streams with backpressure instead of being held in memory', async ({
+  sails,
+  expect
+}) => {
+  const outputBytes = 4 * 1024 * 1024
+  let writtenBytes = 0
+  const output = new Writable({
+    highWaterMark: 1024,
+    write(chunk, encoding, callback) {
+      writtenBytes += chunk.length
+      setImmediate(callback)
+    }
+  })
+
+  const result = await sails.helpers.streams.runProcess.with({
+    command: process.execPath,
+    args: [
+      '-e',
+      `const chunk = Buffer.alloc(65536); let left = ${outputBytes}; function write() { while (left > 0) { const next = chunk.subarray(0, Math.min(left, chunk.length)); left -= next.length; if (!process.stdout.write(next)) return process.stdout.once('drain', write) } } write()`
+    ],
+    output,
+    timeoutMs: 5000,
+    maxOutputBytes: outputBytes,
+    maxStderrBytes: 1024
+  })
+
+  expect(writtenBytes).toBe(outputBytes)
+  expect(result.outputBytes).toBe(outputBytes)
+  expect(result.stdout).toBe('')
+})
+
+test('an AbortSignal cancels a running process', async ({ sails, expect }) => {
+  const controller = new AbortController()
+  const operation = sails.helpers.streams.runProcess.with({
+    command: process.execPath,
+    args: ['-e', 'setInterval(() => {}, 1000)'],
+    timeoutMs: 5000,
+    maxOutputBytes: 1024,
+    maxStderrBytes: 1024,
+    signal: controller.signal,
+    killGraceMs: 50
+  })
+
+  setTimeout(() => controller.abort(), 20)
+  const error = await captureError(operation)
+
+  expect(error.code).toBe('PROCESS_ABORTED')
+})
+
+test('a disk-full output error stops the producing process', async ({
+  sails,
+  expect
+}) => {
+  let writes = 0
+  const output = new Writable({
+    write(chunk, encoding, callback) {
+      writes += 1
+      const error = new Error('No space left on device')
+      error.code = 'ENOSPC'
+      callback(error)
+    }
+  })
+
+  const error = await captureError(
+    sails.helpers.streams.runProcess.with({
+      command: process.execPath,
+      args: [
+        '-e',
+        'setInterval(() => process.stdout.write(Buffer.alloc(65536)), 1)'
+      ],
+      output,
+      timeoutMs: 5000,
+      maxOutputBytes: 8 * 1024 * 1024,
+      maxStderrBytes: 1024,
+      killGraceMs: 50
+    })
+  )
+
+  expect(writes).toBe(1)
+  expect(error.code).toBe('ENOSPC')
+})
+
+test('process stderr is truncated at its configured memory limit', async ({
+  sails,
+  expect
+}) => {
+  const error = await captureError(
+    sails.helpers.streams.runProcess.with({
+      command: process.execPath,
+      args: ['-e', "process.stderr.write('x'.repeat(16384)); process.exit(7)"],
+      timeoutMs: 5000,
+      maxOutputBytes: 1024,
+      maxStderrBytes: 512
+    })
+  )
+
+  expect(error.code).toBe('PROCESS_FAILED')
+  expect(Buffer.byteLength(error.stderr)).toBe(512)
+  expect(error.stderrTruncated).toBe(true)
+})
+
+test('a failed process reports stderr instead of a streaming EPIPE', async ({
+  sails,
+  expect
+}) => {
+  const input = Readable.from(
+    (async function* () {
+      for (let index = 0; index < 256; index += 1) {
+        yield Buffer.alloc(64 * 1024)
+      }
+    })()
+  )
+
+  const error = await captureError(
+    sails.helpers.streams.runProcess.with({
+      command: process.execPath,
+      args: [
+        '-e',
+        "process.stderr.write('invalid database dump'); process.exit(6)"
+      ],
+      input,
+      timeoutMs: 5000,
+      maxInputBytes: 32 * 1024 * 1024,
+      maxOutputBytes: 1024,
+      maxStderrBytes: 1024
+    })
+  )
+
+  expect(error.code).toBe('PROCESS_FAILED')
+  expect(error.stderr).toContain('invalid database dump')
+})
+
+test('an aborted stream copy tears down both ends', async ({
+  sails,
+  expect
+}) => {
+  const controller = new AbortController()
+  const input = new Readable({
+    read() {
+      setTimeout(() => this.push(Buffer.alloc(1024)), 5)
+    }
+  })
+  const output = new Writable({
+    write(chunk, encoding, callback) {
+      setTimeout(callback, 5)
+    }
+  })
+
+  const operation = sails.helpers.streams.copy.with({
+    input,
+    output,
+    maxBytes: 1024 * 1024,
+    signal: controller.signal
+  })
+  setTimeout(() => controller.abort(), 20)
+
+  const error = await captureError(operation)
+  expect(error.code).toBe('ABORT_ERR')
+  expect(input.destroyed).toBe(true)
+  expect(output.destroyed).toBe(true)
+})
+
+test('a stream copy has an explicit transfer deadline', async ({
+  sails,
+  expect
+}) => {
+  const input = new Readable({
+    read() {}
+  })
+  const output = new Writable({
+    write(chunk, encoding, callback) {
+      callback()
+    }
+  })
+
+  const error = await captureError(
+    sails.helpers.streams.copy.with({
+      input,
+      output,
+      maxBytes: 1024,
+      label: 'Test transfer',
+      timeoutMs: 20
+    })
+  )
+
+  expect(error.code).toBe('STREAM_TIMEOUT')
+  expect(input.destroyed).toBe(true)
+  expect(output.destroyed).toBe(true)
+})
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}


### PR DESCRIPTION
## Summary

- stream database backups, restores, object transfers, and Dock imports with backpressure instead of buffering payloads in the Slipway process
- enforce configurable size, disk reserve, timeout, cancellation, stdout, and stderr limits with consistent temporary and partial-object cleanup
- require a persisted, verified safety snapshot before any destructive restore and preserve bounded dump-header verification
- add Sounding 0.2 trials for large streams, cancellation, transfer deadlines, disk-full failures, bounded stderr, EPIPE diagnostics, streamed imports, and failed safety snapshots

## Verification

- npm run lint
- npm test — 95 unit, 23 functional, and 10 browser trials passed

Closes #234