### PR TITLE
fix(content): persist edits and deploy exact commits

### DIFF
--- a/api/controllers/api/v1/deploy/trigger-deployment.js
+++ b/api/controllers/api/v1/deploy/trigger-deployment.js
@@ -78,100 +78,27 @@ module.exports = {
       throw 'notFound'
     }
 
-    // Resolve target app
-    let targetApp
-    if (appSlug) {
-      targetApp = await App.findOne({
-        environment: environment.id,
-        slug: appSlug
-      })
-      if (!targetApp) {
-        throw 'notFound'
-      }
-    } else {
-      targetApp =
-        (await App.findOne({ environment: environment.id, isDefault: true })) ||
-        (await App.findOne({ environment: environment.id }))
-    }
-
-    // Source availability is a request precondition. Keep this check fast and
-    // side-effect free; repository synchronization belongs in the recorded
-    // deployment pipeline so failures have durable logs and status.
-    const sourceReadiness = await sails.helpers.deploy.getSourceReadiness.with({
-      project,
-      environment,
-      app: targetApp
-    })
-
-    if (!sourceReadiness.available) {
-      throw {
-        badRequest: {
-          code: 'deploymentSourceUnavailable',
-          message: sourceReadiness.message,
-          guidance:
-            'Run `slipway slide` from your project or connect a repository, then try again.'
-        }
-      }
-    }
-
-    // Repository deployments may reuse metadata from the most recent deploy
-    // for this app. Pushed-source deploys must not inherit stale Git metadata.
-    let finalGitCommit = gitCommit
-    let finalGitBranch = gitBranch
-    let finalGitMessage = gitMessage
-
-    if (sourceReadiness.mode === 'repository' && (!gitCommit || !gitBranch)) {
-      const previousDeploymentCriteria = {
-        environment: environment.id,
-        gitCommit: { '!=': null }
-      }
-      if (targetApp) {
-        previousDeploymentCriteria.or = targetApp.isDefault
-          ? [{ app: targetApp.id }, { app: null }]
-          : [{ app: targetApp.id }]
-      }
-
-      const lastDeployments = await Deployment.find(previousDeploymentCriteria)
-        .sort('id DESC')
-        .limit(1)
-
-      if (lastDeployments.length > 0) {
-        const lastDeployment = lastDeployments[0]
-        finalGitCommit = gitCommit || lastDeployment.gitCommit
-        finalGitBranch = gitBranch || lastDeployment.gitBranch
-        finalGitMessage = gitMessage || lastDeployment.gitMessage
-      }
-    }
-
-    const queued = await sails.helpers.deploy.queueDeployment.with({
-      values: {
-        gitCommit: finalGitCommit,
-        gitBranch: finalGitBranch,
-        gitMessage: finalGitMessage,
-        triggeredBy: user.id,
+    const queued = await sails.helpers.deploy.triggerDeployment
+      .with({
+        project,
+        environment,
+        user,
+        appSlug,
+        gitCommit,
+        gitBranch,
+        gitMessage,
         triggerType: 'api',
-        environment: environment.id
-      },
-      app: targetApp
-    })
+        ipAddress: this.req.ip
+      })
+      .intercept('appNotFound', 'notFound')
+      .intercept('sourceUnavailable', (error) => ({
+        badRequest: error.raw || error
+      }))
     const deployment = queued.deployment
 
     sails.log.info(
       `Deployment ${deployment.id} triggered for ${project.slug}/${environment.slug}`
     )
-
-    // Audit log
-    sails.helpers.audit.log
-      .with({
-        action: 'deployment.triggered',
-        resourceType: 'deployment',
-        resourceId: deployment.id,
-        details: { projectSlug, environmentSlug, gitCommit: finalGitCommit },
-        userId: user.id,
-        teamId: project.team.id,
-        ipAddress: this.req.ip
-      })
-      .exec(() => {})
 
     return {
       deployment: {

--- a/api/controllers/api/v1/webhook/github.js
+++ b/api/controllers/api/v1/webhook/github.js
@@ -2,6 +2,7 @@ const crypto = require('crypto')
 const { execFileSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
+const { isContentCommit } = require('../../../../lib/content-commit')
 
 module.exports = {
   friendlyName: 'GitHub webhook',
@@ -79,6 +80,10 @@ module.exports = {
 
     if (event !== 'push') {
       return { message: `Ignored event: ${event}` }
+    }
+
+    if (isContentCommit(body.head_commit?.message)) {
+      return { message: 'Content Manager commit handled by Slipway' }
     }
 
     // Check branch

--- a/api/controllers/project/content-create.js
+++ b/api/controllers/project/content-create.js
@@ -81,15 +81,10 @@ module.exports = {
     const contentDir = contentFeature.contentDir || 'content'
     const appPath = `${sails.config.custom.slipwayAppsDir}/${project.slug}`
     const resolved = await sails.helpers.deploy.resolveTargetApp
-      .with({ environment, appSlug, requireExplicit: true })
+      .with({ environment, appSlug })
       .intercept('appNotFound', () => ({
         badRequest: {
           problems: [{ appSlug: 'Choose an app that still exists.' }]
-        }
-      }))
-      .intercept('appSelectionRequired', () => ({
-        badRequest: {
-          problems: [{ appSlug: 'Choose which app owns this content.' }]
         }
       }))
 

--- a/api/controllers/project/content-create.js
+++ b/api/controllers/project/content-create.js
@@ -17,7 +17,8 @@ module.exports = {
     },
     collection: {
       type: 'string',
-      required: true
+      required: true,
+      regex: /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
     },
     contentSlug: {
       type: 'string',
@@ -25,6 +26,10 @@ module.exports = {
     },
     title: {
       type: 'string'
+    },
+    appSlug: {
+      type: 'string',
+      description: 'App whose source repository owns this content file'
     }
   },
 
@@ -40,7 +45,14 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug, collection, contentSlug, title }) {
+  fn: async function ({
+    slug,
+    envSlug,
+    collection,
+    contentSlug,
+    title,
+    appSlug
+  }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -68,6 +80,18 @@ module.exports = {
     const contentFeature = environment.features['sails-content']
     const contentDir = contentFeature.contentDir || 'content'
     const appPath = `${sails.config.custom.slipwayAppsDir}/${project.slug}`
+    const resolved = await sails.helpers.deploy.resolveTargetApp
+      .with({ environment, appSlug, requireExplicit: true })
+      .intercept('appNotFound', () => ({
+        badRequest: {
+          problems: [{ appSlug: 'Choose an app that still exists.' }]
+        }
+      }))
+      .intercept('appSelectionRequired', () => ({
+        badRequest: {
+          problems: [{ appSlug: 'Choose which app owns this content.' }]
+        }
+      }))
 
     // Sanitize slug
     const safeSlug = contentSlug
@@ -75,6 +99,14 @@ module.exports = {
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-|-$/g, '')
+
+    if (!safeSlug) {
+      throw {
+        badRequest: {
+          problems: [{ contentSlug: 'Enter a valid content slug.' }]
+        }
+      }
+    }
 
     const collectionPath = path.join(appPath, contentDir, collection)
     const filePath = path.join(collectionPath, `${safeSlug}.md`)
@@ -84,11 +116,6 @@ module.exports = {
       throw {
         badRequest: { error: `Content file "${safeSlug}.md" already exists` }
       }
-    }
-
-    // Ensure collection directory exists
-    if (!fs.existsSync(collectionPath)) {
-      fs.mkdirSync(collectionPath, { recursive: true })
     }
 
     // Build frontmatter
@@ -111,13 +138,43 @@ module.exports = {
     content += '---\n\n'
     content += `# ${title || safeSlug}\n\nStart writing your content here.\n`
 
-    // Write file
+    const relativeFilePath = path.posix.join(
+      String(contentDir).replace(/\\/g, '/'),
+      collection,
+      `${safeSlug}.md`
+    )
+    await sails.helpers.git.commitContentFile
+      .with({
+        environment,
+        app: resolved.app,
+        user,
+        filePath: relativeFilePath,
+        content,
+        operation: 'create',
+        message: `chore(content): create ${collection}/${safeSlug}`
+      })
+      .intercept('conflict', (error) => ({
+        badRequest: {
+          problems: [{ contentSlug: (error.raw || error).message }]
+        }
+      }))
+      .intercept('writeUnavailable', (error) => ({
+        badRequest: {
+          problems: [{ contentSlug: (error.raw || error).message }]
+        }
+      }))
+
+    if (!fs.existsSync(collectionPath)) {
+      fs.mkdirSync(collectionPath, { recursive: true })
+    }
     fs.writeFileSync(filePath, content, 'utf8')
 
     sails.log.info(`[content] Created ${collection}/${safeSlug}.md in ${slug}`)
 
     // Redirect to editor
     const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/content/${collection}/${safeSlug}`
+    return `/projects/${slug}${envPath}/content/${collection}/${safeSlug}?appSlug=${encodeURIComponent(
+      resolved.app.slug
+    )}`
   }
 }

--- a/api/controllers/project/content-delete.js
+++ b/api/controllers/project/content-delete.js
@@ -76,15 +76,10 @@ module.exports = {
     const contentDir = contentFeature.contentDir || 'content'
     const appPath = `${sails.config.custom.slipwayAppsDir}/${project.slug}`
     const resolved = await sails.helpers.deploy.resolveTargetApp
-      .with({ environment, appSlug, requireExplicit: true })
+      .with({ environment, appSlug })
       .intercept('appNotFound', () => ({
         badRequest: {
           problems: [{ appSlug: 'Choose an app that still exists.' }]
-        }
-      }))
-      .intercept('appSelectionRequired', () => ({
-        badRequest: {
-          problems: [{ appSlug: 'Choose which app owns this content.' }]
         }
       }))
 
@@ -132,6 +127,8 @@ module.exports = {
 
     // Redirect to content manager
     const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/content`
+    return `/projects/${slug}${envPath}/content?appSlug=${encodeURIComponent(
+      resolved.app.slug
+    )}`
   }
 }

--- a/api/controllers/project/content-delete.js
+++ b/api/controllers/project/content-delete.js
@@ -17,11 +17,21 @@ module.exports = {
     },
     collection: {
       type: 'string',
-      required: true
+      required: true,
+      regex: /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
     },
     file: {
       type: 'string',
-      required: true
+      required: true,
+      regex: /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
+    },
+    appSlug: {
+      type: 'string',
+      description: 'App whose source repository owns this content file'
+    },
+    sourceSha: {
+      type: 'string',
+      description: 'Git blob SHA loaded by the editor'
     }
   },
 
@@ -37,7 +47,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug, collection, file }) {
+  fn: async function ({ slug, envSlug, collection, file, appSlug, sourceSha }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -65,6 +75,18 @@ module.exports = {
     const contentFeature = environment.features['sails-content']
     const contentDir = contentFeature.contentDir || 'content'
     const appPath = `${sails.config.custom.slipwayAppsDir}/${project.slug}`
+    const resolved = await sails.helpers.deploy.resolveTargetApp
+      .with({ environment, appSlug, requireExplicit: true })
+      .intercept('appNotFound', () => ({
+        badRequest: {
+          problems: [{ appSlug: 'Choose an app that still exists.' }]
+        }
+      }))
+      .intercept('appSelectionRequired', () => ({
+        badRequest: {
+          problems: [{ appSlug: 'Choose which app owns this content.' }]
+        }
+      }))
 
     // Try .md first, then .json
     let filePath = path.join(appPath, contentDir, collection, `${file}.md`)
@@ -77,7 +99,33 @@ module.exports = {
       throw { badRequest: { error: 'Content file not found' } }
     }
 
-    // Delete the file
+    const extension = path.extname(filePath).slice(1)
+    const relativeFilePath = path.posix.join(
+      String(contentDir).replace(/\\/g, '/'),
+      collection,
+      `${file}.${extension}`
+    )
+    await sails.helpers.git.commitContentFile
+      .with({
+        environment,
+        app: resolved.app,
+        user,
+        filePath: relativeFilePath,
+        operation: 'delete',
+        expectedSha: sourceSha,
+        message: `chore(content): delete ${collection}/${file}`
+      })
+      .intercept('conflict', (error) => ({
+        badRequest: {
+          problems: [{ content: (error.raw || error).message }]
+        }
+      }))
+      .intercept('writeUnavailable', (error) => ({
+        badRequest: {
+          problems: [{ content: (error.raw || error).message }]
+        }
+      }))
+
     fs.unlinkSync(filePath)
 
     sails.log.info(`[content] Deleted ${collection}/${file} in ${slug}`)

--- a/api/controllers/project/content-update.js
+++ b/api/controllers/project/content-update.js
@@ -107,17 +107,11 @@ module.exports = {
     const resolved = await sails.helpers.deploy.resolveTargetApp
       .with({
         environment,
-        appSlug,
-        requireExplicit: true
+        appSlug
       })
       .intercept('appNotFound', () => ({
         badRequest: {
           problems: [{ appSlug: 'Choose an app that still exists.' }]
-        }
-      }))
-      .intercept('appSelectionRequired', () => ({
-        badRequest: {
-          problems: [{ appSlug: 'Choose which app owns this content.' }]
         }
       }))
     const targetApp = resolved.app

--- a/api/controllers/project/content-update.js
+++ b/api/controllers/project/content-update.js
@@ -17,11 +17,13 @@ module.exports = {
     },
     collection: {
       type: 'string',
-      required: true
+      required: true,
+      regex: /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
     },
     file: {
       type: 'string',
-      required: true
+      required: true,
+      regex: /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/
     },
     frontmatter: {
       type: 'ref',
@@ -40,6 +42,14 @@ module.exports = {
       type: 'boolean',
       defaultsTo: false,
       description: 'Whether to trigger a deploy after saving'
+    },
+    appSlug: {
+      type: 'string',
+      description: 'App whose source repository owns this content file'
+    },
+    sourceSha: {
+      type: 'string',
+      description: 'Git blob SHA loaded by the editor'
     }
   },
 
@@ -63,7 +73,9 @@ module.exports = {
     frontmatter,
     body,
     raw,
-    deploy
+    deploy,
+    appSlug,
+    sourceSha
   }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
@@ -92,6 +104,23 @@ module.exports = {
     const contentFeature = environment.features['sails-content']
     const contentDir = contentFeature.contentDir || 'content'
     const appPath = `${sails.config.custom.slipwayAppsDir}/${project.slug}`
+    const resolved = await sails.helpers.deploy.resolveTargetApp
+      .with({
+        environment,
+        appSlug,
+        requireExplicit: true
+      })
+      .intercept('appNotFound', () => ({
+        badRequest: {
+          problems: [{ appSlug: 'Choose an app that still exists.' }]
+        }
+      }))
+      .intercept('appSelectionRequired', () => ({
+        badRequest: {
+          problems: [{ appSlug: 'Choose which app owns this content.' }]
+        }
+      }))
+    const targetApp = resolved.app
 
     // Determine file path and type
     let filePath = path.join(appPath, contentDir, collection, `${file}.md`)
@@ -124,27 +153,76 @@ module.exports = {
       content = JSON.stringify(frontmatter, null, 2)
     }
 
-    // Write file
+    if (deploy) {
+      const sourceReadiness =
+        await sails.helpers.deploy.getSourceReadiness.with({
+          project,
+          environment,
+          app: targetApp
+        })
+
+      if (!sourceReadiness.available) {
+        throw {
+          badRequest: {
+            problems: [{ deploy: sourceReadiness.message }]
+          }
+        }
+      }
+    }
+
+    const relativeFilePath = path.posix.join(
+      String(contentDir).replace(/\\/g, '/'),
+      collection,
+      `${file}.${fileType === 'json' ? 'json' : 'md'}`
+    )
+    const commitMessage = `chore(content): update ${collection}/${file}`
+    const persistence = await sails.helpers.git.commitContentFile
+      .with({
+        environment,
+        app: targetApp,
+        user,
+        filePath: relativeFilePath,
+        content,
+        operation: 'update',
+        expectedSha: sourceSha,
+        message: commitMessage
+      })
+      .intercept('conflict', (error) => ({
+        badRequest: {
+          problems: [{ content: (error.raw || error).message }]
+        }
+      }))
+      .intercept('writeUnavailable', (error) => ({
+        badRequest: {
+          problems: [{ content: (error.raw || error).message }]
+        }
+      }))
+
+    // Keep the local build context in sync only after the source-of-truth
+    // write succeeds. Repository deployments will refresh this exact commit.
     fs.writeFileSync(filePath, content, 'utf8')
 
     sails.log.info(`[content] Updated ${collection}/${file} in ${slug}`)
 
     // Trigger deploy if requested
     if (deploy) {
-      const app =
-        (await App.findOne({
-          environment: environment.id,
-          isDefault: true
-        })) || (await App.findOne({ environment: environment.id }))
-      const queued = await sails.helpers.deploy.queueDeployment.with({
-        values: {
-          gitMessage: `Content update: ${collection}/${file}`,
-          triggeredBy: user.id,
-          triggerType: 'manual',
-          environment: environment.id
-        },
-        app
-      })
+      const queued = await sails.helpers.deploy.triggerDeployment
+        .with({
+          project,
+          environment,
+          user,
+          app: targetApp,
+          gitCommit: persistence.commitSha,
+          gitBranch: persistence.branch,
+          gitMessage: commitMessage,
+          triggerType: 'content',
+          ipAddress: this.req.ip
+        })
+        .intercept('sourceUnavailable', (error) => ({
+          badRequest: {
+            problems: [{ deploy: (error.raw || error).message }]
+          }
+        }))
       const deployment = queued.deployment
 
       sails.log.info(
@@ -157,7 +235,9 @@ module.exports = {
 
     // Stay on the same page (Inertia will reload props)
     const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/content/${collection}/${file}`
+    return `/projects/${slug}${envPath}/content/${collection}/${file}?appSlug=${encodeURIComponent(
+      targetApp.slug
+    )}`
   }
 }
 

--- a/api/controllers/project/view-content-editor.js
+++ b/api/controllers/project/view-content-editor.js
@@ -78,16 +78,12 @@ module.exports = {
     const contentFeature = environment.features['sails-content']
     const contentDir = contentFeature.contentDir || 'content'
     const appPath = `${sails.config.custom.slipwayAppsDir}/${project.slug}`
-    const apps = await App.find({ environment: environment.id }).sort([
-      'isDefault DESC',
-      'name ASC',
-      'id ASC'
-    ])
-    const selectedApp = appSlug
-      ? apps.find((app) => app.slug === appSlug)
-      : apps.length === 1
-      ? apps[0]
-      : null
+    const resolved = await sails.helpers.deploy.resolveTargetApp
+      .with({ environment, appSlug })
+      .intercept('appNotFound', () => ({
+        notFound: `/projects/${slug}/environments/${envSlug}`
+      }))
+    const selectedApp = resolved.app
 
     // Load the content file
     let content = null
@@ -112,32 +108,30 @@ module.exports = {
       let sourceSha = gitBlobSha(rawContent)
       let sourceMode = 'local'
       let repository = null
-      if (selectedApp) {
-        const relativeFilePath = path.posix.join(
-          String(contentDir).replace(/\\/g, '/'),
-          collection,
-          `${file}.${fileType === 'json' ? 'json' : 'md'}`
+      const relativeFilePath = path.posix.join(
+        String(contentDir).replace(/\\/g, '/'),
+        collection,
+        `${file}.${fileType === 'json' ? 'json' : 'md'}`
+      )
+      const remote = await sails.helpers.git.readContentFile
+        .with({
+          environment,
+          app: selectedApp,
+          filePath: relativeFilePath
+        })
+        .intercept(
+          'notFound',
+          (error) => new Error((error.raw || error).message)
         )
-        const remote = await sails.helpers.git.readContentFile
-          .with({
-            environment,
-            app: selectedApp,
-            filePath: relativeFilePath
-          })
-          .intercept(
-            'notFound',
-            (error) => new Error((error.raw || error).message)
-          )
-          .intercept(
-            'unavailable',
-            (error) => new Error((error.raw || error).message)
-          )
-        if (remote.mode === 'repository') {
-          rawContent = remote.content
-          sourceSha = remote.sha
-          sourceMode = 'repository'
-          repository = remote.repository
-        }
+        .intercept(
+          'unavailable',
+          (error) => new Error((error.raw || error).message)
+        )
+      if (remote.mode === 'repository') {
+        rawContent = remote.content
+        sourceSha = remote.sha
+        sourceMode = 'repository'
+        repository = remote.repository
       }
 
       // Parse frontmatter for markdown files
@@ -191,13 +185,12 @@ module.exports = {
         contentFeature,
         content,
         contentError,
-        selectedAppSlug: selectedApp?.slug || '',
-        apps: apps.map((app) => ({
-          id: app.id,
-          name: app.name,
-          slug: app.slug,
-          isDefault: app.isDefault
-        }))
+        app: {
+          id: selectedApp.id,
+          name: selectedApp.name,
+          slug: selectedApp.slug,
+          isDefault: selectedApp.isDefault
+        }
       }
     }
   }

--- a/api/controllers/project/view-content-editor.js
+++ b/api/controllers/project/view-content-editor.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const crypto = require('crypto')
 
 module.exports = {
   friendlyName: 'View content editor',
@@ -21,12 +22,18 @@ module.exports = {
     collection: {
       type: 'string',
       required: true,
+      regex: /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
       description: 'Collection name'
     },
     file: {
       type: 'string',
       required: true,
+      regex: /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/,
       description: 'File slug'
+    },
+    appSlug: {
+      type: 'string',
+      description: 'App whose source repository owns this content file'
     }
   },
 
@@ -39,7 +46,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug, collection, file }) {
+  fn: async function ({ slug, envSlug, collection, file, appSlug }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -71,6 +78,16 @@ module.exports = {
     const contentFeature = environment.features['sails-content']
     const contentDir = contentFeature.contentDir || 'content'
     const appPath = `${sails.config.custom.slipwayAppsDir}/${project.slug}`
+    const apps = await App.find({ environment: environment.id }).sort([
+      'isDefault DESC',
+      'name ASC',
+      'id ASC'
+    ])
+    const selectedApp = appSlug
+      ? apps.find((app) => app.slug === appSlug)
+      : apps.length === 1
+      ? apps[0]
+      : null
 
     // Load the content file
     let content = null
@@ -90,8 +107,38 @@ module.exports = {
         throw new Error('Content file not found')
       }
 
-      const rawContent = fs.readFileSync(filePath, 'utf8')
+      let rawContent = fs.readFileSync(filePath, 'utf8')
       const stats = fs.statSync(filePath)
+      let sourceSha = gitBlobSha(rawContent)
+      let sourceMode = 'local'
+      let repository = null
+      if (selectedApp) {
+        const relativeFilePath = path.posix.join(
+          String(contentDir).replace(/\\/g, '/'),
+          collection,
+          `${file}.${fileType === 'json' ? 'json' : 'md'}`
+        )
+        const remote = await sails.helpers.git.readContentFile
+          .with({
+            environment,
+            app: selectedApp,
+            filePath: relativeFilePath
+          })
+          .intercept(
+            'notFound',
+            (error) => new Error((error.raw || error).message)
+          )
+          .intercept(
+            'unavailable',
+            (error) => new Error((error.raw || error).message)
+          )
+        if (remote.mode === 'repository') {
+          rawContent = remote.content
+          sourceSha = remote.sha
+          sourceMode = 'repository'
+          repository = remote.repository
+        }
+      }
 
       // Parse frontmatter for markdown files
       let frontmatter = {}
@@ -116,6 +163,9 @@ module.exports = {
         frontmatter,
         body,
         raw: rawContent,
+        sourceSha,
+        sourceMode,
+        repository,
         updatedAt: stats.mtime.toISOString()
       }
     } catch (err) {
@@ -140,10 +190,26 @@ module.exports = {
         file,
         contentFeature,
         content,
-        contentError
+        contentError,
+        selectedAppSlug: selectedApp?.slug || '',
+        apps: apps.map((app) => ({
+          id: app.id,
+          name: app.name,
+          slug: app.slug,
+          isDefault: app.isDefault
+        }))
       }
     }
   }
+}
+
+function gitBlobSha(content) {
+  const value = Buffer.from(content, 'utf8')
+  return crypto
+    .createHash('sha1')
+    .update(`blob ${value.length}\0`)
+    .update(value)
+    .digest('hex')
 }
 
 /**

--- a/api/controllers/project/view-content-manager.js
+++ b/api/controllers/project/view-content-manager.js
@@ -59,6 +59,11 @@ module.exports = {
     const contentFeature = hasContentFeature
       ? environment.features['sails-content']
       : null
+    const apps = await App.find({ environment: environment.id }).sort([
+      'isDefault DESC',
+      'name ASC',
+      'id ASC'
+    ])
 
     // Load collections if feature is available
     let collections = []
@@ -114,7 +119,13 @@ module.exports = {
         hasContentFeature,
         contentFeature,
         collections,
-        collectionsError
+        collectionsError,
+        apps: apps.map((app) => ({
+          id: app.id,
+          name: app.name,
+          slug: app.slug,
+          isDefault: app.isDefault
+        }))
       }
     }
   }

--- a/api/controllers/project/view-content-manager.js
+++ b/api/controllers/project/view-content-manager.js
@@ -16,6 +16,10 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production',
       description: 'Environment slug'
+    },
+    appSlug: {
+      type: 'string',
+      description: 'App that owns this content workspace'
     }
   },
 
@@ -28,7 +32,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug }) {
+  fn: async function ({ slug, envSlug, appSlug }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -59,11 +63,12 @@ module.exports = {
     const contentFeature = hasContentFeature
       ? environment.features['sails-content']
       : null
-    const apps = await App.find({ environment: environment.id }).sort([
-      'isDefault DESC',
-      'name ASC',
-      'id ASC'
-    ])
+    const resolved = await sails.helpers.deploy.resolveTargetApp
+      .with({ environment, appSlug })
+      .intercept('appNotFound', () => ({
+        notFound: `/projects/${slug}/environments/${envSlug}`
+      }))
+    const app = resolved.app
 
     // Load collections if feature is available
     let collections = []
@@ -120,12 +125,12 @@ module.exports = {
         contentFeature,
         collections,
         collectionsError,
-        apps: apps.map((app) => ({
+        app: {
           id: app.id,
           name: app.name,
           slug: app.slug,
           isDefault: app.isDefault
-        }))
+        }
       }
     }
   }

--- a/api/controllers/webhook/github.js
+++ b/api/controllers/webhook/github.js
@@ -1,4 +1,5 @@
 const path = require('path')
+const { isContentCommit } = require('../../lib/content-commit')
 
 /**
  * GitHub Webhook Handler
@@ -92,6 +93,16 @@ async function handlePush(repo, payload) {
   const branch = payload.ref?.replace('refs/heads/', '')
   const commit = payload.after
   const pusher = payload.pusher?.name
+
+  // Content Manager owns deployment orchestration for its commits. Skipping
+  // here keeps Save as commit-only and Save & Deploy to exactly one pipeline.
+  if (isContentCommit(payload.head_commit?.message)) {
+    return {
+      received: true,
+      action: 'skipped',
+      reason: 'content_manager_commit'
+    }
+  }
 
   sails.log.info(`[webhook] Push to ${repo.fullName}/${branch} by ${pusher}`)
 

--- a/api/helpers/deploy/ensure-build-context.js
+++ b/api/helpers/deploy/ensure-build-context.js
@@ -25,6 +25,10 @@ module.exports = {
     gitBranch: {
       type: 'string'
     },
+    gitCommit: {
+      type: 'string',
+      description: 'Exact repository commit to build when one was recorded.'
+    },
     refreshRepository: {
       type: 'boolean',
       defaultsTo: false,
@@ -45,6 +49,7 @@ module.exports = {
     app,
     deploymentId,
     gitBranch,
+    gitCommit,
     refreshRepository
   }) {
     const readiness = await inspectBuildContext({
@@ -76,6 +81,7 @@ module.exports = {
         await sails.helpers.git.cloneOrPull.with({
           cloneUrl: repo.cloneUrl,
           branch,
+          ...(gitCommit ? { commit: gitCommit } : {}),
           targetDir: contextPath,
           deployKeyPrivate: repo.deployKeyPrivate,
           deploymentId

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -128,6 +128,7 @@ module.exports = {
           app: targetApp,
           deploymentId,
           gitBranch: deployment?.gitBranch,
+          gitCommit: deployment?.gitCommit,
           refreshRepository: true
         })
 

--- a/api/helpers/deploy/resolve-target-app.js
+++ b/api/helpers/deploy/resolve-target-app.js
@@ -2,7 +2,7 @@ module.exports = {
   friendlyName: 'Resolve target app',
 
   description:
-    'Resolve an environment deployment target and optionally require an explicit choice for multi-app environments.',
+    'Resolve an app-scoped deployment target, falling back to the default app.',
 
   inputs: {
     environment: {
@@ -14,10 +14,6 @@ module.exports = {
     },
     appSlug: {
       type: 'string'
-    },
-    requireExplicit: {
-      type: 'boolean',
-      defaultsTo: false
     }
   },
 
@@ -27,13 +23,10 @@ module.exports = {
     },
     appNotFound: {
       description: 'No matching app exists in the environment.'
-    },
-    appSelectionRequired: {
-      description: 'The environment has multiple apps and needs a choice.'
     }
   },
 
-  fn: async function ({ environment, app, appSlug, requireExplicit }) {
+  fn: async function ({ environment, app, appSlug }) {
     const apps = await App.find({ environment: environment.id }).sort([
       'isDefault DESC',
       'name ASC',
@@ -47,14 +40,12 @@ module.exports = {
       )
     } else if (appSlug) {
       targetApp = apps.find((candidate) => candidate.slug === appSlug)
-    } else if (requireExplicit && apps.length > 1) {
-      throw 'appSelectionRequired'
     } else {
       targetApp = apps.find((candidate) => candidate.isDefault) || apps[0]
     }
 
     if (!targetApp) throw 'appNotFound'
 
-    return { app: targetApp, apps }
+    return { app: targetApp }
   }
 }

--- a/api/helpers/deploy/resolve-target-app.js
+++ b/api/helpers/deploy/resolve-target-app.js
@@ -1,0 +1,60 @@
+module.exports = {
+  friendlyName: 'Resolve target app',
+
+  description:
+    'Resolve an environment deployment target and optionally require an explicit choice for multi-app environments.',
+
+  inputs: {
+    environment: {
+      type: 'ref',
+      required: true
+    },
+    app: {
+      type: 'ref'
+    },
+    appSlug: {
+      type: 'string'
+    },
+    requireExplicit: {
+      type: 'boolean',
+      defaultsTo: false
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    },
+    appNotFound: {
+      description: 'No matching app exists in the environment.'
+    },
+    appSelectionRequired: {
+      description: 'The environment has multiple apps and needs a choice.'
+    }
+  },
+
+  fn: async function ({ environment, app, appSlug, requireExplicit }) {
+    const apps = await App.find({ environment: environment.id }).sort([
+      'isDefault DESC',
+      'name ASC',
+      'id ASC'
+    ])
+
+    let targetApp = app
+    if (targetApp) {
+      targetApp = apps.find(
+        (candidate) => Number(candidate.id) === Number(targetApp.id)
+      )
+    } else if (appSlug) {
+      targetApp = apps.find((candidate) => candidate.slug === appSlug)
+    } else if (requireExplicit && apps.length > 1) {
+      throw 'appSelectionRequired'
+    } else {
+      targetApp = apps.find((candidate) => candidate.isDefault) || apps[0]
+    }
+
+    if (!targetApp) throw 'appNotFound'
+
+    return { app: targetApp, apps }
+  }
+}

--- a/api/helpers/deploy/trigger-deployment.js
+++ b/api/helpers/deploy/trigger-deployment.js
@@ -1,0 +1,166 @@
+module.exports = {
+  friendlyName: 'Trigger deployment',
+
+  description:
+    'Resolve, preflight, record, and queue a deployment through the shared durable pipeline.',
+
+  inputs: {
+    project: {
+      type: 'ref',
+      required: true
+    },
+    environment: {
+      type: 'ref',
+      required: true
+    },
+    user: {
+      type: 'ref',
+      required: true
+    },
+    app: {
+      type: 'ref'
+    },
+    appSlug: {
+      type: 'string'
+    },
+    requireExplicitApp: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    gitCommit: {
+      type: 'string'
+    },
+    gitBranch: {
+      type: 'string'
+    },
+    gitMessage: {
+      type: 'string'
+    },
+    triggerType: {
+      type: 'string',
+      isIn: ['manual', 'cli', 'webhook', 'api', 'content'],
+      required: true
+    },
+    ipAddress: {
+      type: 'string'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    },
+    appNotFound: {},
+    appSelectionRequired: {},
+    sourceUnavailable: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    project,
+    environment,
+    user,
+    app,
+    appSlug,
+    requireExplicitApp,
+    gitCommit,
+    gitBranch,
+    gitMessage,
+    triggerType,
+    ipAddress
+  }) {
+    const resolved = await sails.helpers.deploy.resolveTargetApp
+      .with({
+        environment,
+        app,
+        appSlug,
+        requireExplicit: requireExplicitApp
+      })
+      .intercept('appNotFound', 'appNotFound')
+      .intercept('appSelectionRequired', 'appSelectionRequired')
+    const targetApp = resolved.app
+    const sourceReadiness = await sails.helpers.deploy.getSourceReadiness.with({
+      project,
+      environment,
+      app: targetApp
+    })
+
+    if (!sourceReadiness.available) {
+      throw {
+        sourceUnavailable: {
+          code: 'deploymentSourceUnavailable',
+          message: sourceReadiness.message,
+          guidance:
+            'Run `slipway slide` from your project or connect a repository, then try again.'
+        }
+      }
+    }
+
+    let finalGitCommit = gitCommit
+    let finalGitBranch = gitBranch
+    let finalGitMessage = gitMessage
+
+    if (sourceReadiness.mode === 'repository' && (!gitCommit || !gitBranch)) {
+      const previousCriteria = {
+        environment: environment.id,
+        gitCommit: { '!=': null },
+        or: targetApp.isDefault
+          ? [{ app: targetApp.id }, { app: null }]
+          : [{ app: targetApp.id }]
+      }
+      const previous = await Deployment.find(previousCriteria)
+        .sort('id DESC')
+        .limit(1)
+
+      if (previous.length > 0) {
+        finalGitCommit = gitCommit || previous[0].gitCommit
+        finalGitBranch = gitBranch || previous[0].gitBranch
+        finalGitMessage = gitMessage || previous[0].gitMessage
+      }
+    }
+
+    const queued = await sails.helpers.deploy.queueDeployment.with({
+      values: {
+        gitCommit: finalGitCommit,
+        gitBranch: finalGitBranch,
+        gitMessage: finalGitMessage,
+        triggeredBy: user.id,
+        triggerType,
+        environment: environment.id
+      },
+      app: targetApp
+    })
+
+    sails.helpers.audit.log
+      .with({
+        action: 'deployment.triggered',
+        resourceType: 'deployment',
+        resourceId: queued.deployment.id,
+        details: {
+          projectSlug: project.slug,
+          environmentSlug: environment.slug,
+          appSlug: targetApp.slug,
+          gitCommit: finalGitCommit,
+          triggerType
+        },
+        userId: user.id,
+        teamId: normalizeId(project.team),
+        ipAddress
+      })
+      .exec(() => {})
+
+    return {
+      ...queued,
+      app: targetApp,
+      sourceReadiness,
+      gitCommit: finalGitCommit,
+      gitBranch: finalGitBranch,
+      gitMessage: finalGitMessage
+    }
+  }
+}
+
+function normalizeId(value) {
+  return value && typeof value === 'object' ? value.id : value
+}

--- a/api/helpers/deploy/trigger-deployment.js
+++ b/api/helpers/deploy/trigger-deployment.js
@@ -23,10 +23,6 @@ module.exports = {
     appSlug: {
       type: 'string'
     },
-    requireExplicitApp: {
-      type: 'boolean',
-      defaultsTo: false
-    },
     gitCommit: {
       type: 'string'
     },
@@ -51,7 +47,6 @@ module.exports = {
       outputType: 'ref'
     },
     appNotFound: {},
-    appSelectionRequired: {},
     sourceUnavailable: {
       outputType: 'ref'
     }
@@ -63,7 +58,6 @@ module.exports = {
     user,
     app,
     appSlug,
-    requireExplicitApp,
     gitCommit,
     gitBranch,
     gitMessage,
@@ -74,11 +68,9 @@ module.exports = {
       .with({
         environment,
         app,
-        appSlug,
-        requireExplicit: requireExplicitApp
+        appSlug
       })
       .intercept('appNotFound', 'appNotFound')
-      .intercept('appSelectionRequired', 'appSelectionRequired')
     const targetApp = resolved.app
     const sourceReadiness = await sails.helpers.deploy.getSourceReadiness.with({
       project,

--- a/api/helpers/deployment/get-history.js
+++ b/api/helpers/deployment/get-history.js
@@ -7,7 +7,7 @@ const VALID_STATUS_FILTERS = [
   'failed',
   'cancelled'
 ]
-const VALID_SOURCES = ['manual', 'cli', 'webhook', 'api']
+const VALID_SOURCES = ['manual', 'cli', 'webhook', 'api', 'content']
 
 function encodeCursor(deployment) {
   return Buffer.from(
@@ -63,6 +63,7 @@ function titleFor(deployment) {
   if (deployment.triggerType === 'webhook') return 'Git deployment'
   if (deployment.triggerType === 'cli') return 'Pushed source deployment'
   if (deployment.triggerType === 'api') return 'API deployment'
+  if (deployment.triggerType === 'content') return 'Content deployment'
   return 'Manual deployment'
 }
 
@@ -71,7 +72,8 @@ function sourceLabel(triggerType) {
     webhook: 'Git',
     cli: 'CLI',
     api: 'API',
-    manual: 'Manual'
+    manual: 'Manual',
+    content: 'Content'
   }[triggerType]
 }
 

--- a/api/helpers/git/clone-or-pull.js
+++ b/api/helpers/git/clone-or-pull.js
@@ -21,6 +21,10 @@ module.exports = {
       required: true,
       description: 'Branch to checkout'
     },
+    commit: {
+      type: 'string',
+      description: 'Exact commit SHA to checkout after fetching the branch.'
+    },
     targetDir: {
       type: 'string',
       required: true,
@@ -40,10 +44,12 @@ module.exports = {
   fn: async function ({
     cloneUrl,
     branch,
+    commit,
     targetDir,
     deployKeyPrivate,
     deploymentId
   }) {
+    const exactCommit = isCommitSha(commit) ? commit : null
     // Normalize the key: fix escaped newlines and ensure trailing newline
     let key = deployKeyPrivate.replace(/\\n/g, '\n')
     if (!key.endsWith('\n')) {
@@ -95,17 +101,14 @@ module.exports = {
           env,
           timeout
         })
-        await execFileAsync(
-          'git',
-          ['checkout', '-B', branch, `origin/${branch}`],
-          { cwd: targetDir, env, timeout: 30_000 }
-        )
-        await execFileAsync('git', ['clean', '-fd'], {
-          cwd: targetDir,
+        await checkoutSource({
+          targetDir,
+          branch,
+          commit: exactCommit,
           env,
-          timeout: 30_000
+          timeout,
+          log
         })
-        await log(`Updated to latest ${branch}`)
       } else {
         // Fresh clone
         if (fs.existsSync(targetDir)) {
@@ -127,6 +130,14 @@ module.exports = {
           { env, timeout }
         )
         await log(`Cloned successfully`)
+        await checkoutSource({
+          targetDir,
+          branch,
+          commit: exactCommit,
+          env,
+          timeout,
+          log
+        })
       }
 
       // Log the HEAD commit for traceability
@@ -146,3 +157,56 @@ module.exports = {
     }
   }
 }
+
+async function checkoutSource({
+  targetDir,
+  branch,
+  commit,
+  env,
+  timeout,
+  log
+}) {
+  if (commit) {
+    await log(`Fetching exact commit ${commit.slice(0, 12)}...`)
+    await execFileAsync('git', ['fetch', '--depth', '1', 'origin', commit], {
+      cwd: targetDir,
+      env,
+      timeout
+    })
+    await execFileAsync('git', ['checkout', '--detach', commit], {
+      cwd: targetDir,
+      env,
+      timeout: 30_000
+    })
+    await execFileAsync('git', ['reset', '--hard', commit], {
+      cwd: targetDir,
+      env,
+      timeout: 30_000
+    })
+    await log(`Checked out exact commit ${commit.slice(0, 12)}`)
+  } else {
+    await execFileAsync('git', ['checkout', '-B', branch, `origin/${branch}`], {
+      cwd: targetDir,
+      env,
+      timeout: 30_000
+    })
+    await execFileAsync('git', ['reset', '--hard', `origin/${branch}`], {
+      cwd: targetDir,
+      env,
+      timeout: 30_000
+    })
+    await log(`Updated to latest ${branch}`)
+  }
+
+  await execFileAsync('git', ['clean', '-fd'], {
+    cwd: targetDir,
+    env,
+    timeout: 30_000
+  })
+}
+
+function isCommitSha(value) {
+  return typeof value === 'string' && /^[a-f0-9]{40,64}$/i.test(value)
+}
+
+module.exports._private = { checkoutSource, isCommitSha }

--- a/api/helpers/git/commit-content-file.js
+++ b/api/helpers/git/commit-content-file.js
@@ -1,0 +1,203 @@
+const { withContentCommitTrailer } = require('../../lib/content-commit')
+
+module.exports = {
+  friendlyName: 'Commit content file',
+
+  description:
+    'Commit a Content Manager file to its connected GitHub repository with optimistic conflict protection.',
+
+  inputs: {
+    environment: {
+      type: 'ref',
+      required: true
+    },
+    app: {
+      type: 'ref',
+      required: true
+    },
+    user: {
+      type: 'ref',
+      required: true
+    },
+    filePath: {
+      type: 'string',
+      required: true,
+      description: 'Repository-relative content file path.'
+    },
+    content: {
+      type: 'string',
+      description: 'Complete replacement file contents.'
+    },
+    operation: {
+      type: 'string',
+      isIn: ['create', 'update', 'delete'],
+      defaultsTo: 'update'
+    },
+    expectedSha: {
+      type: 'string',
+      description: 'Blob SHA loaded by the editor.'
+    },
+    message: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    },
+    conflict: {
+      description: 'The repository file changed after the editor loaded it.',
+      outputType: 'ref'
+    },
+    writeUnavailable: {
+      description: 'The connected repository cannot be written.',
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    environment,
+    app,
+    user,
+    filePath,
+    content,
+    operation,
+    expectedSha,
+    message
+  }) {
+    const repository = await findRepository({ environment, app })
+    if (!repository) {
+      return { mode: 'local' }
+    }
+
+    const providerId = normalizeId(repository.provider)
+    const provider = providerId
+      ? await GitProvider.findOne({ id: providerId }).decrypt()
+      : null
+
+    if (!provider || provider.type !== 'github' || !provider.clientSecret) {
+      throw {
+        writeUnavailable: {
+          message:
+            'The connected repository cannot accept Content Manager changes. Reconnect GitHub and try again.'
+        }
+      }
+    }
+
+    if (operation !== 'create' && !expectedSha) {
+      throw {
+        conflict: {
+          message:
+            'The editor does not have a repository revision for this file. Reload it before saving.'
+        }
+      }
+    }
+
+    const branch = resolveBranch(repository, environment.slug)
+    const encodedPath = filePath
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/')
+    const url = `https://api.github.com/repos/${encodeURIComponent(
+      repository.owner
+    )}/${encodeURIComponent(repository.name)}/contents/${encodedPath}`
+    const body = {
+      message: withContentCommitTrailer(message),
+      branch,
+      author: {
+        name: user.fullName,
+        email: user.email
+      }
+    }
+    if (operation === 'delete') {
+      body.sha = expectedSha
+    } else {
+      body.content = Buffer.from(content || '', 'utf8').toString('base64')
+      if (expectedSha) body.sha = expectedSha
+    }
+
+    const response = await fetch(url, {
+      method: operation === 'delete' ? 'DELETE' : 'PUT',
+      headers: {
+        Authorization: `Bearer ${provider.clientSecret}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(body)
+    })
+
+    if (response.status === 409 || response.status === 422) {
+      throw {
+        conflict: {
+          message:
+            'This file changed in Git while you were editing it. Reload the latest version before saving.'
+        }
+      }
+    }
+
+    if (response.status === 401 || response.status === 403) {
+      throw {
+        writeUnavailable: {
+          message:
+            'GitHub rejected this content commit. Reconnect GitHub with repository write access and try again.'
+        }
+      }
+    }
+
+    if (!response.ok) {
+      let detail = ''
+      try {
+        const error = await response.json()
+        detail = error.message ? ` ${error.message}` : ''
+      } catch {
+        /* GitHub did not return JSON. */
+      }
+
+      throw {
+        writeUnavailable: {
+          message: `GitHub could not save this content.${detail}`
+        }
+      }
+    }
+
+    const result = await response.json()
+    return {
+      mode: 'repository',
+      branch,
+      commitSha: result.commit?.sha || null,
+      contentSha: result.content?.sha || null,
+      repository: {
+        id: repository.id,
+        fullName: repository.fullName,
+        htmlUrl: repository.htmlUrl
+      }
+    }
+  }
+}
+
+async function findRepository({ environment, app }) {
+  let query = GitRepository.findOne({ app: app.id })
+  if (query && typeof query.decrypt === 'function') query = query.decrypt()
+  const appRepository = await query
+  if (appRepository) return appRepository
+
+  query = GitRepository.findOne({ environment: environment.id })
+  if (query && typeof query.decrypt === 'function') query = query.decrypt()
+  return query
+}
+
+function resolveBranch(repository, environmentSlug) {
+  const mappings = repository.branchMappings || {}
+  const mapped = Object.entries(mappings).find(
+    ([, mappedEnvironment]) => mappedEnvironment === environmentSlug
+  )
+
+  return mapped?.[0] || repository.defaultBranch || 'main'
+}
+
+function normalizeId(value) {
+  return value && typeof value === 'object' ? value.id : value
+}

--- a/api/helpers/git/read-content-file.js
+++ b/api/helpers/git/read-content-file.js
@@ -1,0 +1,135 @@
+module.exports = {
+  friendlyName: 'Read content file',
+
+  description:
+    'Read the current Content Manager file from a connected GitHub repository.',
+
+  inputs: {
+    environment: {
+      type: 'ref',
+      required: true
+    },
+    app: {
+      type: 'ref',
+      required: true
+    },
+    filePath: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    },
+    notFound: {
+      outputType: 'ref'
+    },
+    unavailable: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ environment, app, filePath }) {
+    const repository = await findRepository({ environment, app })
+    if (!repository) return { mode: 'local' }
+
+    const providerId = normalizeId(repository.provider)
+    const provider = providerId
+      ? await GitProvider.findOne({ id: providerId }).decrypt()
+      : null
+    if (!provider || provider.type !== 'github' || !provider.clientSecret) {
+      throw {
+        unavailable: {
+          message:
+            'GitHub could not load the latest content. Reconnect the repository and try again.'
+        }
+      }
+    }
+
+    const branch = resolveBranch(repository, environment.slug)
+    const encodedPath = filePath
+      .split('/')
+      .map((segment) => encodeURIComponent(segment))
+      .join('/')
+    const url = new URL(
+      `https://api.github.com/repos/${encodeURIComponent(
+        repository.owner
+      )}/${encodeURIComponent(repository.name)}/contents/${encodedPath}`
+    )
+    url.searchParams.set('ref', branch)
+
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${provider.clientSecret}`,
+        Accept: 'application/vnd.github+json',
+        'X-GitHub-Api-Version': '2022-11-28'
+      }
+    })
+
+    if (response.status === 404) {
+      throw {
+        notFound: {
+          message: `This content file no longer exists on ${branch}.`
+        }
+      }
+    }
+
+    if (!response.ok) {
+      throw {
+        unavailable: {
+          message:
+            'GitHub could not load the latest content. Try again before editing this file.'
+        }
+      }
+    }
+
+    const result = await response.json()
+    if (result.type !== 'file' || !result.content || !result.sha) {
+      throw {
+        unavailable: {
+          message: 'GitHub returned an invalid content file response.'
+        }
+      }
+    }
+
+    return {
+      mode: 'repository',
+      branch,
+      content: Buffer.from(
+        String(result.content).replace(/\s/g, ''),
+        'base64'
+      ).toString('utf8'),
+      sha: result.sha,
+      repository: {
+        id: repository.id,
+        fullName: repository.fullName,
+        htmlUrl: repository.htmlUrl
+      }
+    }
+  }
+}
+
+async function findRepository({ environment, app }) {
+  let query = GitRepository.findOne({ app: app.id })
+  if (query && typeof query.decrypt === 'function') query = query.decrypt()
+  const appRepository = await query
+  if (appRepository) return appRepository
+
+  query = GitRepository.findOne({ environment: environment.id })
+  if (query && typeof query.decrypt === 'function') query = query.decrypt()
+  return query
+}
+
+function resolveBranch(repository, environmentSlug) {
+  const mappings = repository.branchMappings || {}
+  const mapped = Object.entries(mappings).find(
+    ([, mappedEnvironment]) => mappedEnvironment === environmentSlug
+  )
+  return mapped?.[0] || repository.defaultBranch || 'main'
+}
+
+function normalizeId(value) {
+  return value && typeof value === 'object' ? value.id : value
+}

--- a/api/lib/content-commit.js
+++ b/api/lib/content-commit.js
@@ -1,0 +1,18 @@
+const TRAILER = 'Slipway-Content-Change: true'
+
+function withContentCommitTrailer(message) {
+  const trimmed = String(message || '').trim()
+  return `${trimmed}\n\n${TRAILER}`
+}
+
+function isContentCommit(message) {
+  return String(message || '')
+    .split(/\r?\n/)
+    .some((line) => line.trim() === TRAILER)
+}
+
+module.exports = {
+  TRAILER,
+  isContentCommit,
+  withContentCommitTrailer
+}

--- a/api/models/Deployment.js
+++ b/api/models/Deployment.js
@@ -110,7 +110,7 @@ module.exports = {
 
     triggerType: {
       type: 'string',
-      isIn: ['manual', 'cli', 'webhook', 'api'],
+      isIn: ['manual', 'cli', 'webhook', 'api', 'content'],
       defaultsTo: 'manual',
       description: 'How the deployment was triggered',
       columnName: 'trigger_type'

--- a/api/responses/badRequest.js
+++ b/api/responses/badRequest.js
@@ -1,4 +1,18 @@
 module.exports = function badRequest(optionalData) {
+  // inertia-sails 1.5 uses Express's removed two-argument redirect signature
+  // for this path. Preserve its normal validation-error contract while using
+  // the Sails/Express v4-compatible status + redirect form.
+  if (this.req.header?.('X-Inertia') && !this.req.header?.('Precognition')) {
+    const humanizeValidationErrors = require('inertia-sails/lib/helpers/humanize-validation-errors')
+    const errors = humanizeValidationErrors(optionalData)
+
+    if (Object.keys(errors).length > 0) {
+      this.req.session = this.req.session || {}
+      this.req.session.errors = errors
+      return this.res.status(303).redirect(this.req.get('Referrer') || '/')
+    }
+  }
+
   return this.req._sails.inertia.handleBadRequest(
     this.req,
     this.res,

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -952,6 +952,7 @@ onBeforeUnmount(() => {
             <!-- More menu -->
             <div class="relative">
               <button
+                data-test="app-more-menu"
                 @click.stop="moreMenuOpen = !moreMenuOpen"
                 class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
               >
@@ -1072,7 +1073,7 @@ onBeforeUnmount(() => {
                         environment.features &&
                         environment.features['sails-content']
                       "
-                      :href="`/projects/${project.slug}/environments/${environment.slug}/content`"
+                      :href="`/projects/${project.slug}/environments/${environment.slug}/content?appSlug=${app.slug}`"
                       class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                     >
                       <svg

--- a/assets/js/pages/projects/content-editor.vue
+++ b/assets/js/pages/projects/content-editor.vue
@@ -17,8 +17,7 @@ const props = defineProps({
   contentFeature: Object,
   content: Object,
   contentError: String,
-  selectedAppSlug: String,
-  apps: Array
+  app: Object
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -47,16 +46,12 @@ const saveForm = useForm({
   body: '',
   raw: '',
   deploy: false,
-  appSlug:
-    props.selectedAppSlug ||
-    (props.apps?.length === 1 ? props.apps[0].slug : ''),
+  appSlug: props.app.slug,
   sourceSha: props.content?.sourceSha || ''
 })
 
 const deleteForm = useForm({
-  appSlug:
-    props.selectedAppSlug ||
-    (props.apps?.length === 1 ? props.apps[0].slug : ''),
+  appSlug: props.app.slug,
   sourceSha: props.content?.sourceSha || ''
 })
 
@@ -95,9 +90,11 @@ const envPath = computed(() => {
 })
 
 function getContentManagerPath() {
-  return props.environment.slug !== 'production'
-    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/content`
-    : `/projects/${props.project.slug}/content`
+  const path =
+    props.environment.slug !== 'production'
+      ? `/projects/${props.project.slug}/environments/${props.environment.slug}/content`
+      : `/projects/${props.project.slug}/content`
+  return `${path}?appSlug=${props.app.slug}`
 }
 
 function getActionPath(action) {
@@ -107,12 +104,6 @@ function getActionPath(action) {
 // Save content
 function saveContent(triggerDeploy = false) {
   if (saveForm.processing) return
-
-  if (props.apps?.length > 1 && !saveForm.appSlug) {
-    saveForm.setError('appSlug', 'Choose which app owns this content.')
-    showSaveMenu.value = true
-    return
-  }
 
   if (editingRaw.value) {
     saveForm.raw = raw.value
@@ -152,26 +143,8 @@ function saveAndDeployAndCloseMenu() {
   saveContent(true)
 }
 
-function selectTargetApp() {
-  saveForm.clearErrors('appSlug')
-
-  const url = new URL(window.location.href)
-  if (saveForm.appSlug) {
-    url.searchParams.set('appSlug', saveForm.appSlug)
-  } else {
-    url.searchParams.delete('appSlug')
-  }
-  window.history.replaceState({}, '', url)
-}
-
 // Delete content
 function openDeleteModal() {
-  if (props.apps?.length > 1 && !saveForm.appSlug) {
-    saveForm.setError('appSlug', 'Choose which app owns this content.')
-    showSaveMenu.value = true
-    return
-  }
-
   deleteModalOpen.value = true
 }
 
@@ -552,40 +525,6 @@ function handleKeydown(e) {
             data-test="content-save-menu"
             class="absolute right-0 top-full z-10 mt-1 w-64 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
           >
-            <div
-              v-if="apps?.length > 1"
-              class="border-b border-gray-100 px-3 py-2 dark:border-gray-700"
-            >
-              <label
-                for="content-target-app"
-                class="block text-xs font-medium text-gray-500 dark:text-gray-400"
-              >
-                Target app
-              </label>
-              <select
-                id="content-target-app"
-                data-test="content-target-app"
-                v-model="saveForm.appSlug"
-                :aria-invalid="Boolean(saveForm.errors.appSlug)"
-                :aria-describedby="
-                  saveForm.errors.appSlug ? 'content-target-app-error' : null
-                "
-                class="mt-1 block w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 focus:border-gray-400 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
-                @change="selectTargetApp"
-              >
-                <option value="" disabled>Choose an app</option>
-                <option v-for="app in apps" :key="app.id" :value="app.slug">
-                  {{ app.name }}
-                </option>
-              </select>
-              <p
-                v-if="saveForm.errors.appSlug"
-                id="content-target-app-error"
-                class="mt-1 text-xs text-red-600 dark:text-red-400"
-              >
-                {{ saveForm.errors.appSlug }}
-              </p>
-            </div>
             <button
               @click="saveOnlyAndCloseMenu"
               :disabled="!hasChanges"
@@ -601,11 +540,19 @@ function handleKeydown(e) {
               Save & Deploy
             </button>
             <p
-              v-if="saveForm.errors.content || saveForm.errors.deploy"
+              v-if="
+                saveForm.errors.content ||
+                saveForm.errors.deploy ||
+                saveForm.errors.appSlug
+              "
               role="alert"
               class="border-t border-gray-100 px-3 py-2 text-xs leading-5 text-red-600 dark:border-gray-700 dark:text-red-400"
             >
-              {{ saveForm.errors.content || saveForm.errors.deploy }}
+              {{
+                saveForm.errors.content ||
+                saveForm.errors.deploy ||
+                saveForm.errors.appSlug
+              }}
             </p>
           </div>
         </div>

--- a/assets/js/pages/projects/content-editor.vue
+++ b/assets/js/pages/projects/content-editor.vue
@@ -16,7 +16,9 @@ const props = defineProps({
   file: String,
   contentFeature: Object,
   content: Object,
-  contentError: String
+  contentError: String,
+  selectedAppSlug: String,
+  apps: Array
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -44,10 +46,19 @@ const saveForm = useForm({
   frontmatter: {},
   body: '',
   raw: '',
-  deploy: false
+  deploy: false,
+  appSlug:
+    props.selectedAppSlug ||
+    (props.apps?.length === 1 ? props.apps[0].slug : ''),
+  sourceSha: props.content?.sourceSha || ''
 })
 
-const deleteForm = useForm({})
+const deleteForm = useForm({
+  appSlug:
+    props.selectedAppSlug ||
+    (props.apps?.length === 1 ? props.apps[0].slug : ''),
+  sourceSha: props.content?.sourceSha || ''
+})
 
 // Preview
 const previewHtml = computed(() => {
@@ -97,6 +108,12 @@ function getActionPath(action) {
 function saveContent(triggerDeploy = false) {
   if (saveForm.processing) return
 
+  if (props.apps?.length > 1 && !saveForm.appSlug) {
+    saveForm.setError('appSlug', 'Choose which app owns this content.')
+    showSaveMenu.value = true
+    return
+  }
+
   if (editingRaw.value) {
     saveForm.raw = raw.value
     saveForm.frontmatter = {}
@@ -107,15 +124,20 @@ function saveContent(triggerDeploy = false) {
     saveForm.raw = ''
   }
   saveForm.deploy = triggerDeploy
+  saveForm.clearErrors()
 
   saveForm.post(getActionPath('update'), {
     preserveScroll: true,
-    onSuccess: () => {
+    onSuccess: (page) => {
       hasChanges.value = false
       // Update updatedAt from refreshed props
-      if (props.content) {
-        updatedAt.value = props.content.updatedAt
+      if (page.props.content) {
+        updatedAt.value = page.props.content.updatedAt
+        saveForm.sourceSha = page.props.content.sourceSha
       }
+    },
+    onError: () => {
+      showSaveMenu.value = true
     }
   })
 }
@@ -130,11 +152,42 @@ function saveAndDeployAndCloseMenu() {
   saveContent(true)
 }
 
+function selectTargetApp() {
+  saveForm.clearErrors('appSlug')
+
+  const url = new URL(window.location.href)
+  if (saveForm.appSlug) {
+    url.searchParams.set('appSlug', saveForm.appSlug)
+  } else {
+    url.searchParams.delete('appSlug')
+  }
+  window.history.replaceState({}, '', url)
+}
+
 // Delete content
+function openDeleteModal() {
+  if (props.apps?.length > 1 && !saveForm.appSlug) {
+    saveForm.setError('appSlug', 'Choose which app owns this content.')
+    showSaveMenu.value = true
+    return
+  }
+
+  deleteModalOpen.value = true
+}
+
 function deleteContent() {
+  deleteForm.appSlug = saveForm.appSlug
+  deleteForm.sourceSha = saveForm.sourceSha
   deleteForm.post(getActionPath('delete'), {
     onSuccess: () => {
       deleteModalOpen.value = false
+    },
+    onError: (errors) => {
+      deleteModalOpen.value = false
+      for (const [field, message] of Object.entries(errors)) {
+        saveForm.setError(field, message)
+      }
+      showSaveMenu.value = true
     }
   })
 }
@@ -439,7 +492,7 @@ function handleKeydown(e) {
         <!-- Delete (hidden on mobile) -->
         <Tooltip text="Delete">
           <button
-            @click="deleteModalOpen = true"
+            @click="openDeleteModal"
             class="hidden rounded-md p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400 sm:block"
           >
             <svg
@@ -474,6 +527,7 @@ function handleKeydown(e) {
             }}
           </button>
           <button
+            data-test="content-save-menu-toggle"
             @click="showSaveMenu = !showSaveMenu"
             :disabled="saveForm.processing"
             class="rounded-r-md border-l border-gray-700 bg-gray-900 px-2 py-1.5 text-white hover:bg-gray-800 disabled:opacity-50 dark:border-gray-300 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
@@ -495,8 +549,43 @@ function handleKeydown(e) {
           <!-- Dropdown -->
           <div
             v-if="showSaveMenu"
-            class="absolute right-0 top-full z-10 mt-1 w-48 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+            data-test="content-save-menu"
+            class="absolute right-0 top-full z-10 mt-1 w-64 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
           >
+            <div
+              v-if="apps?.length > 1"
+              class="border-b border-gray-100 px-3 py-2 dark:border-gray-700"
+            >
+              <label
+                for="content-target-app"
+                class="block text-xs font-medium text-gray-500 dark:text-gray-400"
+              >
+                Target app
+              </label>
+              <select
+                id="content-target-app"
+                data-test="content-target-app"
+                v-model="saveForm.appSlug"
+                :aria-invalid="Boolean(saveForm.errors.appSlug)"
+                :aria-describedby="
+                  saveForm.errors.appSlug ? 'content-target-app-error' : null
+                "
+                class="mt-1 block w-full rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 focus:border-gray-400 focus:outline-none dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+                @change="selectTargetApp"
+              >
+                <option value="" disabled>Choose an app</option>
+                <option v-for="app in apps" :key="app.id" :value="app.slug">
+                  {{ app.name }}
+                </option>
+              </select>
+              <p
+                v-if="saveForm.errors.appSlug"
+                id="content-target-app-error"
+                class="mt-1 text-xs text-red-600 dark:text-red-400"
+              >
+                {{ saveForm.errors.appSlug }}
+              </p>
+            </div>
             <button
               @click="saveOnlyAndCloseMenu"
               :disabled="!hasChanges"
@@ -511,6 +600,13 @@ function handleKeydown(e) {
             >
               Save & Deploy
             </button>
+            <p
+              v-if="saveForm.errors.content || saveForm.errors.deploy"
+              role="alert"
+              class="border-t border-gray-100 px-3 py-2 text-xs leading-5 text-red-600 dark:border-gray-700 dark:text-red-400"
+            >
+              {{ saveForm.errors.content || saveForm.errors.deploy }}
+            </p>
           </div>
         </div>
       </div>
@@ -570,6 +666,7 @@ function handleKeydown(e) {
           <!-- Body editor -->
           <textarea
             v-model="body"
+            data-test="content-body"
             class="flex-1 resize-none bg-white p-4 font-mono text-sm text-gray-900 focus:outline-none dark:bg-gray-950 dark:text-white"
             placeholder="Write your markdown content here..."
             spellcheck="false"

--- a/assets/js/pages/projects/content-manager.vue
+++ b/assets/js/pages/projects/content-manager.vue
@@ -14,7 +14,8 @@ const props = defineProps({
   hasContentFeature: Boolean,
   contentFeature: Object,
   collections: Array,
-  collectionsError: String
+  collectionsError: String,
+  apps: Array
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -28,7 +29,8 @@ const selectedCollection = ref(null)
 // Create form
 const createForm = useForm({
   contentSlug: '',
-  title: ''
+  title: '',
+  appSlug: props.apps?.length === 1 ? props.apps[0].slug : ''
 })
 
 function openCreateModal(collection) {
@@ -341,6 +343,7 @@ function refresh() {
                 </span>
               </div>
               <button
+                data-test="content-new-button"
                 @click="openCreateModal(collection)"
                 class="flex items-center space-x-1 rounded-md px-2 py-1 text-sm text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
               >
@@ -457,6 +460,7 @@ function refresh() {
     >
       <div class="fixed inset-0 bg-black/50" @click="closeCreateModal" />
       <div
+        data-test="content-create-modal"
         class="relative w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-900"
       >
         <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
@@ -477,6 +481,12 @@ function refresh() {
             <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
               Will be used as the filename
             </p>
+            <p
+              v-if="createForm.errors.contentSlug"
+              class="mt-1 text-xs text-red-600 dark:text-red-400"
+            >
+              {{ createForm.errors.contentSlug }}
+            </p>
           </div>
           <div>
             <label
@@ -489,6 +499,38 @@ function refresh() {
               placeholder="My New Post"
               class="focus:border-brand mt-1 block w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
             />
+          </div>
+          <div v-if="apps?.length > 1">
+            <label
+              for="content-create-target-app"
+              class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Target app
+            </label>
+            <select
+              id="content-create-target-app"
+              v-model="createForm.appSlug"
+              :aria-invalid="Boolean(createForm.errors.appSlug)"
+              :aria-describedby="
+                createForm.errors.appSlug
+                  ? 'content-create-target-app-error'
+                  : null
+              "
+              class="mt-1 block w-full rounded-md border border-gray-200 bg-white px-2 py-2 text-sm text-gray-900 focus:border-gray-400 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+              @change="createForm.clearErrors('appSlug')"
+            >
+              <option value="" disabled>Choose an app</option>
+              <option v-for="app in apps" :key="app.id" :value="app.slug">
+                {{ app.name }}
+              </option>
+            </select>
+            <p
+              v-if="createForm.errors.appSlug"
+              id="content-create-target-app-error"
+              class="mt-1 text-xs text-red-600 dark:text-red-400"
+            >
+              {{ createForm.errors.appSlug }}
+            </p>
           </div>
           <div class="flex items-center justify-end space-x-3 pt-2">
             <button

--- a/assets/js/pages/projects/content-manager.vue
+++ b/assets/js/pages/projects/content-manager.vue
@@ -15,7 +15,7 @@ const props = defineProps({
   contentFeature: Object,
   collections: Array,
   collectionsError: String,
-  apps: Array
+  app: Object
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -30,7 +30,7 @@ const selectedCollection = ref(null)
 const createForm = useForm({
   contentSlug: '',
   title: '',
-  appSlug: props.apps?.length === 1 ? props.apps[0].slug : ''
+  appSlug: props.app.slug
 })
 
 function openCreateModal(collection) {
@@ -84,7 +84,7 @@ function getEditorPath(collection, file) {
     props.environment.slug !== 'production'
       ? `/projects/${props.project.slug}/environments/${props.environment.slug}/content`
       : `/projects/${props.project.slug}/content`
-  return `${basePath}/${collection}/${file}`
+  return `${basePath}/${collection}/${file}?appSlug=${props.app.slug}`
 }
 
 function refresh() {
@@ -500,38 +500,6 @@ function refresh() {
               class="focus:border-brand mt-1 block w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
             />
           </div>
-          <div v-if="apps?.length > 1">
-            <label
-              for="content-create-target-app"
-              class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-            >
-              Target app
-            </label>
-            <select
-              id="content-create-target-app"
-              v-model="createForm.appSlug"
-              :aria-invalid="Boolean(createForm.errors.appSlug)"
-              :aria-describedby="
-                createForm.errors.appSlug
-                  ? 'content-create-target-app-error'
-                  : null
-              "
-              class="mt-1 block w-full rounded-md border border-gray-200 bg-white px-2 py-2 text-sm text-gray-900 focus:border-gray-400 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-              @change="createForm.clearErrors('appSlug')"
-            >
-              <option value="" disabled>Choose an app</option>
-              <option v-for="app in apps" :key="app.id" :value="app.slug">
-                {{ app.name }}
-              </option>
-            </select>
-            <p
-              v-if="createForm.errors.appSlug"
-              id="content-create-target-app-error"
-              class="mt-1 text-xs text-red-600 dark:text-red-400"
-            >
-              {{ createForm.errors.appSlug }}
-            </p>
-          </div>
           <div class="flex items-center justify-end space-x-3 pt-2">
             <button
               type="button"
@@ -545,7 +513,7 @@ function refresh() {
               :disabled="
                 !createForm.contentSlug.trim() || createForm.processing
               "
-              class="rounded-md bg-violet-600 px-4 py-2 text-sm font-medium text-white hover:bg-violet-500 disabled:opacity-50"
+              class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ createForm.processing ? 'Creating...' : 'Create' }}
             </button>

--- a/tests/e2e/pages/projects/content-manager.test.js
+++ b/tests/e2e/pages/projects/content-manager.test.js
@@ -5,7 +5,7 @@ const path = require('path')
 const { test } = require('sounding')
 
 test(
-  'Content Manager keeps app targeting inside its existing save and create UI',
+  'Content Manager inherits app scope and keeps the existing Slipway UI',
   {
     browser: true,
     world: {
@@ -29,6 +29,7 @@ test(
     )
     const collectionRoot = path.join(projectRoot, 'content', 'posts')
     const originalAppsDir = sails.config.custom.slipwayAppsDir
+    const originalGetContainerStatus = sails.helpers.docker.getContainerStatus
 
     fs.mkdirSync(collectionRoot, { recursive: true })
     fs.writeFileSync(
@@ -55,39 +56,55 @@ test(
       isDefault: false,
       routePath: null
     })
+    await sails.models.app
+      .updateOne({ id: current.apps.web.id })
+      .set({ status: 'running', containerName: 'content-manager-ui-web' })
+    sails.helpers.docker.getContainerStatus = async () => ({
+      running: true,
+      health: 'healthy'
+    })
 
     try {
       await login.withPassword('genesisUser', page, {
         password: current.auth.genesisUserPassword
       })
 
-      const basePath = `/projects/${current.projects.deploymentTarget.slug}/content`
-      await page.goto(`${basePath}/posts/welcome`)
+      const basePath = `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/content`
+      const appScope = `appSlug=${current.apps.web.slug}`
+      await page.goto(
+        `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/apps/${current.apps.web.slug}`
+      )
+      await page.click('@app-more-menu')
+      expect(
+        await page.raw.locator(`a[href="${basePath}?${appScope}"]`).count()
+      ).toBe(1)
+      await page.goto(`${basePath}/posts/welcome?${appScope}`)
       await page.fill('@content-body', 'A polished Content Manager draft.')
       await page.click('@content-save-menu-toggle')
       await page.wait('@content-save-menu')
-      await expect(page).toSee('Target app')
       await expect(page).toSee('Save & Deploy')
-      await page.raw
-        .locator('[data-test="content-target-app"]')
-        .selectOption(current.apps.web.slug)
-      expect(page.raw.url().includes(`appSlug=${current.apps.web.slug}`)).toBe(
-        true
-      )
+      expect(await page.raw.getByText('Target app').count()).toBe(0)
       await page.screenshot('.tmp/content-manager-save-deploy.png', {
         fullPage: true
       })
 
-      await page.goto(basePath)
+      await page.goto(`${basePath}?${appScope}`)
       await page.click('@content-new-button')
       await page.wait('@content-create-modal')
       await expect(page).toSee('Create new content in posts')
-      await expect(page).toSee('Target app')
+      expect(await page.raw.getByText('Target app').count()).toBe(0)
+      await page.raw.getByPlaceholder('my-new-post').fill('release-notes')
+      expect(
+        await page.raw
+          .getByRole('button', { name: 'Create' })
+          .getAttribute('class')
+      ).toContain('bg-gray-900')
       await page.screenshot('.tmp/content-manager-create.png', {
         fullPage: true
       })
       expect(page).toHaveNoJavascriptErrors()
     } finally {
+      sails.helpers.docker.getContainerStatus = originalGetContainerStatus
       sails.config.custom.slipwayAppsDir = originalAppsDir
       fs.rmSync(tempRoot, { recursive: true, force: true })
     }

--- a/tests/e2e/pages/projects/content-manager.test.js
+++ b/tests/e2e/pages/projects/content-manager.test.js
@@ -1,0 +1,95 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { test } = require('sounding')
+
+test(
+  'Content Manager keeps app targeting inside its existing save and create UI',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'content-manager-ui',
+          name: 'Content Manager UI'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'slipway-content-manager-ui-')
+    )
+    const projectRoot = path.join(
+      tempRoot,
+      current.projects.deploymentTarget.slug
+    )
+    const collectionRoot = path.join(projectRoot, 'content', 'posts')
+    const originalAppsDir = sails.config.custom.slipwayAppsDir
+
+    fs.mkdirSync(collectionRoot, { recursive: true })
+    fs.writeFileSync(
+      path.join(collectionRoot, 'welcome.md'),
+      '---\ntitle: Welcome\n---\n\nHello.\n'
+    )
+    fs.writeFileSync(path.join(projectRoot, 'Dockerfile'), 'FROM node:22\n')
+    sails.config.custom.slipwayAppsDir = tempRoot
+
+    await sails.models.environment
+      .updateOne({ id: current.environments.production.id })
+      .set({
+        features: {
+          'sails-content': {
+            version: '1.0.0',
+            contentDir: 'content'
+          }
+        }
+      })
+    await world.create('app').with({
+      name: 'Worker',
+      slug: 'worker',
+      environment: current.environments.production.id,
+      isDefault: false,
+      routePath: null
+    })
+
+    try {
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+
+      const basePath = `/projects/${current.projects.deploymentTarget.slug}/content`
+      await page.goto(`${basePath}/posts/welcome`)
+      await page.fill('@content-body', 'A polished Content Manager draft.')
+      await page.click('@content-save-menu-toggle')
+      await page.wait('@content-save-menu')
+      await expect(page).toSee('Target app')
+      await expect(page).toSee('Save & Deploy')
+      await page.raw
+        .locator('[data-test="content-target-app"]')
+        .selectOption(current.apps.web.slug)
+      expect(page.raw.url().includes(`appSlug=${current.apps.web.slug}`)).toBe(
+        true
+      )
+      await page.screenshot('.tmp/content-manager-save-deploy.png', {
+        fullPage: true
+      })
+
+      await page.goto(basePath)
+      await page.click('@content-new-button')
+      await page.wait('@content-create-modal')
+      await expect(page).toSee('Create new content in posts')
+      await expect(page).toSee('Target app')
+      await page.screenshot('.tmp/content-manager-create.png', {
+        fullPage: true
+      })
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.config.custom.slipwayAppsDir = originalAppsDir
+      fs.rmSync(tempRoot, { recursive: true, force: true })
+    }
+  }
+)

--- a/tests/factories/gitprovider.js
+++ b/tests/factories/gitprovider.js
@@ -1,0 +1,7 @@
+module.exports = ({ defineFactory }) =>
+  defineFactory('gitprovider', {
+    type: 'github',
+    name: 'GitHub (builder)',
+    clientSecret: 'github-token',
+    isActive: true
+  })

--- a/tests/factories/gitrepository.js
+++ b/tests/factories/gitrepository.js
@@ -1,0 +1,13 @@
+module.exports = ({ defineFactory }) =>
+  defineFactory('gitrepository', ({ sequence }) => {
+    const number = sequence('gitrepository', (value) => value)
+    return {
+      externalId: `repository-${number}`,
+      fullName: `sailscastshq/site-${number}`,
+      name: `site-${number}`,
+      owner: 'sailscastshq',
+      cloneUrl: `git@github.com:sailscastshq/site-${number}.git`,
+      defaultBranch: 'main',
+      branchMappings: { main: 'production' }
+    }
+  })

--- a/tests/functional/pages/content-manager.test.js
+++ b/tests/functional/pages/content-manager.test.js
@@ -1,0 +1,506 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+function contentWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: { slug }
+    }
+  }
+}
+
+test(
+  'Content Manager saves pushed-source content without creating a deployment',
+  { world: contentWorld('content-save-only') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+
+    try {
+      const editor = await withCsrfFromPage(
+        request,
+        workspace.editorPath,
+        'genesisUser'
+      )
+      const sourceSha = editor.page.data.props.content.sourceSha
+      const response = await editor.request.post(workspace.updatePath, {
+        raw: '# Updated locally\n',
+        deploy: false,
+        appSlug: workspace.app.slug,
+        sourceSha
+      })
+
+      expect(response).toHaveStatus(302)
+      expect(response).toRedirectTo(
+        `${workspace.editorPath}?appSlug=${workspace.app.slug}`
+      )
+      expect(fs.readFileSync(workspace.filePath, 'utf8')).toBe(
+        '# Updated locally\n'
+      )
+      const deployments = await sails.models.deployment.find({
+        environment: workspace.environment.id
+      })
+      expect(deployments).toEqual([])
+    } finally {
+      workspace.restore()
+    }
+  }
+)
+
+test(
+  'Content Manager commits and queues one targeted deployment',
+  { world: contentWorld('content-save-deploy') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+    const originalExecutePipeline = sails.helpers.deploy.executePipeline
+    const pipelineCalls = []
+    sails.helpers.deploy.executePipeline = {
+      with: async (values) => {
+        pipelineCalls.push(values)
+        await sails.models.deployment
+          .updateOne({ id: values.deploymentId })
+          .set({
+            status: 'running',
+            finishedAt: Date.now()
+          })
+      }
+    }
+    const provider = await world.create('gitprovider').with({
+      team: world.current.teams.genesisTeam.id
+    })
+    await world.create('gitrepository').with({
+      provider: provider.id,
+      environment: workspace.environment.id,
+      app: workspace.app.id
+    })
+    await world.create('app').with({
+      name: 'Worker',
+      slug: 'worker',
+      environment: workspace.environment.id,
+      isDefault: false,
+      routePath: null
+    })
+    expect(
+      await sails.models.gitrepository.count({ app: workspace.app.id })
+    ).toBe(1)
+    const originalFetch = global.fetch
+    const commitCalls = []
+
+    try {
+      global.fetch = async (url, options = {}) => {
+        if (!options.method || options.method === 'GET') {
+          return githubContentResponse(workspace.originalContent)
+        }
+        commitCalls.push({ url, options })
+        return githubCommitResponse({
+          contentSha: 'content-blob-sha',
+          commitSha: 'content-commit-sha'
+        })
+      }
+      const editor = await withCsrfFromPage(
+        request,
+        `${workspace.editorPath}?appSlug=${workspace.app.slug}`,
+        'genesisUser'
+      )
+      expect(editor.page).toHaveInertiaPropCount('apps', 2)
+      const response = await editor.request.post(workspace.updatePath, {
+        raw: '# Published from Slipway\n',
+        deploy: true,
+        appSlug: workspace.app.slug,
+        sourceSha: editor.page.data.props.content.sourceSha
+      })
+
+      expect(response).toHaveStatus(302)
+      const deployment = await waitFor(async () => {
+        const records = await sails.models.deployment.find({
+          environment: workspace.environment.id
+        })
+        return records[0]
+      })
+      await waitFor(() => pipelineCalls.length === 1)
+      expect(response).toRedirectTo(
+        `/projects/${workspace.project.slug}/deployments/${deployment.id}`
+      )
+      expect(commitCalls.length).toBe(1)
+      const commitBody = JSON.parse(commitCalls[0].options.body)
+      expect(commitBody.message).toBe(
+        'chore(content): update posts/welcome\n\nSlipway-Content-Change: true'
+      )
+      expect(pipelineCalls.length).toBe(1)
+      expect(deployment.app).toBe(workspace.app.id)
+      expect(deployment.triggerType).toBe('content')
+      expect(deployment.gitCommit).toBe('content-commit-sha')
+      expect(deployment.gitBranch).toBe('main')
+      expect(deployment.gitMessage).toBe('chore(content): update posts/welcome')
+      await waitForDeploymentJob(sails, deployment.id)
+    } finally {
+      global.fetch = originalFetch
+      sails.helpers.deploy.executePipeline = originalExecutePipeline
+      workspace.restore()
+    }
+  }
+)
+
+test(
+  'Content Manager does not overwrite a newer Git revision',
+  { world: contentWorld('content-git-conflict') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+    const provider = await world.create('gitprovider').with({
+      team: world.current.teams.genesisTeam.id
+    })
+    await world.create('gitrepository').with({
+      provider: provider.id,
+      environment: workspace.environment.id,
+      app: workspace.app.id
+    })
+    const originalFetch = global.fetch
+
+    try {
+      global.fetch = async (_url, options = {}) => {
+        if (!options.method || options.method === 'GET') {
+          return githubContentResponse(workspace.originalContent)
+        }
+        return { ok: false, status: 409 }
+      }
+      const editor = await withCsrfFromPage(
+        request,
+        `${workspace.editorPath}?appSlug=${workspace.app.slug}`,
+        'genesisUser'
+      )
+      const response = await editor.request.post(workspace.updatePath, {
+        raw: '# Stale browser edit\n',
+        deploy: false,
+        appSlug: workspace.app.slug,
+        sourceSha: editor.page.data.props.content.sourceSha
+      })
+
+      expect(response).toHaveStatus(303)
+      expect(fs.readFileSync(workspace.filePath, 'utf8')).toBe(
+        workspace.originalContent
+      )
+      const page = await editor.request.get(
+        `${workspace.editorPath}?appSlug=${workspace.app.slug}`
+      )
+      expect(page).toHaveInertiaError(
+        'content',
+        'This file changed in Git while you were editing it. Reload the latest version before saving'
+      )
+      const deployments = await sails.models.deployment.find({
+        environment: workspace.environment.id
+      })
+      expect(deployments).toEqual([])
+    } finally {
+      global.fetch = originalFetch
+      workspace.restore()
+    }
+  }
+)
+
+test(
+  'Content Manager creates Git-backed content with a conventional commit',
+  { world: contentWorld('content-git-create') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+    const provider = await world.create('gitprovider').with({
+      team: world.current.teams.genesisTeam.id
+    })
+    await world.create('gitrepository').with({
+      provider: provider.id,
+      environment: workspace.environment.id,
+      app: workspace.app.id
+    })
+    const originalFetch = global.fetch
+    const commitCalls = []
+
+    try {
+      const managerPath = `/projects/${workspace.project.slug}/content`
+      const manager = await withCsrfFromPage(
+        request,
+        managerPath,
+        'genesisUser'
+      )
+      global.fetch = async (url, options) => {
+        commitCalls.push({ url, options })
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            content: { sha: 'created-blob-sha' },
+            commit: { sha: 'created-commit-sha' }
+          })
+        }
+      }
+      const response = await manager.request.post(
+        `${managerPath}/posts/create`,
+        {
+          contentSlug: 'release-notes',
+          title: 'Release notes',
+          appSlug: workspace.app.slug
+        }
+      )
+
+      expect(response).toHaveStatus(302)
+      expect(response).toRedirectTo(
+        `${managerPath}/posts/release-notes?appSlug=${workspace.app.slug}`
+      )
+      expect(commitCalls.length).toBe(1)
+      expect(commitCalls[0].options.method).toBe('PUT')
+      const body = JSON.parse(commitCalls[0].options.body)
+      expect(body.sha).toBe(undefined)
+      expect(body.message).toBe(
+        'chore(content): create posts/release-notes\n\nSlipway-Content-Change: true'
+      )
+      expect(
+        fs.existsSync(
+          path.join(path.dirname(workspace.filePath), 'release-notes.md')
+        )
+      ).toBe(true)
+    } finally {
+      global.fetch = originalFetch
+      workspace.restore()
+    }
+  }
+)
+
+test(
+  'Content Manager deletes Git-backed content with a conventional commit',
+  { world: contentWorld('content-git-delete') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+    const provider = await world.create('gitprovider').with({
+      team: world.current.teams.genesisTeam.id
+    })
+    await world.create('gitrepository').with({
+      provider: provider.id,
+      environment: workspace.environment.id,
+      app: workspace.app.id
+    })
+    const originalFetch = global.fetch
+    const commitCalls = []
+
+    try {
+      global.fetch = async (url, options = {}) => {
+        if (!options.method || options.method === 'GET') {
+          return githubContentResponse(workspace.originalContent)
+        }
+        commitCalls.push({ url, options })
+        return githubCommitResponse({ commitSha: 'deleted-commit-sha' })
+      }
+      const editor = await withCsrfFromPage(
+        request,
+        `${workspace.editorPath}?appSlug=${workspace.app.slug}`,
+        'genesisUser'
+      )
+      const sourceSha = editor.page.data.props.content.sourceSha
+      const response = await editor.request.post(
+        `${workspace.editorPath}/delete`,
+        {
+          appSlug: workspace.app.slug,
+          sourceSha
+        }
+      )
+
+      expect(response).toHaveStatus(302)
+      expect(response).toRedirectTo(
+        `/projects/${workspace.project.slug}/content`
+      )
+      expect(commitCalls.length).toBe(1)
+      expect(commitCalls[0].options.method).toBe('DELETE')
+      const body = JSON.parse(commitCalls[0].options.body)
+      expect(body.sha).toBe(sourceSha)
+      expect(body.message).toBe(
+        'chore(content): delete posts/welcome\n\nSlipway-Content-Change: true'
+      )
+      expect(fs.existsSync(workspace.filePath)).toBe(false)
+    } finally {
+      global.fetch = originalFetch
+      workspace.restore()
+    }
+  }
+)
+
+test(
+  'Content Manager keeps the draft and shows a missing-source error',
+  { world: contentWorld('content-missing-source') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+    const originalGetSourceReadiness = sails.helpers.deploy.getSourceReadiness
+    sails.helpers.deploy.getSourceReadiness = {
+      with: async () => ({
+        available: false,
+        mode: 'none',
+        message: 'No deployable source is available.'
+      })
+    }
+
+    try {
+      const editor = await withCsrfFromPage(
+        request,
+        workspace.editorPath,
+        'genesisUser'
+      )
+      const response = await editor.request.post(workspace.updatePath, {
+        raw: '# Must not be written\n',
+        deploy: true,
+        appSlug: workspace.app.slug,
+        sourceSha: editor.page.data.props.content.sourceSha
+      })
+
+      expect(response).toHaveStatus(303)
+      expect(fs.readFileSync(workspace.filePath, 'utf8')).toBe(
+        workspace.originalContent
+      )
+      const page = await editor.request.get(workspace.editorPath)
+      expect(page).toHaveInertiaError(
+        'deploy',
+        'No deployable source is available'
+      )
+      const deployments = await sails.models.deployment.find({
+        environment: workspace.environment.id
+      })
+      expect(deployments).toEqual([])
+    } finally {
+      sails.helpers.deploy.getSourceReadiness = originalGetSourceReadiness
+      workspace.restore()
+    }
+  }
+)
+
+test(
+  'Content Manager requires an app choice in a multi-app environment',
+  { world: contentWorld('content-multi-app') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+    await world.create('app').with({
+      name: 'Worker',
+      slug: 'worker',
+      environment: workspace.environment.id,
+      isDefault: false,
+      routePath: null
+    })
+
+    try {
+      const editor = await withCsrfFromPage(
+        request,
+        workspace.editorPath,
+        'genesisUser'
+      )
+      expect(editor.page).toHaveInertiaPropCount('apps', 2)
+      const response = await editor.request.post(workspace.updatePath, {
+        raw: '# Ambiguous target\n',
+        deploy: true,
+        sourceSha: editor.page.data.props.content.sourceSha
+      })
+
+      expect(response).toHaveStatus(303)
+      expect(fs.readFileSync(workspace.filePath, 'utf8')).toBe(
+        workspace.originalContent
+      )
+      const page = await editor.request.get(workspace.editorPath)
+      expect(page).toHaveInertiaError(
+        'appSlug',
+        'Choose which app owns this content'
+      )
+    } finally {
+      workspace.restore()
+    }
+  }
+)
+
+async function prepareContentWorkspace({ sails, world }) {
+  const current = world.current
+  const project = current.projects.deploymentTarget
+  const environment = current.environments.production
+  const app = current.apps.web
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-content-manager-')
+  )
+  const projectRoot = path.join(tempRoot, project.slug)
+  const collectionRoot = path.join(projectRoot, 'content', 'posts')
+  const filePath = path.join(collectionRoot, 'welcome.md')
+  const originalContent = '---\ntitle: Welcome\n---\n\nHello.\n'
+  fs.mkdirSync(collectionRoot, { recursive: true })
+  fs.writeFileSync(path.join(projectRoot, 'Dockerfile'), 'FROM node:22\n')
+  fs.writeFileSync(filePath, originalContent)
+
+  await sails.models.environment.updateOne({ id: environment.id }).set({
+    features: {
+      'sails-content': {
+        version: '1.0.0',
+        contentDir: 'content'
+      }
+    }
+  })
+  environment.features = {
+    'sails-content': {
+      version: '1.0.0',
+      contentDir: 'content'
+    }
+  }
+
+  const originalAppsDir = sails.config.custom.slipwayAppsDir
+  sails.config.custom.slipwayAppsDir = tempRoot
+  const editorPath = `/projects/${project.slug}/content/posts/welcome`
+
+  return {
+    app,
+    editorPath,
+    environment,
+    filePath,
+    originalContent,
+    project,
+    updatePath: `${editorPath}/update`,
+    restore() {
+      sails.config.custom.slipwayAppsDir = originalAppsDir
+      fs.rmSync(tempRoot, { recursive: true, force: true })
+    }
+  }
+}
+
+async function waitFor(predicate, timeout = 2000) {
+  const deadline = Date.now() + timeout
+  let result
+  while (!(result = await predicate())) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for state.')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  return result
+}
+
+async function waitForDeploymentJob(sails, deploymentId) {
+  await waitFor(async () => {
+    const [job, leases] = await Promise.all([
+      sails.models.deploymentjob.findOne({ deployment: deploymentId }),
+      sails.models.deploymentlease.count({ deployment: deploymentId })
+    ])
+    return job?.stage === 'complete' && leases === 0
+  })
+}
+
+function githubContentResponse(content, sha = 'source-blob-sha') {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      type: 'file',
+      sha,
+      content: Buffer.from(content, 'utf8').toString('base64')
+    })
+  }
+}
+
+function githubCommitResponse({ contentSha = null, commitSha }) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      content: contentSha ? { sha: contentSha } : null,
+      commit: { sha: commitSha }
+    })
+  }
+}

--- a/tests/functional/pages/content-manager.test.js
+++ b/tests/functional/pages/content-manager.test.js
@@ -106,7 +106,7 @@ test(
         `${workspace.editorPath}?appSlug=${workspace.app.slug}`,
         'genesisUser'
       )
-      expect(editor.page).toHaveInertiaPropCount('apps', 2)
+      expect(editor.page).toHaveInertiaProp('app.slug', workspace.app.slug)
       const response = await editor.request.post(workspace.updatePath, {
         raw: '# Published from Slipway\n',
         deploy: true,
@@ -307,7 +307,7 @@ test(
 
       expect(response).toHaveStatus(302)
       expect(response).toRedirectTo(
-        `/projects/${workspace.project.slug}/content`
+        `/projects/${workspace.project.slug}/content?appSlug=${workspace.app.slug}`
       )
       expect(commitCalls.length).toBe(1)
       expect(commitCalls[0].options.method).toBe('DELETE')
@@ -372,11 +372,11 @@ test(
 )
 
 test(
-  'Content Manager requires an app choice in a multi-app environment',
+  'Content Manager inherits its app scope in a multi-app environment',
   { world: contentWorld('content-multi-app') },
   async ({ sails, world, request, expect }) => {
     const workspace = await prepareContentWorkspace({ sails, world })
-    await world.create('app').with({
+    const worker = await world.create('app').with({
       name: 'Worker',
       slug: 'worker',
       environment: workspace.environment.id,
@@ -387,24 +387,23 @@ test(
     try {
       const editor = await withCsrfFromPage(
         request,
-        workspace.editorPath,
+        `${workspace.editorPath}?appSlug=${worker.slug}`,
         'genesisUser'
       )
-      expect(editor.page).toHaveInertiaPropCount('apps', 2)
+      expect(editor.page).toHaveInertiaProp('app.slug', worker.slug)
       const response = await editor.request.post(workspace.updatePath, {
-        raw: '# Ambiguous target\n',
-        deploy: true,
+        raw: '# Worker-owned content\n',
+        deploy: false,
+        appSlug: worker.slug,
         sourceSha: editor.page.data.props.content.sourceSha
       })
 
-      expect(response).toHaveStatus(303)
-      expect(fs.readFileSync(workspace.filePath, 'utf8')).toBe(
-        workspace.originalContent
+      expect(response).toHaveStatus(302)
+      expect(response).toRedirectTo(
+        `${workspace.editorPath}?appSlug=${worker.slug}`
       )
-      const page = await editor.request.get(workspace.editorPath)
-      expect(page).toHaveInertiaError(
-        'appSlug',
-        'Choose which app owns this content'
+      expect(fs.readFileSync(workspace.filePath, 'utf8')).toBe(
+        '# Worker-owned content\n'
       )
     } finally {
       workspace.restore()

--- a/tests/unit/helpers/deploy/ensure-build-context.test.js
+++ b/tests/unit/helpers/deploy/ensure-build-context.test.js
@@ -144,6 +144,7 @@ test('connected repository refreshes an existing source cache before a manual de
       project: { slug: 'sailscasts' },
       environment: { id: 1, slug: 'production' },
       app: { id: 1 },
+      gitCommit: '1234567890abcdef1234567890abcdef12345678',
       refreshRepository: true
     })
 
@@ -151,6 +152,9 @@ test('connected repository refreshes an existing source cache before a manual de
     expect(result.sourceMode).toBe('repository')
     expect(cloneCalls.length).toBe(1)
     expect(cloneCalls[0].branch).toBe('main')
+    expect(cloneCalls[0].commit).toBe(
+      '1234567890abcdef1234567890abcdef12345678'
+    )
   } finally {
     global.sails = originalSails
     global.GitRepository = originalGitRepository

--- a/tests/unit/helpers/git/clone-or-pull.test.js
+++ b/tests/unit/helpers/git/clone-or-pull.test.js
@@ -1,0 +1,83 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { execFileSync } = require('child_process')
+
+const { test } = require('sounding')
+
+const cloneOrPull = require('../../../../api/helpers/git/clone-or-pull')
+
+test('repository deployments check out their recorded commit', async ({
+  expect
+}) => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'slipway-git-sync-'))
+  const sourceDir = path.join(tempRoot, 'source')
+  const targetDir = path.join(tempRoot, 'target')
+  const originalSails = global.sails
+  const originalDeployment = global.Deployment
+
+  fs.mkdirSync(sourceDir)
+  git(['init', '-b', 'main'], sourceDir)
+  fs.writeFileSync(path.join(sourceDir, 'version.txt'), 'first\n')
+  git(['add', 'version.txt'], sourceDir)
+  git(
+    [
+      '-c',
+      'user.name=Slipway Test',
+      '-c',
+      'user.email=slipway@example.com',
+      'commit',
+      '-m',
+      'chore(content): create version'
+    ],
+    sourceDir
+  )
+  const firstCommit = git(['rev-parse', 'HEAD'], sourceDir)
+
+  fs.writeFileSync(path.join(sourceDir, 'version.txt'), 'second\n')
+  git(['add', 'version.txt'], sourceDir)
+  git(
+    [
+      '-c',
+      'user.name=Slipway Test',
+      '-c',
+      'user.email=slipway@example.com',
+      'commit',
+      '-m',
+      'chore(content): update version'
+    ],
+    sourceDir
+  )
+
+  global.sails = {
+    log: {
+      debug: () => {},
+      info: () => {}
+    }
+  }
+  global.Deployment = { appendBuildLog: async () => {} }
+
+  try {
+    await cloneOrPull.fn({
+      cloneUrl: sourceDir,
+      branch: 'main',
+      commit: firstCommit,
+      targetDir,
+      deployKeyPrivate:
+        '-----BEGIN OPENSSH PRIVATE KEY-----\ntest\n-----END OPENSSH PRIVATE KEY-----\n'
+    })
+
+    expect(git(['rev-parse', 'HEAD'], targetDir)).toBe(firstCommit)
+    expect(fs.readFileSync(path.join(targetDir, 'version.txt'), 'utf8')).toBe(
+      'first\n'
+    )
+  } finally {
+    global.sails = originalSails
+    global.Deployment = originalDeployment
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+function git(args, cwd) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim()
+}

--- a/tests/unit/helpers/git/commit-content-file.test.js
+++ b/tests/unit/helpers/git/commit-content-file.test.js
@@ -1,0 +1,126 @@
+const { test } = require('sounding')
+
+test(
+  'Git-backed content saves use a conventional commit and optimistic SHA',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'git-content-save' }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const provider = await world.create('gitprovider').with({
+      team: current.teams.genesisTeam.id
+    })
+    await world.create('gitrepository').with({
+      fullName: 'sailscastshq/site',
+      name: 'site',
+      owner: 'sailscastshq',
+      cloneUrl: 'git@github.com:sailscastshq/site.git',
+      branchMappings: { production: 'unused', main: 'production' },
+      provider: provider.id,
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+
+    const originalFetch = global.fetch
+    const calls = []
+    global.fetch = async (url, options) => {
+      calls.push({ url, options })
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          content: { sha: 'new-blob-sha' },
+          commit: { sha: 'new-commit-sha' }
+        })
+      }
+    }
+
+    try {
+      const result = await sails.helpers.git.commitContentFile.with({
+        environment: current.environments.production,
+        app: current.apps.web,
+        user: current.users.genesisUser,
+        filePath: 'content/posts/welcome.md',
+        content: '# Hello\n',
+        expectedSha: 'loaded-blob-sha',
+        message: 'chore(content): update posts/welcome'
+      })
+
+      expect(result.commitSha).toBe('new-commit-sha')
+      expect(result.branch).toBe('main')
+      expect(calls.length).toBe(1)
+      expect(calls[0].url).toBe(
+        'https://api.github.com/repos/sailscastshq/site/contents/content/posts/welcome.md'
+      )
+      const body = JSON.parse(calls[0].options.body)
+      expect(body.sha).toBe('loaded-blob-sha')
+      expect(body.branch).toBe('main')
+      expect(body.message).toBe(
+        'chore(content): update posts/welcome\n\nSlipway-Content-Change: true'
+      )
+      expect(body.author.name).toBe(current.users.genesisUser.fullName)
+      expect(body.author.email).toBe(current.users.genesisUser.email)
+    } finally {
+      global.fetch = originalFetch
+    }
+  }
+)
+
+test(
+  'Git-backed content saves reject a stale editor SHA',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'git-content-conflict' }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const provider = await world.create('gitprovider').with({
+      team: current.teams.genesisTeam.id
+    })
+    await world.create('gitrepository').with({
+      fullName: 'sailscastshq/site',
+      name: 'site',
+      owner: 'sailscastshq',
+      cloneUrl: 'git@github.com:sailscastshq/site.git',
+      provider: provider.id,
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+
+    const originalFetch = global.fetch
+    global.fetch = async () => ({ ok: false, status: 409 })
+
+    try {
+      let conflict
+      try {
+        await sails.helpers.git.commitContentFile.with({
+          environment: current.environments.production,
+          app: current.apps.web,
+          user: current.users.genesisUser,
+          filePath: 'content/posts/welcome.md',
+          content: '# Stale edit\n',
+          expectedSha: 'stale-sha',
+          message: 'chore(content): update posts/welcome'
+        })
+      } catch (error) {
+        conflict = error
+      }
+
+      expect(conflict.code).toBe('conflict')
+      expect(conflict.raw.message).toBe(
+        'This file changed in Git while you were editing it. Reload the latest version before saving.'
+      )
+    } finally {
+      global.fetch = originalFetch
+    }
+  }
+)

--- a/tests/unit/helpers/git/read-content-file.test.js
+++ b/tests/unit/helpers/git/read-content-file.test.js
@@ -1,0 +1,66 @@
+const { test } = require('sounding')
+
+test(
+  'Content Manager loads the canonical file and blob SHA from GitHub',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'git-content-read' }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const provider = await world.create('gitprovider').with({
+      team: current.teams.genesisTeam.id
+    })
+    await world.create('gitrepository').with({
+      fullName: 'sailscastshq/site',
+      name: 'site',
+      owner: 'sailscastshq',
+      cloneUrl: 'git@github.com:sailscastshq/site.git',
+      branchMappings: { main: 'production' },
+      provider: provider.id,
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+
+    const originalFetch = global.fetch
+    const calls = []
+    global.fetch = async (url, options) => {
+      calls.push({ url: String(url), options })
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({
+          type: 'file',
+          sha: 'canonical-blob-sha',
+          content: Buffer.from('# Canonical content\n', 'utf8').toString(
+            'base64'
+          )
+        })
+      }
+    }
+
+    try {
+      const result = await sails.helpers.git.readContentFile.with({
+        environment: current.environments.production,
+        app: current.apps.web,
+        filePath: 'content/posts/welcome.md'
+      })
+
+      expect(result.mode).toBe('repository')
+      expect(result.branch).toBe('main')
+      expect(result.sha).toBe('canonical-blob-sha')
+      expect(result.content).toBe('# Canonical content\n')
+      expect(calls.length).toBe(1)
+      expect(calls[0].url).toBe(
+        'https://api.github.com/repos/sailscastshq/site/contents/content/posts/welcome.md?ref=main'
+      )
+      expect(calls[0].options.headers.Authorization).toBe('Bearer github-token')
+    } finally {
+      global.fetch = originalFetch
+    }
+  }
+)


### PR DESCRIPTION
## Summary

- persist Content Manager create, update, and delete operations to the connected GitHub repository with `chore(content): ...` Conventional Commits
- load canonical repository content and use optimistic blob SHAs to prevent stale browser edits from overwriting newer changes
- inherit app ownership from the app-scoped Content entrypoint and carry it invisibly through manager, editor, create, save, delete, and deploy
- route Save & Deploy through the shared durable deployment trigger and build the exact commit created by the editor
- suppress duplicate auto-deploy webhooks for Slipway content commits while preserving save-only behavior
- preserve the existing Content UI and standard Slipway black/white action styling

## Verification

- `npm run lint`
- `npm test` — 99 unit, 30 functional, and 11 browser tests passed

Closes #235