### PR TITLE
fix(deploy): stop active work on cancellation

### DIFF
--- a/api/controllers/api/v1/deploy/cancel-deployment.js
+++ b/api/controllers/api/v1/deploy/cancel-deployment.js
@@ -1,3 +1,16 @@
+const deploymentCancellation = require('../../../../lib/deployment-cancellation')
+
+const CANCELLABLE_STAGES = [
+  'queued',
+  'claimed',
+  'initialization',
+  'source_preparation',
+  'image_build',
+  'container_startup',
+  'health_check',
+  'cancel_requested'
+]
+
 module.exports = {
   friendlyName: 'Cancel deployment',
 
@@ -49,35 +62,89 @@ module.exports = {
       throw 'forbidden'
     }
 
-    // Can only cancel pending or building deployments
-    if (!['pending', 'building', 'deploying'].includes(deployment.status)) {
+    if (deployment.status === 'cancelled') {
+      return {
+        success: true,
+        status: 'cancelled',
+        message: 'Deployment is already cancelled'
+      }
+    }
+
+    const job = await DeploymentJob.findOne({ deployment: deploymentId })
+    if (
+      !['pending', 'building', 'deploying'].includes(deployment.status) ||
+      (job && !CANCELLABLE_STAGES.includes(job.stage))
+    ) {
       throw {
-        badRequest: `Cannot cancel deployment with status: ${deployment.status}`
+        badRequest:
+          job && !CANCELLABLE_STAGES.includes(job.stage)
+            ? `Cannot cancel deployment after ${job.stage.replace(
+                /_/g,
+                ' '
+              )} has started`
+            : `Cannot cancel deployment with status: ${deployment.status}`
       }
     }
 
     const lease = await DeploymentLease.findOne({ deployment: deploymentId })
+    if (job) {
+      const claimedJob = await DeploymentJob.updateOne({
+        id: job.id,
+        stage: job.stage
+      }).set({
+        stage: lease ? 'cancel_requested' : 'cancelled'
+      })
 
-    // Mark as cancelled. An active worker keeps the lease while it unwinds so
-    // the next queued deployment cannot overlap its resource cleanup.
-    await Deployment.updateOne({ id: deploymentId }).set({
+      if (!claimedJob) {
+        const observedJob = await DeploymentJob.findOne({ id: job.id })
+        if (!CANCELLABLE_STAGES.includes(observedJob?.stage)) {
+          throw {
+            badRequest: `Cannot cancel deployment after ${String(
+              observedJob?.stage || 'completion'
+            ).replace(/_/g, ' ')} has started`
+          }
+        }
+      }
+    }
+
+    const cancellationMessage = `Cancelled by ${user.fullName || user.email}`
+    const cancelled = await Deployment.updateOne({
+      id: deploymentId,
+      status: { in: ['pending', 'building', 'deploying'] }
+    }).set({
       status: 'cancelled',
-      errorMessage: `Cancelled by ${user.fullName || user.email}`,
+      errorMessage: cancellationMessage,
       finishedAt: Date.now()
     })
-    await DeploymentJob.updateOne({ deployment: deploymentId }).set({
-      stage: lease ? 'cancel_requested' : 'cancelled'
-    })
 
+    if (!cancelled) {
+      const observed = await Deployment.findOne({ id: deploymentId })
+      if (observed?.status === 'cancelled') {
+        return {
+          success: true,
+          status: 'cancelled',
+          message: 'Deployment is already cancelled'
+        }
+      }
+
+      throw {
+        badRequest: `Cannot cancel deployment with status: ${observed?.status}`
+      }
+    }
+
+    // An active worker keeps the lease while it unwinds so the next queued
+    // deployment cannot overlap its resource cleanup.
     await Deployment.appendBuildLog(
       deploymentId,
       `\n⚠️ Deployment cancelled by ${user.fullName || user.email}\n`
     )
 
+    deploymentCancellation.request(deploymentId, cancellationMessage)
     sails.log.info(`Deployment ${deploymentId} cancelled by ${user.email}`)
 
     return {
       success: true,
+      status: 'cancelled',
       message: 'Deployment cancelled'
     }
   }

--- a/api/helpers/deploy/cleanup-build-context.js
+++ b/api/helpers/deploy/cleanup-build-context.js
@@ -1,0 +1,44 @@
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+module.exports = {
+  friendlyName: 'Cleanup build context',
+
+  description:
+    'Remove a deployment-owned temporary build context without touching persistent source.',
+
+  inputs: {
+    contextPath: {
+      type: 'string',
+      required: true
+    },
+    deploymentId: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ contextPath, deploymentId }) {
+    const ownedRoot = path.resolve(
+      os.tmpdir(),
+      'slipway',
+      'deployments',
+      String(deploymentId)
+    )
+    const resolved = path.resolve(contextPath)
+    const isOwned =
+      resolved === ownedRoot || resolved.startsWith(`${ownedRoot}${path.sep}`)
+
+    if (!isOwned) return { removed: false }
+
+    fs.rmSync(resolved, { recursive: true, force: true })
+    return { removed: true }
+  }
+}

--- a/api/helpers/deploy/ensure-build-context.js
+++ b/api/helpers/deploy/ensure-build-context.js
@@ -1,5 +1,6 @@
 const fs = require('fs')
 const path = require('path')
+const deploymentCancellation = require('../../lib/deployment-cancellation')
 
 module.exports = {
   friendlyName: 'Ensure build context',
@@ -34,6 +35,10 @@ module.exports = {
       defaultsTo: false,
       description:
         'Sync a connected repository even when a local source cache already exists.'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Abort signal for an operator-requested cancellation.'
     }
   },
 
@@ -50,8 +55,10 @@ module.exports = {
     deploymentId,
     gitBranch,
     gitCommit,
-    refreshRepository
+    refreshRepository,
+    signal
   }) {
+    deploymentCancellation.throwIfCancelled(signal, deploymentId)
     const readiness = await inspectBuildContext({
       project,
       environment,
@@ -84,9 +91,13 @@ module.exports = {
           ...(gitCommit ? { commit: gitCommit } : {}),
           targetDir: contextPath,
           deployKeyPrivate: repo.deployKeyPrivate,
-          deploymentId
+          deploymentId,
+          ...(signal ? { signal } : {})
         })
       } catch (err) {
+        if (signal?.aborted) {
+          throw deploymentCancellation.cancellationError(signal, deploymentId)
+        }
         const errorMessage = `Source sync failed for ${project.slug}: ${
           err.message || err
         }`
@@ -94,6 +105,7 @@ module.exports = {
         throw new Error(errorMessage)
       }
 
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
       if (hasSourceFiles(contextPath)) {
         return {
           contextPath,

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -1,3 +1,5 @@
+const deploymentCancellation = require('../../lib/deployment-cancellation')
+
 module.exports = {
   friendlyName: 'Execute deployment pipeline',
 
@@ -28,6 +30,10 @@ module.exports = {
     leaseToken: {
       type: 'string',
       description: 'Fencing token held by the durable deployment worker.'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Abort signal for an operator-requested cancellation.'
     }
   },
 
@@ -42,15 +48,18 @@ module.exports = {
     project,
     environment,
     app: appInput,
-    leaseToken
+    leaseToken,
+    signal
   }) {
     let deployContainerName = null
     let deployImageName = null
     let deployHostPort = null
     let deployHostPortReserved = false
+    let deployBuildContextPath = null
     let currentStage = 'initialization'
 
     const recordStage = async (stage, resources = {}) => {
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
       currentStage = stage.replace(/_/g, ' ')
       const result = await sails.helpers.deploy.recordDeploymentStage.with({
         deploymentId,
@@ -59,23 +68,28 @@ module.exports = {
         ...resources
       })
       requireValidCoordinatorResult(result)
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
     }
 
     const assertLease = async () => {
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
       const result = await sails.helpers.deploy.assertDeploymentLease.with({
         deploymentId,
         leaseToken
       })
       requireValidCoordinatorResult(result)
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
     }
 
     const updateDeployment = async (values) => {
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
       const result = await sails.helpers.deploy.updateDeploymentForLease.with({
         deploymentId,
         leaseToken,
         values
       })
       requireValidCoordinatorResult(result)
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
       return result.deployment
     }
 
@@ -129,8 +143,10 @@ module.exports = {
           deploymentId,
           gitBranch: deployment?.gitBranch,
           gitCommit: deployment?.gitCommit,
-          refreshRepository: true
+          refreshRepository: true,
+          signal
         })
+      deployBuildContextPath = contextPath
 
       // 4. Build the Docker image (use app's dockerfilePath, fall back to project's)
       const dockerfilePath =
@@ -142,7 +158,8 @@ module.exports = {
         contextPath,
         imageName,
         dockerfilePath,
-        deploymentId
+        deploymentId,
+        signal
       })
 
       // 4b. Detect Sails features (sails-content, sails-quest, etc.)
@@ -231,7 +248,8 @@ module.exports = {
         host: appBindHost,
         envVars,
         deploymentId,
-        resourceLimits
+        resourceLimits,
+        signal
       })
 
       // 10. HTTP health check on the new container (Docker DNS, with localhost fallback for local dev)
@@ -241,7 +259,8 @@ module.exports = {
         port: 1337,
         hostPort: deployHostPort,
         path: healthPath,
-        deploymentId
+        deploymentId,
+        signal
       })
 
       // === Health check passed — switch traffic ===
@@ -388,24 +407,37 @@ module.exports = {
           sails.log.debug('Deployment notification failed:', err.message || err)
         })
     } catch (err) {
-      const errorMessage = err.message || String(err)
-      sails.log.error(
-        `Deployment ${deploymentId} failed during ${currentStage}: ${errorMessage}`
-      )
+      const cancelled =
+        deploymentCancellation.isCancellationError(err) || signal?.aborted
+      const failure = cancelled
+        ? deploymentCancellation.cancellationError(signal, deploymentId)
+        : err
+      const errorMessage = failure.message || String(failure)
+      if (cancelled) {
+        sails.log.info(
+          `Deployment ${deploymentId} cancelled during ${currentStage}: ${errorMessage}`
+        )
+      } else {
+        sails.log.error(
+          `Deployment ${deploymentId} failed during ${currentStage}: ${errorMessage}`
+        )
+      }
 
       // Preserve a useful failure line even when the failing command did not
       // produce stream output (for example source or startup failures).
       try {
         await Deployment.appendDeployLog(
           deploymentId,
-          `\nERROR [${currentStage}]: ${errorMessage}\n`
+          cancelled
+            ? `\nCancellation acknowledged during ${currentStage}. Cleaning up the candidate release...\n`
+            : `\nERROR [${currentStage}]: ${errorMessage}\n`
         )
       } catch {
         /* best-effort; the original failure still wins */
       }
 
       // Capture container logs before removing — shows the actual crash reason
-      if (deployContainerName) {
+      if (deployContainerName && !cancelled) {
         try {
           const containerLogs =
             await sails.helpers.docker.getContainerLogs.with({
@@ -457,6 +489,21 @@ module.exports = {
         }
       }
 
+      if (deployBuildContextPath) {
+        try {
+          await sails.helpers.deploy.cleanupBuildContext.with({
+            contextPath: deployBuildContextPath,
+            deploymentId
+          })
+        } catch (cleanupError) {
+          sails.log.verbose(
+            `Could not remove temporary build context ${deployBuildContextPath}: ${
+              cleanupError.message || cleanupError
+            }`
+          )
+        }
+      }
+
       // Mark deployment as failed only while this worker still owns the
       // fenced lease. A stale worker must not overwrite recovery state.
       const current = await Deployment.findOne({ id: deploymentId })
@@ -479,21 +526,23 @@ module.exports = {
       }
 
       // Send failure notification (fire and forget)
-      const failedDeployment = await Deployment.findOne({ id: deploymentId })
-      sails.helpers.notification.sendDeploymentNotification
-        .with({
-          deployment: failedDeployment,
-          project,
-          environment
-        })
-        .catch((notifyErr) => {
-          sails.log.debug(
-            'Deployment notification failed:',
-            notifyErr.message || notifyErr
-          )
-        })
+      if (!cancelled) {
+        const failedDeployment = await Deployment.findOne({ id: deploymentId })
+        sails.helpers.notification.sendDeploymentNotification
+          .with({
+            deployment: failedDeployment,
+            project,
+            environment
+          })
+          .catch((notifyErr) => {
+            sails.log.debug(
+              'Deployment notification failed:',
+              notifyErr.message || notifyErr
+            )
+          })
+      }
 
-      throw err
+      throw failure
     }
   }
 }

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -1,3 +1,5 @@
+const deploymentCancellation = require('../../lib/deployment-cancellation')
+
 module.exports = {
   friendlyName: 'Execute rollback',
 
@@ -23,6 +25,10 @@ module.exports = {
     leaseToken: {
       type: 'string',
       description: 'Fencing token held by the durable deployment worker.'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Abort signal for an operator-requested cancellation.'
     }
   },
 
@@ -31,7 +37,8 @@ module.exports = {
     targetDeployment,
     environment,
     app: appInput,
-    leaseToken
+    leaseToken,
+    signal
   }) {
     let candidateContainerName = null
     let hostPort = null
@@ -39,6 +46,7 @@ module.exports = {
     let currentStage = 'initialization'
 
     const recordStage = async (stage, resources = {}) => {
+      deploymentCancellation.throwIfCancelled(signal, rollbackId)
       currentStage = stage.replace(/_/g, ' ')
       const result = await sails.helpers.deploy.recordDeploymentStage.with({
         deploymentId: rollbackId,
@@ -47,23 +55,28 @@ module.exports = {
         ...resources
       })
       requireValidCoordinatorResult(result)
+      deploymentCancellation.throwIfCancelled(signal, rollbackId)
     }
 
     const assertLease = async () => {
+      deploymentCancellation.throwIfCancelled(signal, rollbackId)
       const result = await sails.helpers.deploy.assertDeploymentLease.with({
         deploymentId: rollbackId,
         leaseToken
       })
       requireValidCoordinatorResult(result)
+      deploymentCancellation.throwIfCancelled(signal, rollbackId)
     }
 
     const updateDeployment = async (values) => {
+      deploymentCancellation.throwIfCancelled(signal, rollbackId)
       const result = await sails.helpers.deploy.updateDeploymentForLease.with({
         deploymentId: rollbackId,
         leaseToken,
         values
       })
       requireValidCoordinatorResult(result)
+      deploymentCancellation.throwIfCancelled(signal, rollbackId)
       return result.deployment
     }
 
@@ -146,7 +159,8 @@ module.exports = {
         host: appBindHost,
         envVars,
         deploymentId: rollbackId,
-        resourceLimits: existingApp?.resourceLimits
+        resourceLimits: existingApp?.resourceLimits,
+        signal
       })
 
       await recordStage('health_check')
@@ -155,7 +169,8 @@ module.exports = {
         port: 1337,
         hostPort,
         path: healthPath,
-        deploymentId: rollbackId
+        deploymentId: rollbackId,
+        signal
       })
 
       await recordStage('traffic_cutover')
@@ -266,15 +281,28 @@ module.exports = {
 
       sails.log.info(`Rollback ${rollbackId} completed successfully`)
     } catch (error) {
-      const errorMessage = error.message || String(error)
-      sails.log.error(
-        `Rollback ${rollbackId} failed during ${currentStage}: ${errorMessage}`
-      )
+      const cancelled =
+        deploymentCancellation.isCancellationError(error) || signal?.aborted
+      const failure = cancelled
+        ? deploymentCancellation.cancellationError(signal, rollbackId)
+        : error
+      const errorMessage = failure.message || String(failure)
+      if (cancelled) {
+        sails.log.info(
+          `Rollback ${rollbackId} cancelled during ${currentStage}: ${errorMessage}`
+        )
+      } else {
+        sails.log.error(
+          `Rollback ${rollbackId} failed during ${currentStage}: ${errorMessage}`
+        )
+      }
 
       try {
         await Deployment.appendDeployLog(
           rollbackId,
-          `\nERROR [${currentStage}]: ${errorMessage}\n`
+          cancelled
+            ? `\nCancellation acknowledged during ${currentStage}. Cleaning up the candidate release...\n`
+            : `\nERROR [${currentStage}]: ${errorMessage}\n`
         )
       } catch {
         /* preserve the original failure */
@@ -313,7 +341,7 @@ module.exports = {
         })
       }
 
-      throw error
+      throw failure
     }
   }
 }

--- a/api/helpers/deploy/reconcile-deployments.js
+++ b/api/helpers/deploy/reconcile-deployments.js
@@ -1,7 +1,5 @@
 const crypto = require('node:crypto')
-const fs = require('node:fs')
 const os = require('node:os')
-const path = require('node:path')
 
 const RECOVERY_LEASE_TTL = 30 * 1000
 const ACTIVE_STATUSES = ['pending', 'building', 'pushing', 'deploying']
@@ -187,7 +185,12 @@ async function recoverLease(lease) {
   if (job.kind === 'deploy') {
     await removeImage(job.imageName || deployment.imageName)
   }
-  cleanupTemporaryBuildContext(job.buildContextPath, deployment.id)
+  if (job.buildContextPath) {
+    await sails.helpers.deploy.cleanupBuildContext.with({
+      contextPath: job.buildContextPath,
+      deploymentId: deployment.id
+    })
+  }
 
   const wasCancelled = deployment.status === 'cancelled'
   const errorMessage = `Slipway restarted during ${humanizeStage(
@@ -355,20 +358,6 @@ async function markOtherDeploymentsStopped(deployment, app) {
   await Deployment.update(criteria).set({ status: 'stopped' })
 }
 
-function cleanupTemporaryBuildContext(contextPath, deploymentId) {
-  if (!contextPath) return
-  const ownedRoot = path.join(
-    os.tmpdir(),
-    'slipway',
-    'deployments',
-    String(deploymentId)
-  )
-  const resolved = path.resolve(contextPath)
-  if (resolved !== ownedRoot && !resolved.startsWith(`${ownedRoot}${path.sep}`))
-    return
-  fs.rmSync(resolved, { recursive: true, force: true })
-}
-
 function humanizeStage(stage) {
   return String(stage || 'an unknown deployment stage').replace(/_/g, ' ')
 }
@@ -376,6 +365,5 @@ function humanizeStage(stage) {
 module.exports._private = {
   claimForRecovery,
   createRecoveryLease,
-  recoverLease,
-  cleanupTemporaryBuildContext
+  recoverLease
 }

--- a/api/helpers/deploy/record-deployment-stage.js
+++ b/api/helpers/deploy/record-deployment-stage.js
@@ -85,7 +85,22 @@ module.exports = {
     if (buildContextPath !== undefined)
       updates.buildContextPath = buildContextPath
 
-    await DeploymentJob.updateOne({ deployment: deploymentId }).set(updates)
+    const updatedJob = await DeploymentJob.updateOne({
+      deployment: deploymentId,
+      stage: { nin: ['cancel_requested', 'cancelled'] }
+    }).set(updates)
+
+    if (!updatedJob) {
+      const job = await DeploymentJob.findOne({ deployment: deploymentId })
+      if (['cancel_requested', 'cancelled'].includes(job?.stage)) {
+        return {
+          valid: false,
+          code: 'DEPLOYMENT_CANCELLED',
+          message: `Deployment ${deploymentId} was cancelled.`
+        }
+      }
+    }
+
     return { valid: true }
   }
 }

--- a/api/helpers/deploy/run-queued-deployments.js
+++ b/api/helpers/deploy/run-queued-deployments.js
@@ -1,8 +1,10 @@
 const crypto = require('node:crypto')
 const os = require('node:os')
+const deploymentCancellation = require('../../lib/deployment-cancellation')
 
 const LEASE_TTL = 30 * 1000
 const HEARTBEAT_INTERVAL = 10 * 1000
+const CANCELLATION_POLL_INTERVAL = 250
 
 module.exports = {
   friendlyName: 'Run queued deployments',
@@ -107,6 +109,8 @@ async function claimNextJob(targetKey) {
 }
 
 async function runClaimedJob({ job, deployment, lease }) {
+  const cancellation = deploymentCancellation.register(deployment.id)
+  let cancellationCheckInFlight = false
   const heartbeat = setInterval(async () => {
     try {
       const now = Date.now()
@@ -128,6 +132,30 @@ async function runClaimedJob({ job, deployment, lease }) {
   }, HEARTBEAT_INTERVAL)
 
   if (typeof heartbeat.unref === 'function') heartbeat.unref()
+
+  const cancellationMonitor = setInterval(async () => {
+    if (cancellationCheckInFlight || cancellation.signal.aborted) return
+    cancellationCheckInFlight = true
+    try {
+      const current = await Deployment.findOne({ id: deployment.id })
+      if (current?.status === 'cancelled') {
+        cancellation.abort(
+          current.errorMessage || `Deployment ${deployment.id} was cancelled.`
+        )
+      }
+    } catch (error) {
+      sails.log.verbose(
+        `Could not check cancellation for deployment ${deployment.id}: ${
+          error.message || error
+        }`
+      )
+    } finally {
+      cancellationCheckInFlight = false
+    }
+  }, CANCELLATION_POLL_INTERVAL)
+  if (typeof cancellationMonitor.unref === 'function') {
+    cancellationMonitor.unref()
+  }
 
   try {
     const environment = await Environment.findOne({
@@ -165,7 +193,8 @@ async function runClaimedJob({ job, deployment, lease }) {
         targetDeployment,
         environment,
         app,
-        leaseToken: lease.token
+        leaseToken: lease.token,
+        signal: cancellation.signal
       })
     } else {
       await sails.helpers.deploy.executePipeline.with({
@@ -173,14 +202,22 @@ async function runClaimedJob({ job, deployment, lease }) {
         project: environment.project,
         environment,
         app,
-        leaseToken: lease.token
+        leaseToken: lease.token,
+        signal: cancellation.signal
       })
     }
   } catch (error) {
     const errorMessage = error.message || String(error)
-    sails.log.error(
-      `Deployment worker ${deployment.id} stopped: ${errorMessage}`
-    )
+    const cancelled = deploymentCancellation.isCancellationError(error)
+    if (cancelled) {
+      sails.log.info(
+        `Deployment worker ${deployment.id} stopped: ${errorMessage}`
+      )
+    } else {
+      sails.log.error(
+        `Deployment worker ${deployment.id} stopped: ${errorMessage}`
+      )
+    }
 
     // Pipeline helpers persist their own failures, but coordinator preflight
     // can also fail (for example, a deleted environment or rollback source).
@@ -213,24 +250,29 @@ async function runClaimedJob({ job, deployment, lease }) {
     }
   } finally {
     clearInterval(heartbeat)
+    clearInterval(cancellationMonitor)
 
-    const ownedLease = await DeploymentLease.findOne({
-      id: lease.id,
-      token: lease.token
-    })
+    try {
+      const ownedLease = await DeploymentLease.findOne({
+        id: lease.id,
+        token: lease.token
+      })
 
-    if (!ownedLease) return
+      if (ownedLease) {
+        const current = await Deployment.findOne({ id: deployment.id })
+        const stage =
+          current?.status === 'running'
+            ? 'complete'
+            : current?.status === 'cancelled'
+            ? 'cancelled'
+            : 'failed'
 
-    const current = await Deployment.findOne({ id: deployment.id })
-    const stage =
-      current?.status === 'running'
-        ? 'complete'
-        : current?.status === 'cancelled'
-        ? 'cancelled'
-        : 'failed'
-
-    await DeploymentJob.updateOne({ id: job.id }).set({ stage })
-    await DeploymentLease.destroyOne({ id: lease.id, token: lease.token })
+        await DeploymentJob.updateOne({ id: job.id }).set({ stage })
+        await DeploymentLease.destroyOne({ id: lease.id, token: lease.token })
+      }
+    } finally {
+      cancellation.release()
+    }
   }
 }
 

--- a/api/helpers/docker/build-image.js
+++ b/api/helpers/docker/build-image.js
@@ -1,5 +1,6 @@
 const { spawn } = require('child_process')
 const path = require('path')
+const deploymentCancellation = require('../../lib/deployment-cancellation')
 
 module.exports = {
   friendlyName: 'Build image',
@@ -42,6 +43,10 @@ module.exports = {
       defaultsTo: false,
       description:
         'Disable Docker layer caching (slower but ensures fresh build)'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Abort signal for an operator-requested cancellation.'
     }
   },
 
@@ -62,8 +67,11 @@ module.exports = {
     deploymentId,
     buildArgs,
     timeout,
-    noCache
+    noCache,
+    signal
   }) {
+    deploymentCancellation.throwIfCancelled(signal, deploymentId)
+
     return new Promise((resolve, reject) => {
       const dockerPath = sails.config.docker?.binaryPath || 'docker'
       const fullDockerfilePath = path.resolve(contextPath, dockerfilePath)
@@ -95,29 +103,67 @@ module.exports = {
       })
       let stdout = ''
       let stderr = ''
-      let killed = false
+      let settled = false
+      let terminationError = null
+      let forceKillId
 
-      // Set up timeout
-      const timeoutId = setTimeout(async () => {
-        killed = true
-        buildProcess.kill('SIGTERM')
+      const cleanup = () => {
+        clearTimeout(timeoutId)
+        clearTimeout(forceKillId)
+        signal?.removeEventListener('abort', abort)
+      }
 
-        // Give it 5 seconds to terminate gracefully, then force kill
-        setTimeout(() => {
-          if (!buildProcess.killed) {
-            buildProcess.kill('SIGKILL')
+      const settle = (done, value) => {
+        if (settled) return
+        settled = true
+        cleanup()
+        done(value)
+      }
+
+      const terminate = (error) => {
+        if (terminationError || settled) return
+        terminationError = error
+
+        try {
+          buildProcess.kill('SIGTERM')
+        } catch {
+          // The process may have exited between the cancellation and signal.
+        }
+
+        forceKillId = setTimeout(() => {
+          if (buildProcess.exitCode === null) {
+            try {
+              buildProcess.kill('SIGKILL')
+            } catch {
+              // The process has already stopped.
+            }
           }
         }, 5000)
+        if (typeof forceKillId.unref === 'function') forceKillId.unref()
+      }
 
+      const abort = () => {
+        terminate(
+          deploymentCancellation.cancellationError(signal, deploymentId)
+        )
+      }
+
+      // Set up timeout
+      const timeoutId = setTimeout(() => {
         const timeoutMinutes = Math.round(timeout / 60000)
         const errorMsg = `Build timed out after ${timeoutMinutes} minutes`
         sails.log.error(errorMsg)
 
         if (deploymentId) {
-          await Deployment.appendBuildLog(deploymentId, `\n⚠️ ${errorMsg}\n`)
+          Deployment.appendBuildLog(deploymentId, `\n⚠️ ${errorMsg}\n`).catch(
+            () => {}
+          )
         }
-        reject(new Error(errorMsg))
+        terminate(new Error(errorMsg))
       }, timeout)
+
+      signal?.addEventListener('abort', abort, { once: true })
+      if (signal?.aborted) abort()
 
       buildProcess.stdout.on('data', async (data) => {
         const chunk = data.toString()
@@ -142,32 +188,33 @@ module.exports = {
       })
 
       buildProcess.on('close', async (code) => {
-        clearTimeout(timeoutId)
-
-        if (killed) return // Already handled by timeout
+        if (terminationError) {
+          settle(reject, terminationError)
+          return
+        }
 
         if (code === 0) {
           sails.log.info(`Successfully built image: ${imageName}`)
-          resolve({
+          settle(resolve, {
             success: true,
             imageName,
             output: stdout
           })
         } else {
           sails.log.error(`Docker build failed with code ${code}`)
-          reject(
+          settle(
+            reject,
             new Error(`Docker build failed with exit code ${code}\n${stderr}`)
           )
         }
       })
 
       buildProcess.on('error', async (error) => {
-        clearTimeout(timeoutId)
-
-        if (killed) return // Already handled by timeout
-
-        sails.log.error(`Docker build error: ${error.message}`)
-        reject(error)
+        const failure = terminationError || error
+        if (!terminationError) {
+          sails.log.error(`Docker build error: ${error.message}`)
+        }
+        settle(reject, failure)
       })
     })
   }

--- a/api/helpers/docker/health-check.js
+++ b/api/helpers/docker/health-check.js
@@ -1,4 +1,5 @@
 const http = require('http')
+const deploymentCancellation = require('../../lib/deployment-cancellation')
 
 module.exports = {
   friendlyName: 'Health check',
@@ -41,6 +42,10 @@ module.exports = {
     deploymentId: {
       type: 'string',
       description: 'Deployment ID for logging progress'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Abort signal for an operator-requested cancellation.'
     }
   },
 
@@ -60,8 +65,10 @@ module.exports = {
     path,
     timeout,
     interval,
-    deploymentId
+    deploymentId,
+    signal
   }) {
+    deploymentCancellation.throwIfCancelled(signal, deploymentId)
     const healthPath = normalizePath(path)
     const startTime = Date.now()
     let lastError = null
@@ -78,6 +85,7 @@ module.exports = {
     }
 
     while (Date.now() - startTime < timeout) {
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
       attempts++
 
       const checkHost = usingFallback ? 'localhost' : containerName
@@ -85,7 +93,13 @@ module.exports = {
       const endpoint = `http://${checkHost}:${checkPort}${healthPath}`
 
       try {
-        const statusCode = await httpGet(checkHost, checkPort, healthPath)
+        const statusCode = await httpGet(
+          checkHost,
+          checkPort,
+          healthPath,
+          signal,
+          deploymentId
+        )
 
         if (statusCode >= 200 && statusCode < 300) {
           sails.log.info(
@@ -102,6 +116,9 @@ module.exports = {
 
         lastError = `${endpoint} returned HTTP ${statusCode}`
       } catch (err) {
+        if (signal?.aborted) {
+          throw deploymentCancellation.cancellationError(signal, deploymentId)
+        }
         // If Docker DNS can't resolve the container name, fall back to localhost:hostPort
         // EAI_AGAIN is a transient DNS failure that also indicates Docker DNS is unavailable
         if (
@@ -127,7 +144,7 @@ module.exports = {
       sails.log.verbose(`Health check attempt ${attempts} failed: ${lastError}`)
 
       // Wait before next attempt
-      await new Promise((resolve) => setTimeout(resolve, interval))
+      await wait(interval, signal, deploymentId)
     }
 
     const elapsed = Math.round((Date.now() - startTime) / 1000)
@@ -146,19 +163,57 @@ module.exports = {
  * Make an HTTP GET request and return the status code.
  * Resolves with the status code, rejects on connection errors.
  */
-function httpGet(hostname, port, path) {
+function httpGet(hostname, port, path, signal, deploymentId) {
   return new Promise((resolve, reject) => {
+    let settled = false
     const req = http.get({ hostname, port, path, timeout: 5000 }, (res) => {
       // Consume response data to free up memory
       res.resume()
-      resolve(res.statusCode)
+      settle(resolve, res.statusCode)
     })
 
-    req.on('error', reject)
+    const abort = () => {
+      req.destroy()
+      settle(
+        reject,
+        deploymentCancellation.cancellationError(signal, deploymentId)
+      )
+    }
+
+    const settle = (done, value) => {
+      if (settled) return
+      settled = true
+      signal?.removeEventListener('abort', abort)
+      done(value)
+    }
+
+    signal?.addEventListener('abort', abort, { once: true })
+    if (signal?.aborted) abort()
+
+    req.on('error', (error) => settle(reject, error))
     req.on('timeout', () => {
       req.destroy()
-      reject(new Error('Request timed out'))
+      settle(reject, new Error('Request timed out'))
     })
+  })
+}
+
+function wait(duration, signal, deploymentId) {
+  return new Promise((resolve, reject) => {
+    let timeoutId
+    const abort = () => {
+      clearTimeout(timeoutId)
+      signal?.removeEventListener('abort', abort)
+      reject(deploymentCancellation.cancellationError(signal, deploymentId))
+    }
+
+    signal?.addEventListener('abort', abort, { once: true })
+    if (signal?.aborted) return abort()
+
+    timeoutId = setTimeout(() => {
+      signal?.removeEventListener('abort', abort)
+      resolve()
+    }, duration)
   })
 }
 

--- a/api/helpers/docker/run-container.js
+++ b/api/helpers/docker/run-container.js
@@ -1,6 +1,7 @@
 const { execFile } = require('child_process')
 const util = require('util')
 const execFileAsync = util.promisify(execFile)
+const deploymentCancellation = require('../../lib/deployment-cancellation')
 
 module.exports = {
   friendlyName: 'Run container',
@@ -50,6 +51,10 @@ module.exports = {
       type: 'ref',
       defaultsTo: {},
       description: 'Docker resource limits (cpus, memory)'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Abort signal for an operator-requested cancellation.'
     }
   },
 
@@ -69,8 +74,10 @@ module.exports = {
     envVars,
     network,
     deploymentId,
-    resourceLimits
+    resourceLimits,
+    signal
   }) {
+    deploymentCancellation.throwIfCancelled(signal, deploymentId)
     const networkName =
       network || sails.config.custom.slipwayNetwork || 'slipway'
     const bindHost = normalizeHost(
@@ -127,7 +134,8 @@ module.exports = {
     }
 
     try {
-      const { stdout } = await execFileAsync(dockerPath, args)
+      const { stdout } = await execFileAsync(dockerPath, args, { signal })
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
       const containerId = stdout.trim()
 
       sails.log.info(
@@ -147,6 +155,7 @@ module.exports = {
         hostPort,
         host: bindHost
       })
+      deploymentCancellation.throwIfCancelled(signal, deploymentId)
 
       if (!portBinding.valid) {
         throw new Error(
@@ -169,6 +178,9 @@ module.exports = {
         portBinding
       }
     } catch (error) {
+      if (signal?.aborted) {
+        throw deploymentCancellation.cancellationError(signal, deploymentId)
+      }
       const errorMessage = error.message || String(error)
       sails.log.error(`Failed to run container: ${errorMessage}`)
 

--- a/api/helpers/git/clone-or-pull.js
+++ b/api/helpers/git/clone-or-pull.js
@@ -4,6 +4,7 @@ const fs = require('fs')
 const path = require('path')
 const os = require('os')
 const execFileAsync = util.promisify(execFile)
+const deploymentCancellation = require('../../lib/deployment-cancellation')
 
 module.exports = {
   friendlyName: 'Clone or pull',
@@ -38,6 +39,10 @@ module.exports = {
     deploymentId: {
       type: 'string',
       description: 'Deployment ID for logging'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Abort signal for an operator-requested cancellation.'
     }
   },
 
@@ -47,8 +52,10 @@ module.exports = {
     commit,
     targetDir,
     deployKeyPrivate,
-    deploymentId
+    deploymentId,
+    signal
   }) {
+    deploymentCancellation.throwIfCancelled(signal, deploymentId)
     const exactCommit = isCommitSha(commit) ? commit : null
     // Normalize the key: fix escaped newlines and ensure trailing newline
     let key = deployKeyPrivate.replace(/\\n/g, '\n')
@@ -99,7 +106,8 @@ module.exports = {
         await execFileAsync('git', ['fetch', 'origin', branch], {
           cwd: targetDir,
           env,
-          timeout
+          timeout,
+          signal
         })
         await checkoutSource({
           targetDir,
@@ -107,7 +115,8 @@ module.exports = {
           commit: exactCommit,
           env,
           timeout,
-          log
+          log,
+          signal
         })
       } else {
         // Fresh clone
@@ -127,7 +136,7 @@ module.exports = {
             cloneUrl,
             targetDir
           ],
-          { env, timeout }
+          { env, timeout, signal }
         )
         await log(`Cloned successfully`)
         await checkoutSource({
@@ -136,7 +145,8 @@ module.exports = {
           commit: exactCommit,
           env,
           timeout,
-          log
+          log,
+          signal
         })
       }
 
@@ -144,9 +154,14 @@ module.exports = {
       const { stdout: headSha } = await execFileAsync(
         'git',
         ['rev-parse', '--short', 'HEAD'],
-        { cwd: targetDir, env, timeout: 5_000 }
+        { cwd: targetDir, env, timeout: 5_000, signal }
       )
       await log(`HEAD is now at ${headSha.trim()}`)
+    } catch (error) {
+      if (signal?.aborted) {
+        throw deploymentCancellation.cancellationError(signal, deploymentId)
+      }
+      throw error
     } finally {
       // Always clean up the key file
       try {
@@ -164,36 +179,42 @@ async function checkoutSource({
   commit,
   env,
   timeout,
-  log
+  log,
+  signal
 }) {
   if (commit) {
     await log(`Fetching exact commit ${commit.slice(0, 12)}...`)
     await execFileAsync('git', ['fetch', '--depth', '1', 'origin', commit], {
       cwd: targetDir,
       env,
-      timeout
+      timeout,
+      signal
     })
     await execFileAsync('git', ['checkout', '--detach', commit], {
       cwd: targetDir,
       env,
-      timeout: 30_000
+      timeout: 30_000,
+      signal
     })
     await execFileAsync('git', ['reset', '--hard', commit], {
       cwd: targetDir,
       env,
-      timeout: 30_000
+      timeout: 30_000,
+      signal
     })
     await log(`Checked out exact commit ${commit.slice(0, 12)}`)
   } else {
     await execFileAsync('git', ['checkout', '-B', branch, `origin/${branch}`], {
       cwd: targetDir,
       env,
-      timeout: 30_000
+      timeout: 30_000,
+      signal
     })
     await execFileAsync('git', ['reset', '--hard', `origin/${branch}`], {
       cwd: targetDir,
       env,
-      timeout: 30_000
+      timeout: 30_000,
+      signal
     })
     await log(`Updated to latest ${branch}`)
   }
@@ -201,7 +222,8 @@ async function checkoutSource({
   await execFileAsync('git', ['clean', '-fd'], {
     cwd: targetDir,
     env,
-    timeout: 30_000
+    timeout: 30_000,
+    signal
   })
 }
 

--- a/api/lib/deployment-cancellation.js
+++ b/api/lib/deployment-cancellation.js
@@ -1,0 +1,78 @@
+const activeDeployments = new Map()
+
+function register(deploymentId) {
+  const key = String(deploymentId)
+  const controller = new AbortController()
+  activeDeployments.set(key, controller)
+
+  return {
+    signal: controller.signal,
+    abort(message) {
+      abortController(controller, deploymentId, message)
+    },
+    release() {
+      if (activeDeployments.get(key) === controller) {
+        activeDeployments.delete(key)
+      }
+    }
+  }
+}
+
+function request(deploymentId, message) {
+  const controller = activeDeployments.get(String(deploymentId))
+  if (!controller) return false
+
+  abortController(controller, deploymentId, message)
+  return true
+}
+
+function throwIfCancelled(signal, deploymentId) {
+  if (!signal?.aborted) return
+  throw cancellationError(signal, deploymentId)
+}
+
+function cancellationError(signal, deploymentId) {
+  if (
+    signal?.reason instanceof Error &&
+    signal.reason.code === 'DEPLOYMENT_CANCELLED'
+  ) {
+    return signal.reason
+  }
+
+  const reason =
+    signal?.reason instanceof Error
+      ? signal.reason.message
+      : typeof signal?.reason === 'string'
+      ? signal.reason
+      : null
+  const error = new Error(
+    reason || `Deployment ${deploymentId || ''} was cancelled.`.trim()
+  )
+  error.code = 'DEPLOYMENT_CANCELLED'
+  return error
+}
+
+function isCancellationError(error) {
+  return (
+    error?.code === 'DEPLOYMENT_CANCELLED' ||
+    error?.cause?.code === 'DEPLOYMENT_CANCELLED'
+  )
+}
+
+function abortController(controller, deploymentId, message) {
+  if (controller.signal.aborted) return
+
+  const error = new Error(
+    message || `Deployment ${deploymentId} was cancelled.`
+  )
+  error.code = 'DEPLOYMENT_CANCELLED'
+  controller.abort(error)
+}
+
+module.exports = {
+  register,
+  request,
+  throwIfCancelled,
+  cancellationError,
+  isCancellationError
+}

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -522,7 +522,7 @@ function executeRollback() {
             data-test="cancel-deployment"
             @click="cancelDeployment"
             :disabled="cancelling"
-            class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            class="rounded-md bg-red-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {{ cancelling ? 'Cancelling...' : 'Cancel' }}
           </button>
@@ -632,24 +632,14 @@ function executeRollback() {
 
         <!-- Failure summary remains visible even when the pipeline failed before logs started. -->
         <section
-          v-if="deployment.errorMessage"
+          v-if="deployment.errorMessage && deployment.status !== 'cancelled'"
           role="alert"
           aria-labelledby="deployment-error-title"
-          :class="[
-            'mb-6 rounded-lg border p-4',
-            deployment.status === 'cancelled'
-              ? 'border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900'
-              : 'border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/30'
-          ]"
+          class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/60 dark:bg-red-950/30"
         >
           <div class="flex items-start gap-3">
             <svg
-              :class="[
-                'mt-0.5 h-5 w-5 shrink-0',
-                deployment.status === 'cancelled'
-                  ? 'text-gray-500 dark:text-gray-400'
-                  : 'text-red-600 dark:text-red-400'
-              ]"
+              class="mt-0.5 h-5 w-5 shrink-0 text-red-600 dark:text-red-400"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -665,42 +655,18 @@ function executeRollback() {
             <div class="min-w-0">
               <h2
                 id="deployment-error-title"
-                :class="[
-                  'text-sm font-semibold',
-                  deployment.status === 'cancelled'
-                    ? 'text-gray-900 dark:text-gray-100'
-                    : 'text-red-900 dark:text-red-200'
-                ]"
+                class="text-sm font-semibold text-red-900 dark:text-red-200"
               >
-                {{
-                  deployment.status === 'cancelled'
-                    ? 'Deployment cancelled'
-                    : 'Deployment failed'
-                }}
+                Deployment failed
               </h2>
               <p
-                :class="[
-                  'mt-1 break-words text-sm leading-6',
-                  deployment.status === 'cancelled'
-                    ? 'text-gray-700 dark:text-gray-300'
-                    : 'text-red-800 dark:text-red-300'
-                ]"
+                class="mt-1 break-words text-sm leading-6 text-red-800 dark:text-red-300"
               >
                 {{ deployment.errorMessage }}
               </p>
-              <p
-                :class="[
-                  'mt-2 text-xs',
-                  deployment.status === 'cancelled'
-                    ? 'text-gray-600 dark:text-gray-400'
-                    : 'text-red-700 dark:text-red-400'
-                ]"
-              >
-                {{
-                  deployment.status === 'cancelled'
-                    ? 'Any candidate release was cleaned up before traffic changed.'
-                    : 'Review the stage logs below, correct the problem, and deploy again.'
-                }}
+              <p class="mt-2 text-xs text-red-700 dark:text-red-400">
+                Review the stage logs below, correct the problem, and deploy
+                again.
               </p>
             </div>
           </div>

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -233,6 +233,8 @@ async function cancelDeployment() {
     )
 
     if (res.ok) {
+      disconnectDeploymentStream()
+      sseStatus.value = 'cancelled'
       router.reload()
     } else {
       const data = await res.json()
@@ -517,6 +519,7 @@ function executeRollback() {
           <!-- Cancel button (for in-progress deployments) -->
           <button
             v-if="isInProgress"
+            data-test="cancel-deployment"
             @click="cancelDeployment"
             :disabled="cancelling"
             class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
@@ -632,11 +635,21 @@ function executeRollback() {
           v-if="deployment.errorMessage"
           role="alert"
           aria-labelledby="deployment-error-title"
-          class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/60 dark:bg-red-950/30"
+          :class="[
+            'mb-6 rounded-lg border p-4',
+            deployment.status === 'cancelled'
+              ? 'border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900'
+              : 'border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/30'
+          ]"
         >
           <div class="flex items-start gap-3">
             <svg
-              class="mt-0.5 h-5 w-5 shrink-0 text-red-600 dark:text-red-400"
+              :class="[
+                'mt-0.5 h-5 w-5 shrink-0',
+                deployment.status === 'cancelled'
+                  ? 'text-gray-500 dark:text-gray-400'
+                  : 'text-red-600 dark:text-red-400'
+              ]"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -652,18 +665,42 @@ function executeRollback() {
             <div class="min-w-0">
               <h2
                 id="deployment-error-title"
-                class="text-sm font-semibold text-red-900 dark:text-red-200"
+                :class="[
+                  'text-sm font-semibold',
+                  deployment.status === 'cancelled'
+                    ? 'text-gray-900 dark:text-gray-100'
+                    : 'text-red-900 dark:text-red-200'
+                ]"
               >
-                Deployment failed
+                {{
+                  deployment.status === 'cancelled'
+                    ? 'Deployment cancelled'
+                    : 'Deployment failed'
+                }}
               </h2>
               <p
-                class="mt-1 break-words text-sm leading-6 text-red-800 dark:text-red-300"
+                :class="[
+                  'mt-1 break-words text-sm leading-6',
+                  deployment.status === 'cancelled'
+                    ? 'text-gray-700 dark:text-gray-300'
+                    : 'text-red-800 dark:text-red-300'
+                ]"
               >
                 {{ deployment.errorMessage }}
               </p>
-              <p class="mt-2 text-xs text-red-700 dark:text-red-400">
-                Review the stage logs below, correct the problem, and deploy
-                again.
+              <p
+                :class="[
+                  'mt-2 text-xs',
+                  deployment.status === 'cancelled'
+                    ? 'text-gray-600 dark:text-gray-400'
+                    : 'text-red-700 dark:text-red-400'
+                ]"
+              >
+                {{
+                  deployment.status === 'cancelled'
+                    ? 'Any candidate release was cleaned up before traffic changed.'
+                    : 'Review the stage logs below, correct the problem, and deploy again.'
+                }}
               </p>
             </div>
           </div>

--- a/tests/e2e/pages/projects/deployment-cancellation.test.js
+++ b/tests/e2e/pages/projects/deployment-cancellation.test.js
@@ -1,0 +1,76 @@
+const { test } = require('sounding')
+
+test(
+  'deployment cancellation keeps the existing detail UI and reports the truthful terminal state',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'deployment-cancellation',
+          name: 'Deployment Cancellation'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      status: 'building',
+      triggerType: 'manual',
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      triggeredBy: current.users.genesisUser.id,
+      startedAt: Date.now() - 5000,
+      buildLogs: 'Building image for deployment cancellation proof...\n'
+    })
+    await world.create('deploymentjob').with({
+      deployment: deployment.id,
+      targetKey: `environment:${current.environments.production.id}`,
+      appSlug: current.apps.web.slug,
+      stage: 'image_build'
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/deployments/${deployment.id}`
+    )
+
+    await expect(page).toSee('Building')
+    await expect(page).toSee('In progress')
+    await expect(page).toSee('Cancel')
+    await page.screenshot('.tmp/deployment-cancellation-active.png', {
+      fullPage: true
+    })
+
+    await page.click('@cancel-deployment')
+    await page.raw
+      .getByRole('heading', { name: 'Deployment cancelled' })
+      .waitFor({ state: 'visible' })
+    await expect(page).toSee('Cancelled')
+    await expect(page).toSee('Deployment cancelled')
+    await expect(page).toSee(
+      'Any candidate release was cleaned up before traffic changed.'
+    )
+    await page.raw
+      .locator('.pointer-events-none.fixed.bottom-4.right-4')
+      .getByText('Cancelled', { exact: true })
+      .waitFor({ state: 'visible' })
+    const pageText = await page.raw.locator('body').textContent()
+    expect(pageText.includes('Deployment failed')).toBe(false)
+    await page.screenshot('.tmp/deployment-cancellation-complete.png', {
+      fullPage: true
+    })
+
+    const [persistedDeployment, persistedJob] = await Promise.all([
+      sails.models.deployment.findOne({ id: deployment.id }),
+      sails.models.deploymentjob.findOne({ deployment: deployment.id })
+    ])
+    expect(persistedDeployment.status).toBe('cancelled')
+    expect(persistedJob.stage).toBe('cancelled')
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)

--- a/tests/e2e/pages/projects/deployment-cancellation.test.js
+++ b/tests/e2e/pages/projects/deployment-cancellation.test.js
@@ -42,19 +42,21 @@ test(
     await expect(page).toSee('Building')
     await expect(page).toSee('In progress')
     await expect(page).toSee('Cancel')
+    const cancelButtonClasses = await page.raw
+      .locator('[data-test="cancel-deployment"]')
+      .getAttribute('class')
+    expect(cancelButtonClasses).toContain('bg-red-600')
+    expect(cancelButtonClasses).toContain('text-white')
+    expect(cancelButtonClasses).toContain('hover:bg-red-700')
     await page.screenshot('.tmp/deployment-cancellation-active.png', {
       fullPage: true
     })
 
     await page.click('@cancel-deployment')
     await page.raw
-      .getByRole('heading', { name: 'Deployment cancelled' })
+      .getByText('Cancelled', { exact: true })
       .waitFor({ state: 'visible' })
     await expect(page).toSee('Cancelled')
-    await expect(page).toSee('Deployment cancelled')
-    await expect(page).toSee(
-      'Any candidate release was cleaned up before traffic changed.'
-    )
     await page.raw
       .locator('.pointer-events-none.fixed.bottom-4.right-4')
       .getByText('Cancelled', { exact: true })

--- a/tests/functional/api/deploy.test.js
+++ b/tests/functional/api/deploy.test.js
@@ -173,6 +173,156 @@ test(
   }
 )
 
+test(
+  'queued deployment cancellation is idempotent and recorded once',
+  { transport: 'http', world: deploymentWorld('cancel-queued-deployment') },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const queued = await sails.helpers.deploy.queueDeployment.with({
+      values: {
+        triggerType: 'manual',
+        environment: current.environments.production.id
+      },
+      app: current.apps.web,
+      dispatch: false
+    })
+    const cancelPath = `/api/v1/deployments/${queued.deployment.id}/cancel`
+
+    const first = await request.as('genesisUser').post(cancelPath, {})
+    const second = await request.as('genesisUser').post(cancelPath, {})
+    const [deployment, job, leaseCount] = await Promise.all([
+      sails.models.deployment.findOne({ id: queued.deployment.id }),
+      sails.models.deploymentjob.findOne({ id: queued.job.id }),
+      sails.models.deploymentlease.count({
+        deployment: queued.deployment.id
+      })
+    ])
+
+    expect(first).toHaveStatus(200)
+    expect(first).toHaveJsonPath('status', 'cancelled')
+    expect(second).toHaveStatus(200)
+    expect(second).toHaveJsonPath('status', 'cancelled')
+    expect(deployment.status).toBe('cancelled')
+    expect(job.stage).toBe('cancelled')
+    expect(leaseCount).toBe(0)
+    expect(deployment.buildLogs.match(/Deployment cancelled by/g)?.length).toBe(
+      1
+    )
+  }
+)
+
+test(
+  'active deployment cancellation aborts its worker and preserves the cancelled terminal state',
+  { transport: 'http', world: deploymentWorld('cancel-active-deployment') },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const originalExecutePipeline = sails.helpers.deploy.executePipeline
+    let workerStarted = false
+    let workerAborted = false
+
+    sails.helpers.deploy.executePipeline = {
+      with: async ({ deploymentId, leaseToken, signal }) => {
+        const stage = await sails.helpers.deploy.recordDeploymentStage.with({
+          deploymentId,
+          leaseToken,
+          stage: 'image_build'
+        })
+        expect(stage.valid).toBe(true)
+        const building =
+          await sails.helpers.deploy.updateDeploymentForLease.with({
+            deploymentId,
+            leaseToken,
+            values: { status: 'building' }
+          })
+        expect(building.valid).toBe(true)
+        workerStarted = true
+
+        await new Promise((resolve, reject) => {
+          const abort = () => {
+            workerAborted = true
+            reject(signal.reason)
+          }
+          signal.addEventListener('abort', abort, { once: true })
+          if (signal.aborted) abort()
+        })
+      }
+    }
+
+    try {
+      const queued = await sails.helpers.deploy.queueDeployment.with({
+        values: {
+          triggerType: 'manual',
+          environment: current.environments.production.id
+        },
+        app: current.apps.web,
+        dispatch: false
+      })
+      const drain = sails.helpers.deploy.runQueuedDeployments
+        .with({
+          targetKey: queued.job.targetKey
+        })
+        .then((result) => result)
+      await waitFor(() => workerStarted)
+
+      const response = await request
+        .as('genesisUser')
+        .post(`/api/v1/deployments/${queued.deployment.id}/cancel`, {})
+      await drain
+
+      const [deployment, job, leaseCount] = await Promise.all([
+        sails.models.deployment.findOne({ id: queued.deployment.id }),
+        sails.models.deploymentjob.findOne({ id: queued.job.id }),
+        sails.models.deploymentlease.count({
+          deployment: queued.deployment.id
+        })
+      ])
+
+      expect(response).toHaveStatus(200)
+      expect(workerAborted).toBe(true)
+      expect(deployment.status).toBe('cancelled')
+      expect(job.stage).toBe('cancelled')
+      expect(leaseCount).toBe(0)
+      expect(deployment.errorMessage).toContain('Cancelled by')
+    } finally {
+      sails.helpers.deploy.executePipeline = originalExecutePipeline
+    }
+  }
+)
+
+test(
+  'deployment cancellation is refused after traffic cutover begins',
+  { transport: 'http', world: deploymentWorld('cancel-after-cutover') },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const queued = await sails.helpers.deploy.queueDeployment.with({
+      values: {
+        triggerType: 'manual',
+        environment: current.environments.production.id
+      },
+      app: current.apps.web,
+      dispatch: false
+    })
+    await Promise.all([
+      sails.models.deployment
+        .updateOne({ id: queued.deployment.id })
+        .set({ status: 'deploying' }),
+      sails.models.deploymentjob
+        .updateOne({ id: queued.job.id })
+        .set({ stage: 'traffic_cutover' })
+    ])
+
+    const response = await request
+      .as('genesisUser')
+      .post(`/api/v1/deployments/${queued.deployment.id}/cancel`, {})
+    const deployment = await sails.models.deployment.findOne({
+      id: queued.deployment.id
+    })
+
+    expect(response).toHaveStatus(400)
+    expect(deployment.status).toBe('deploying')
+  }
+)
+
 async function waitFor(predicate, timeout = 2000) {
   const deadline = Date.now() + timeout
   while (!(await predicate())) {

--- a/tests/unit/helpers/deploy/cleanup-build-context.test.js
+++ b/tests/unit/helpers/deploy/cleanup-build-context.test.js
@@ -1,0 +1,44 @@
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+test('deployment cleanup removes only its owned temporary build context', async ({
+  sails,
+  expect
+}) => {
+  const deploymentId = `cleanup-${Date.now()}`
+  const ownedRoot = path.join(
+    os.tmpdir(),
+    'slipway',
+    'deployments',
+    deploymentId
+  )
+  const ownedContext = path.join(ownedRoot, 'source')
+  const persistentContext = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-persistent-source-')
+  )
+  fs.mkdirSync(ownedContext, { recursive: true })
+  fs.writeFileSync(path.join(ownedContext, 'Dockerfile'), 'FROM node:22\n')
+  fs.writeFileSync(path.join(persistentContext, 'Dockerfile'), 'FROM node:22\n')
+
+  try {
+    const removed = await sails.helpers.deploy.cleanupBuildContext.with({
+      contextPath: ownedContext,
+      deploymentId
+    })
+    const preserved = await sails.helpers.deploy.cleanupBuildContext.with({
+      contextPath: persistentContext,
+      deploymentId
+    })
+
+    expect(removed).toEqual({ removed: true })
+    expect(preserved).toEqual({ removed: false })
+    expect(fs.existsSync(ownedContext)).toBe(false)
+    expect(fs.existsSync(persistentContext)).toBe(true)
+  } finally {
+    fs.rmSync(ownedRoot, { recursive: true, force: true })
+    fs.rmSync(persistentContext, { recursive: true, force: true })
+  }
+})

--- a/tests/unit/helpers/deploy/cutover-traffic.test.js
+++ b/tests/unit/helpers/deploy/cutover-traffic.test.js
@@ -448,6 +448,123 @@ test(
 )
 
 test(
+  'cancellation before cutover removes the candidate release and preserves the live app',
+  { world: cutoverWorld('cancel-before-cutover') },
+  async ({ sails, world, expect }) => {
+    const setup = await prepareCutover({ sails, world })
+    const originals = {
+      ensureNetwork: sails.helpers.docker.ensureNetwork,
+      ensureBuildContext: sails.helpers.deploy.ensureBuildContext,
+      buildImage: sails.helpers.docker.buildImage,
+      detectFeatures: sails.helpers.sails.detectFeatures,
+      allocatePort: sails.helpers.docker.allocatePort,
+      runContainer: sails.helpers.docker.runContainer,
+      healthCheck: sails.helpers.docker.healthCheck,
+      cutoverTraffic: sails.helpers.deploy.cutoverTraffic,
+      releasePort: sails.helpers.docker.releasePort,
+      stopContainer: sails.helpers.docker.stopContainer,
+      removeImage: sails.helpers.docker.removeImage
+    }
+    const controller = new AbortController()
+    const cancellation = new Error('Cancelled by Builder')
+    cancellation.code = 'DEPLOYMENT_CANCELLED'
+    const sequence = []
+    let candidateName
+    let candidateImage
+
+    sails.helpers.docker.ensureNetwork = machineStub(async () => {})
+    sails.helpers.deploy.ensureBuildContext = machineStub(async () => ({
+      contextPath: '/tmp/slipway-cancel-before-cutover'
+    }))
+    sails.helpers.docker.buildImage = machineStub(async ({ imageName }) => {
+      candidateImage = imageName
+      sequence.push('image-built')
+    })
+    sails.helpers.sails.detectFeatures = machineStub(async () => ({}))
+    sails.helpers.docker.allocatePort = machineStub(async () => 1405)
+    sails.helpers.docker.runContainer = machineStub(async (inputs) => {
+      candidateName = inputs.containerName
+      sequence.push(`started:${candidateName}`)
+      return {
+        containerId: 'cancelled-candidate-id',
+        containerName: candidateName,
+        hostPort: inputs.hostPort,
+        portBinding: { diagnostic: 'verified' }
+      }
+    })
+    sails.helpers.docker.healthCheck = machineStub(async ({ signal }) => {
+      sequence.push('health-check-started')
+      await sails.models.deployment.updateOne({ id: setup.deployment.id }).set({
+        status: 'cancelled',
+        errorMessage: cancellation.message,
+        finishedAt: Date.now()
+      })
+      controller.abort(cancellation)
+      throw signal.reason
+    })
+    sails.helpers.deploy.cutoverTraffic = machineStub(async () => {
+      sequence.push('cutover')
+    })
+    sails.helpers.docker.stopContainer = machineStub(
+      async ({ containerName }) => {
+        sequence.push(`stopped:${containerName}`)
+      }
+    )
+    sails.helpers.docker.releasePort = machineStub(async () => {
+      sequence.push('port-released')
+      return { released: 1 }
+    })
+    sails.helpers.docker.removeImage = machineStub(async ({ imageName }) => {
+      sequence.push(`removed:${imageName}`)
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.executePipeline.with({
+          deploymentId: setup.deployment.id,
+          project: world.current.projects.deploymentTarget,
+          environment: setup.environment,
+          app: setup.app,
+          signal: controller.signal
+        })
+      )
+      const [app, deployment] = await Promise.all([
+        sails.models.app.findOne({ id: setup.app.id }),
+        sails.models.deployment.findOne({ id: setup.deployment.id })
+      ])
+
+      expect(error.code).toBe('DEPLOYMENT_CANCELLED')
+      expect(deployment.status).toBe('cancelled')
+      expect(app.containerName).toBe('slipway-web-previous')
+      expect(app.hostPort).toBe(1401)
+      expect(sequence).toEqual([
+        'image-built',
+        `started:${candidateName}`,
+        'health-check-started',
+        `stopped:${candidateName}`,
+        'port-released',
+        `removed:${candidateImage}`
+      ])
+      expect(deployment.deployLogs).toContain(
+        'Cancellation acknowledged during health check'
+      )
+    } finally {
+      sails.helpers.docker.ensureNetwork = originals.ensureNetwork
+      sails.helpers.deploy.ensureBuildContext = originals.ensureBuildContext
+      sails.helpers.docker.buildImage = originals.buildImage
+      sails.helpers.sails.detectFeatures = originals.detectFeatures
+      sails.helpers.docker.allocatePort = originals.allocatePort
+      sails.helpers.docker.runContainer = originals.runContainer
+      sails.helpers.docker.healthCheck = originals.healthCheck
+      sails.helpers.deploy.cutoverTraffic = originals.cutoverTraffic
+      sails.helpers.docker.releasePort = originals.releasePort
+      sails.helpers.docker.stopContainer = originals.stopContainer
+      sails.helpers.docker.removeImage = originals.removeImage
+    }
+  }
+)
+
+test(
   'rollback uses a deployment-scoped candidate and retires the old container only after cutover',
   { world: cutoverWorld('transactional-rollback') },
   async ({ sails, world, expect }) => {

--- a/tests/unit/helpers/docker/build-image-cancellation.test.js
+++ b/tests/unit/helpers/docker/build-image-cancellation.test.js
@@ -12,10 +12,22 @@ test('docker image build terminates its process when the deployment is cancelled
     path.join(os.tmpdir(), 'slipway-cancel-build-')
   )
   const dockerPath = path.join(tempRoot, 'docker')
+  const readyPath = path.join(tempRoot, 'ready')
+  const terminatedPath = path.join(tempRoot, 'terminated')
   const originalDockerPath = sails.config.docker?.binaryPath
   fs.writeFileSync(
     dockerPath,
-    '#!/bin/sh\ntrap "exit 0" TERM\nwhile true; do sleep 1; done\n'
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs')",
+      "process.on('SIGTERM', () => {",
+      `  fs.writeFileSync(${JSON.stringify(terminatedPath)}, 'SIGTERM')`,
+      '  process.exit(0)',
+      '})',
+      `fs.writeFileSync(${JSON.stringify(readyPath)}, 'ready')`,
+      'setInterval(() => {}, 1000)',
+      ''
+    ].join('\n')
   )
   fs.chmodSync(dockerPath, 0o755)
   sails.config.docker = sails.config.docker || {}
@@ -24,27 +36,29 @@ test('docker image build terminates its process when the deployment is cancelled
   const controller = new AbortController()
   const cancellation = new Error('Cancelled by Builder')
   cancellation.code = 'DEPLOYMENT_CANCELLED'
-  const startedAt = Date.now()
+  let build
+  let buildError
 
   try {
-    const build = sails.helpers.docker.buildImage.with({
-      contextPath: tempRoot,
-      imageName: 'slipway/cancelled:latest',
-      timeout: 10_000,
-      signal: controller.signal
-    })
-    setTimeout(() => controller.abort(cancellation), 30)
+    build = sails.helpers.docker.buildImage
+      .with({
+        contextPath: tempRoot,
+        imageName: 'slipway/cancelled:latest',
+        timeout: 10_000,
+        signal: controller.signal
+      })
+      .catch((error) => {
+        buildError = error
+      })
+    await waitFor(() => fs.existsSync(readyPath))
+    controller.abort(cancellation)
+    await build
 
-    let error
-    try {
-      await build
-    } catch (err) {
-      error = err
-    }
-
-    expect(error.code).toBe('DEPLOYMENT_CANCELLED')
-    expect(Date.now() - startedAt < 1000).toBe(true)
+    expect(buildError.code).toBe('DEPLOYMENT_CANCELLED')
+    expect(fs.readFileSync(terminatedPath, 'utf8')).toBe('SIGTERM')
   } finally {
+    if (!controller.signal.aborted) controller.abort(cancellation)
+    if (build) await build
     if (originalDockerPath === undefined) {
       delete sails.config.docker.binaryPath
     } else {
@@ -53,3 +67,13 @@ test('docker image build terminates its process when the deployment is cancelled
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
 })
+
+async function waitFor(predicate, timeout = 5000) {
+  const deadline = Date.now() + timeout
+  while (!predicate()) {
+    if (Date.now() >= deadline) {
+      throw new Error('Timed out waiting for the fake Docker process.')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}

--- a/tests/unit/helpers/docker/build-image-cancellation.test.js
+++ b/tests/unit/helpers/docker/build-image-cancellation.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { test } = require('sounding')
+
+test('docker image build terminates its process when the deployment is cancelled', async ({
+  sails,
+  expect
+}) => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-cancel-build-')
+  )
+  const dockerPath = path.join(tempRoot, 'docker')
+  const originalDockerPath = sails.config.docker?.binaryPath
+  fs.writeFileSync(
+    dockerPath,
+    '#!/bin/sh\ntrap "exit 0" TERM\nwhile true; do sleep 1; done\n'
+  )
+  fs.chmodSync(dockerPath, 0o755)
+  sails.config.docker = sails.config.docker || {}
+  sails.config.docker.binaryPath = dockerPath
+
+  const controller = new AbortController()
+  const cancellation = new Error('Cancelled by Builder')
+  cancellation.code = 'DEPLOYMENT_CANCELLED'
+  const startedAt = Date.now()
+
+  try {
+    const build = sails.helpers.docker.buildImage.with({
+      contextPath: tempRoot,
+      imageName: 'slipway/cancelled:latest',
+      timeout: 10_000,
+      signal: controller.signal
+    })
+    setTimeout(() => controller.abort(cancellation), 30)
+
+    let error
+    try {
+      await build
+    } catch (err) {
+      error = err
+    }
+
+    expect(error.code).toBe('DEPLOYMENT_CANCELLED')
+    expect(Date.now() - startedAt < 1000).toBe(true)
+  } finally {
+    if (originalDockerPath === undefined) {
+      delete sails.config.docker.binaryPath
+    } else {
+      sails.config.docker.binaryPath = originalDockerPath
+    }
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/tests/unit/helpers/docker/health-check.test.js
+++ b/tests/unit/helpers/docker/health-check.test.js
@@ -93,6 +93,36 @@ test('docker health check rejects non-2xx responses from the configured path', a
   }
 })
 
+test('docker health check stops polling when its deployment is cancelled', async ({
+  sails,
+  expect
+}) => {
+  const controller = new AbortController()
+  const cancellation = new Error('Cancelled by Builder')
+  cancellation.code = 'DEPLOYMENT_CANCELLED'
+  const startedAt = Date.now()
+  const check = sails.helpers.docker.healthCheck.with({
+    containerName: '127.0.0.1',
+    port: 1,
+    path: '/health',
+    timeout: 10_000,
+    interval: 5_000,
+    signal: controller.signal
+  })
+
+  setTimeout(() => controller.abort(cancellation), 20)
+
+  let error
+  try {
+    await check
+  } catch (err) {
+    error = err
+  }
+
+  expect(error.code).toBe('DEPLOYMENT_CANCELLED')
+  expect(Date.now() - startedAt < 1000).toBe(true)
+})
+
 function listen(server) {
   return new Promise((resolve, reject) => {
     server.once('error', reject)
@@ -104,6 +134,8 @@ function listen(server) {
 }
 
 function close(server) {
+  if (!server.listening) return Promise.resolve()
+
   return new Promise((resolve, reject) => {
     server.close((err) => (err ? reject(err) : resolve()))
   })


### PR DESCRIPTION
## Summary

- turn deployment cancellation into a real signal shared by the coordinator, normal deploys, and rollbacks
- interrupt active Git sync, Docker build, container startup, and health-check work
- fence cancellation against traffic cutover and terminal writes so `cancelled` cannot become `running` or `failed`
- clean deploy-scoped containers, images, port reservations, and guarded temporary build contexts while preserving the previous live release
- make repeated cancellation idempotent and return the observed final state
- keep the existing deployment-detail layout, use Slipway’s destructive red treatment for Cancel, and report cancellation through the existing badge, logs, and global toast

## Root cause

The cancellation endpoint only changed the `Deployment` row. The worker and its child processes had no cancellation signal, so they could keep building or deploying after the UI reported cancellation. A stale SSE status could then keep the detail page visually stuck on `Building` even after the database was cancelled.

## Impact

Cancel now stops active pre-cutover work, safely unwinds the candidate release, keeps the previous app live, releases the durable lease only after cleanup, and lets the next queued deployment proceed without overlapping resources. Requests are rejected once traffic cutover has begun.

## Validation

- `npm run lint`
- `npm run test:unit` — 103 passed
- `npm run test:functional` — 33 passed
- `npm run test:e2e` — 12 passed
- browser proof captures both the existing active state and the simplified cancelled state

Closes #231