### PR TITLE
feat: pin supported service image versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Slipway is an open-source, self-hosted platform purpose-built for **Sails.js** a
 - **Self-hosted** — Runs on any Linux VPS you control. Your code, your data, your servers
 - **Sails-native** — Understands your models, helpers, hooks, and config out of the box
 - **Automatic HTTPS** — SSL certificates provisioned automatically via Caddy
-- **Database management** — Provision PostgreSQL, MySQL, or Redis with one click. Connection URLs auto-injected
+- **Database management** — Provision PostgreSQL, MySQL, Redis, or MongoDB from [pinned, tested image versions](docs/service-versions.md). Connection URLs auto-injected
 - **Built-in platform** — Helm (production REPL), Bridge (data management), Dock (SQL console), Quest (job scheduler), Content (CMS)
 - **Backups** — Database backups to S3-compatible storage with one-click restore
 - **Team collaboration** — Multi-user access with team management

--- a/api/controllers/api/v1/service/create-service.js
+++ b/api/controllers/api/v1/service/create-service.js
@@ -30,7 +30,6 @@ module.exports = {
     },
     version: {
       type: 'string',
-      defaultsTo: 'latest',
       description: 'Docker image version/tag'
     }
   },
@@ -51,6 +50,7 @@ module.exports = {
   },
 
   fn: async function ({ projectSlug, environmentSlug, name, type, version }) {
+    const { inspectVersion } = require('../../../../lib/service-image-policy')
     const user = await User.findOne({ id: this.req.session.userId })
 
     const project = await Project.findOne({ slug: projectSlug }).populate(
@@ -92,6 +92,17 @@ module.exports = {
       }
     }
 
+    let versionSelection
+    try {
+      versionSelection = inspectVersion(type, version)
+    } catch (error) {
+      throw {
+        badRequest: {
+          problems: [{ version: error.message }]
+        }
+      }
+    }
+
     // Generate credentials
     const password = await sails.helpers.strings.random('url-friendly')
     const username = `slipway_${name.replace(/-/g, '_')}`
@@ -105,7 +116,7 @@ module.exports = {
     const service = await Service.create({
       name,
       type,
-      version,
+      version: versionSelection.version,
       status: 'creating',
       containerName,
       internalHost,
@@ -117,7 +128,21 @@ module.exports = {
     }).fetch()
 
     // Create the Docker container
-    await sails.helpers.docker.createService(service.id)
+    try {
+      await sails.helpers.docker.createService(service.id)
+    } catch (error) {
+      throw {
+        badRequest: {
+          problems: [
+            {
+              service:
+                error?.message ||
+                'Docker could not create the service container.'
+            }
+          ]
+        }
+      }
+    }
 
     // Get connection URL
     const connectionUrl = await Service.getConnectionUrl(service.id)
@@ -158,6 +183,9 @@ module.exports = {
         name: service.name,
         type: service.type,
         version: service.version,
+        versionSupport: versionSelection.supported ? 'supported' : 'custom',
+        imageReference: (await Service.findOne({ id: service.id }))
+          .imageReference,
         status: 'running',
         connectionUrl,
         internalHost: service.internalHost,

--- a/api/controllers/api/v1/service/get-service.js
+++ b/api/controllers/api/v1/service/get-service.js
@@ -24,6 +24,7 @@ module.exports = {
   },
 
   fn: async function ({ id }) {
+    const { inspectVersion } = require('../../../../lib/service-image-policy')
     const user = await User.findOne({ id: this.req.session.userId })
 
     const service = await Service.findOne(id).populate('environment')
@@ -46,6 +47,16 @@ module.exports = {
     }
 
     const connectionUrl = await Service.getConnectionUrl(service.id)
+    let versionSupport = 'unresolved'
+    try {
+      versionSupport = inspectVersion(service.type, service.version, {
+        useDefault: false
+      }).supported
+        ? 'supported'
+        : 'custom'
+    } catch {
+      /* Legacy mutable records stay visibly unresolved. */
+    }
 
     return {
       service: {
@@ -53,6 +64,8 @@ module.exports = {
         name: service.name,
         type: service.type,
         version: service.version,
+        versionSupport,
+        imageReference: service.imageReference,
         status: service.status,
         connectionUrl,
         internalHost: service.internalHost,

--- a/api/controllers/api/v1/service/list-services.js
+++ b/api/controllers/api/v1/service/list-services.js
@@ -29,6 +29,7 @@ module.exports = {
   },
 
   fn: async function ({ projectSlug, environmentSlug }) {
+    const { inspectVersion } = require('../../../../lib/service-image-policy')
     const user = await User.findOne({ id: this.req.session.userId })
 
     const project = await Project.findOne({ slug: projectSlug }).populate(
@@ -57,17 +58,32 @@ module.exports = {
     )
 
     // Add connection URLs (without exposing passwords in list)
-    const servicesWithInfo = services.map((service) => ({
-      id: service.id,
-      name: service.name,
-      type: service.type,
-      version: service.version,
-      status: service.status,
-      internalHost: service.internalHost,
-      internalPort: service.internalPort,
-      database: service.database,
-      createdAt: service.createdAt
-    }))
+    const servicesWithInfo = services.map((service) => {
+      let versionSupport = 'unresolved'
+      try {
+        versionSupport = inspectVersion(service.type, service.version, {
+          useDefault: false
+        }).supported
+          ? 'supported'
+          : 'custom'
+      } catch {
+        /* Legacy mutable records stay visibly unresolved. */
+      }
+
+      return {
+        id: service.id,
+        name: service.name,
+        type: service.type,
+        version: service.version,
+        versionSupport,
+        imageReference: service.imageReference,
+        status: service.status,
+        internalHost: service.internalHost,
+        internalPort: service.internalPort,
+        database: service.database,
+        createdAt: service.createdAt
+      }
+    })
 
     return { services: servicesWithInfo }
   }

--- a/api/controllers/api/v1/service/list-versions.js
+++ b/api/controllers/api/v1/service/list-versions.js
@@ -1,0 +1,18 @@
+const { getPublicMatrix } = require('../../../../lib/service-image-policy')
+
+module.exports = {
+  friendlyName: 'List service versions',
+
+  description:
+    'Return the tested service-version matrix and pinned defaults used by Slipway.',
+
+  exits: {
+    success: {
+      statusCode: 200
+    }
+  },
+
+  fn: async function () {
+    return { services: getPublicMatrix() }
+  }
+}

--- a/api/controllers/api/v1/service/restart-service.js
+++ b/api/controllers/api/v1/service/restart-service.js
@@ -21,6 +21,9 @@ module.exports = {
     },
     notFound: {
       statusCode: 404
+    },
+    conflict: {
+      statusCode: 409
     }
   },
 
@@ -43,6 +46,9 @@ module.exports = {
     if (!project || project.team !== user.team.id) throw 'notFound'
 
     if (!service.containerName) throw 'notFound'
+    if (service.status === 'upgrading') {
+      throw { conflict: { message: 'The service is currently upgrading.' } }
+    }
 
     try {
       const dockerPath = sails.config.docker?.binaryPath || 'docker'

--- a/api/controllers/api/v1/service/stop-service.js
+++ b/api/controllers/api/v1/service/stop-service.js
@@ -21,6 +21,9 @@ module.exports = {
     },
     notFound: {
       statusCode: 404
+    },
+    conflict: {
+      statusCode: 409
     }
   },
 
@@ -43,6 +46,9 @@ module.exports = {
     if (!project || project.team !== user.team.id) throw 'notFound'
 
     if (!service.containerName) throw 'notFound'
+    if (service.status === 'upgrading') {
+      throw { conflict: { message: 'The service is currently upgrading.' } }
+    }
 
     try {
       const dockerPath = sails.config.docker?.binaryPath || 'docker'

--- a/api/controllers/api/v1/service/stream-upgrade.js
+++ b/api/controllers/api/v1/service/stream-upgrade.js
@@ -1,0 +1,53 @@
+module.exports = {
+  friendlyName: 'Stream service upgrade',
+
+  description: 'Stream service version upgrade progress.',
+
+  inputs: {
+    serviceId: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      description: 'SSE stream started.'
+    },
+    notFound: {
+      statusCode: 404
+    }
+  },
+
+  fn: async function ({ serviceId }) {
+    const user = await User.findOne({ id: this.req.session.userId }).populate(
+      'team'
+    )
+    const service = await Service.findOne({ id: serviceId }).populate(
+      'environment'
+    )
+    if (!service) throw 'notFound'
+
+    const environment = await Environment.findOne({
+      id: service.environment.id
+    }).populate('project')
+    const project = await Project.findOne({ id: environment.project.id })
+    if (!project || project.team !== user.team.id) throw 'notFound'
+
+    if (
+      service.upgradeState?.status === 'completed' ||
+      service.upgradeState?.status === 'failed'
+    ) {
+      const stream = this.res.sse()
+      stream.send(service.upgradeState)
+      stream.close()
+      return stream.wait()
+    }
+
+    return sails.sse.subscribe(
+      this.req,
+      this.res,
+      `service-upgrade:${service.id}`
+    )
+  }
+}

--- a/api/controllers/api/v1/service/upgrade-service.js
+++ b/api/controllers/api/v1/service/upgrade-service.js
@@ -1,0 +1,146 @@
+const { getUpgradePlan } = require('../../../../lib/service-image-policy')
+
+module.exports = {
+  friendlyName: 'Upgrade service',
+
+  description: 'Start a guarded service version upgrade.',
+
+  inputs: {
+    serviceId: {
+      type: 'string',
+      required: true
+    },
+    targetVersion: {
+      type: 'string',
+      required: true
+    },
+    confirmation: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      statusCode: 202
+    },
+    notFound: {
+      statusCode: 404
+    },
+    badRequest: {
+      statusCode: 400
+    }
+  },
+
+  fn: async function ({ serviceId, targetVersion, confirmation }) {
+    const user = await User.findOne({ id: this.req.session.userId }).populate(
+      'team'
+    )
+    const service = await Service.findOne({ id: serviceId }).populate(
+      'environment'
+    )
+    if (!service) throw 'notFound'
+
+    const environment = await Environment.findOne({
+      id: service.environment.id
+    }).populate('project')
+    const project = await Project.findOne({ id: environment.project.id })
+    if (!project || project.team !== user.team.id) throw 'notFound'
+
+    if (confirmation !== service.name) {
+      throw {
+        badRequest: {
+          message: `Type ${service.name} to confirm the upgrade.`
+        }
+      }
+    }
+    if (service.status !== 'running') {
+      throw {
+        badRequest: {
+          message: 'The service must be running before it can be upgraded.'
+        }
+      }
+    }
+    if (!service.imageReference || service.version === 'latest') {
+      throw {
+        badRequest: {
+          message:
+            'Slipway must resolve the current service image before it can plan an upgrade.'
+        }
+      }
+    }
+    if (!Service.isBackupSupported(service.type)) {
+      throw {
+        badRequest: {
+          message:
+            'Automated upgrades are disabled until this service type supports verified backups.'
+        }
+      }
+    }
+
+    try {
+      getUpgradePlan(service.type, service.version, targetVersion)
+    } catch (error) {
+      throw { badRequest: { message: error.message } }
+    }
+
+    const initialState = {
+      status: 'queued',
+      fromVersion: service.version,
+      targetVersion,
+      step: 'backup',
+      message: 'Upgrade queued.',
+      startedAt: Date.now()
+    }
+    const claimed = await Service.updateOne({
+      id: service.id,
+      status: 'running'
+    }).set({
+      status: 'upgrading',
+      upgradeState: initialState
+    })
+    if (!claimed) {
+      throw {
+        badRequest: {
+          message: 'Another service operation started before the upgrade.'
+        }
+      }
+    }
+
+    sails.helpers.service.runVersionUpgrade
+      .with({
+        serviceId: service.id,
+        targetVersion,
+        userId: user.id,
+        teamId: user.team.id,
+        ipAddress: this.req.ip || null
+      })
+      .catch(async (error) => {
+        const failedState = {
+          ...initialState,
+          status: 'failed',
+          message: `Upgrade worker stopped before it could begin: ${error.message}`,
+          failedAt: Date.now()
+        }
+
+        try {
+          await Service.updateOne({
+            id: service.id,
+            status: 'upgrading'
+          }).set({
+            status: 'running',
+            upgradeState: failedState
+          })
+          sails.sse.publish(`service-upgrade:${service.id}`, failedState)
+        } catch (stateError) {
+          sails.log.error(
+            `Could not recover service upgrade state: ${stateError.message}`
+          )
+        }
+
+        sails.log.error(`Service upgrade worker failed: ${error.message}`)
+      })
+
+    return { upgrade: initialState }
+  }
+}

--- a/api/controllers/project/view-environment.js
+++ b/api/controllers/project/view-environment.js
@@ -46,6 +46,10 @@ module.exports = {
     deploymentSource,
     deploymentCursor
   }) {
+    const {
+      getPublicMatrix,
+      inspectVersion
+    } = require('../../lib/service-image-policy')
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -90,7 +94,8 @@ module.exports = {
           ...service,
           connectionUrl,
           lastBackup,
-          backupSupported: Service.isBackupSupported(service.type)
+          backupSupported: Service.isBackupSupported(service.type),
+          versionSupport: getVersionSupport(service)
         }
       })
     )
@@ -193,9 +198,22 @@ module.exports = {
         envVars: environment.envVars || {},
         deploymentHistory,
         checklist,
+        serviceVersions: getPublicMatrix(),
         backupConfigured,
         githubConnected,
         sourceReadinessByApp
+      }
+    }
+
+    function getVersionSupport(service) {
+      try {
+        return inspectVersion(service.type, service.version, {
+          useDefault: false
+        }).supported
+          ? 'supported'
+          : 'custom'
+      } catch {
+        return 'unresolved'
       }
     }
   }

--- a/api/controllers/project/view-service-settings.js
+++ b/api/controllers/project/view-service-settings.js
@@ -31,6 +31,11 @@ module.exports = {
   },
 
   fn: async function ({ slug, envSlug, serviceId }) {
+    const {
+      getPolicy,
+      getUpgradePlan,
+      inspectVersion
+    } = require('../../lib/service-image-policy')
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -51,6 +56,36 @@ module.exports = {
     if (!service)
       throw { notFound: `/projects/${slug}/environments/${envSlug}` }
 
+    const policy = getPolicy(service.type)
+    let versionSupport = 'unresolved'
+    try {
+      versionSupport = inspectVersion(service.type, service.version, {
+        useDefault: false
+      }).supported
+        ? 'supported'
+        : 'custom'
+    } catch {
+      /* Legacy mutable records stay visibly unresolved. */
+    }
+
+    const availableUpgrades = (policy?.versions || [])
+      .map((entry) => {
+        try {
+          return getUpgradePlan(service.type, service.version, entry.version)
+        } catch {
+          return null
+        }
+      })
+      .filter(Boolean)
+
+    let backupConfigured = false
+    try {
+      await sails.helpers.backup.getStorageConfig()
+      backupConfigured = true
+    } catch {
+      /* The page shows the storage prerequisite. */
+    }
+
     return {
       page: 'projects/service-settings',
       props: {
@@ -68,9 +103,23 @@ module.exports = {
           id: service.id,
           name: service.name,
           type: service.type,
+          version: service.version,
+          versionSupport,
+          imageReference: service.imageReference,
+          imageMetadata: service.imageMetadata,
+          upgradeState: service.upgradeState,
           status: service.status,
           resourceLimits: service.resourceLimits
-        }
+        },
+        versionPolicy: policy
+          ? {
+              label: policy.label,
+              defaultVersion: policy.defaultVersion,
+              versions: policy.versions.map((entry) => ({ ...entry }))
+            }
+          : null,
+        availableUpgrades,
+        backupConfigured
       }
     }
   }

--- a/api/helpers/backup/restore-backup.js
+++ b/api/helpers/backup/restore-backup.js
@@ -19,6 +19,16 @@ module.exports = {
     signal: {
       type: 'ref',
       description: 'Optional AbortSignal.'
+    },
+    targetContainerName: {
+      type: 'string',
+      description: 'Optional fresh container to restore into.'
+    },
+    skipSafetySnapshot: {
+      type: 'boolean',
+      defaultsTo: false,
+      description:
+        'Skip a second safety snapshot when restoring a verified upgrade backup into an empty candidate.'
     }
   },
 
@@ -28,7 +38,12 @@ module.exports = {
     }
   },
 
-  fn: async function ({ backupId, signal }) {
+  fn: async function ({
+    backupId,
+    signal,
+    targetContainerName,
+    skipSafetySnapshot
+  }) {
     const backup = await Backup.findOne({ id: backupId })
     if (!backup || !backup.service) {
       throw new Error('Backup or service not found')
@@ -45,7 +60,11 @@ module.exports = {
 
     const storageConfig = await sails.helpers.backup.getStorageConfig()
     const limits = sails.config.custom.databaseOperations
-    const restoreArgs = getRestoreArgs(service)
+    const restoreTarget = {
+      ...service,
+      containerName: targetContainerName || service.containerName
+    }
+    const restoreArgs = getRestoreArgs(restoreTarget)
     const capacityInputs = {
       directory: os.tmpdir(),
       maxBytes: limits.restoreMaxBytes,
@@ -56,7 +75,9 @@ module.exports = {
     const capacity = await sails.helpers.streams.getDiskCapacity.with(
       capacityInputs
     )
-    await createVerifiedSafetySnapshot({ service, signal })
+    if (!skipSafetySnapshot) {
+      await createVerifiedSafetySnapshot({ service, signal })
+    }
 
     const extension = getExtension(service.type)
     const tmpDirectory = await fsPromises.mkdtemp(
@@ -102,7 +123,7 @@ module.exports = {
       })
 
       sails.log.info(
-        `Backup ${backupId} restored successfully to ${service.containerName}`
+        `Backup ${backupId} restored successfully to ${restoreTarget.containerName}`
       )
 
       return { success: true, backupId, serviceName: service.name }

--- a/api/helpers/docker/create-service.js
+++ b/api/helpers/docker/create-service.js
@@ -1,12 +1,8 @@
-const { execFile } = require('child_process')
-const util = require('util')
-const execFileAsync = util.promisify(execFile)
-
 module.exports = {
   friendlyName: 'Create service',
 
   description:
-    'Create a backing service container (PostgreSQL, MySQL, Redis, MongoDB).',
+    'Create a backing service container from its pinned image reference.',
 
   inputs: {
     serviceId: {
@@ -20,133 +16,74 @@ module.exports = {
     success: {
       description: 'Service container is running',
       outputType: 'ref'
-    },
-    createFailed: {
-      description: 'Failed to create service container'
     }
   },
 
   fn: async function ({ serviceId }) {
     const service = await Service.findOne({ id: serviceId }).decrypt()
-    if (!service) {
-      throw new Error('Service not found')
-    }
+    if (!service) throw new Error('Service not found')
 
-    const dockerPath = sails.config.docker?.binaryPath || 'docker'
-    const networkName = sails.config.custom.slipwayNetwork || 'slipway'
-    const image = Service.getDockerImage(service.type, service.version)
-
-    // Build docker run args based on service type
-    const args = [
-      'run',
-      '-d',
-      '--name',
-      service.containerName,
-      '--network',
-      networkName,
-      '--restart',
-      'unless-stopped'
-    ]
-
-    // Mount a named volume so data persists independently of the container
-    const dataDirs = {
-      postgresql: '/var/lib/postgresql',
-      mysql: '/var/lib/mysql',
-      mongodb: '/data/db',
-      redis: '/data'
-    }
-    const dataDir = dataDirs[service.type]
-    if (dataDir) {
-      const volumeName = `slipway-${service.containerName}-data`
-      args.push('-v', `${volumeName}:${dataDir}`)
-    }
-
-    // Add resource limits (per-type defaults for databases vs Redis)
-    const typeDefaults = {
-      postgresql: { cpus: '1', memory: '512m' },
-      mysql: { cpus: '1', memory: '512m' },
-      mongodb: { cpus: '1', memory: '512m' },
-      redis: { cpus: '0.25', memory: '128m' }
-    }
-    const resourceLimits = service.resourceLimits ||
-      typeDefaults[service.type] || { cpus: '0.5', memory: '256m' }
-    if (resourceLimits.cpus) {
-      args.push('--cpus', String(resourceLimits.cpus))
-    }
-    if (resourceLimits.memory) {
-      args.push('--memory', String(resourceLimits.memory))
-      args.push('--memory-swap', '-1')
-    }
-
-    // Add service-specific environment variables
-    switch (service.type) {
-      case 'postgresql':
-        args.push('-e', `POSTGRES_USER=${service.username}`)
-        args.push('-e', `POSTGRES_PASSWORD=${service.password}`)
-        args.push('-e', `POSTGRES_DB=${service.database}`)
-        args.push('-e', 'PGDATA=/var/lib/postgresql/data')
-        break
-
-      case 'mysql':
-        args.push('-e', `MYSQL_ROOT_PASSWORD=${service.password}`)
-        args.push('-e', `MYSQL_USER=${service.username}`)
-        args.push('-e', `MYSQL_PASSWORD=${service.password}`)
-        args.push('-e', `MYSQL_DATABASE=${service.database}`)
-        break
-
-      case 'redis':
-        // Redis needs the image first, then the command
-        args.push(image)
-        if (service.password) {
-          args.push('redis-server', '--requirepass', service.password)
-        }
-        break
-
-      case 'mongodb':
-        args.push('-e', `MONGO_INITDB_ROOT_USERNAME=${service.username}`)
-        args.push('-e', `MONGO_INITDB_ROOT_PASSWORD=${service.password}`)
-        args.push('-e', `MONGO_INITDB_DATABASE=${service.database}`)
-        break
-    }
-
-    // Add image at the end (unless redis already added it)
-    if (service.type !== 'redis') {
-      args.push(image)
-    }
-
-    sails.log.info(`Creating ${service.type} service: ${service.containerName}`)
-    sails.log.verbose(`Command: docker ${args.join(' ')}`)
+    let imageReference = service.imageReference
+    let imageMetadata = service.imageMetadata || {}
+    const volumeName =
+      imageMetadata.volumeName ||
+      Service.getDataVolumeName(service.containerName)
 
     try {
-      const { stdout } = await execFileAsync(dockerPath, args, {
-        timeout: 300000 // 5 minute timeout for image pulls
+      if (!imageReference) {
+        const resolved = await sails.helpers.docker.resolveServiceImage.with({
+          type: service.type,
+          version: service.version
+        })
+        imageReference = resolved.imageReference
+        imageMetadata = {
+          source: 'provisioning',
+          tag: resolved.imageTag,
+          imageId: resolved.imageId,
+          repoDigest: resolved.repoDigest,
+          resolvedAt: resolved.resolvedAt,
+          usedLocalFallback: resolved.usedLocalFallback,
+          volumeName
+        }
+
+        await Service.updateOne({ id: service.id }).set({
+          imageReference,
+          imageMetadata
+        })
+      }
+
+      sails.log.info(
+        `Creating ${service.type} service: ${service.containerName}`
+      )
+
+      const started = await sails.helpers.docker.runServiceContainer.with({
+        service,
+        containerName: service.containerName,
+        imageReference,
+        volumeName
       })
-      const containerId = stdout.trim()
 
       await Service.updateOne({ id: serviceId }).set({
-        containerId,
+        containerId: started.containerId,
+        imageReference,
+        imageMetadata: { ...imageMetadata, volumeName },
         status: 'running'
       })
 
       sails.log.info(
-        `Service started: ${service.containerName} (${containerId.substring(
-          0,
-          12
-        )})`
+        `Service started: ${
+          service.containerName
+        } (${started.containerId.substring(0, 12)})`
       )
 
       return {
-        containerId,
-        containerName: service.containerName,
+        ...started,
         type: service.type
       }
     } catch (error) {
-      sails.log.error(`Failed to create service: ${error.message}`)
-      if (error.stderr) {
-        sails.log.error(`stderr: ${error.stderr}`)
-      }
+      sails.log.error(`Failed to create service: ${error.message || error}`)
       await Service.updateOne({ id: serviceId }).set({ status: 'failed' })
-      throw 'createFailed'
+      throw error
     }
   }
 }

--- a/api/helpers/docker/discard-service-candidate.js
+++ b/api/helpers/docker/discard-service-candidate.js
@@ -1,0 +1,36 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Discard service candidate',
+
+  description:
+    'Remove an unused upgrade candidate container and its fresh data volume.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    volumeName: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ containerName, volumeName }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    await tolerate(dockerPath, ['rm', '-f', containerName])
+    await tolerate(dockerPath, ['volume', 'rm', volumeName])
+  }
+}
+
+async function tolerate(dockerPath, args) {
+  try {
+    await execFileAsync(dockerPath, args)
+  } catch {
+    /* The candidate may not have reached this stage. */
+  }
+}

--- a/api/helpers/docker/inspect-running-service-image.js
+++ b/api/helpers/docker/inspect-running-service-image.js
@@ -1,0 +1,121 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const {
+  findSupportedLine,
+  getPolicy
+} = require('../../lib/service-image-policy')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Inspect running service image',
+
+  description:
+    'Inspect an existing service container and recover its version and immutable image reference without recreating it.',
+
+  inputs: {
+    type: {
+      type: 'string',
+      required: true
+    },
+    containerName: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ type, containerName }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const container = await inspect(dockerPath, ['inspect', containerName])
+    const containerDetails = container[0]
+
+    if (!containerDetails?.Image) {
+      const error = new Error(
+        `Container ${containerName} does not expose an image ID.`
+      )
+      error.code = 'SERVICE_CONTAINER_IMAGE_NOT_FOUND'
+      throw error
+    }
+
+    const images = await inspect(dockerPath, [
+      'image',
+      'inspect',
+      containerDetails.Image
+    ])
+    const image = images[0]
+    const policy = getPolicy(type)
+    const detectedVersion = detectVersion(type, containerDetails, image)
+    const version = findSupportedLine(type, detectedVersion)
+    const imageReference =
+      image?.RepoDigests?.find((digest) =>
+        digest.startsWith(`${policy.repository}@`)
+      ) ||
+      image?.RepoDigests?.[0] ||
+      image?.Id ||
+      containerDetails.Image
+
+    return {
+      version,
+      detectedVersion,
+      imageReference,
+      imageId: image?.Id || containerDetails.Image,
+      repoDigest: image?.RepoDigests?.[0] || null,
+      configuredImage: containerDetails.Config?.Image || null,
+      inspectedAt: Date.now()
+    }
+  }
+}
+
+async function inspect(dockerPath, args) {
+  try {
+    const { stdout } = await execFileAsync(dockerPath, args, {
+      timeout: 30000,
+      maxBuffer: 2 * 1024 * 1024
+    })
+    return JSON.parse(stdout)
+  } catch (cause) {
+    const error = new Error(
+      `Could not inspect Docker resource ${args.at(-1)}: ${String(
+        cause.stderr || cause.message || cause
+      )
+        .trim()
+        .split('\n')
+        .at(-1)}`
+    )
+    error.code = 'SERVICE_CONTAINER_IMAGE_NOT_FOUND'
+    throw error
+  }
+}
+
+function detectVersion(type, container, image) {
+  const env = Object.fromEntries(
+    (image?.Config?.Env || [])
+      .map((entry) => entry.split(/=(.*)/s))
+      .filter(([key, value]) => key && value !== undefined)
+  )
+
+  const envKeys = {
+    postgresql: ['PG_MAJOR', 'PG_VERSION'],
+    mysql: ['MYSQL_VERSION', 'MYSQL_MAJOR'],
+    redis: ['REDIS_VERSION'],
+    mongodb: ['MONGO_VERSION', 'MONGO_MAJOR']
+  }
+
+  for (const key of envKeys[type] || []) {
+    const numeric = env[key]?.match(/\d+(?:\.\d+){0,2}/)?.[0]
+    if (numeric) return numeric
+  }
+
+  const configuredTag = container.Config?.Image?.match(/:([^:@]+)$/)?.[1]
+  if (configuredTag && configuredTag !== 'latest') {
+    return configuredTag
+  }
+
+  for (const repoTag of image?.RepoTags || []) {
+    const tag = repoTag.match(/:([^:@]+)$/)?.[1]
+    if (tag && tag !== 'latest') return tag
+  }
+
+  return null
+}

--- a/api/helpers/docker/resolve-service-image.js
+++ b/api/helpers/docker/resolve-service-image.js
@@ -1,0 +1,125 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const { inspectVersion } = require('../../lib/service-image-policy')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Resolve service image',
+
+  description:
+    'Resolve a pinned service tag to an immutable Docker digest, with an offline local-image fallback.',
+
+  inputs: {
+    type: {
+      type: 'string',
+      required: true
+    },
+    version: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ type, version }) {
+    const selection = inspectVersion(type, version, { useDefault: false })
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const localImage = await inspectImage(dockerPath, selection.imageTag)
+    let usedLocalFallback = false
+
+    try {
+      await execFileAsync(dockerPath, ['pull', selection.imageTag], {
+        timeout: 300000,
+        maxBuffer: 1024 * 1024
+      })
+    } catch (error) {
+      if (!localImage) {
+        const unavailable = new Error(
+          `${
+            selection.imageTag
+          } is not available locally and Docker could not pull it: ${cleanDockerError(
+            error
+          )}`
+        )
+        unavailable.code = 'SERVICE_IMAGE_UNAVAILABLE'
+        throw unavailable
+      }
+
+      usedLocalFallback = true
+      sails.log.warn(
+        `Could not refresh ${selection.imageTag}; using the existing local image.`
+      )
+    }
+
+    const image =
+      (usedLocalFallback ? localImage : null) ||
+      (await inspectImage(dockerPath, selection.imageTag))
+
+    if (!image) {
+      const unavailable = new Error(
+        `Docker resolved ${selection.imageTag}, but the image could not be inspected.`
+      )
+      unavailable.code = 'SERVICE_IMAGE_UNAVAILABLE'
+      throw unavailable
+    }
+
+    const imageReference = selectImmutableReference(selection.repository, image)
+
+    if (!imageReference) {
+      const unresolved = new Error(
+        `Docker did not return an immutable digest or image ID for ${selection.imageTag}.`
+      )
+      unresolved.code = 'SERVICE_IMAGE_UNRESOLVED'
+      throw unresolved
+    }
+
+    return {
+      ...selection,
+      imageReference,
+      imageId: image.Id || null,
+      repoDigest:
+        image.RepoDigests?.find((digest) =>
+          digest.startsWith(`${selection.repository}@`)
+        ) ||
+        image.RepoDigests?.[0] ||
+        null,
+      usedLocalFallback,
+      resolvedAt: Date.now()
+    }
+  }
+}
+
+async function inspectImage(dockerPath, reference) {
+  try {
+    const { stdout } = await execFileAsync(
+      dockerPath,
+      ['image', 'inspect', reference],
+      {
+        timeout: 30000,
+        maxBuffer: 2 * 1024 * 1024
+      }
+    )
+    return JSON.parse(stdout)[0] || null
+  } catch {
+    return null
+  }
+}
+
+function selectImmutableReference(repository, image) {
+  return (
+    image.RepoDigests?.find((digest) => digest.startsWith(`${repository}@`)) ||
+    image.RepoDigests?.[0] ||
+    image.Id ||
+    null
+  )
+}
+
+function cleanDockerError(error) {
+  return (
+    String(error.stderr || error.message || error)
+      .trim()
+      .split('\n')
+      .at(-1) || 'unknown Docker error'
+  )
+}

--- a/api/helpers/docker/run-service-container.js
+++ b/api/helpers/docker/run-service-container.js
@@ -1,0 +1,108 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Run service container',
+
+  description:
+    'Launch a service container from an immutable image reference and an explicit data volume.',
+
+  inputs: {
+    service: {
+      type: 'ref',
+      required: true
+    },
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    imageReference: {
+      type: 'string',
+      required: true
+    },
+    volumeName: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ service, containerName, imageReference, volumeName }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const networkName = sails.config.custom.slipwayNetwork || 'slipway'
+    const args = [
+      'run',
+      '-d',
+      '--name',
+      containerName,
+      '--network',
+      networkName,
+      '--restart',
+      'unless-stopped'
+    ]
+
+    const dataDirs = {
+      postgresql: '/var/lib/postgresql',
+      mysql: '/var/lib/mysql',
+      mongodb: '/data/db',
+      redis: '/data'
+    }
+    const dataDir = dataDirs[service.type]
+    if (dataDir) args.push('-v', `${volumeName}:${dataDir}`)
+
+    const typeDefaults = {
+      postgresql: { cpus: '1', memory: '512m' },
+      mysql: { cpus: '1', memory: '512m' },
+      mongodb: { cpus: '1', memory: '512m' },
+      redis: { cpus: '0.25', memory: '128m' }
+    }
+    const resourceLimits = service.resourceLimits ||
+      typeDefaults[service.type] || { cpus: '0.5', memory: '256m' }
+
+    if (resourceLimits.cpus) {
+      args.push('--cpus', String(resourceLimits.cpus))
+    }
+    if (resourceLimits.memory) {
+      args.push('--memory', String(resourceLimits.memory))
+      args.push('--memory-swap', '-1')
+    }
+
+    switch (service.type) {
+      case 'postgresql':
+        args.push('-e', `POSTGRES_USER=${service.username}`)
+        args.push('-e', `POSTGRES_PASSWORD=${service.password}`)
+        args.push('-e', `POSTGRES_DB=${service.database}`)
+        args.push('-e', 'PGDATA=/var/lib/postgresql/data')
+        break
+      case 'mysql':
+        args.push('-e', `MYSQL_ROOT_PASSWORD=${service.password}`)
+        args.push('-e', `MYSQL_USER=${service.username}`)
+        args.push('-e', `MYSQL_PASSWORD=${service.password}`)
+        args.push('-e', `MYSQL_DATABASE=${service.database}`)
+        break
+      case 'mongodb':
+        args.push('-e', `MONGO_INITDB_ROOT_USERNAME=${service.username}`)
+        args.push('-e', `MONGO_INITDB_ROOT_PASSWORD=${service.password}`)
+        args.push('-e', `MONGO_INITDB_DATABASE=${service.database}`)
+        break
+    }
+
+    args.push(imageReference)
+    if (service.type === 'redis' && service.password) {
+      args.push('redis-server', '--requirepass', service.password)
+    }
+
+    const { stdout } = await execFileAsync(dockerPath, args, {
+      timeout: 300000,
+      maxBuffer: 1024 * 1024
+    })
+
+    return {
+      containerId: stdout.trim(),
+      containerName,
+      volumeName,
+      imageReference
+    }
+  }
+}

--- a/api/helpers/docker/swap-service-containers.js
+++ b/api/helpers/docker/swap-service-containers.js
@@ -1,0 +1,71 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Swap service containers',
+
+  description:
+    'Atomically promote an upgraded service container or restore the retained previous container.',
+
+  inputs: {
+    action: {
+      type: 'string',
+      isIn: ['commit', 'rollback'],
+      required: true
+    },
+    canonicalName: {
+      type: 'string',
+      required: true
+    },
+    candidateName: {
+      type: 'string',
+      required: true
+    },
+    rollbackName: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ action, canonicalName, candidateName, rollbackName }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+
+    if (action === 'rollback') {
+      await tolerate(dockerPath, ['stop', canonicalName])
+      await tolerate(dockerPath, ['rename', canonicalName, candidateName])
+      await execFileAsync(dockerPath, ['rename', rollbackName, canonicalName])
+      await execFileAsync(dockerPath, ['start', canonicalName])
+      return { rolledBack: true }
+    }
+
+    let previousRenamed = false
+    let candidatePromoted = false
+    try {
+      await execFileAsync(dockerPath, ['stop', canonicalName])
+      await execFileAsync(dockerPath, ['rename', canonicalName, rollbackName])
+      previousRenamed = true
+      await execFileAsync(dockerPath, ['rename', candidateName, canonicalName])
+      candidatePromoted = true
+      return { committed: true }
+    } catch (error) {
+      if (candidatePromoted) {
+        await tolerate(dockerPath, ['rename', canonicalName, candidateName])
+      }
+      if (previousRenamed) {
+        await tolerate(dockerPath, ['rename', rollbackName, canonicalName])
+      }
+      await tolerate(dockerPath, ['start', canonicalName])
+      throw error
+    }
+  }
+}
+
+async function tolerate(dockerPath, args) {
+  try {
+    await execFileAsync(dockerPath, args)
+  } catch {
+    /* Best-effort rollback cleanup. */
+  }
+}

--- a/api/helpers/docker/wait-for-service.js
+++ b/api/helpers/docker/wait-for-service.js
@@ -1,0 +1,111 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Wait for service',
+
+  description: 'Wait until a newly created service container accepts commands.',
+
+  inputs: {
+    service: {
+      type: 'ref',
+      required: true
+    },
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    attempts: {
+      type: 'number',
+      defaultsTo: 60
+    },
+    intervalMs: {
+      type: 'number',
+      defaultsTo: 1000
+    }
+  },
+
+  fn: async function ({ service, containerName, attempts, intervalMs }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const command = getReadinessCommand(service, containerName)
+    let lastError
+
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        await execFileAsync(dockerPath, command, {
+          timeout: 10000,
+          maxBuffer: 64 * 1024
+        })
+        return { ready: true, attempts: attempt }
+      } catch (error) {
+        lastError = error
+        if (attempt < attempts) await delay(intervalMs)
+      }
+    }
+
+    const error = new Error(
+      `${service.type} did not become ready after ${attempts} attempts: ${
+        lastError?.stderr || lastError?.message || 'readiness check failed'
+      }`
+    )
+    error.code = 'SERVICE_NOT_READY'
+    throw error
+  }
+}
+
+function getReadinessCommand(service, containerName) {
+  switch (service.type) {
+    case 'postgresql':
+      return [
+        'exec',
+        containerName,
+        'pg_isready',
+        '-U',
+        service.username,
+        '-d',
+        service.database
+      ]
+    case 'mysql':
+      return [
+        'exec',
+        containerName,
+        'mysqladmin',
+        'ping',
+        '-u',
+        'root',
+        `-p${service.password}`,
+        '--silent'
+      ]
+    case 'mongodb':
+      return [
+        'exec',
+        containerName,
+        'mongosh',
+        '--quiet',
+        '--username',
+        service.username,
+        '--password',
+        service.password,
+        '--authenticationDatabase',
+        'admin',
+        '--eval',
+        'quit(db.adminCommand({ ping: 1 }).ok ? 0 : 1)'
+      ]
+    case 'redis':
+      return [
+        'exec',
+        containerName,
+        'redis-cli',
+        ...(service.password ? ['-a', service.password] : []),
+        'ping'
+      ]
+    default:
+      throw new Error(`Unsupported service type: ${service.type}`)
+  }
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}

--- a/api/helpers/service/ensure-version-schema.js
+++ b/api/helpers/service/ensure-version-schema.js
@@ -1,0 +1,32 @@
+module.exports = {
+  friendlyName: 'Ensure service version schema',
+
+  description:
+    'Add immutable service-image and upgrade-state columns on existing production SQLite databases.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore()
+    const result = await datastore.sendNativeQuery(
+      'PRAGMA table_info(services)'
+    )
+    const existing = new Set(
+      (result.rows || result || []).map((row) => row.name)
+    )
+
+    const columns = [
+      ['image_reference', 'TEXT'],
+      ['image_metadata', 'TEXT'],
+      ['upgrade_state', 'TEXT']
+    ]
+
+    for (const [name, type] of columns) {
+      if (!existing.has(name)) {
+        await datastore.sendNativeQuery(
+          `ALTER TABLE services ADD COLUMN ${name} ${type}`
+        )
+      }
+    }
+  }
+}

--- a/api/helpers/service/migrate-legacy-versions.js
+++ b/api/helpers/service/migrate-legacy-versions.js
@@ -1,0 +1,72 @@
+module.exports = {
+  friendlyName: 'Migrate legacy service versions',
+
+  description:
+    'Backfill mutable or unresolved service image records from their existing Docker containers without recreating them.',
+
+  inputs: {},
+
+  fn: async function () {
+    const services = await Service.find()
+    const candidates = services.filter(
+      (service) =>
+        service.version === 'latest' ||
+        !service.imageReference ||
+        !service.imageMetadata
+    )
+    const result = { migrated: 0, unresolved: 0 }
+
+    for (const service of candidates) {
+      if (!service.containerName) {
+        result.unresolved += 1
+        continue
+      }
+
+      try {
+        const inspected =
+          await sails.helpers.docker.inspectRunningServiceImage.with({
+            type: service.type,
+            containerName: service.containerName
+          })
+
+        if (service.version === 'latest' && !inspected.version) {
+          result.unresolved += 1
+          sails.log.warn(
+            `Could not determine the pinned version for legacy service ${service.name}; leaving it unresolved.`
+          )
+          continue
+        }
+
+        await Service.updateOne({ id: service.id }).set({
+          version:
+            service.version === 'latest' ? inspected.version : service.version,
+          imageReference: inspected.imageReference,
+          imageMetadata: {
+            source: 'running-container',
+            migratedAt: Date.now(),
+            configuredImage: inspected.configuredImage,
+            detectedVersion: inspected.detectedVersion,
+            imageId: inspected.imageId,
+            repoDigest: inspected.repoDigest
+          }
+        })
+        result.migrated += 1
+      } catch (error) {
+        result.unresolved += 1
+        sails.log.warn(
+          `Could not pin legacy service ${service.name}: ${error.message}`
+        )
+      }
+    }
+
+    if (result.migrated > 0) {
+      sails.log.info(
+        `Pinned ${result.migrated} existing service image${
+          result.migrated === 1 ? '' : 's'
+        } without recreating containers.`
+      )
+    }
+
+    return result
+  }
+}

--- a/api/helpers/service/run-version-upgrade.js
+++ b/api/helpers/service/run-version-upgrade.js
@@ -1,0 +1,298 @@
+const { getUpgradePlan } = require('../../lib/service-image-policy')
+
+const STEPS = [
+  'backup',
+  'image',
+  'candidate',
+  'restore',
+  'cutover',
+  'completed'
+]
+
+module.exports = {
+  friendlyName: 'Run service version upgrade',
+
+  description:
+    'Upgrade a database on a fresh volume after a verified backup, retaining the previous container for recovery.',
+
+  inputs: {
+    serviceId: {
+      type: 'string',
+      required: true
+    },
+    targetVersion: {
+      type: 'string',
+      required: true
+    },
+    userId: {
+      type: 'string',
+      required: true
+    },
+    teamId: {
+      type: 'string',
+      required: true
+    },
+    ipAddress: {
+      type: 'string',
+      allowNull: true
+    }
+  },
+
+  fn: async function ({ serviceId, targetVersion, userId, teamId, ipAddress }) {
+    const service = await Service.findOne({ id: serviceId }).decrypt()
+    if (!service) throw new Error('Service not found')
+
+    const plan = getUpgradePlan(service.type, service.version, targetVersion)
+    const suffix = Date.now()
+    const candidateName = `${service.containerName}-upgrade-${suffix}`
+    const rollbackName = `${
+      service.containerName
+    }-previous-${service.version.replace(/\./g, '-')}-${suffix}`
+    const candidateVolumeName = Service.getDataVolumeName(candidateName)
+    const previousVolumeName =
+      service.imageMetadata?.volumeName ||
+      Service.getDataVolumeName(service.containerName)
+    let backup
+    let cutoverCommitted = false
+    let candidateContainerId = null
+    let activeStep = 'backup'
+
+    await publish('backup', 'Creating and verifying a recovery backup.')
+
+    try {
+      backup = await Backup.create({
+        status: 'pending',
+        type: 'manual',
+        service: service.id,
+        triggeredBy: userId
+      }).fetch()
+      const completedBackup = await sails.helpers.backup.runBackup.with({
+        backupId: backup.id
+      })
+      if (
+        completedBackup.status !== 'completed' ||
+        !completedBackup.s3Key ||
+        !completedBackup.sizeBytes
+      ) {
+        throw new Error(
+          `Upgrade stopped because the recovery backup failed: ${
+            completedBackup.errorMessage || 'backup was not verified'
+          }`
+        )
+      }
+
+      await publish('image', `Resolving ${plan.label} ${plan.toVersion}.`, {
+        backupId: backup.id
+      })
+      const resolved = await sails.helpers.docker.resolveServiceImage.with({
+        type: service.type,
+        version: plan.toVersion
+      })
+
+      await publish(
+        'candidate',
+        'Starting the new version on a fresh data volume.',
+        {
+          backupId: backup.id,
+          imageReference: resolved.imageReference
+        }
+      )
+      const candidate = await sails.helpers.docker.runServiceContainer.with({
+        service: { ...service, version: plan.toVersion },
+        containerName: candidateName,
+        imageReference: resolved.imageReference,
+        volumeName: candidateVolumeName
+      })
+      candidateContainerId = candidate.containerId
+      await sails.helpers.docker.waitForService.with({
+        service,
+        containerName: candidateName
+      })
+
+      await publish('restore', 'Restoring the verified backup.', {
+        backupId: backup.id,
+        imageReference: resolved.imageReference
+      })
+      await sails.helpers.backup.restoreBackup.with({
+        backupId: backup.id,
+        targetContainerName: candidateName,
+        skipSafetySnapshot: true
+      })
+      await sails.helpers.docker.waitForService.with({
+        service: { ...service, version: plan.toVersion },
+        containerName: candidateName
+      })
+
+      await publish(
+        'cutover',
+        'Promoting the restored container and retaining the previous version.',
+        {
+          backupId: backup.id,
+          imageReference: resolved.imageReference
+        }
+      )
+      await sails.helpers.docker.swapServiceContainers.with({
+        action: 'commit',
+        canonicalName: service.containerName,
+        candidateName,
+        rollbackName
+      })
+      cutoverCommitted = true
+
+      const completedAt = Date.now()
+      const recovery = {
+        previousVersion: service.version,
+        previousContainerName: rollbackName,
+        previousVolumeName,
+        backupId: backup.id,
+        instructions: `If verification fails, stop ${service.containerName}, restore ${rollbackName} to the canonical name, and start it. The verified backup remains available as backup #${backup.id}.`
+      }
+      const state = await publish(
+        'completed',
+        `${plan.label} ${plan.toVersion} is running. The previous container is retained for recovery.`,
+        {
+          status: 'completed',
+          backupId: backup.id,
+          completedAt,
+          imageReference: resolved.imageReference,
+          recovery
+        }
+      )
+
+      await Service.updateOne({ id: service.id }).set({
+        version: plan.toVersion,
+        imageReference: resolved.imageReference,
+        imageMetadata: {
+          source: 'upgrade',
+          tag: resolved.imageTag,
+          imageId: resolved.imageId,
+          repoDigest: resolved.repoDigest,
+          resolvedAt: resolved.resolvedAt,
+          usedLocalFallback: resolved.usedLocalFallback,
+          volumeName: candidateVolumeName,
+          previous: {
+            version: service.version,
+            imageReference: service.imageReference,
+            imageMetadata: service.imageMetadata,
+            containerName: rollbackName,
+            volumeName: previousVolumeName
+          }
+        },
+        upgradeState: state,
+        containerId: candidateContainerId,
+        status: 'running'
+      })
+
+      try {
+        await sails.helpers.audit.log.with({
+          action: 'service.version-upgraded',
+          resourceType: 'service',
+          resourceId: service.id,
+          details: {
+            name: service.name,
+            type: service.type,
+            fromVersion: service.version,
+            toVersion: plan.toVersion,
+            backupId: backup.id,
+            rollbackContainer: rollbackName
+          },
+          userId,
+          teamId,
+          ipAddress
+        })
+      } catch (auditError) {
+        sails.log.warn(
+          `Could not record service upgrade audit event: ${auditError.message}`
+        )
+      }
+
+      return state
+    } catch (error) {
+      if (cutoverCommitted) {
+        try {
+          await sails.helpers.docker.swapServiceContainers.with({
+            action: 'rollback',
+            canonicalName: service.containerName,
+            candidateName,
+            rollbackName
+          })
+          await sails.helpers.docker.discardServiceCandidate.with({
+            containerName: candidateName,
+            volumeName: candidateVolumeName
+          })
+        } catch (rollbackError) {
+          error.message += ` Automatic rollback also failed: ${rollbackError.message}`
+        }
+      } else {
+        await sails.helpers.docker.discardServiceCandidate.with({
+          containerName: candidateName,
+          volumeName: candidateVolumeName
+        })
+      }
+
+      const failedState = await publish(currentStep(), error.message, {
+        status: 'failed',
+        failedAt: Date.now(),
+        backupId: backup?.id || null,
+        recovery: backup
+          ? {
+              backupId: backup.id,
+              instructions:
+                'The original service was kept in place. Review the error, verify the backup, and retry the upgrade.'
+            }
+          : null
+      })
+      await Service.updateOne({ id: service.id }).set({
+        status: 'running',
+        upgradeState: failedState
+      })
+      sails.log.error(
+        `Service upgrade failed for ${service.name}: ${error.message}`
+      )
+      return failedState
+    }
+
+    async function publish(step, message, extra = {}) {
+      activeStep = step
+      const previous =
+        (await Service.findOne({ id: service.id }))?.upgradeState || {}
+      const state = {
+        ...previous,
+        status: extra.status || 'running',
+        fromVersion: service.version,
+        targetVersion: plan.toVersion,
+        candidateContainerName: candidateName,
+        rollbackContainerName: rollbackName,
+        candidateVolumeName,
+        previousVolumeName,
+        step,
+        message,
+        steps: STEPS.map((name) => ({
+          name,
+          status:
+            name === step
+              ? extra.status === 'failed'
+                ? 'failed'
+                : extra.status === 'completed'
+                ? 'completed'
+                : 'running'
+              : STEPS.indexOf(name) < STEPS.indexOf(step)
+              ? 'completed'
+              : 'pending'
+        })),
+        startedAt: previous.startedAt || Date.now(),
+        ...extra
+      }
+      await Service.updateOne({ id: service.id }).set({
+        status: state.status === 'running' ? 'upgrading' : service.status,
+        upgradeState: state
+      })
+      sails.sse.publish(`service-upgrade:${service.id}`, state)
+      return state
+    }
+
+    function currentStep() {
+      return activeStep
+    }
+  }
+}

--- a/api/lib/service-image-policy.js
+++ b/api/lib/service-image-policy.js
@@ -1,0 +1,201 @@
+const SERVICE_IMAGE_POLICY = Object.freeze({
+  postgresql: Object.freeze({
+    label: 'PostgreSQL',
+    repository: 'postgres',
+    defaultVersion: '17',
+    versions: Object.freeze([
+      version('17', {
+        recommended: true,
+        upgradeFrom: ['16'],
+        guidance:
+          'Slipway takes a verified logical backup, restores it into a fresh PostgreSQL 17 volume, and keeps the previous container for recovery.'
+      }),
+      version('16')
+    ])
+  }),
+  mysql: Object.freeze({
+    label: 'MySQL',
+    repository: 'mysql',
+    defaultVersion: '8.4',
+    versions: Object.freeze([
+      version('8.4', {
+        recommended: true,
+        upgradeFrom: ['8.0'],
+        guidance:
+          'Slipway takes a verified logical backup, restores it into a fresh MySQL 8.4 volume, and keeps the previous container for recovery.'
+      }),
+      version('8.0')
+    ])
+  }),
+  redis: Object.freeze({
+    label: 'Redis',
+    repository: 'redis',
+    defaultVersion: '7.2',
+    versions: Object.freeze([
+      version('7.2', {
+        recommended: true,
+        guidance:
+          'Slipway pins Redis 7.2. Automated Redis major upgrades remain disabled until a verified persistence backup can be guaranteed.'
+      })
+    ])
+  }),
+  mongodb: Object.freeze({
+    label: 'MongoDB',
+    repository: 'mongo',
+    defaultVersion: '8.0',
+    versions: Object.freeze([
+      version('8.0', {
+        recommended: true,
+        upgradeFrom: ['7.0'],
+        guidance:
+          'Slipway takes a verified logical backup, restores it into a fresh MongoDB 8.0 volume, and keeps the previous container for recovery.'
+      }),
+      version('7.0')
+    ])
+  })
+})
+
+const SAFE_VERSION_PATTERN = /^\d+(?:\.\d+){0,2}$/
+
+function version(value, options = {}) {
+  return Object.freeze({
+    version: value,
+    recommended: options.recommended === true,
+    upgradeFrom: Object.freeze(options.upgradeFrom || []),
+    guidance: options.guidance || null
+  })
+}
+
+function getPolicy(type) {
+  return SERVICE_IMAGE_POLICY[type] || null
+}
+
+function getPublicMatrix() {
+  return Object.fromEntries(
+    Object.entries(SERVICE_IMAGE_POLICY).map(([type, policy]) => [
+      type,
+      {
+        type,
+        label: policy.label,
+        repository: policy.repository,
+        defaultVersion: policy.defaultVersion,
+        versions: policy.versions.map((entry) => ({ ...entry }))
+      }
+    ])
+  )
+}
+
+function inspectVersion(type, requestedVersion, { useDefault = true } = {}) {
+  const policy = getPolicy(type)
+  if (!policy) {
+    throw policyError(`Unsupported service type: ${type}`)
+  }
+
+  const raw =
+    requestedVersion === undefined || requestedVersion === null
+      ? ''
+      : String(requestedVersion).trim()
+  const value = raw || (useDefault ? policy.defaultVersion : '')
+
+  if (!value) {
+    throw policyError('A service version is required.')
+  }
+
+  if (value.toLowerCase() === 'latest') {
+    throw policyError(
+      `The mutable "latest" tag is not allowed. Use ${policy.defaultVersion} for ${policy.label}.`
+    )
+  }
+
+  if (!SAFE_VERSION_PATTERN.test(value)) {
+    throw policyError(
+      'Versions must be numeric Docker tags such as 17, 8.4, or 8.0.12.'
+    )
+  }
+
+  const supportedEntry =
+    policy.versions.find((entry) => entry.version === value) || null
+
+  return {
+    type,
+    version: value,
+    repository: policy.repository,
+    imageTag: `${policy.repository}:${value}`,
+    supported: Boolean(supportedEntry),
+    recommended: supportedEntry?.recommended === true,
+    defaultVersion: policy.defaultVersion,
+    guidance: supportedEntry?.guidance || null
+  }
+}
+
+function getUpgradePlan(type, fromVersion, toVersion) {
+  const policy = getPolicy(type)
+  if (!policy) {
+    throw policyError(`Unsupported service type: ${type}`)
+  }
+
+  const source = inspectVersion(type, fromVersion, { useDefault: false })
+  const target = inspectVersion(type, toVersion, { useDefault: false })
+  const targetEntry = policy.versions.find(
+    (entry) => entry.version === target.version
+  )
+
+  if (!source.supported) {
+    throw policyError(
+      `Slipway cannot automate an upgrade from unsupported ${policy.label} ${source.version}.`
+    )
+  }
+
+  if (!targetEntry) {
+    throw policyError(
+      `${policy.label} ${target.version} is not in Slipway's tested upgrade matrix.`
+    )
+  }
+
+  if (!targetEntry.upgradeFrom.includes(source.version)) {
+    throw policyError(
+      `Slipway does not support upgrading ${policy.label} ${source.version} to ${target.version}.`
+    )
+  }
+
+  return {
+    type,
+    label: policy.label,
+    fromVersion: source.version,
+    toVersion: target.version,
+    targetImageTag: target.imageTag,
+    guidance: targetEntry.guidance,
+    requiresBackup: true
+  }
+}
+
+function findSupportedLine(type, detectedVersion) {
+  const policy = getPolicy(type)
+  if (!policy || !detectedVersion) return null
+
+  const numeric = String(detectedVersion).match(/\d+(?:\.\d+){0,2}/)?.[0]
+  if (!numeric) return null
+
+  return (
+    policy.versions.find(
+      (entry) =>
+        numeric === entry.version || numeric.startsWith(`${entry.version}.`)
+    )?.version || numeric
+  )
+}
+
+function policyError(message) {
+  const error = new Error(message)
+  error.code = 'INVALID_SERVICE_VERSION'
+  return error
+}
+
+module.exports = {
+  SAFE_VERSION_PATTERN,
+  SERVICE_IMAGE_POLICY,
+  findSupportedLine,
+  getPolicy,
+  getPublicMatrix,
+  getUpgradePlan,
+  inspectVersion
+}

--- a/api/models/Service.js
+++ b/api/models/Service.js
@@ -25,14 +25,35 @@ module.exports = {
 
     version: {
       type: 'string',
-      defaultsTo: 'latest',
-      description: 'Docker image version/tag',
-      example: '16'
+      required: true,
+      description: 'Pinned Docker image version line',
+      example: '17'
+    },
+
+    imageReference: {
+      type: 'string',
+      allowNull: true,
+      description:
+        'Immutable Docker digest or image ID used to create the service',
+      columnName: 'image_reference'
+    },
+
+    imageMetadata: {
+      type: 'json',
+      description:
+        'Resolution provenance and retained recovery details for the service image',
+      columnName: 'image_metadata'
+    },
+
+    upgradeState: {
+      type: 'json',
+      description: 'Current or most recent service version upgrade state',
+      columnName: 'upgrade_state'
     },
 
     status: {
       type: 'string',
-      isIn: ['creating', 'running', 'stopped', 'failed'],
+      isIn: ['creating', 'running', 'stopped', 'upgrading', 'failed'],
       defaultsTo: 'creating',
       description: 'Current status of the service'
     },
@@ -152,16 +173,18 @@ module.exports = {
   },
 
   /**
+   * Get the durable Docker volume name for a service container
+   */
+  getDataVolumeName: function (containerName) {
+    return `slipway-${containerName}-data`
+  },
+
+  /**
    * Get Docker image for service type
    */
-  getDockerImage: function (type, version = 'latest') {
-    const images = {
-      postgresql: `postgres:${version}`,
-      mysql: `mysql:${version}`,
-      redis: `redis:${version}`,
-      mongodb: `mongo:${version}`
-    }
-    return images[type] || `postgres:${version}`
+  getDockerImage: function (type, version) {
+    const { inspectVersion } = require('../lib/service-image-policy')
+    return inspectVersion(type, version).imageTag
   },
 
   /**

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -31,6 +31,7 @@ const props = defineProps({
   envVars: Object,
   deploymentHistory: Object,
   checklist: Array,
+  serviceVersions: Object,
   backupConfigured: Boolean,
   githubConnected: Boolean,
   sourceReadinessByApp: Object
@@ -531,7 +532,10 @@ watch(servicesOpen, (open) => {
 const addServiceOpen = ref(false)
 const newServiceName = ref('')
 const newServiceType = ref('postgresql')
-const newServiceVersion = ref('latest')
+const newServiceVersion = ref(
+  props.serviceVersions?.postgresql?.defaultVersion || '17'
+)
+const customServiceVersion = ref(false)
 const creatingService = ref(false)
 const deletingServiceId = ref(null)
 const serviceMenuOpen = ref(null)
@@ -545,6 +549,32 @@ const serviceTypes = [
   { value: 'redis', label: 'Redis' },
   { value: 'mongodb', label: 'MongoDB' }
 ]
+
+const selectedServicePolicy = computed(
+  () => props.serviceVersions?.[newServiceType.value] || null
+)
+const selectedVersionSupported = computed(() =>
+  (selectedServicePolicy.value?.versions || []).some(
+    ({ version }) => version === newServiceVersion.value
+  )
+)
+
+watch(newServiceType, (type) => {
+  newServiceVersion.value = props.serviceVersions?.[type]?.defaultVersion || ''
+  customServiceVersion.value = false
+})
+
+function handleServiceVersionChange() {
+  if (newServiceVersion.value === '__custom__') {
+    customServiceVersion.value = true
+    newServiceVersion.value = ''
+  }
+}
+
+function useTestedServiceVersion() {
+  customServiceVersion.value = false
+  newServiceVersion.value = selectedServicePolicy.value?.defaultVersion || ''
+}
 
 function serviceIcon(type) {
   const icons = { postgresql: 'PG', mysql: 'My', redis: 'Rd', mongodb: 'Mg' }
@@ -586,17 +616,30 @@ async function createService() {
         body: JSON.stringify({
           name: serviceName,
           type: serviceType,
-          version: newServiceVersion.value || 'latest'
+          version: newServiceVersion.value
         })
       }
     )
+    if (!res.ok) {
+      const data = await res.json()
+      const message =
+        data.problems?.[0]?.version ||
+        data.message ||
+        'Could not create the service.'
+      throw new Error(message)
+    }
     completeAction(actionId, res.ok)
     newServiceName.value = ''
-    newServiceVersion.value = 'latest'
+    newServiceVersion.value = selectedServicePolicy.value?.defaultVersion || ''
+    customServiceVersion.value = false
     addServiceOpen.value = false
     router.reload({ only: ['environment', 'envVars', 'checklist'] })
   } catch (err) {
     completeAction(actionId, false)
+    toast({
+      message: err.message || 'Could not create the service.',
+      type: 'error'
+    })
   } finally {
     creatingService.value = false
   }
@@ -818,6 +861,11 @@ function statusBadge(status) {
     },
     creating: {
       label: 'Creating',
+      classes:
+        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    },
+    upgrading: {
+      label: 'Upgrading',
       classes:
         'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
     }
@@ -1864,13 +1912,14 @@ onBeforeUnmount(() => {
                         >
                         <span
                           class="ml-2 text-xs text-gray-400 dark:text-gray-500"
-                          >{{ service.type
-                          }}{{
-                            service.version !== 'latest'
-                              ? ` ${service.version}`
-                              : ''
-                          }}</span
+                          >{{ service.type }} {{ service.version }}</span
                         >
+                        <span
+                          v-if="service.versionSupport === 'unresolved'"
+                          class="ml-2 text-[10px] font-medium text-amber-600 dark:text-amber-400"
+                        >
+                          Version unresolved
+                        </span>
                       </div>
                     </div>
                     <div class="flex items-center space-x-2">
@@ -2222,13 +2271,48 @@ onBeforeUnmount(() => {
                         {{ st.label }}
                       </option>
                     </select>
-                    <input
+                    <select
+                      v-if="!customServiceVersion"
                       v-model="newServiceVersion"
-                      type="text"
-                      placeholder="version"
-                      class="focus:border-brand w-20 border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                    />
+                      aria-label="Service version"
+                      class="focus:border-brand rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+                      @change="handleServiceVersionChange"
+                    >
+                      <option
+                        v-for="entry in selectedServicePolicy?.versions || []"
+                        :key="entry.version"
+                        :value="entry.version"
+                      >
+                        {{ entry.version
+                        }}{{ entry.recommended ? ' · recommended' : '' }}
+                      </option>
+                      <option value="__custom__">Custom version…</option>
+                    </select>
+                    <div v-else class="flex items-center gap-2">
+                      <input
+                        v-model="newServiceVersion"
+                        type="text"
+                        inputmode="decimal"
+                        aria-label="Custom service version"
+                        placeholder="e.g. 17.4"
+                        class="focus:border-brand w-24 border-b border-dashed border-amber-300 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-amber-800 dark:text-white dark:placeholder-gray-500"
+                      />
+                      <button
+                        type="button"
+                        class="text-xs text-gray-400 hover:text-gray-700 dark:hover:text-gray-200"
+                        @click="useTestedServiceVersion"
+                      >
+                        Use tested
+                      </button>
+                    </div>
                   </div>
+                  <p
+                    v-if="customServiceVersion && !selectedVersionSupported"
+                    class="text-xs text-amber-700 dark:text-amber-400"
+                  >
+                    Custom versions are outside Slipway's tested matrix. The
+                    numeric tag will be pinned exactly after Docker resolves it.
+                  </p>
                   <div class="flex items-center justify-end space-x-2">
                     <button
                       @click="addServiceOpen = false"
@@ -2238,7 +2322,11 @@ onBeforeUnmount(() => {
                     </button>
                     <button
                       @click="createService"
-                      :disabled="!newServiceName.trim() || creatingService"
+                      :disabled="
+                        !newServiceName.trim() ||
+                        !newServiceVersion.trim() ||
+                        creatingService
+                      "
                       class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                     >
                       {{ creatingService ? 'Creating...' : 'Create' }}

--- a/assets/js/pages/projects/service-settings.vue
+++ b/assets/js/pages/projects/service-settings.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { Link, Head, router, usePage } from '@inertiajs/vue3'
-import { ref, computed, inject } from 'vue'
+import { ref, computed, inject, onMounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { useToast } from '@/composables/toast'
+import { useEventSource } from '@/composables/sse'
 
 defineOptions({
   layout: AppLayout
@@ -13,7 +14,10 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environment: Object,
-  service: Object
+  service: Object,
+  versionPolicy: Object,
+  availableUpgrades: Array,
+  backupConfigured: Boolean
 })
 
 const page = usePage()
@@ -39,6 +43,37 @@ const cpus = ref(props.service.resourceLimits?.cpus || defaults.cpus)
 const memory = ref(props.service.resourceLimits?.memory || defaults.memory)
 const saving = ref(false)
 const savingAndRestarting = ref(false)
+const upgradeOpen = ref(false)
+const upgradeConfirmation = ref('')
+const upgradeStarting = ref(false)
+const upgradeState = ref(props.service.upgradeState || null)
+const selectedUpgrade = computed(() => props.availableUpgrades?.[0] || null)
+const upgradeInProgress = computed(
+  () =>
+    upgradeState.value?.status === 'queued' ||
+    upgradeState.value?.status === 'running'
+)
+const displayedImageReference = computed(() => {
+  const reference = props.service.imageReference
+  if (!reference) return 'Not resolved'
+  if (reference.length <= 54) return reference
+  return `${reference.slice(0, 26)}…${reference.slice(-20)}`
+})
+
+const { connect: connectUpgrade, close: closeUpgrade } = useEventSource(
+  `/api/v1/services/${props.service.id}/upgrade/stream`,
+  {
+    immediate: false,
+    autoReconnect: false,
+    onMessage(state) {
+      upgradeState.value = state
+      if (state.status === 'completed' || state.status === 'failed') {
+        closeUpgrade()
+        router.reload()
+      }
+    }
+  }
+)
 
 const isDirty = computed(
   () =>
@@ -96,6 +131,58 @@ async function saveSettings({ restart = false } = {}) {
     savingAndRestarting.value = false
   }
 }
+
+async function startUpgrade() {
+  if (
+    !selectedUpgrade.value ||
+    upgradeConfirmation.value !== props.service.name ||
+    upgradeStarting.value
+  ) {
+    return
+  }
+
+  upgradeStarting.value = true
+  try {
+    const response = await fetch(
+      `/api/v1/services/${props.service.id}/upgrade`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'x-csrf-token': page.props._csrf || ''
+        },
+        body: JSON.stringify({
+          targetVersion: selectedUpgrade.value.toVersion,
+          confirmation: upgradeConfirmation.value
+        })
+      }
+    )
+    const data = await response.json()
+    if (!response.ok) {
+      throw new Error(data.message || 'Could not start the upgrade.')
+    }
+
+    upgradeState.value = data.upgrade
+    upgradeOpen.value = false
+    connectUpgrade()
+  } catch (error) {
+    toast({
+      message: error.message || 'Could not start the upgrade.',
+      type: 'error'
+    })
+  } finally {
+    upgradeStarting.value = false
+  }
+}
+
+function cancelUpgrade() {
+  upgradeOpen.value = false
+  upgradeConfirmation.value = ''
+}
+
+onMounted(() => {
+  if (upgradeInProgress.value) connectUpgrade()
+})
 
 const serviceTypeLabel = {
   postgresql: 'PostgreSQL',
@@ -225,10 +312,213 @@ const serviceTypeLabel = {
             {{ service.name }} settings
           </h1>
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Configure resource limits for this
+            Manage the version and resource limits for this
             {{ serviceTypeLabel[service.type] || service.type }} service.
           </p>
         </div>
+
+        <section
+          aria-labelledby="service-version-heading"
+          class="mb-8 space-y-4 border-b border-gray-100 pb-8 dark:border-gray-800"
+        >
+          <div class="flex items-start justify-between gap-4">
+            <div>
+              <h2
+                id="service-version-heading"
+                class="text-sm font-medium text-gray-900 dark:text-white"
+              >
+                Service version
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                Slipway recreates this service from the same immutable image.
+              </p>
+            </div>
+            <span
+              class="rounded-md bg-gray-100 px-2.5 py-1 font-mono text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+            >
+              {{ versionPolicy?.label }} {{ service.version }}
+            </span>
+          </div>
+
+          <dl class="grid gap-3 text-sm sm:grid-cols-[8rem_1fr]">
+            <dt class="text-gray-400 dark:text-gray-500">Image</dt>
+            <dd
+              class="min-w-0 truncate font-mono text-xs text-gray-600 dark:text-gray-300"
+              :title="service.imageReference || 'Not resolved'"
+            >
+              {{ displayedImageReference }}
+            </dd>
+            <dt class="text-gray-400 dark:text-gray-500">Support</dt>
+            <dd class="text-gray-700 dark:text-gray-300">
+              <span v-if="service.versionSupport === 'supported'">
+                Tested by Slipway
+              </span>
+              <span
+                v-else-if="service.versionSupport === 'custom'"
+                class="text-amber-700 dark:text-amber-400"
+              >
+                Custom version outside the tested matrix
+              </span>
+              <span v-else class="text-amber-700 dark:text-amber-400">
+                Legacy version has not been resolved from Docker
+              </span>
+            </dd>
+          </dl>
+
+          <div
+            v-if="upgradeState"
+            :class="[
+              'rounded-lg border px-4 py-3',
+              upgradeState.status === 'failed'
+                ? 'border-red-200 bg-red-50 dark:border-red-900/60 dark:bg-red-950/20'
+                : upgradeState.status === 'completed'
+                ? 'border-emerald-200 bg-emerald-50 dark:border-emerald-900/60 dark:bg-emerald-950/20'
+                : 'border-gray-200 bg-gray-50 dark:border-gray-700 dark:bg-gray-900'
+            ]"
+            aria-live="polite"
+          >
+            <div class="flex items-center justify-between gap-3">
+              <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+                {{
+                  upgradeState.status === 'failed'
+                    ? 'Upgrade stopped safely'
+                    : upgradeState.status === 'completed'
+                    ? 'Upgrade completed'
+                    : `Upgrading to ${upgradeState.targetVersion}`
+                }}
+              </p>
+              <span
+                v-if="upgradeInProgress"
+                class="h-3.5 w-3.5 animate-spin rounded-full border-2 border-gray-300 border-t-gray-800 dark:border-gray-700 dark:border-t-white"
+                aria-hidden="true"
+              ></span>
+            </div>
+            <p
+              class="mt-1 text-sm text-gray-600 dark:text-gray-400"
+              :class="{
+                'text-red-700 dark:text-red-400':
+                  upgradeState.status === 'failed'
+              }"
+            >
+              {{ upgradeState.message }}
+            </p>
+            <ol
+              v-if="upgradeState.steps"
+              class="mt-3 grid grid-cols-3 gap-2 sm:grid-cols-6"
+              aria-label="Upgrade progress"
+            >
+              <li
+                v-for="step in upgradeState.steps"
+                :key="step.name"
+                class="min-w-0"
+              >
+                <span
+                  :class="[
+                    'mb-1 block h-1 rounded-full',
+                    step.status === 'failed'
+                      ? 'bg-red-500'
+                      : step.status === 'completed'
+                      ? 'bg-emerald-500'
+                      : step.status === 'running'
+                      ? 'bg-gray-900 dark:bg-white'
+                      : 'bg-gray-200 dark:bg-gray-700'
+                  ]"
+                ></span>
+                <span
+                  class="block truncate text-[10px] capitalize text-gray-500 dark:text-gray-400"
+                >
+                  {{ step.name }}
+                </span>
+              </li>
+            </ol>
+            <p
+              v-if="upgradeState.recovery?.instructions"
+              class="mt-3 text-xs leading-5 text-gray-500 dark:text-gray-400"
+            >
+              {{ upgradeState.recovery.instructions }}
+            </p>
+          </div>
+
+          <div
+            v-if="selectedUpgrade && !upgradeInProgress"
+            class="flex justify-end"
+          >
+            <button
+              v-if="!upgradeOpen"
+              type="button"
+              class="rounded-md bg-gray-900 px-3.5 py-2 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+              @click="upgradeOpen = true"
+            >
+              Upgrade to {{ versionPolicy.label }}
+              {{ selectedUpgrade.toVersion }}
+            </button>
+
+            <div
+              v-else
+              class="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-gray-700 dark:bg-gray-900"
+            >
+              <h3 class="text-sm font-medium text-gray-900 dark:text-white">
+                Upgrade {{ service.version }} →
+                {{ selectedUpgrade.toVersion }}
+              </h3>
+              <p
+                class="mt-1 text-sm leading-6 text-gray-600 dark:text-gray-400"
+              >
+                {{ selectedUpgrade.guidance }}
+              </p>
+
+              <div
+                v-if="!backupConfigured"
+                class="mt-3 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-900/60 dark:bg-amber-950/20 dark:text-amber-300"
+              >
+                Configure backup storage before upgrading.
+                <Link
+                  href="/settings/uploads"
+                  class="font-medium underline underline-offset-2"
+                >
+                  Open storage settings
+                </Link>
+              </div>
+
+              <label
+                for="upgrade-confirmation"
+                class="mt-4 block text-sm font-medium text-gray-700 dark:text-gray-300"
+              >
+                Type <span class="font-mono">{{ service.name }}</span> to
+                confirm
+              </label>
+              <input
+                id="upgrade-confirmation"
+                v-model="upgradeConfirmation"
+                type="text"
+                autocomplete="off"
+                class="focus:border-brand mt-1.5 w-full border-b border-dashed border-gray-300 bg-transparent px-1 py-2 font-mono text-sm text-gray-900 focus:outline-none dark:border-gray-600 dark:text-white"
+              />
+
+              <div class="mt-4 flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  class="rounded-md px-3 py-2 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                  @click="cancelUpgrade"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  :disabled="
+                    !backupConfigured ||
+                    upgradeConfirmation !== service.name ||
+                    upgradeStarting
+                  "
+                  class="rounded-md bg-gray-900 px-3.5 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+                  @click="startUpgrade"
+                >
+                  {{ upgradeStarting ? 'Starting…' : 'Back up and upgrade' }}
+                </button>
+              </div>
+            </div>
+          </div>
+        </section>
 
         <form @submit.prevent="saveSettings()" class="space-y-6">
           <div class="grid grid-cols-2 gap-4">

--- a/assets/js/pages/projects/service.vue
+++ b/assets/js/pages/projects/service.vue
@@ -100,6 +100,11 @@ const statusClasses = computed(() => {
       dot: 'bg-blue-500',
       text: 'text-blue-700 dark:text-blue-400'
     },
+    upgrading: {
+      bg: 'bg-blue-100 dark:bg-blue-900/30',
+      dot: 'bg-blue-500',
+      text: 'text-blue-700 dark:text-blue-400'
+    },
     failed: {
       bg: 'bg-red-100 dark:bg-red-900/30',
       dot: 'bg-red-500',
@@ -114,6 +119,7 @@ const statusLabel = computed(() => {
     running: 'Running',
     stopped: 'Stopped',
     creating: 'Creating',
+    upgrading: 'Upgrading',
     failed: 'Failed'
   }
   return labels[serviceStatus.value] || serviceStatus.value

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -13,6 +13,7 @@ module.exports.bootstrap = async function () {
   // Production uses `migrate: safe`; create coordinator tables before any
   // deployment job queries run on an existing installation.
   await sails.helpers.deploy.ensureQueueSchema()
+  await sails.helpers.service.ensureVersionSchema()
 
   // Initialize CLI tokens map for Bearer token authentication
   sails.cliTokens = new Map()
@@ -31,6 +32,10 @@ module.exports.bootstrap = async function () {
 
   const skipInfraBootstrap = sails.config.environment === 'test'
   const isQuestWorker = sails.config.environment === 'console'
+
+  if (!skipInfraBootstrap) {
+    await sails.helpers.service.migrateLegacyVersions()
+  }
 
   // One-time migration: backfill multi-app fields on existing App/Deployment records
   const migrationDone = await sails.helpers.setting.get('multiAppMigrationDone')

--- a/config/routes.js
+++ b/config/routes.js
@@ -169,6 +169,7 @@ module.exports.routes = {
   'GET /api/v1/deployments/:id/logs': 'api/v1/deploy/get-deployment-logs',
 
   // Services
+  'GET /api/v1/service-versions': 'api/v1/service/list-versions',
   'GET /api/v1/projects/:projectSlug/services': 'api/v1/service/list-services',
   'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/services':
     'api/v1/service/list-services',
@@ -184,6 +185,9 @@ module.exports.routes = {
   'POST /api/v1/services/:serviceId/stop': 'api/v1/service/stop-service',
   'POST /api/v1/services/:serviceId/start': 'api/v1/service/restart-service',
   'POST /api/v1/services/:serviceId/restart': 'api/v1/service/restart-service',
+  'POST /api/v1/services/:serviceId/upgrade': 'api/v1/service/upgrade-service',
+  'GET /api/v1/services/:serviceId/upgrade/stream':
+    'api/v1/service/stream-upgrade',
   'PATCH /api/v1/services/:serviceId': 'api/v1/service/update-service',
 
   // Backups

--- a/docs/service-versions.md
+++ b/docs/service-versions.md
@@ -1,0 +1,90 @@
+# Service image versions
+
+Slipway provisions backing services from tested numeric Docker tags and records
+the immutable digest or image ID that Docker actually ran. It never stores
+`latest` for a newly created service.
+
+## Tested matrix
+
+| Service    | Default | Other tested line | Automated upgrade |
+| ---------- | ------- | ----------------- | ----------------- |
+| PostgreSQL | 17      | 16                | 16 → 17           |
+| MySQL      | 8.4     | 8.0               | 8.0 → 8.4         |
+| Redis      | 7.2     | —                 | Not yet           |
+| MongoDB    | 8.0     | 7.0               | 7.0 → 8.0         |
+
+The defaults are deliberately stable release lines rather than aliases that
+can cross a major-version boundary. Docker may publish newer patches within a
+line, but every service stores the exact resolved digest. Restarting,
+recreating, restoring, or updating Slipway therefore reuses the same image.
+
+The current matrix is also available to authenticated clients:
+
+```text
+GET /api/v1/service-versions
+```
+
+## Creating services
+
+Omit `version` to use the tested default:
+
+```bash
+slipway db:create main-db --type postgresql
+```
+
+Choose another tested line explicitly:
+
+```bash
+slipway db:create main-db --type postgresql --version 16
+```
+
+Custom versions must be numeric tags such as `17.4` or `8.0.12`. Slipway marks
+them as outside the tested matrix. Mutable aliases, image variants, repository
+names, and shell syntax are rejected; examples include `latest`,
+`17-alpine`, and `postgres:17`.
+
+## Existing services
+
+At startup, Slipway finds legacy service records that still say `latest` or do
+not have an immutable image reference. It inspects the existing Docker
+container and image, records the detected version and digest, and leaves the
+container and data volume untouched.
+
+If the original container no longer exists, Slipway leaves the record visibly
+unresolved instead of guessing. Restore the original container or recover the
+actual version before attempting a recreation or upgrade.
+
+## Upgrading a service
+
+Supported upgrades are available from the service settings page. Slipway:
+
+1. creates and verifies a logical backup in configured object storage;
+2. resolves the target image before interrupting the running service;
+3. starts the target version on a fresh named volume;
+4. restores the verified backup and waits for the database to become ready;
+5. promotes the restored container to the canonical service name; and
+6. retains the stopped previous container and volume for recovery.
+
+The page streams each step and records the backup and retained container in
+the service upgrade state. An upgrade stops safely before cutover if the
+backup, pull, startup, or restore fails.
+
+Major-version upgrades are intentionally limited to tested adjacent lines.
+Slipway does not automate downgrades, skipped releases, custom-version
+upgrades, or Redis upgrades without a verified backup path.
+
+## Recovery
+
+After a successful upgrade, verify the application before deleting the
+retained previous container or volume. The service settings page records the
+exact previous container name and backup.
+
+If verification fails:
+
+1. stop the promoted service container;
+2. rename the retained previous container back to the canonical service name;
+3. start it; and
+4. use the verified upgrade backup if a data restore is also required.
+
+Retained containers and volumes are not deleted automatically. This keeps the
+recovery boundary explicit until the operator confirms the upgrade.

--- a/packages/cli/src/commands/db-create.js
+++ b/packages/cli/src/commands/db-create.js
@@ -16,7 +16,7 @@ export default async function dbCreate(options, positionals) {
   const project = requireProject()
   const environment = options.env || 'production'
   const dbType = options.type || 'postgresql'
-  const version = options.version || 'latest'
+  const version = options.version
 
   console.log()
   console.log(`  ${c.bold(c.highlight('Create Database'))}`)
@@ -31,7 +31,7 @@ export default async function dbCreate(options, positionals) {
       {
         name,
         type: dbType,
-        version
+        ...(version ? { version } : {})
       }
     )
 
@@ -40,6 +40,13 @@ export default async function dbCreate(options, positionals) {
     console.log(`  ${c.dim('Name:')} ${service.name}`)
     console.log(`  ${c.dim('Type:')} ${service.type}`)
     console.log(`  ${c.dim('Version:')} ${service.version}`)
+    if (service.versionSupport === 'custom') {
+      console.log(
+        `  ${c.dim('Support:')} ${c.warn(
+          'Custom version — outside Slipway’s tested matrix'
+        )}`
+      )
+    }
     console.log(`  ${c.dim('Environment:')} ${environment}`)
     console.log()
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -115,7 +115,7 @@ const commands = {
     args: '<name>',
     options: {
       type: { type: 'string', short: 't', default: 'postgresql' },
-      version: { type: 'string', short: 'v', default: 'latest' },
+      version: { type: 'string', short: 'v' },
       env: { type: 'string', short: 'e', default: 'production' }
     }
   },

--- a/tests/functional/api/service-versions.test.js
+++ b/tests/functional/api/service-versions.test.js
@@ -1,0 +1,80 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'authenticated clients can discover the tested service version matrix',
+  { world: 'configured-slipway' },
+  async ({ request, expect }) => {
+    const response = await request
+      .as('genesisUser')
+      .get('/api/v1/service-versions')
+
+    expect(response).toHaveStatus(200)
+    expect(response).toHaveJsonPath('services.postgresql.defaultVersion', '17')
+    expect(response).toHaveJsonPath('services.mysql.defaultVersion', '8.4')
+    expect(response).toHaveJsonPath('services.redis.defaultVersion', '7.2')
+    expect(response).toHaveJsonPath('services.mongodb.defaultVersion', '8.0')
+  }
+)
+
+test(
+  'service creation persists the tested default and rejects latest',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'service-defaults',
+          name: 'Service Defaults'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const originalCreate = sails.helpers.docker.createService
+    const markRunning = async (serviceId) => {
+      await sails.models.service.updateOne({ id: serviceId }).set({
+        status: 'running',
+        containerId: 'test-service-container',
+        imageReference: 'postgres@sha256:test-default'
+      })
+      return { containerId: 'test-service-container' }
+    }
+    sails.helpers.docker.createService = markRunning
+
+    try {
+      const dashboard = await withCsrfFromPage(
+        request,
+        '/projects/service-defaults/environments/production',
+        'genesisUser'
+      )
+      const client = dashboard.request
+      const url =
+        '/api/v1/projects/service-defaults/environments/production/services'
+      const created = await client.post(url, {
+        name: 'main-db',
+        type: 'postgresql'
+      })
+
+      expect(created).toHaveStatus(201)
+      expect(created).toHaveJsonPath('service.version', '17')
+      expect(created).toHaveJsonPath('service.versionSupport', 'supported')
+
+      const persisted = await sails.models.service.findOne({
+        environment: world.current.environments.production.id,
+        name: 'main-db'
+      })
+      expect(persisted.version).toBe('17')
+
+      const mutable = await client.post(url, {
+        name: 'mutable-db',
+        type: 'postgresql',
+        version: 'latest'
+      })
+      expect(mutable).toHaveStatus(303)
+      expect(mutable).toHaveHeader('x-exit', 'badRequest')
+    } finally {
+      sails.helpers.docker.createService = originalCreate
+    }
+  }
+)

--- a/tests/unit/helpers/docker/resolve-service-image.test.js
+++ b/tests/unit/helpers/docker/resolve-service-image.test.js
@@ -1,0 +1,57 @@
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+test('image resolution uses an immutable local digest when the registry is offline', async ({
+  sails,
+  expect
+}) => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-service-image-')
+  )
+  const dockerPath = path.join(tempRoot, 'docker')
+  const originalDockerPath = sails.config.docker?.binaryPath
+  fs.writeFileSync(
+    dockerPath,
+    [
+      '#!/usr/bin/env node',
+      'const args = process.argv.slice(2)',
+      "if (args[0] === 'pull') {",
+      "  process.stderr.write('registry unavailable')",
+      '  process.exit(1)',
+      '}',
+      "if (args[0] === 'image' && args[1] === 'inspect') {",
+      '  process.stdout.write(JSON.stringify([{',
+      "    Id: 'sha256:local-image-id',",
+      "    RepoDigests: ['postgres@sha256:immutable-digest'],",
+      "    RepoTags: ['postgres:17']",
+      '  }]))',
+      '  process.exit(0)',
+      '}',
+      'process.exit(2)',
+      ''
+    ].join('\n')
+  )
+  fs.chmodSync(dockerPath, 0o755)
+  sails.config.docker = sails.config.docker || {}
+  sails.config.docker.binaryPath = dockerPath
+
+  try {
+    const result = await sails.helpers.docker.resolveServiceImage.with({
+      type: 'postgresql',
+      version: '17'
+    })
+
+    expect(result.imageReference).toBe('postgres@sha256:immutable-digest')
+    expect(result.usedLocalFallback).toBe(true)
+  } finally {
+    if (originalDockerPath === undefined) {
+      delete sails.config.docker.binaryPath
+    } else {
+      sails.config.docker.binaryPath = originalDockerPath
+    }
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})

--- a/tests/unit/helpers/service/service-version-lifecycle.test.js
+++ b/tests/unit/helpers/service/service-version-lifecycle.test.js
@@ -1,0 +1,348 @@
+const { test } = require('sounding')
+
+test(
+  'service recreation reuses its immutable image and existing volume',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'pinned-service',
+          name: 'Pinned Service'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'main-db',
+      version: '16',
+      status: 'stopped',
+      containerName: 'slipway-pinned-service-production-main-db',
+      imageReference: 'postgres@sha256:existing',
+      imageMetadata: {
+        volumeName: 'slipway-pinned-service-data'
+      }
+    })
+    const originalResolve = sails.helpers.docker.resolveServiceImage
+    const originalRun = sails.helpers.docker.runServiceContainer
+    let runInputs
+
+    const rejectResolution = async () => {
+      throw new Error('The mutable tag must not be resolved again')
+    }
+    rejectResolution.with = rejectResolution
+    sails.helpers.docker.resolveServiceImage = rejectResolution
+
+    const captureRun = async (inputs) => {
+      runInputs = inputs
+      return {
+        containerId: 'immutable-container-id',
+        containerName: inputs.containerName,
+        volumeName: inputs.volumeName,
+        imageReference: inputs.imageReference
+      }
+    }
+    captureRun.with = captureRun
+    sails.helpers.docker.runServiceContainer = captureRun
+
+    try {
+      await sails.helpers.docker.createService(service.id)
+
+      expect(runInputs.imageReference).toBe('postgres@sha256:existing')
+      expect(runInputs.volumeName).toBe('slipway-pinned-service-data')
+      const updated = await sails.models.service.findOne({ id: service.id })
+      expect(updated.status).toBe('running')
+      expect(updated.imageReference).toBe('postgres@sha256:existing')
+    } finally {
+      sails.helpers.docker.resolveServiceImage = originalResolve
+      sails.helpers.docker.runServiceContainer = originalRun
+    }
+  }
+)
+
+test(
+  'legacy latest records are pinned from Docker without recreating the service',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'legacy-service',
+          name: 'Legacy Service'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'legacy-db',
+      version: 'latest',
+      status: 'running',
+      containerName: 'slipway-legacy-service-production-legacy-db'
+    })
+    const originalInspect = sails.helpers.docker.inspectRunningServiceImage
+
+    const inspectExisting = async () => ({
+      version: '17',
+      detectedVersion: '17.6',
+      imageReference: 'postgres@sha256:running',
+      imageId: 'sha256:running',
+      repoDigest: 'postgres@sha256:running',
+      configuredImage: 'postgres:latest'
+    })
+    inspectExisting.with = inspectExisting
+    sails.helpers.docker.inspectRunningServiceImage = inspectExisting
+
+    try {
+      const result = await sails.helpers.service.migrateLegacyVersions()
+      const updated = await sails.models.service.findOne({ id: service.id })
+
+      expect(result.migrated).toBe(1)
+      expect(updated.version).toBe('17')
+      expect(updated.imageReference).toBe('postgres@sha256:running')
+      expect(updated.containerName).toBe(service.containerName)
+      expect(updated.status).toBe('running')
+    } finally {
+      sails.helpers.docker.inspectRunningServiceImage = originalInspect
+    }
+  }
+)
+
+test(
+  'a deliberate major upgrade backs up, restores, and retains recovery state',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'upgrade-service',
+          name: 'Upgrade Service'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'main-db',
+      version: '16',
+      status: 'running',
+      containerName: 'slipway-upgrade-service-production-main-db',
+      imageReference: 'postgres@sha256:version-16',
+      imageMetadata: {
+        volumeName: 'slipway-upgrade-service-main-db-data'
+      },
+      database: 'upgrade_service',
+      username: 'slipway_main_db',
+      password: 'secret'
+    })
+    const calls = []
+    const originals = {
+      runBackup: sails.helpers.backup.runBackup,
+      restoreBackup: sails.helpers.backup.restoreBackup,
+      resolve: sails.helpers.docker.resolveServiceImage,
+      run: sails.helpers.docker.runServiceContainer,
+      wait: sails.helpers.docker.waitForService,
+      swap: sails.helpers.docker.swapServiceContainers,
+      discard: sails.helpers.docker.discardServiceCandidate,
+      audit: sails.helpers.audit.log
+    }
+
+    replace(sails.helpers.backup, 'runBackup', async ({ backupId }) => {
+      calls.push('backup')
+      return sails.models.backup.updateOne({ id: backupId }).set({
+        status: 'completed',
+        s3Key: `backups/${backupId}.dmp`,
+        sizeBytes: 2048,
+        completedAt: Date.now()
+      })
+    })
+    replace(sails.helpers.docker, 'resolveServiceImage', async () => {
+      calls.push('image')
+      return {
+        imageReference: 'postgres@sha256:version-17',
+        imageTag: 'postgres:17',
+        imageId: 'sha256:version-17',
+        repoDigest: 'postgres@sha256:version-17',
+        resolvedAt: Date.now(),
+        usedLocalFallback: false
+      }
+    })
+    replace(sails.helpers.docker, 'runServiceContainer', async (inputs) => {
+      calls.push('candidate')
+      return {
+        containerId: 'candidate-container-id',
+        containerName: inputs.containerName,
+        volumeName: inputs.volumeName,
+        imageReference: inputs.imageReference
+      }
+    })
+    replace(sails.helpers.docker, 'waitForService', async () => {
+      calls.push('ready')
+      return { ready: true }
+    })
+    replace(sails.helpers.backup, 'restoreBackup', async () => {
+      calls.push('restore')
+      return { success: true }
+    })
+    replace(sails.helpers.docker, 'swapServiceContainers', async () => {
+      calls.push('cutover')
+      return { committed: true }
+    })
+    replace(sails.helpers.docker, 'discardServiceCandidate', async () => {})
+    replace(sails.helpers.audit, 'log', async () => {
+      calls.push('audit')
+    })
+
+    try {
+      const state = await sails.helpers.service.runVersionUpgrade.with({
+        serviceId: service.id,
+        targetVersion: '17',
+        userId: String(world.current.users.genesisUser.id),
+        teamId: String(world.current.teams.genesisTeam.id),
+        ipAddress: '127.0.0.1'
+      })
+      const updated = await sails.models.service.findOne({ id: service.id })
+
+      expect(state.status).toBe('completed')
+      expect(calls).toEqual([
+        'backup',
+        'image',
+        'candidate',
+        'ready',
+        'restore',
+        'ready',
+        'cutover',
+        'audit'
+      ])
+      expect(updated.version).toBe('17')
+      expect(updated.imageReference).toBe('postgres@sha256:version-17')
+      expect(updated.imageMetadata.previous.version).toBe('16')
+      expect(updated.upgradeState.recovery.backupId).toBeDefined()
+      expect(updated.status).toBe('running')
+    } finally {
+      sails.helpers.backup.runBackup = originals.runBackup
+      sails.helpers.backup.restoreBackup = originals.restoreBackup
+      sails.helpers.docker.resolveServiceImage = originals.resolve
+      sails.helpers.docker.runServiceContainer = originals.run
+      sails.helpers.docker.waitForService = originals.wait
+      sails.helpers.docker.swapServiceContainers = originals.swap
+      sails.helpers.docker.discardServiceCandidate = originals.discard
+      sails.helpers.audit.log = originals.audit
+    }
+  }
+)
+
+test(
+  'a failed restore discards the candidate and leaves the original service pinned',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'failed-upgrade',
+          name: 'Failed Upgrade'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'main-db',
+      version: '16',
+      status: 'running',
+      containerName: 'slipway-failed-upgrade-production-main-db',
+      imageReference: 'postgres@sha256:version-16',
+      imageMetadata: {
+        volumeName: 'slipway-failed-upgrade-main-db-data'
+      }
+    })
+    const calls = []
+    const originals = {
+      runBackup: sails.helpers.backup.runBackup,
+      restoreBackup: sails.helpers.backup.restoreBackup,
+      resolve: sails.helpers.docker.resolveServiceImage,
+      run: sails.helpers.docker.runServiceContainer,
+      wait: sails.helpers.docker.waitForService,
+      swap: sails.helpers.docker.swapServiceContainers,
+      discard: sails.helpers.docker.discardServiceCandidate
+    }
+
+    replace(sails.helpers.backup, 'runBackup', async ({ backupId }) => {
+      return sails.models.backup.updateOne({ id: backupId }).set({
+        status: 'completed',
+        s3Key: `backups/${backupId}.dmp`,
+        sizeBytes: 2048,
+        completedAt: Date.now()
+      })
+    })
+    replace(sails.helpers.docker, 'resolveServiceImage', async () => ({
+      imageReference: 'postgres@sha256:version-17',
+      imageTag: 'postgres:17',
+      imageId: 'sha256:version-17',
+      repoDigest: 'postgres@sha256:version-17',
+      resolvedAt: Date.now(),
+      usedLocalFallback: false
+    }))
+    replace(sails.helpers.docker, 'runServiceContainer', async (inputs) => ({
+      containerId: 'candidate-container-id',
+      containerName: inputs.containerName,
+      volumeName: inputs.volumeName,
+      imageReference: inputs.imageReference
+    }))
+    replace(sails.helpers.docker, 'waitForService', async () => ({
+      ready: true
+    }))
+    replace(sails.helpers.backup, 'restoreBackup', async () => {
+      throw new Error('The backup is incompatible with the target version.')
+    })
+    replace(sails.helpers.docker, 'swapServiceContainers', async () => {
+      calls.push('cutover')
+    })
+    replace(sails.helpers.docker, 'discardServiceCandidate', async (inputs) => {
+      calls.push({ discarded: inputs })
+    })
+
+    try {
+      const state = await sails.helpers.service.runVersionUpgrade.with({
+        serviceId: service.id,
+        targetVersion: '17',
+        userId: String(world.current.users.genesisUser.id),
+        teamId: String(world.current.teams.genesisTeam.id),
+        ipAddress: '127.0.0.1'
+      })
+      const updated = await sails.models.service.findOne({ id: service.id })
+
+      expect(state.status).toBe('failed')
+      expect(state.message).toContain('incompatible with the target version')
+      expect(calls.some((call) => call === 'cutover')).toBe(false)
+      expect(
+        calls.some(
+          (call) =>
+            call.discarded?.containerName.includes('-upgrade-') &&
+            call.discarded?.volumeName.endsWith('-data')
+        )
+      ).toBe(true)
+      expect(updated.version).toBe('16')
+      expect(updated.imageReference).toBe('postgres@sha256:version-16')
+      expect(updated.status).toBe('running')
+    } finally {
+      sails.helpers.backup.runBackup = originals.runBackup
+      sails.helpers.backup.restoreBackup = originals.restoreBackup
+      sails.helpers.docker.resolveServiceImage = originals.resolve
+      sails.helpers.docker.runServiceContainer = originals.run
+      sails.helpers.docker.waitForService = originals.wait
+      sails.helpers.docker.swapServiceContainers = originals.swap
+      sails.helpers.docker.discardServiceCandidate = originals.discard
+    }
+  }
+)
+
+function replace(namespace, name, implementation) {
+  implementation.with = implementation
+  namespace[name] = implementation
+}

--- a/tests/unit/services/service-image-policy.test.js
+++ b/tests/unit/services/service-image-policy.test.js
@@ -1,0 +1,68 @@
+const { test } = require('sounding')
+
+const {
+  getPublicMatrix,
+  getUpgradePlan,
+  inspectVersion
+} = require('../../../api/lib/service-image-policy')
+
+test('fresh services use tested numeric defaults instead of mutable tags', ({
+  expect
+}) => {
+  expect(inspectVersion('postgresql').version).toBe('17')
+  expect(inspectVersion('mysql').version).toBe('8.4')
+  expect(inspectVersion('redis').version).toBe('7.2')
+  expect(inspectVersion('mongodb').version).toBe('8.0')
+
+  for (const policy of Object.values(getPublicMatrix())) {
+    expect(policy.defaultVersion === 'latest').toBe(false)
+    expect(
+      policy.versions.some(({ version }) => version === policy.defaultVersion)
+    ).toBe(true)
+  }
+})
+
+test('service image policy rejects mutable and unsafe Docker tags', ({
+  expect
+}) => {
+  expect(
+    captureError(() => inspectVersion('postgresql', 'latest')).message
+  ).toContain('mutable "latest" tag is not allowed')
+  expect(
+    captureError(() => inspectVersion('postgresql', '17-alpine')).message
+  ).toContain('Versions must be numeric Docker tags')
+  expect(
+    captureError(() => inspectVersion('postgresql', '17;docker pull evil'))
+      .message
+  ).toContain('Versions must be numeric Docker tags')
+})
+
+test('custom numeric tags are explicit and supported upgrades cannot skip lines', ({
+  expect
+}) => {
+  const custom = inspectVersion('postgresql', '17.4')
+  expect(custom.supported).toBe(false)
+  expect(custom.imageTag).toBe('postgres:17.4')
+
+  const upgrade = getUpgradePlan('postgresql', '16', '17')
+  expect(upgrade.requiresBackup).toBe(true)
+  expect(upgrade.fromVersion).toBe('16')
+  expect(upgrade.toVersion).toBe('17')
+
+  expect(
+    captureError(() => getUpgradePlan('postgresql', '15', '17')).message
+  ).toContain('cannot automate an upgrade from unsupported')
+  expect(
+    captureError(() => getUpgradePlan('redis', '7.2', '8')).message
+  ).toContain("not in Slipway's tested upgrade matrix")
+})
+
+function captureError(fn) {
+  try {
+    fn()
+  } catch (error) {
+    return error
+  }
+
+  throw new Error('Expected operation to fail.')
+}


### PR DESCRIPTION
## Summary
- define tested PostgreSQL, MySQL, Redis, and MongoDB version lines and pin every provisioned service to an immutable Docker reference
- migrate legacy `latest` services from their existing container without recreation and reuse the exact image and volume on later recreation
- add a guarded backup, fresh-volume restore, readiness verification, cutover, progress, and recovery workflow for tested major upgrades
- expose the version matrix in the API, CLI, web UI, and operator documentation

## Verification
- `npm run test:unit` — 117 passed
- `npm run test:functional` — 41 passed
- `npm run test:e2e` — 13 passed
- `npm run lint`
- browser-verified dark-mode settings and confirmation flow with no horizontal overflow and right-aligned upgrade action

Closes #238