### PR TITLE
fix: align docs runtime and production config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies
@@ -25,6 +25,9 @@ jobs:
 
       - name: Run Prettier check
         run: npm run lint
+
+      - name: Check docs and runtime consistency
+        run: npm run check:consistency
 
   test:
     timeout-minutes: 10
@@ -36,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <br><br>
 <p>The complete platform for Sails.js — deploy, manage, monitor, and debug your apps on your own infrastructure.</p>
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 </div>
 
@@ -61,7 +61,8 @@ When you want a local run that mirrors the production installer more closely tha
 npm run local
 ```
 
-This runs [local.sh](/Users/koo/Gringotts/687/slipway/local.sh), the local counterpart to [install.sh](/Users/koo/Gringotts/687/slipway/install.sh). It:
+This runs [local.sh](local.sh), the local counterpart to
+[install.sh](install.sh). It:
 
 - builds the current checkout into a local Docker image
 - creates or reuses the `slipway` Docker network
@@ -184,4 +185,4 @@ This repo is a monorepo containing:
 
 ## License
 
-Slipway is open-source software licensed under the [MIT license](LICENSE.md).
+Slipway is open-source software licensed under the [MIT license](LICENSE).

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,237 +1,46 @@
-/**
- * Production environment settings
- * (sails.config.*)
- *
- * What you see below is a quick outline of the built-in settings you need
- * to configure your Sails app for production.  The configuration in this file
- * is only used in your production environment, i.e. when you lift your app using:
- *
- * ```
- * NODE_ENV=production node app
- * ```
- *
- * > If you're using git as a version control solution for your Sails app,
- * > this file WILL BE COMMITTED to your repository by default, unless you add
- * > it to your .gitignore file.  If your repository will be publicly viewable,
- * > don't add private/sensitive data (like API keys / db passwords) to this file!
- *
- * For more best practices and tips, see:
- * http://sailsjs.com/docs/concepts/deployment
- */
-
 module.exports = {
   hookTimeout: 80000,
 
   custom: {
     baseUrl: process.env.SLIPWAY_URL,
-
-    // Production app hostnames come from a configured wildcard or custom domain.
     slipwayDomain: null,
-
-    // Keep Docker's allocator aligned with the range opened by install.sh.
     slipwayPortRange: {
       start: Number(process.env.SLIPWAY_APP_PORT_START) || 1338,
       end: Number(process.env.SLIPWAY_APP_PORT_END) || 1500
     }
   },
-  /**************************************************************************
-   *                                                                         *
-   * Tell Sails what database(s) it should use in production.                *
-   *                                                                         *
-   * (http://sailsjs.com/config/datastores)                                  *
-   *                                                                         *
-   **************************************************************************/
-  // datastores: inherited from config/datastores.js (SQLite for all environments)
 
   models: {
-    /**************************************************************************
-     *                                                                         *
-     * To help avoid accidents, Sails automatically sets the automigration     *
-     * strategy to "safe" when your app lifts in production mode.              *
-     * (This is just here as a reminder.)                                      *
-     *                                                                         *
-     * More info:                                                              *
-     * http://sailsjs.com/docs/concepts/models-and-orm/model-settings#?migrate *
-     *                                                                         *
-     ***************************************************************************/
     migrate: process.env.SLIPWAY_MIGRATE || 'safe',
-
     dataEncryptionKeys: {
       default: process.env.DATA_ENCRYPTION_KEY
     }
   },
 
-  /**************************************************************************
-   *                                                                         *
-   * Always disable "shortcut" blueprint routes.                             *
-   * (you'll also want to disable any other blueprint routes that you are    *
-   * not actually using)                                                     *
-   *                                                                         *
-   ***************************************************************************/
   blueprints: {
     shortcuts: false
-    // actions: false,
-    // rest: false,
   },
 
-  /***************************************************************************
-   *                                                                          *
-   * Configure your security settings for production.                         *
-   *                                                                          *
-   * IMPORTANT:                                                               *
-   * If web browsers will be communicating with your app, be sure that        *
-   * you have CSRF protection enabled.  To do that, set `csrf: true` over     *
-   * in the `config/security.js` file (not here), so that CSRF app can be     *
-   * tested with CSRF protection turned on in development mode too.           *
-   *                                                                          *
-   ***************************************************************************/
-  security: {
-    /***************************************************************************
-     *                                                                          *
-     * If this app has CORS enabled (see `config/security.js`) with the         *
-     * `allowCredentials` setting enabled, then you should uncomment the        *
-     * `allowOrigins` whitelist below.  This sets which "origins" are allowed   *
-     * to send cross-domain (CORS) requests to your Sails app.                  *
-     *                                                                          *
-     * > Replace "https://example.com" with the URL of your production server.  *
-     * > Be sure to use the right protocol!  ("http://" vs. "https://")         *
-     *                                                                          *
-     ***************************************************************************/
-    cors: {
-      // allowOrigins: [
-      //   'https://example.com',
-      // ]
-    }
-  },
-
-  /***************************************************************************
-   *                                                                          *
-   * Configure how your app handles sessions in production.                   *
-   *                                                                          *
-   * (http://sailsjs.com/config/session)                                      *
-   *                                                                          *
-   * > If you have disabled the "session" hook, then you can safely remove    *
-   * > this section from your `config/env/production.js` file.                *
-   *                                                                          *
-   ***************************************************************************/
   session: {
     secret: process.env.SESSION_SECRET,
     cookie: {
-      // Only require secure cookies if SSL is configured (SLIPWAY_SSL=true)
-      // This allows initial setup via http://<IP>:1337 before domain/SSL is configured
       secure: process.env.SLIPWAY_SSL === 'true',
       httpOnly: true,
       sameSite: 'lax',
-      maxAge: 24 * 60 * 60 * 1000 // 24 hours
+      maxAge: 24 * 60 * 60 * 1000
     }
   },
 
-  /**************************************************************************
-   *                                                                          *
-   * Set up Socket.io for your production environment.                        *
-   *                                                                          *
-   * (http://sailsjs.com/config/sockets)                                      *
-   *                                                                          *
-   * > If you have disabled the "sockets" hook, then you can safely remove    *
-   * > this section from your `config/env/production.js` file.                *
-   *                                                                          *
-   ***************************************************************************/
   sockets: {
-    /***************************************************************************
-     *                                                                          *
-     * Socket origins whitelist - uses SLIPWAY_URL env var if set               *
-     * Example: SLIPWAY_URL=http://123.45.67.89:1337                            *
-     *                                                                          *
-     ***************************************************************************/
     onlyAllowOrigins: [process.env.SLIPWAY_URL]
-
-    /***************************************************************************
-     *                                                                          *
-     * If you are deploying a cluster of multiple servers and/or processes,     *
-     * then uncomment the following lines.  This tells Socket.io about a Redis  *
-     * server it can use to help it deliver broadcasted socket messages.        *
-     *                                                                          *
-     * (http://sailsjs.com/docs/concepts/deployment/scaling)                    *
-     *                                                                          *
-     ***************************************************************************/
-    // adapter: 'socket.io-redis',
-    // url: 'redis://user:password@bigsquid.redistogo.com:9562/dbname',
-    //--------------------------------------------------------------------------
-    // /\   OR, to avoid checking it in to version control, you might opt to
-    // ||   set sensitive credentials like this using an environment variable.
-    //
-    // For example:
-    // ```
-    // sails_sockets__url=redis://admin:myc00lpAssw2D@bigsquid.redistogo.com:9562/
-    // ```
-    //--------------------------------------------------------------------------
   },
 
-  /**************************************************************************
-   *                                                                         *
-   * Set the production log level.                                           *
-   *                                                                         *
-   * (http://sailsjs.com/config/log)                                         *
-   *                                                                         *
-   ***************************************************************************/
   log: {
     level: 'info'
   },
 
   http: {
-    /***************************************************************************
-     *                                                                          *
-     * The number of milliseconds to cache static assets in production.         *
-     * (the "max-age" to include in the "Cache-Control" response header)        *
-     *                                                                          *
-     ***************************************************************************/
-    cache: 365.25 * 24 * 60 * 60 * 1000, // One year
-
-    /***************************************************************************
-     *                                                                          *
-     * Proxy settings                                                           *
-     *                                                                          *
-     * If your app will be deployed behind a proxy/load balancer - for example, *
-     * on a PaaS like Heroku - then uncomment the `trustProxy` setting below.   *
-     * This tells Sails/Express how to interpret X-Forwarded headers.           *
-     *                                                                          *
-     * This setting is especially important if you are using secure cookies     *
-     * (see the `cookies: secure` setting under `session` above) or if your app *
-     * relies on knowing the original IP address that a request came from.      *
-     *                                                                          *
-     * (http://sailsjs.com/config/http)                                         *
-     *                                                                          *
-     ***************************************************************************/
-    trustProxy: true
+    trustProxy: true,
+    cache: 365.25 * 24 * 60 * 60 * 1000
   }
-
-  /**************************************************************************
-   *                                                                         *
-   * Lift the server on port 80.                                             *
-   * (if deploying behind a proxy, or to a PaaS like Heroku or Deis, you     *
-   * probably don't need to set a port here, because it is oftentimes        *
-   * handled for you automatically.  If you are not sure if you need to set  *
-   * this, just try deploying without setting it and see if it works.)       *
-   *                                                                         *
-   ***************************************************************************/
-  // port: 80,
-
-  /**************************************************************************
-   *                                                                         *
-   * Configure an SSL certificate                                            *
-   *                                                                         *
-   * For the safety of your users' data, you should use SSL in production.   *
-   * ...But in many cases, you may not actually want to set it up _here_.    *
-   *                                                                         *
-   * Normally, this setting is only relevant when running a single-process   *
-   * deployment, with no proxy/load balancer in the mix.  But if, on the     *
-   * other hand, you are using a PaaS like Heroku, you'll want to set up     *
-   * SSL in your load balancer settings (usually somewhere in your hosting   *
-   * provider's dashboard-- not here.)                                       *
-   *                                                                         *
-   * > For more information about configuring SSL in Sails, see:             *
-   * > http://sailsjs.com/config/*#?ssl-configuration-example                *
-   *                                                                         *
-   **************************************************************************/
-  // ssl: undefined,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "tailwindcss": "^4.1.16"
       },
       "engines": {
-        "node": ">=18.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -9686,7 +9686,7 @@
         "slipway": "src/index.js"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       }
     },
     "packages/hook": {
@@ -9694,7 +9694,7 @@
       "version": "0.0.3",
       "license": "MIT",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.0.0"
       },
       "peerDependencies": {
         "sails": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "start": "NODE_ENV=production node app.js",
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",
+    "check:consistency": "node scripts/check-docs-config-consistency.js",
     "test:unit": "sounding test --lane unit --test-concurrency=1",
     "test:functional": "sounding test --lane functional --test-concurrency=1",
     "test:e2e": "sounding test --lane e2e --test-concurrency=1",
@@ -81,6 +82,6 @@
   },
   "main": "app.js",
   "engines": {
-    "node": ">=18.0"
+    "node": ">=22.0.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,7 +21,7 @@
     "directory": "packages/cli"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -5,6 +5,7 @@ import { readFileSync } from 'node:fs'
 import { fileURLToPath } from 'node:url'
 import { dirname, join } from 'node:path'
 import { c } from './lib/colors.js'
+import { assertSupportedNodeVersion } from './lib/runtime.js'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const pkg = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8'))
@@ -250,6 +251,8 @@ function showVersion() {
 }
 
 async function main() {
+  assertSupportedNodeVersion()
+
   // Parse global options first
   const { values: globalValues, positionals } = parseArgs({
     allowPositionals: true,

--- a/packages/cli/src/lib/runtime.js
+++ b/packages/cli/src/lib/runtime.js
@@ -1,0 +1,13 @@
+export const MINIMUM_NODE_MAJOR = 22
+
+export function assertSupportedNodeVersion(version = process.versions.node) {
+  const major = Number.parseInt(String(version).split('.')[0], 10)
+
+  if (!Number.isInteger(major) || major < MINIMUM_NODE_MAJOR) {
+    const error = new Error(
+      `Slipway CLI requires Node.js ${MINIMUM_NODE_MAJOR} or newer. Current version: ${version}.`
+    )
+    error.code = 'UNSUPPORTED_NODE_VERSION'
+    throw error
+  }
+}

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -44,6 +44,8 @@ The Slipway Dashboard proxies requests, providing single sign-on across all apps
 
 ## Installation
 
+Requires Node.js 22 or newer.
+
 ```bash
 npm install sails-hook-slipway
 ```

--- a/packages/hook/package.json
+++ b/packages/hook/package.json
@@ -21,7 +21,7 @@
     "sails": "^1.5.0"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.0.0"
   },
   "author": "Kelvin Omereshone <kelvin@sailscasts.com>",
   "license": "MIT",

--- a/scripts/check-docs-config-consistency.js
+++ b/scripts/check-docs-config-consistency.js
@@ -1,0 +1,170 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const appRoot = path.resolve(__dirname, '..')
+const supportedNodeMajor = 22
+const supportedNodeRange = `>=${supportedNodeMajor}.0.0`
+const failures = []
+
+checkReadmeLinks()
+checkNodeSupport()
+
+if (failures.length > 0) {
+  console.error('Documentation/config consistency checks failed:')
+  for (const failure of failures) {
+    console.error(`- ${failure}`)
+  }
+  process.exit(1)
+}
+
+console.log(
+  `Documentation links and Node.js ${supportedNodeMajor}+ requirements are consistent.`
+)
+
+function checkReadmeLinks() {
+  for (const readmePath of findReadmes(appRoot)) {
+    const markdown = fs.readFileSync(readmePath, 'utf8')
+    const linkPatterns = [
+      /!?\[[^\]]*]\(([^)\s]+)(?:\s+["'][^"']*["'])?\)/g,
+      /^\s*\[[^\]]+]:\s*(\S+)/gm,
+      /(?:href|src)=["']([^"']+)["']/gi
+    ]
+
+    for (const linkPattern of linkPatterns) {
+      for (const match of markdown.matchAll(linkPattern)) {
+        checkLocalLink(readmePath, match[1])
+      }
+    }
+  }
+}
+
+function checkLocalLink(readmePath, target) {
+  const rawTarget = target.replace(/^<|>$/g, '')
+  if (rawTarget.startsWith('#') || /^[a-z][a-z\d+.-]*:/i.test(rawTarget)) {
+    return
+  }
+
+  const targetWithoutAnchor = rawTarget.split(/[?#]/)[0]
+  if (!targetWithoutAnchor) return
+
+  if (path.isAbsolute(targetWithoutAnchor)) {
+    failures.push(
+      `${relative(readmePath)} contains an absolute local link: ${rawTarget}`
+    )
+    return
+  }
+
+  let decodedTarget
+  try {
+    decodedTarget = decodeURIComponent(targetWithoutAnchor)
+  } catch {
+    failures.push(
+      `${relative(readmePath)} contains an invalid encoded link: ${rawTarget}`
+    )
+    return
+  }
+
+  const resolvedTarget = path.resolve(path.dirname(readmePath), decodedTarget)
+  if (!fs.existsSync(resolvedTarget)) {
+    failures.push(`${relative(readmePath)} links to missing path: ${rawTarget}`)
+  }
+}
+
+function checkNodeSupport() {
+  const packagePaths = [
+    'package.json',
+    'packages/cli/package.json',
+    'packages/hook/package.json'
+  ]
+
+  for (const packagePath of packagePaths) {
+    const packageJson = readJson(packagePath)
+    if (packageJson.engines?.node !== supportedNodeRange) {
+      failures.push(
+        `${packagePath} must declare engines.node as ${supportedNodeRange}`
+      )
+    }
+  }
+
+  const workflow = read('.github/workflows/test.yml')
+  const workflowVersions = [
+    ...workflow.matchAll(/node-version:\s*['"]?(\d+)['"]?/g)
+  ].map((match) => Number(match[1]))
+  if (
+    workflowVersions.length === 0 ||
+    workflowVersions.some((version) => version !== supportedNodeMajor)
+  ) {
+    failures.push(
+      `.github/workflows/test.yml must test on Node.js ${supportedNodeMajor}`
+    )
+  }
+
+  const dockerfile = read('Dockerfile')
+  if (
+    !new RegExp(`^FROM node:${supportedNodeMajor}(?:-|$)`, 'm').test(dockerfile)
+  ) {
+    failures.push(`Dockerfile must use the Node.js ${supportedNodeMajor} line`)
+  }
+
+  const readme = read('README.md')
+  const cliReadme = read('packages/cli/README.md')
+  const hookReadme = read('packages/hook/README.md')
+  if (!readme.includes(`Node.js ${supportedNodeMajor}+`)) {
+    failures.push(`README.md must document Node.js ${supportedNodeMajor}+`)
+  }
+  if (!cliReadme.includes(`Node.js ${supportedNodeMajor}+`)) {
+    failures.push(
+      `packages/cli/README.md must document Node.js ${supportedNodeMajor}+`
+    )
+  }
+  if (!hookReadme.includes(`Node.js ${supportedNodeMajor} or newer`)) {
+    failures.push(
+      `packages/hook/README.md must document Node.js ${supportedNodeMajor} or newer`
+    )
+  }
+
+  const cliRuntime = read('packages/cli/src/lib/runtime.js')
+  if (
+    !cliRuntime.includes(
+      `export const MINIMUM_NODE_MAJOR = ${supportedNodeMajor}`
+    )
+  ) {
+    failures.push(
+      `Slipway CLI must reject runtimes older than Node.js ${supportedNodeMajor}`
+    )
+  }
+}
+
+function findReadmes(directory) {
+  const paths = []
+
+  for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+    if (
+      entry.isDirectory() &&
+      ['.git', '.tmp', 'node_modules'].includes(entry.name)
+    ) {
+      continue
+    }
+
+    const entryPath = path.join(directory, entry.name)
+    if (entry.isDirectory()) {
+      paths.push(...findReadmes(entryPath))
+    } else if (/^readme\.md$/i.test(entry.name)) {
+      paths.push(entryPath)
+    }
+  }
+
+  return paths
+}
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+}
+
+function readJson(relativePath) {
+  return JSON.parse(read(relativePath))
+}
+
+function relative(filePath) {
+  return path.relative(appRoot, filePath)
+}

--- a/tests/unit/cli/runtime.test.js
+++ b/tests/unit/cli/runtime.test.js
@@ -1,0 +1,34 @@
+const path = require('node:path')
+const { pathToFileURL } = require('node:url')
+
+const { test } = require('sounding')
+
+const runtimeModuleUrl = pathToFileURL(
+  path.resolve(__dirname, '../../../packages/cli/src/lib/runtime.js')
+).href
+
+test('CLI accepts the documented Node.js runtime range', async ({ expect }) => {
+  const { MINIMUM_NODE_MAJOR, assertSupportedNodeVersion } = await import(
+    runtimeModuleUrl
+  )
+
+  assertSupportedNodeVersion('22.0.0')
+  assertSupportedNodeVersion('24.1.0')
+  expect(MINIMUM_NODE_MAJOR).toBe(22)
+})
+
+test('CLI rejects runtimes older than the documented minimum', async ({
+  expect
+}) => {
+  const { assertSupportedNodeVersion } = await import(runtimeModuleUrl)
+  let error
+
+  try {
+    assertSupportedNodeVersion('20.19.0')
+  } catch (caughtError) {
+    error = caughtError
+  }
+
+  expect(error.code).toBe('UNSUPPORTED_NODE_VERSION')
+  expect(error.message).toContain('Slipway CLI requires Node.js 22 or newer')
+})

--- a/tests/unit/config/production.test.js
+++ b/tests/unit/config/production.test.js
@@ -1,0 +1,30 @@
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const productionConfigPath = path.resolve(
+  __dirname,
+  '../../../config/env/production.js'
+)
+
+test('production custom config keeps the public URL and domain settings together', ({
+  expect
+}) => {
+  const originalSlipwayUrl = process.env.SLIPWAY_URL
+  process.env.SLIPWAY_URL = 'https://slipway.example.com'
+  delete require.cache[productionConfigPath]
+
+  try {
+    const productionConfig = require(productionConfigPath)
+
+    expect(productionConfig.custom.baseUrl).toBe('https://slipway.example.com')
+    expect(productionConfig.custom.slipwayDomain).toBe(null)
+  } finally {
+    delete require.cache[productionConfigPath]
+    if (originalSlipwayUrl === undefined) {
+      delete process.env.SLIPWAY_URL
+    } else {
+      process.env.SLIPWAY_URL = originalSlipwayUrl
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- repair broken and workstation-specific README links
- standardize Slipway on Node.js 22+ across package engines, CI, documentation, Docker verification, and CLI startup
- replace generated production-config boilerplate with Slipway's actual settings while preserving `baseUrl` and `slipwayDomain`
- add an automated README-link and runtime-consistency gate to CI
- add Sounding regression coverage for the CLI runtime guard and production custom configuration

## Impact
Slipway now has one explicit runtime baseline, contributors cannot accidentally reintroduce invalid local documentation links, and production URL/domain settings are protected against object-literal drift.

## Verification
- `npm run check:consistency`
- `npm run lint`
- `npm run test:unit` — 120 passed
- `npm run test:functional` — 41 passed
- `npm run test:e2e` — 13 passed
- `node packages/cli/src/index.js --version`

Closes #239