### PR TITLE
feat(lookout): decouple observability maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ slipway slide
 
 Slipway includes integrated tools that work with your deployed Sails apps:
 
-| Tool        | What it does                                                                      |
-| ----------- | --------------------------------------------------------------------------------- |
-| **Helm**    | Production REPL — query models, run helpers, inspect config from the browser      |
-| **Bridge**  | Auto-generated data management UI from your Waterline models                      |
-| **Dock**    | SQL console, schema diff, and migration tool for your databases                   |
-| **Quest**   | Job scheduler dashboard for [sails-hook-quest](https://docs.sailscasts.com/quest) |
-| **Content** | CMS for [sails-content](https://docs.sailscasts.com/content) markdown files       |
-| **Lookout** | Infrastructure monitoring via [sails-hook-slipway](packages/hook) telemetry       |
+| Tool        | What it does                                                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| **Helm**    | Production REPL — query models, run helpers, inspect config from the browser                                                          |
+| **Bridge**  | Auto-generated data management UI from your Waterline models                                                                          |
+| **Dock**    | SQL console, schema diff, and migration tool for your databases                                                                       |
+| **Quest**   | Job scheduler dashboard for [sails-hook-quest](https://docs.sailscasts.com/quest)                                                     |
+| **Content** | CMS for [sails-content](https://docs.sailscasts.com/content) markdown files                                                           |
+| **Lookout** | Infrastructure monitoring via [sails-hook-slipway](packages/hook) telemetry with [bounded retention](docs/observability-retention.md) |
 
 ## Requirements
 

--- a/api/controllers/api/v1/lookout/get-overview.js
+++ b/api/controllers/api/v1/lookout/get-overview.js
@@ -24,16 +24,22 @@ module.exports = {
     if (!user) return { containers: [], hostDisk: null }
 
     const hostDisk = await sails.helpers.lookout.getDiskSpace()
+    const observabilityHealth =
+      await sails.helpers.lookout.getObservabilityHealth()
 
     // Get all projects for the user's team
     const projects = await Project.find({ team: user.team.id })
     const projectIds = projects.map((p) => p.id)
-    if (projectIds.length === 0) return { containers: [], hostDisk }
+    if (projectIds.length === 0) {
+      return { containers: [], hostDisk, observabilityHealth }
+    }
 
     // Get all environments for these projects
     const environments = await Environment.find({ project: projectIds })
     const environmentIds = environments.map((e) => e.id)
-    if (environmentIds.length === 0) return { containers: [], hostDisk }
+    if (environmentIds.length === 0) {
+      return { containers: [], hostDisk, observabilityHealth }
+    }
 
     // Get all running apps and services
     const apps = await App.find({
@@ -51,7 +57,9 @@ module.exports = {
       ...services.map((s) => s.containerName)
     ].filter(Boolean)
 
-    if (containerNames.length === 0) return { containers: [], hostDisk }
+    if (containerNames.length === 0) {
+      return { containers: [], hostDisk, observabilityHealth }
+    }
 
     // Get latest metric for each container (most recent recordedAt)
     const latestMetrics = await ContainerMetric.find({
@@ -131,6 +139,6 @@ module.exports = {
       })
     }
 
-    return { containers, hostDisk }
+    return { containers, hostDisk, observabilityHealth }
   }
 }

--- a/api/controllers/lookout/view-lookout.js
+++ b/api/controllers/lookout/view-lookout.js
@@ -28,6 +28,8 @@ module.exports = {
     }
 
     const hostDisk = await sails.helpers.lookout.getDiskSpace()
+    const observabilityHealth =
+      await sails.helpers.lookout.getObservabilityHealth()
 
     // Get all projects for the user's team
     const projects = await Project.find({ team: user.team.id })
@@ -36,7 +38,12 @@ module.exports = {
     if (projectIds.length === 0) {
       return {
         page: 'lookout/index',
-        props: { containers: [], telemetrySummary: {}, hostDisk }
+        props: {
+          containers: [],
+          telemetrySummary: {},
+          hostDisk,
+          observabilityHealth
+        }
       }
     }
 
@@ -47,7 +54,12 @@ module.exports = {
     if (environmentIds.length === 0) {
       return {
         page: 'lookout/index',
-        props: { containers: [], telemetrySummary: {}, hostDisk }
+        props: {
+          containers: [],
+          telemetrySummary: {},
+          hostDisk,
+          observabilityHealth
+        }
       }
     }
 
@@ -171,7 +183,12 @@ module.exports = {
 
     return {
       page: 'lookout/index',
-      props: { containers, telemetrySummary, hostDisk }
+      props: {
+        containers,
+        telemetrySummary,
+        hostDisk,
+        observabilityHealth
+      }
     }
   }
 }

--- a/api/helpers/lookout/collect-container-metrics.js
+++ b/api/helpers/lookout/collect-container-metrics.js
@@ -1,0 +1,131 @@
+module.exports = {
+  friendlyName: 'Collect container metrics',
+
+  description:
+    'Collect and persist one Lookout sample while recording durable collector health.',
+
+  inputs: {},
+
+  fn: async function () {
+    const attemptedAt = Date.now()
+
+    try {
+      const stats = (await sails.helpers.docker.getContainerStats()) || []
+      const slipwayStats = stats.filter(
+        (stat) => stat.name && stat.name.startsWith('slipway-')
+      )
+      const records = []
+      const alertSamples = []
+
+      if (slipwayStats.length > 0) {
+        const [apps, services] = await Promise.all([
+          App.find({ status: 'running' }).populate('environment'),
+          Service.find({ status: 'running' }).populate('environment')
+        ])
+
+        for (const stat of slipwayStats) {
+          const matchedApp = apps.find((app) => app.containerName === stat.name)
+          const matchedService = matchedApp
+            ? null
+            : services.find((service) => service.containerName === stat.name)
+          const owner = matchedApp || matchedService
+
+          if (!owner) {
+            sails.log.verbose('Lookout: Unmatched container:', stat.name)
+            continue
+          }
+
+          records.push({
+            containerName: stat.name,
+            containerType: matchedApp ? 'app' : 'service',
+            cpuPercent: stat.cpuPercent,
+            memoryUsage: stat.memUsage,
+            memoryLimit: stat.memLimit,
+            memoryPercent: stat.memPercent,
+            netIO: stat.netIO,
+            blockIO: stat.blockIO,
+            pids: stat.pids,
+            recordedAt: attemptedAt,
+            environment: owner.environment.id,
+            app: matchedApp ? matchedApp.id : null,
+            service: matchedService ? matchedService.id : null
+          })
+          alertSamples.push({
+            stat,
+            containerName: owner.containerName
+          })
+        }
+      }
+
+      if (records.length > 0) {
+        await ContainerMetric.createEach(records)
+        publishMetrics(records)
+      }
+
+      const rowCount = await ContainerMetric.count()
+      const completedAt = Date.now()
+      const details = {
+        dockerRows: stats.length,
+        managedRows: slipwayStats.length,
+        recordedRows: records.length
+      }
+
+      await sails.helpers.lookout.recordObservabilityHealth.with({
+        jobName: 'collector',
+        succeeded: true,
+        attemptedAt,
+        completedAt,
+        rowCount,
+        details
+      })
+
+      return { records, alertSamples, rowCount, details }
+    } catch (error) {
+      const completedAt = Date.now()
+      try {
+        await sails.helpers.lookout.recordObservabilityHealth.with({
+          jobName: 'collector',
+          succeeded: false,
+          attemptedAt,
+          completedAt,
+          details: {},
+          error: error.message || String(error)
+        })
+      } catch (healthError) {
+        sails.log.warn(
+          `Lookout: Could not persist collector failure: ${healthError.message}`
+        )
+      }
+      throw error
+    }
+  }
+}
+
+function publishMetrics(records) {
+  if (!sails.sse?.publish) return
+
+  const byEnvironment = {}
+  for (const record of records) {
+    if (!byEnvironment[record.environment]) {
+      byEnvironment[record.environment] = []
+    }
+    byEnvironment[record.environment].push({
+      containerName: record.containerName,
+      containerType: record.containerType,
+      cpuPercent: record.cpuPercent,
+      memoryUsage: record.memoryUsage,
+      memoryLimit: record.memoryLimit,
+      memoryPercent: record.memoryPercent,
+      netIO: record.netIO,
+      blockIO: record.blockIO,
+      pids: record.pids,
+      recordedAt: record.recordedAt
+    })
+  }
+
+  for (const environmentId of Object.keys(byEnvironment)) {
+    sails.sse.publish(`lookout:env:${environmentId}`, {
+      metrics: byEnvironment[environmentId]
+    })
+  }
+}

--- a/api/helpers/lookout/ensure-observability-schema.js
+++ b/api/helpers/lookout/ensure-observability-schema.js
@@ -1,0 +1,172 @@
+module.exports = {
+  friendlyName: 'Ensure observability schema',
+
+  description:
+    'Create Lookout telemetry tables and query-shaped indexes on existing production databases.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore('observability')
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS container_metrics (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER,
+        container_name TEXT,
+        container_type TEXT,
+        cpu_percent INTEGER,
+        memory_usage INTEGER,
+        memory_limit INTEGER,
+        memory_percent INTEGER,
+        net_io TEXT,
+        block_io TEXT,
+        pids INTEGER,
+        recorded_at INTEGER,
+        environment INTEGER,
+        app INTEGER,
+        service INTEGER,
+        legacy_source_id INTEGER
+      )
+    `)
+
+    const containerColumns = await datastore.sendNativeQuery(
+      'PRAGMA table_info(container_metrics)'
+    )
+    const existingContainerColumns = new Set(
+      rows(containerColumns).map((column) => column.name)
+    )
+    if (!existingContainerColumns.has('legacy_source_id')) {
+      await datastore.sendNativeQuery(
+        'ALTER TABLE container_metrics ADD COLUMN legacy_source_id INTEGER'
+      )
+    }
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS telemetry_spans (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER,
+        trace_id TEXT,
+        span_id TEXT,
+        parent_span_id TEXT,
+        name TEXT,
+        kind TEXT,
+        method TEXT,
+        url TEXT,
+        status_code INTEGER,
+        duration INTEGER,
+        started_at INTEGER,
+        attributes TEXT,
+        environment TEXT
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS telemetry_exceptions (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER,
+        exception_type TEXT,
+        message TEXT,
+        stack_trace TEXT,
+        handled TEXT,
+        method TEXT,
+        url TEXT,
+        trace_id TEXT,
+        occurred_at INTEGER,
+        environment TEXT
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS telemetry_metrics (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER,
+        name TEXT,
+        value INTEGER,
+        unit TEXT,
+        attributes TEXT,
+        recorded_at INTEGER,
+        environment TEXT
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS observability_job_health (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER,
+        job_name TEXT NOT NULL UNIQUE,
+        last_attempt_at INTEGER,
+        last_success_at INTEGER,
+        last_failure_at INTEGER,
+        last_error TEXT,
+        last_duration_ms INTEGER,
+        row_count INTEGER NOT NULL DEFAULT 0,
+        details TEXT
+      )
+    `)
+
+    const indexes = [
+      [
+        'container_metrics_environment_recorded_at',
+        'container_metrics (environment, recorded_at DESC)'
+      ],
+      [
+        'container_metrics_container_recorded_at',
+        'container_metrics (container_name, recorded_at DESC)'
+      ],
+      ['container_metrics_recorded_at', 'container_metrics (recorded_at, id)'],
+      [
+        'telemetry_spans_environment_started_at',
+        'telemetry_spans (environment, started_at DESC)'
+      ],
+      [
+        'telemetry_spans_trace_started_at',
+        'telemetry_spans (trace_id, started_at DESC)'
+      ],
+      ['telemetry_spans_started_at', 'telemetry_spans (started_at, id)'],
+      [
+        'telemetry_exceptions_environment_occurred_at',
+        'telemetry_exceptions (environment, occurred_at DESC)'
+      ],
+      [
+        'telemetry_exceptions_trace_occurred_at',
+        'telemetry_exceptions (trace_id, occurred_at DESC)'
+      ],
+      [
+        'telemetry_exceptions_occurred_at',
+        'telemetry_exceptions (occurred_at, id)'
+      ],
+      [
+        'telemetry_metrics_environment_recorded_at',
+        'telemetry_metrics (environment, recorded_at DESC)'
+      ],
+      [
+        'telemetry_metrics_environment_name_recorded_at',
+        'telemetry_metrics (environment, name, recorded_at DESC)'
+      ],
+      ['telemetry_metrics_recorded_at', 'telemetry_metrics (recorded_at, id)']
+    ]
+
+    for (const [name, shape] of indexes) {
+      await datastore.sendNativeQuery(
+        `CREATE INDEX IF NOT EXISTS ${name} ON ${shape}`
+      )
+    }
+
+    await datastore.sendNativeQuery(`
+      CREATE UNIQUE INDEX IF NOT EXISTS container_metrics_legacy_source_unique
+      ON container_metrics (legacy_source_id)
+    `)
+
+    return await sails.helpers.lookout.migrateContainerMetrics()
+  }
+}
+
+function rows(result) {
+  return result.rows || result || []
+}

--- a/api/helpers/lookout/get-observability-health.js
+++ b/api/helpers/lookout/get-observability-health.js
@@ -1,0 +1,70 @@
+const EXPECTED_INTERVALS = {
+  collector: 30 * 1000,
+  retention: 5 * 60 * 1000
+}
+
+module.exports = {
+  friendlyName: 'Get observability health',
+
+  description:
+    'Return collector and retention freshness, failures, and retained row counts.',
+
+  inputs: {
+    now: {
+      type: 'number',
+      defaultsTo: 0
+    }
+  },
+
+  fn: async function ({ now }) {
+    const currentTime = now || Date.now()
+    const records = await ObservabilityJobHealth.find({
+      jobName: Object.keys(EXPECTED_INTERVALS)
+    })
+    const byName = Object.fromEntries(
+      records.map((record) => [record.jobName, record])
+    )
+
+    return Object.fromEntries(
+      Object.entries(EXPECTED_INTERVALS).map(([jobName, expectedInterval]) => {
+        const record = byName[jobName]
+        if (!record) {
+          return [
+            jobName,
+            {
+              status: 'waiting',
+              lastSuccessAt: null,
+              lastFailureAt: null,
+              lagMs: null,
+              rowCount: 0,
+              details: {}
+            }
+          ]
+        }
+
+        const lagMs = record.lastSuccessAt
+          ? Math.max(0, currentTime - record.lastSuccessAt)
+          : null
+        const failed =
+          record.lastFailureAt &&
+          (!record.lastSuccessAt || record.lastFailureAt > record.lastSuccessAt)
+        const stale = lagMs !== null && lagMs > expectedInterval * 3
+
+        return [
+          jobName,
+          {
+            status: failed ? 'failed' : stale ? 'stale' : 'healthy',
+            lastAttemptAt: record.lastAttemptAt,
+            lastSuccessAt: record.lastSuccessAt,
+            lastFailureAt: record.lastFailureAt,
+            lastError: record.lastError,
+            lastDurationMs: record.lastDurationMs,
+            lagMs,
+            rowCount: record.rowCount,
+            details: record.details || {}
+          }
+        ]
+      })
+    )
+  }
+}

--- a/api/helpers/lookout/migrate-container-metrics.js
+++ b/api/helpers/lookout/migrate-container-metrics.js
@@ -1,0 +1,118 @@
+const MIGRATION_BATCH_SIZE = 50
+
+module.exports = {
+  friendlyName: 'Migrate container metrics',
+
+  description:
+    'Copy legacy container metrics from the application datastore into observability without duplicating rows after a restart.',
+
+  inputs: {},
+
+  fn: async function () {
+    const source = sails.getDatastore()
+    const destination = sails.getDatastore('observability')
+    const sourceTable = await source.sendNativeQuery(
+      "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'container_metrics'"
+    )
+
+    if (rows(sourceTable).length === 0) {
+      return { migrated: 0, sourceRowsRemaining: 0 }
+    }
+
+    const sourceColumns = await source.sendNativeQuery(
+      'PRAGMA table_info(container_metrics)'
+    )
+    if (
+      rows(sourceColumns).some((column) => column.name === 'legacy_source_id')
+    ) {
+      return { migrated: 0, sourceRowsRemaining: 0 }
+    }
+
+    const sourceCountResult = await source.sendNativeQuery(
+      'SELECT COUNT(*) AS total FROM container_metrics'
+    )
+    const sourceCount = Number(rows(sourceCountResult)[0]?.total || 0)
+    if (sourceCount === 0) {
+      return { migrated: 0, sourceRowsRemaining: 0 }
+    }
+
+    let lastId = 0
+    let copied = 0
+
+    while (true) {
+      const batchResult = await source.sendNativeQuery(
+        `SELECT
+          id, created_at, updated_at, container_name, container_type,
+          cpu_percent, memory_usage, memory_limit, memory_percent, net_io,
+          block_io, pids, recorded_at, environment, app, service
+        FROM container_metrics
+        WHERE id > ?
+        ORDER BY id ASC
+        LIMIT ?`,
+        [lastId, MIGRATION_BATCH_SIZE]
+      )
+      const batch = rows(batchResult)
+      if (batch.length === 0) break
+
+      const placeholders = batch.map(
+        () => `(${Array(16).fill('?').join(', ')})`
+      )
+      const values = []
+      for (const row of batch) {
+        values.push(
+          row.id,
+          row.created_at,
+          row.updated_at,
+          row.container_name,
+          row.container_type,
+          row.cpu_percent,
+          row.memory_usage,
+          row.memory_limit,
+          row.memory_percent,
+          row.net_io,
+          row.block_io,
+          row.pids,
+          row.recorded_at,
+          row.environment,
+          row.app,
+          row.service
+        )
+      }
+
+      await destination.sendNativeQuery(
+        `INSERT OR IGNORE INTO container_metrics (
+          legacy_source_id, created_at, updated_at, container_name,
+          container_type, cpu_percent, memory_usage, memory_limit,
+          memory_percent, net_io, block_io, pids, recorded_at, environment,
+          app, service
+        ) VALUES ${placeholders.join(', ')}`,
+        values
+      )
+
+      copied += batch.length
+      lastId = batch[batch.length - 1].id
+    }
+
+    const verifiedResult = await destination.sendNativeQuery(
+      'SELECT COUNT(*) AS total FROM container_metrics WHERE legacy_source_id IS NOT NULL'
+    )
+    const verifiedCount = Number(rows(verifiedResult)[0]?.total || 0)
+
+    if (verifiedCount < sourceCount) {
+      throw new Error(
+        `Container metric migration copied ${verifiedCount} of ${sourceCount} legacy rows`
+      )
+    }
+
+    await source.sendNativeQuery('DELETE FROM container_metrics')
+
+    return {
+      migrated: copied,
+      sourceRowsRemaining: 0
+    }
+  }
+}
+
+function rows(result) {
+  return result.rows || result || []
+}

--- a/api/helpers/lookout/prune-observability.js
+++ b/api/helpers/lookout/prune-observability.js
@@ -1,0 +1,142 @@
+module.exports = {
+  friendlyName: 'Prune observability',
+
+  description:
+    'Delete expired infrastructure and application telemetry in bounded SQLite batches.',
+
+  inputs: {
+    now: {
+      type: 'number',
+      required: true
+    },
+    containerRetentionMs: {
+      type: 'number',
+      required: true
+    },
+    telemetryRetentionMs: {
+      type: 'number',
+      required: true
+    },
+    batchSize: {
+      type: 'number',
+      required: true
+    },
+    maxBatches: {
+      type: 'number',
+      required: true
+    }
+  },
+
+  fn: async function ({
+    now,
+    containerRetentionMs,
+    telemetryRetentionMs,
+    batchSize,
+    maxBatches
+  }) {
+    const datastore = sails.getDatastore('observability')
+    const safeBatchSize = Math.max(1, Math.min(900, Math.floor(batchSize)))
+    const safeMaxBatches = Math.max(1, Math.floor(maxBatches))
+    const tables = [
+      {
+        key: 'containerMetrics',
+        table: 'container_metrics',
+        timestamp: 'recorded_at',
+        cutoff: now - containerRetentionMs
+      },
+      {
+        key: 'spans',
+        table: 'telemetry_spans',
+        timestamp: 'started_at',
+        cutoff: now - telemetryRetentionMs
+      },
+      {
+        key: 'exceptions',
+        table: 'telemetry_exceptions',
+        timestamp: 'occurred_at',
+        cutoff: now - telemetryRetentionMs
+      },
+      {
+        key: 'metrics',
+        table: 'telemetry_metrics',
+        timestamp: 'recorded_at',
+        cutoff: now - telemetryRetentionMs
+      }
+    ]
+
+    const result = {
+      deletedRows: 0,
+      rowCount: 0,
+      hasBacklog: false,
+      retentionLagMs: 0,
+      tables: {}
+    }
+
+    for (const spec of tables) {
+      let deletedRows = 0
+      let batches = 0
+
+      while (batches < safeMaxBatches) {
+        const expiredResult = await datastore.sendNativeQuery(
+          `SELECT id
+          FROM ${spec.table}
+          WHERE ${spec.timestamp} < ?
+          ORDER BY ${spec.timestamp} ASC, id ASC
+          LIMIT ?`,
+          [spec.cutoff, safeBatchSize]
+        )
+        const expired = rows(expiredResult)
+        if (expired.length === 0) break
+
+        const ids = expired.map((row) => row.id)
+        await datastore.sendNativeQuery(
+          `DELETE FROM ${spec.table}
+          WHERE id IN (${ids.map(() => '?').join(', ')})`,
+          ids
+        )
+
+        deletedRows += ids.length
+        batches += 1
+        if (ids.length < safeBatchSize) break
+      }
+
+      const [countResult, backlogResult] = await Promise.all([
+        datastore.sendNativeQuery(
+          `SELECT COUNT(*) AS total FROM ${spec.table}`
+        ),
+        datastore.sendNativeQuery(
+          `SELECT COUNT(*) AS total, MIN(${spec.timestamp}) AS oldest
+          FROM ${spec.table}
+          WHERE ${spec.timestamp} < ?`,
+          [spec.cutoff]
+        )
+      ])
+      const rowCount = Number(rows(countResult)[0]?.total || 0)
+      const backlog = rows(backlogResult)[0] || {}
+      const backlogRows = Number(backlog.total || 0)
+      const retentionLagMs =
+        backlogRows > 0
+          ? Math.max(0, spec.cutoff - Number(backlog.oldest || spec.cutoff))
+          : 0
+
+      result.tables[spec.key] = {
+        cutoff: spec.cutoff,
+        deletedRows,
+        batches,
+        rowCount,
+        backlogRows,
+        retentionLagMs
+      }
+      result.deletedRows += deletedRows
+      result.rowCount += rowCount
+      result.hasBacklog ||= backlogRows > 0
+      result.retentionLagMs = Math.max(result.retentionLagMs, retentionLagMs)
+    }
+
+    return result
+  }
+}
+
+function rows(result) {
+  return result.rows || result || []
+}

--- a/api/helpers/lookout/record-observability-health.js
+++ b/api/helpers/lookout/record-observability-health.js
@@ -1,0 +1,85 @@
+module.exports = {
+  friendlyName: 'Record observability health',
+
+  description:
+    'Persist the latest collector or retention job result for operator visibility.',
+
+  inputs: {
+    jobName: {
+      type: 'string',
+      isIn: ['collector', 'retention'],
+      required: true
+    },
+    succeeded: {
+      type: 'boolean',
+      required: true
+    },
+    attemptedAt: {
+      type: 'number',
+      required: true
+    },
+    completedAt: {
+      type: 'number',
+      required: true
+    },
+    rowCount: {
+      type: 'number',
+      allowNull: true
+    },
+    details: {
+      type: 'ref',
+      defaultsTo: {}
+    },
+    error: {
+      type: 'string',
+      allowNull: true
+    }
+  },
+
+  fn: async function ({
+    jobName,
+    succeeded,
+    attemptedAt,
+    completedAt,
+    rowCount,
+    details,
+    error
+  }) {
+    const existing = await ObservabilityJobHealth.findOne({ jobName })
+    const values = {
+      lastAttemptAt: attemptedAt,
+      lastDurationMs: Math.max(0, completedAt - attemptedAt),
+      details: details || {}
+    }
+
+    if (Number.isFinite(rowCount)) values.rowCount = rowCount
+
+    if (succeeded) {
+      values.lastSuccessAt = completedAt
+      values.lastError = null
+    } else {
+      values.lastFailureAt = completedAt
+      values.lastError = String(error || 'Unknown error').slice(0, 2000)
+    }
+
+    if (existing) {
+      return await ObservabilityJobHealth.updateOne({ id: existing.id }).set(
+        values
+      )
+    }
+
+    try {
+      return await ObservabilityJobHealth.create({
+        jobName,
+        rowCount: Number.isFinite(rowCount) ? rowCount : 0,
+        ...values
+      }).fetch()
+    } catch (createError) {
+      const raced = await ObservabilityJobHealth.findOne({ jobName })
+      if (!raced) throw createError
+      return await ObservabilityJobHealth.updateOne({ id: raced.id }).set(
+        values
+      )
+    }
+  }
+}

--- a/api/helpers/lookout/run-observability-maintenance.js
+++ b/api/helpers/lookout/run-observability-maintenance.js
@@ -1,0 +1,109 @@
+const DISK_ALERT_COOLDOWN_MS = 15 * 60 * 1000
+
+module.exports = {
+  friendlyName: 'Run observability maintenance',
+
+  description:
+    'Migrate, prune, count, and check disk health independently of Docker metrics.',
+
+  inputs: {
+    now: {
+      type: 'number',
+      defaultsTo: 0
+    }
+  },
+
+  fn: async function ({ now }) {
+    const attemptedAt = now || Date.now()
+
+    try {
+      const migration = await sails.helpers.lookout.ensureObservabilitySchema()
+      const config = sails.config.custom.observability
+      const previous = await ObservabilityJobHealth.findOne({
+        jobName: 'retention'
+      })
+      const prune = await sails.helpers.lookout.pruneObservability.with({
+        now: attemptedAt,
+        containerRetentionMs: config.containerMetricsRetentionMs,
+        telemetryRetentionMs: config.applicationTelemetryRetentionMs,
+        batchSize: config.pruneBatchSize,
+        maxBatches: config.maxPruneBatchesPerRun
+      })
+      const disk = await checkDiskSpace({
+        now: attemptedAt,
+        previousDetails: previous?.details || {}
+      })
+      const completedAt = Date.now()
+      const details = { migration, prune, disk }
+
+      await sails.helpers.lookout.recordObservabilityHealth.with({
+        jobName: 'retention',
+        succeeded: true,
+        attemptedAt,
+        completedAt,
+        rowCount: prune.rowCount,
+        details
+      })
+
+      if (prune.hasBacklog) {
+        sails.log.warn(
+          `Lookout: Retention backlog remains (${prune.retentionLagMs}ms behind after deleting ${prune.deletedRows} rows)`
+        )
+      }
+
+      return details
+    } catch (error) {
+      const completedAt = Date.now()
+      try {
+        await sails.helpers.lookout.recordObservabilityHealth.with({
+          jobName: 'retention',
+          succeeded: false,
+          attemptedAt,
+          completedAt,
+          details: {},
+          error: error.message || String(error)
+        })
+      } catch (healthError) {
+        sails.log.warn(
+          `Lookout: Could not persist retention failure: ${healthError.message}`
+        )
+      }
+      throw error
+    }
+  }
+}
+
+async function checkDiskSpace({ now, previousDetails }) {
+  const diskInfo = await sails.helpers.lookout.getDiskSpace()
+  if (!diskInfo) return { available: false, lastAlertAt: null }
+
+  const previousAlertAt = previousDetails.disk?.lastAlertAt || null
+  const disk = {
+    available: true,
+    ...diskInfo,
+    lastAlertAt: previousAlertAt
+  }
+
+  if (
+    diskInfo.usedPercent < 90 ||
+    (previousAlertAt && now - previousAlertAt < DISK_ALERT_COOLDOWN_MS)
+  ) {
+    return disk
+  }
+
+  disk.lastAlertAt = now
+  sails.log.warn(
+    `Lookout: Disk space critical — ${diskInfo.usedPercent}% used, ${diskInfo.available} available`
+  )
+
+  try {
+    await sails.helpers.notification.sendDiskSpaceAlert.with({
+      usedPercent: diskInfo.usedPercent,
+      availableGb: diskInfo.available
+    })
+  } catch (error) {
+    disk.alertError = error.message || String(error)
+  }
+
+  return disk
+}

--- a/api/hooks/lookout/index.js
+++ b/api/hooks/lookout/index.js
@@ -2,7 +2,7 @@
  * Lookout hook
  *
  * Collects Docker container resource metrics on a 30-second interval.
- * Stores snapshots in the ContainerMetric model and prunes data older than 24h.
+ * Stores snapshots in the ContainerMetric model.
  * Triggers resource alerts when CPU or memory exceeds 90% for 3 consecutive samples (~90s).
  *
  * Also:
@@ -13,6 +13,7 @@
 module.exports = function defineLookoutHook(sails) {
   let pollInterval = null
   let logInterval = null
+  let cycleRunning = false
 
   // Track alert cooldowns: containerName → last alert timestamp
   const alertCooldowns = new Map()
@@ -25,7 +26,15 @@ module.exports = function defineLookoutHook(sails) {
     initialize: async function () {
       sails.log.info('Initializing hook (`lookout`)')
 
-      sails.after('hook:orm:loaded', () => {
+      sails.after('hook:orm:loaded', async () => {
+        try {
+          await sails.helpers.lookout.ensureObservabilitySchema()
+        } catch (error) {
+          sails.log.warn(
+            `Lookout: Could not prepare observability storage: ${error.message}`
+          )
+        }
+
         // Main 30-second interval: lifecycle reconciliation + metrics.
         pollInterval = setInterval(runLookoutCycle, 30000)
         runLookoutCycle()
@@ -43,8 +52,14 @@ module.exports = function defineLookoutHook(sails) {
   }
 
   async function runLookoutCycle() {
-    await reconcileLifecycleStatuses()
-    await collectMetrics()
+    if (cycleRunning) return
+    cycleRunning = true
+    try {
+      await reconcileLifecycleStatuses()
+      await collectMetrics()
+    } finally {
+      cycleRunning = false
+    }
   }
 
   async function reconcileLifecycleStatuses() {
@@ -94,124 +109,10 @@ module.exports = function defineLookoutHook(sails) {
 
   async function collectMetrics() {
     try {
-      const stats = await sails.helpers.docker.getContainerStats()
-
-      // Pre-fetch currently running apps and services for metric matching.
-      // Lifecycle truth is reconciled separately from this stats sample.
-      const apps = await App.find({ status: 'running' }).populate('environment')
-      const services = await Service.find({ status: 'running' }).populate(
-        'environment'
-      )
-      const now = Date.now()
-
-      if (!stats || stats.length === 0) {
-        return
+      const result = await sails.helpers.lookout.collectContainerMetrics()
+      for (const sample of result.alertSamples) {
+        await checkResourceAlert(sample.stat, sample.containerName, Date.now())
       }
-
-      // Filter to slipway-managed containers only
-      const slipwayStats = stats.filter(
-        (s) => s.name && s.name.startsWith('slipway-')
-      )
-
-      if (slipwayStats.length === 0) {
-        return
-      }
-
-      const records = []
-
-      for (const stat of slipwayStats) {
-        // Try to match to an app first
-        const matchedApp = apps.find((a) => a.containerName === stat.name)
-        if (matchedApp) {
-          records.push({
-            containerName: stat.name,
-            containerType: 'app',
-            cpuPercent: stat.cpuPercent,
-            memoryUsage: stat.memUsage,
-            memoryLimit: stat.memLimit,
-            memoryPercent: stat.memPercent,
-            netIO: stat.netIO,
-            blockIO: stat.blockIO,
-            pids: stat.pids,
-            recordedAt: now,
-            environment: matchedApp.environment.id,
-            app: matchedApp.id
-          })
-          await checkResourceAlert(stat, matchedApp.containerName, now)
-          continue
-        }
-
-        // Try to match to a service
-        const matchedService = services.find(
-          (s) => s.containerName === stat.name
-        )
-        if (matchedService) {
-          records.push({
-            containerName: stat.name,
-            containerType: 'service',
-            cpuPercent: stat.cpuPercent,
-            memoryUsage: stat.memUsage,
-            memoryLimit: stat.memLimit,
-            memoryPercent: stat.memPercent,
-            netIO: stat.netIO,
-            blockIO: stat.blockIO,
-            pids: stat.pids,
-            recordedAt: now,
-            environment: matchedService.environment.id,
-            service: matchedService.id
-          })
-          await checkResourceAlert(stat, matchedService.containerName, now)
-          continue
-        }
-
-        // Unknown slipway container — skip (orphaned container)
-        sails.log.verbose('Lookout: Unmatched container:', stat.name)
-      }
-
-      // Bulk create metrics
-      if (records.length > 0) {
-        await ContainerMetric.createEach(records)
-
-        // Publish new data points to SSE channels (one message per environment)
-        const byEnv = {}
-        for (const r of records) {
-          if (!byEnv[r.environment]) byEnv[r.environment] = []
-          byEnv[r.environment].push({
-            containerName: r.containerName,
-            containerType: r.containerType,
-            cpuPercent: r.cpuPercent,
-            memoryUsage: r.memoryUsage,
-            memoryLimit: r.memoryLimit,
-            memoryPercent: r.memoryPercent,
-            netIO: r.netIO,
-            blockIO: r.blockIO,
-            pids: r.pids,
-            recordedAt: r.recordedAt
-          })
-        }
-        for (const envId of Object.keys(byEnv)) {
-          sails.sse.publish(`lookout:env:${envId}`, { metrics: byEnv[envId] })
-        }
-      }
-
-      // Prune container metrics older than 24 hours
-      const cutoff = now - 24 * 60 * 60 * 1000
-      await ContainerMetric.destroy({ recordedAt: { '<': cutoff } })
-
-      // Prune telemetry data older than 7 days (runs alongside metric collection)
-      const telemetryCutoff = now - 7 * 24 * 60 * 60 * 1000
-      await TelemetrySpan.destroy({
-        startedAt: { '<': telemetryCutoff }
-      }).tolerate('error')
-      await TelemetryException.destroy({
-        occurredAt: { '<': telemetryCutoff }
-      }).tolerate('error')
-      await TelemetryMetric.destroy({
-        recordedAt: { '<': telemetryCutoff }
-      }).tolerate('error')
-
-      // Check host disk space (every cycle, but alert on cooldown)
-      await checkDiskSpace(now)
     } catch (err) {
       sails.log.warn('Lookout: Error collecting metrics:', err.message)
     }
@@ -258,32 +159,6 @@ module.exports = function defineLookoutHook(sails) {
       await AppLog.destroy({ endedAt: { '<': logCutoff } })
     } catch (err) {
       sails.log.verbose('Lookout: Error collecting logs:', err.message)
-    }
-  }
-
-  async function checkDiskSpace(now) {
-    try {
-      const cooldownKey = 'disk:space'
-      const lastAlert = alertCooldowns.get(cooldownKey)
-      if (lastAlert && now - lastAlert < ALERT_COOLDOWN_MS) return
-
-      const diskInfo = await sails.helpers.lookout.getDiskSpace()
-      if (!diskInfo) return
-
-      if (diskInfo.usedPercent >= 90) {
-        alertCooldowns.set(cooldownKey, now)
-        sails.log.warn(
-          `Lookout: Disk space critical — ${diskInfo.usedPercent}% used, ${diskInfo.available} available`
-        )
-        await sails.helpers.notification.sendDiskSpaceAlert
-          .with({
-            usedPercent: diskInfo.usedPercent,
-            availableGb: diskInfo.available
-          })
-          .tolerate('error')
-      }
-    } catch (err) {
-      sails.log.verbose('Lookout: Disk space check error:', err.message)
     }
   }
 

--- a/api/models/App.js
+++ b/api/models/App.js
@@ -143,11 +143,6 @@ module.exports = {
     deployments: {
       collection: 'deployment',
       via: 'app'
-    },
-
-    metrics: {
-      collection: 'containermetric',
-      via: 'app'
     }
   },
 

--- a/api/models/ContainerMetric.js
+++ b/api/models/ContainerMetric.js
@@ -2,10 +2,12 @@
  * ContainerMetric.js
  *
  * Stores periodic CPU/memory snapshots for running containers (apps + services).
- * Collected by the Lookout hook every 30 seconds. Pruned after 24 hours.
+ * Collected by the Lookout hook every 30 seconds. Retention is managed by the
+ * independent observability maintenance job.
  */
 
 module.exports = {
+  datastore: 'observability',
   tableName: 'container_metrics',
 
   attributes: {
@@ -79,20 +81,31 @@ module.exports = {
       columnName: 'recorded_at'
     },
 
-    // Associations
+    legacySourceId: {
+      type: 'number',
+      allowNull: true,
+      description:
+        'Original ID from the default datastore during the one-time migration',
+      columnName: 'legacy_source_id'
+    },
+
+    // These IDs refer to records in the default datastore. They intentionally
+    // are not Waterline associations because cross-datastore joins are unsafe.
     environment: {
-      model: 'environment',
+      type: 'number',
       required: true
     },
 
     app: {
-      model: 'app',
+      type: 'number',
+      allowNull: true,
       description:
         'The app this metric belongs to (null for service containers)'
     },
 
     service: {
-      model: 'service',
+      type: 'number',
+      allowNull: true,
       description:
         'The service this metric belongs to (null for app containers)'
     }

--- a/api/models/ObservabilityJobHealth.js
+++ b/api/models/ObservabilityJobHealth.js
@@ -1,0 +1,60 @@
+/**
+ * ObservabilityJobHealth.js
+ *
+ * Durable status for Lookout's collector and retention maintenance jobs.
+ */
+
+module.exports = {
+  datastore: 'observability',
+  tableName: 'observability_job_health',
+
+  attributes: {
+    jobName: {
+      type: 'string',
+      required: true,
+      unique: true,
+      columnName: 'job_name'
+    },
+
+    lastAttemptAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'last_attempt_at'
+    },
+
+    lastSuccessAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'last_success_at'
+    },
+
+    lastFailureAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'last_failure_at'
+    },
+
+    lastError: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'last_error'
+    },
+
+    lastDurationMs: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'last_duration_ms'
+    },
+
+    rowCount: {
+      type: 'number',
+      defaultsTo: 0,
+      columnName: 'row_count'
+    },
+
+    details: {
+      type: 'json',
+      defaultsTo: {}
+    }
+  }
+}

--- a/api/models/Service.js
+++ b/api/models/Service.js
@@ -131,11 +131,6 @@ module.exports = {
     backups: {
       collection: 'backup',
       via: 'service'
-    },
-
-    metrics: {
-      collection: 'containermetric',
-      via: 'service'
     }
   },
 

--- a/assets/js/pages/lookout/index.vue
+++ b/assets/js/pages/lookout/index.vue
@@ -19,6 +19,13 @@ const props = defineProps({
   telemetrySummary: {
     type: Object,
     default: () => ({})
+  },
+  observabilityHealth: {
+    type: Object,
+    default: () => ({
+      collector: { status: 'waiting', rowCount: 0 },
+      retention: { status: 'waiting', rowCount: 0 }
+    })
   }
 })
 
@@ -153,6 +160,30 @@ function timeAgo(timestamp) {
   if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`
   return `${Math.floor(seconds / 86400)}d ago`
+}
+
+function healthLabel(name, label) {
+  const health = props.observabilityHealth?.[name]
+  if (!health || health.status === 'waiting') return `${label} waiting`
+  if (health.status === 'failed') return `${label} failed`
+  if (health.status === 'stale') {
+    return `${label} stale · ${timeAgo(health.lastSuccessAt)}`
+  }
+  return `${label} ${timeAgo(health.lastSuccessAt)}`
+}
+
+function healthDot(name) {
+  const status = props.observabilityHealth?.[name]?.status
+  if (status === 'failed') return 'bg-red-500'
+  if (status === 'stale') return 'bg-yellow-500'
+  if (status === 'healthy') return 'bg-emerald-500'
+  return 'bg-gray-300 dark:bg-gray-600'
+}
+
+function compactNumber(number) {
+  if (number < 1000) return String(number || 0)
+  if (number < 1000000) return `${(number / 1000).toFixed(1)}k`
+  return `${(number / 1000000).toFixed(1)}m`
 }
 
 function serviceIcon(type) {
@@ -512,6 +543,32 @@ function envTelemetry(container) {
                   }"
                 ></div>
               </div>
+            </div>
+
+            <div
+              data-test="lookout-observability-health"
+              class="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 border-t border-gray-100 pt-3 text-xs text-gray-500 dark:border-gray-800 dark:text-gray-400"
+            >
+              <span class="inline-flex items-center gap-1.5">
+                <span
+                  :class="['h-1.5 w-1.5 rounded-full', healthDot('collector')]"
+                ></span>
+                {{ healthLabel('collector', 'Collector') }}
+              </span>
+              <span class="inline-flex items-center gap-1.5">
+                <span
+                  :class="['h-1.5 w-1.5 rounded-full', healthDot('retention')]"
+                ></span>
+                {{ healthLabel('retention', 'Retention') }}
+              </span>
+              <span class="sm:ml-auto">
+                {{
+                  compactNumber(
+                    props.observabilityHealth?.retention?.rowCount || 0
+                  )
+                }}
+                retained rows
+              </span>
             </div>
           </div>
         </section>

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -14,6 +14,7 @@ module.exports.bootstrap = async function () {
   // deployment job queries run on an existing installation.
   await sails.helpers.deploy.ensureQueueSchema()
   await sails.helpers.service.ensureVersionSchema()
+  await sails.helpers.lookout.ensureObservabilitySchema()
 
   // Initialize CLI tokens map for Bearer token authentication
   sails.cliTokens = new Map()

--- a/config/custom.js
+++ b/config/custom.js
@@ -77,6 +77,16 @@ module.exports.custom = {
     killGraceMs: 5000
   },
 
+  // Lookout keeps infrastructure samples for 24 hours and application
+  // telemetry for 7 days. Maintenance uses bounded batches so pruning cannot
+  // hold a long SQLite write lock on a busy host.
+  observability: {
+    containerMetricsRetentionMs: 24 * 60 * 60 * 1000,
+    applicationTelemetryRetentionMs: 7 * 24 * 60 * 60 * 1000,
+    pruneBatchSize: 500,
+    maxPruneBatchesPerRun: 20
+  },
+
   // API version (used for building API URLs)
   apiVersion: 'v1',
 

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -7,6 +7,33 @@ module.exports = {
     slipwayPortRange: {
       start: Number(process.env.SLIPWAY_APP_PORT_START) || 1338,
       end: Number(process.env.SLIPWAY_APP_PORT_END) || 1500
+    },
+    observability: {
+      containerMetricsRetentionMs:
+        positiveNumber(
+          process.env.SLIPWAY_CONTAINER_METRICS_RETENTION_HOURS,
+          24
+        ) *
+        60 *
+        60 *
+        1000,
+      applicationTelemetryRetentionMs:
+        positiveNumber(
+          process.env.SLIPWAY_APPLICATION_TELEMETRY_RETENTION_DAYS,
+          7
+        ) *
+        24 *
+        60 *
+        60 *
+        1000,
+      pruneBatchSize: positiveInteger(
+        process.env.SLIPWAY_OBSERVABILITY_PRUNE_BATCH_SIZE,
+        500
+      ),
+      maxPruneBatchesPerRun: positiveInteger(
+        process.env.SLIPWAY_OBSERVABILITY_MAX_PRUNE_BATCHES,
+        20
+      )
     }
   },
 
@@ -43,4 +70,13 @@ module.exports = {
     trustProxy: true,
     cache: 365.25 * 24 * 60 * 60 * 1000
   }
+}
+
+function positiveNumber(value, fallback) {
+  const parsed = Number(value)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function positiveInteger(value, fallback) {
+  return Math.floor(positiveNumber(value, fallback))
 }

--- a/docs/observability-retention.md
+++ b/docs/observability-retention.md
@@ -1,0 +1,35 @@
+# Observability retention
+
+Lookout stores container samples and application telemetry in
+`db/observability.db`. Collection and maintenance are separate: Docker metric
+collection runs every 30 seconds, while the `maintain-observability` Quest job
+prunes expired rows and checks host disk health every 5 minutes. Maintenance
+therefore continues when Docker is unavailable or no application containers
+are running.
+
+## Defaults
+
+| Data                                               | Default retention | Configuration                                  |
+| -------------------------------------------------- | ----------------: | ---------------------------------------------- |
+| Container CPU, memory, and I/O samples             |          24 hours | `SLIPWAY_CONTAINER_METRICS_RETENTION_HOURS`    |
+| Request spans, exceptions, and application metrics |            7 days | `SLIPWAY_APPLICATION_TELEMETRY_RETENTION_DAYS` |
+
+Pruning deletes at most 500 rows per table and performs at most 20 batches per
+table during one run. These bounds can be changed with
+`SLIPWAY_OBSERVABILITY_PRUNE_BATCH_SIZE` and
+`SLIPWAY_OBSERVABILITY_MAX_PRUNE_BATCHES`.
+
+All values must be positive numbers. Invalid values fall back to the defaults.
+The batch size is capped at 900 rows so each SQLite statement stays within its
+parameter limit.
+
+## Existing installations
+
+On startup, Slipway creates the observability tables and indexes if necessary.
+Container samples from the legacy `db/app.db` location are copied in bounded,
+idempotent batches. Slipway verifies the copied row count before removing the
+legacy rows, so an interrupted startup safely resumes the migration.
+
+Lookout shows the last successful collector and retention run, retained row
+count, and stale or failed state in the existing host-health card. The same
+health object is returned by `GET /api/v1/lookout/overview`.

--- a/scripts/maintain-observability.js
+++ b/scripts/maintain-observability.js
@@ -1,0 +1,15 @@
+module.exports = {
+  friendlyName: 'Maintain observability',
+
+  description:
+    'Prune retained telemetry and check host disk health independently of Docker metrics.',
+
+  quest: {
+    interval: '5 minutes',
+    withoutOverlapping: true
+  },
+
+  fn: async function () {
+    await sails.helpers.lookout.runObservabilityMaintenance()
+  }
+}

--- a/tests/e2e/pages/lookout-health.test.js
+++ b/tests/e2e/pages/lookout-health.test.js
@@ -1,0 +1,74 @@
+const { test } = require('sounding')
+
+test(
+  'Lookout keeps observability health compact in light and dark mode',
+  {
+    browser: true,
+    world: 'configured-slipway'
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const originalDisk = sails.helpers.lookout.getDiskSpace
+    const now = Date.now()
+    const getDiskSpace = async () => ({
+      totalBytes: 1000,
+      usedBytes: 240,
+      availableBytes: 760,
+      usedPercent: 24,
+      mount: '/',
+      total: '100 GB',
+      used: '24 GB',
+      available: '76 GB'
+    })
+    getDiskSpace.with = getDiskSpace
+    sails.helpers.lookout.getDiskSpace = getDiskSpace
+
+    await sails.models.observabilityjobhealth.destroy({})
+    await sails.models.observabilityjobhealth.createEach([
+      {
+        jobName: 'collector',
+        lastAttemptAt: now - 1000,
+        lastSuccessAt: now - 1000,
+        lastDurationMs: 5,
+        rowCount: 1220,
+        details: { recordedRows: 1 }
+      },
+      {
+        jobName: 'retention',
+        lastAttemptAt: now - 2000,
+        lastSuccessAt: now - 2000,
+        lastDurationMs: 10,
+        rowCount: 1220,
+        details: { prune: { deletedRows: 4 } }
+      }
+    ])
+
+    try {
+      await login.withPassword('genesisUser', page, {
+        password: world.current.auth.genesisUserPassword
+      })
+      await page.raw.waitForURL((url) => !url.pathname.startsWith('/login'), {
+        timeout: 10000
+      })
+
+      await page.resize(1440, 900)
+      await page.goto('/lookout')
+      await page.wait('@lookout-observability-health')
+      await expect(page).toSee('Collector just now')
+      await expect(page).toSee('Retention just now')
+      await expect(page).toSee('1.2k retained rows')
+      await page.screenshot('.tmp/lookout-health-light.png', {
+        fullPage: true
+      })
+
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot('.tmp/lookout-health-dark.png', {
+        fullPage: true
+      })
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+
+      expect(page).toHaveNoSmoke()
+    } finally {
+      sails.helpers.lookout.getDiskSpace = originalDisk
+    }
+  }
+)

--- a/tests/functional/pages/lookout.test.js
+++ b/tests/functional/pages/lookout.test.js
@@ -1,0 +1,41 @@
+const { test } = require('sounding')
+
+test(
+  'Lookout exposes collector and retention health in its existing dashboard',
+  { world: 'configured-slipway' },
+  async ({ sails, visit, expect }) => {
+    await sails.models.observabilityjobhealth.destroy({})
+    const now = Date.now()
+    await sails.models.observabilityjobhealth.createEach([
+      {
+        jobName: 'collector',
+        lastAttemptAt: now - 1000,
+        lastSuccessAt: now - 1000,
+        lastDurationMs: 5,
+        rowCount: 42,
+        details: { recordedRows: 1 }
+      },
+      {
+        jobName: 'retention',
+        lastAttemptAt: now - 2000,
+        lastSuccessAt: now - 2000,
+        lastDurationMs: 10,
+        rowCount: 120,
+        details: { prune: { deletedRows: 4 } }
+      }
+    ])
+
+    const page = await visit.as('genesisUser')('/lookout')
+
+    expect(page).toHaveStatus(200)
+    expect(page).toBeInertiaPage('lookout/index')
+    expect(page).toHaveInertiaProp(
+      'observabilityHealth.collector.status',
+      'healthy'
+    )
+    expect(page).toHaveInertiaProp(
+      'observabilityHealth.retention.rowCount',
+      120
+    )
+  }
+)

--- a/tests/unit/config/production.test.js
+++ b/tests/unit/config/production.test.js
@@ -28,3 +28,39 @@ test('production custom config keeps the public URL and domain settings together
     }
   }
 })
+
+test('production observability retention has documented defaults and positive overrides', ({
+  expect
+}) => {
+  const names = [
+    'SLIPWAY_CONTAINER_METRICS_RETENTION_HOURS',
+    'SLIPWAY_APPLICATION_TELEMETRY_RETENTION_DAYS',
+    'SLIPWAY_OBSERVABILITY_PRUNE_BATCH_SIZE',
+    'SLIPWAY_OBSERVABILITY_MAX_PRUNE_BATCHES'
+  ]
+  const original = Object.fromEntries(
+    names.map((name) => [name, process.env[name]])
+  )
+
+  try {
+    process.env.SLIPWAY_CONTAINER_METRICS_RETENTION_HOURS = '12'
+    process.env.SLIPWAY_APPLICATION_TELEMETRY_RETENTION_DAYS = '3'
+    process.env.SLIPWAY_OBSERVABILITY_PRUNE_BATCH_SIZE = '250'
+    process.env.SLIPWAY_OBSERVABILITY_MAX_PRUNE_BATCHES = '8'
+    delete require.cache[productionConfigPath]
+
+    const productionConfig = require(productionConfigPath)
+    expect(productionConfig.custom.observability).toEqual({
+      containerMetricsRetentionMs: 12 * 60 * 60 * 1000,
+      applicationTelemetryRetentionMs: 3 * 24 * 60 * 60 * 1000,
+      pruneBatchSize: 250,
+      maxPruneBatchesPerRun: 8
+    })
+  } finally {
+    delete require.cache[productionConfigPath]
+    for (const name of names) {
+      if (original[name] === undefined) delete process.env[name]
+      else process.env[name] = original[name]
+    }
+  }
+})

--- a/tests/unit/helpers/lookout/observability-maintenance.test.js
+++ b/tests/unit/helpers/lookout/observability-maintenance.test.js
@@ -1,0 +1,300 @@
+const { test } = require('sounding')
+
+test('empty Docker stats still record a successful collector run', async ({
+  sails,
+  expect
+}) => {
+  await resetObservabilityHealth(sails)
+  const original = sails.helpers.docker.getContainerStats
+  replace(sails.helpers.docker, 'getContainerStats', async () => [])
+
+  try {
+    const result = await sails.helpers.lookout.collectContainerMetrics()
+    const health = await sails.helpers.lookout.getObservabilityHealth()
+
+    expect(result.details).toEqual({
+      dockerRows: 0,
+      managedRows: 0,
+      recordedRows: 0
+    })
+    expect(health.collector.status).toBe('healthy')
+    expect(health.collector.rowCount).toBe(0)
+  } finally {
+    sails.helpers.docker.getContainerStats = original
+  }
+})
+
+test('Docker errors are reported without becoming retention failures', async ({
+  sails,
+  expect
+}) => {
+  await resetObservabilityHealth(sails)
+  const originalStats = sails.helpers.docker.getContainerStats
+  const originalDisk = sails.helpers.lookout.getDiskSpace
+  replace(sails.helpers.docker, 'getContainerStats', async () => {
+    throw new Error('Docker socket unavailable')
+  })
+  replace(sails.helpers.lookout, 'getDiskSpace', async () => null)
+
+  try {
+    let collectionError
+    try {
+      await sails.helpers.lookout.collectContainerMetrics()
+    } catch (error) {
+      collectionError = error
+    }
+
+    const maintenance =
+      await sails.helpers.lookout.runObservabilityMaintenance()
+    const health = await sails.helpers.lookout.getObservabilityHealth()
+
+    expect(collectionError.message).toBe('Docker socket unavailable')
+    expect(maintenance.disk.available).toBe(false)
+    expect(health.collector.status).toBe('failed')
+    expect(health.collector.lastError).toBe('Docker socket unavailable')
+    expect(health.retention.status).toBe('healthy')
+  } finally {
+    sails.helpers.docker.getContainerStats = originalStats
+    sails.helpers.lookout.getDiskSpace = originalDisk
+  }
+})
+
+test('retention respects exact cutoffs and drains large tables in batches', async ({
+  sails,
+  expect
+}) => {
+  await clearTelemetry(sails)
+  const now = Date.now()
+  const containerCutoff = now - 24 * 60 * 60 * 1000
+  const telemetryCutoff = now - 7 * 24 * 60 * 60 * 1000
+  const environmentId = 1
+  const expiredMetrics = Array.from({ length: 205 }, (_, index) =>
+    containerMetric({
+      environmentId,
+      recordedAt: containerCutoff - 1000 - index
+    })
+  )
+
+  for (let index = 0; index < expiredMetrics.length; index += 50) {
+    await sails.models.containermetric.createEach(
+      expiredMetrics.slice(index, index + 50)
+    )
+  }
+  await sails.models.containermetric.createEach([
+    containerMetric({ environmentId, recordedAt: containerCutoff }),
+    containerMetric({ environmentId, recordedAt: containerCutoff + 1 })
+  ])
+  await sails.models.telemetryspan.createEach([
+    span({ environmentId, startedAt: telemetryCutoff - 1 }),
+    span({ environmentId, startedAt: telemetryCutoff })
+  ])
+  await sails.models.telemetryexception.createEach([
+    exception({ environmentId, occurredAt: telemetryCutoff - 1 }),
+    exception({ environmentId, occurredAt: telemetryCutoff })
+  ])
+  await sails.models.telemetrymetric.createEach([
+    metric({ environmentId, recordedAt: telemetryCutoff - 1 }),
+    metric({ environmentId, recordedAt: telemetryCutoff })
+  ])
+
+  const first = await sails.helpers.lookout.pruneObservability.with({
+    now,
+    containerRetentionMs: 24 * 60 * 60 * 1000,
+    telemetryRetentionMs: 7 * 24 * 60 * 60 * 1000,
+    batchSize: 50,
+    maxBatches: 3
+  })
+
+  expect(first.tables.containerMetrics.deletedRows).toBe(150)
+  expect(first.tables.containerMetrics.backlogRows).toBe(55)
+  expect(first.hasBacklog).toBe(true)
+  expect(first.retentionLagMs > 0).toBe(true)
+
+  const second = await sails.helpers.lookout.pruneObservability.with({
+    now,
+    containerRetentionMs: 24 * 60 * 60 * 1000,
+    telemetryRetentionMs: 7 * 24 * 60 * 60 * 1000,
+    batchSize: 50,
+    maxBatches: 3
+  })
+
+  expect(second.tables.containerMetrics.deletedRows).toBe(55)
+  expect(second.hasBacklog).toBe(false)
+  expect(await sails.models.containermetric.count()).toBe(2)
+  expect(await sails.models.telemetryspan.count()).toBe(1)
+  expect(await sails.models.telemetryexception.count()).toBe(1)
+  expect(await sails.models.telemetrymetric.count()).toBe(1)
+})
+
+test('legacy container metrics migrate once and are verified before removal', async ({
+  sails,
+  expect
+}) => {
+  await sails.models.containermetric.destroy({})
+  await sails.models.containermetric.create({
+    ...containerMetric({ environmentId: 1, recordedAt: 1000 }),
+    containerName: 'slipway-one',
+    legacySourceId: 1
+  })
+  const source = sails.getDatastore()
+
+  await source.sendNativeQuery('DROP TABLE IF EXISTS container_metrics')
+  await source.sendNativeQuery(`
+    CREATE TABLE container_metrics (
+      id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+      created_at INTEGER,
+      updated_at INTEGER,
+      container_name TEXT,
+      container_type TEXT,
+      cpu_percent INTEGER,
+      memory_usage INTEGER,
+      memory_limit INTEGER,
+      memory_percent INTEGER,
+      net_io TEXT,
+      block_io TEXT,
+      pids INTEGER,
+      recorded_at INTEGER,
+      environment INTEGER,
+      app INTEGER,
+      service INTEGER
+    )
+  `)
+  await source.sendNativeQuery(
+    `INSERT INTO container_metrics (
+      created_at, updated_at, container_name, container_type, cpu_percent,
+      memory_usage, memory_limit, memory_percent, pids, recorded_at,
+      environment
+    ) VALUES
+      (1, 1, 'slipway-one', 'app', 1, 10, 100, 10, 1, 1000, 1),
+      (2, 2, 'slipway-two', 'service', 2, 20, 100, 20, 2, 2000, 1)`
+  )
+
+  const first = await sails.helpers.lookout.ensureObservabilitySchema()
+  const second = await sails.helpers.lookout.ensureObservabilitySchema()
+  const sourceCount = await source.sendNativeQuery(
+    'SELECT COUNT(*) AS total FROM container_metrics'
+  )
+  const migrated = await sails.models.containermetric
+    .find()
+    .sort('legacySourceId ASC')
+
+  expect(first.migrated).toBe(2)
+  expect(second.migrated).toBe(0)
+  expect((sourceCount.rows || sourceCount)[0].total).toBe(0)
+  expect(migrated.map((row) => row.containerName)).toEqual([
+    'slipway-one',
+    'slipway-two'
+  ])
+  expect(migrated.map((row) => row.legacySourceId)).toEqual([1, 2])
+})
+
+test('SQLite query plans use the observability time-shape indexes', async ({
+  sails,
+  expect
+}) => {
+  await sails.helpers.lookout.ensureObservabilitySchema()
+  const database = sails.getDatastore('observability').manager
+  const plans = [
+    database
+      .prepare(
+        `EXPLAIN QUERY PLAN
+        SELECT * FROM container_metrics
+        WHERE environment = ? AND recorded_at >= ?
+        ORDER BY recorded_at DESC`
+      )
+      .all(1, 0),
+    database
+      .prepare(
+        `EXPLAIN QUERY PLAN
+        SELECT * FROM container_metrics
+        WHERE container_name = ? AND recorded_at >= ?
+        ORDER BY recorded_at DESC`
+      )
+      .all('slipway-one', 0),
+    database
+      .prepare(
+        `EXPLAIN QUERY PLAN
+        SELECT * FROM telemetry_spans
+        WHERE trace_id = ?
+        ORDER BY started_at DESC`
+      )
+      .all('trace-1'),
+    database
+      .prepare(
+        `EXPLAIN QUERY PLAN
+        SELECT id FROM telemetry_metrics
+        WHERE recorded_at < ?
+        ORDER BY recorded_at ASC, id ASC
+        LIMIT ?`
+      )
+      .all(Date.now(), 50)
+  ]
+  const details = plans.map((plan) => plan.map((row) => row.detail).join(' '))
+
+  expect(details[0]).toContain('container_metrics_environment_recorded_at')
+  expect(details[1]).toContain('container_metrics_container_recorded_at')
+  expect(details[2]).toContain('telemetry_spans_trace_started_at')
+  expect(details[3]).toContain('telemetry_metrics_recorded_at')
+})
+
+async function resetObservabilityHealth(sails) {
+  await sails.models.observabilityjobhealth.destroy({})
+  await clearTelemetry(sails)
+}
+
+async function clearTelemetry(sails) {
+  await Promise.all([
+    sails.models.containermetric.destroy({}),
+    sails.models.telemetryspan.destroy({}),
+    sails.models.telemetryexception.destroy({}),
+    sails.models.telemetrymetric.destroy({})
+  ])
+}
+
+function replace(namespace, name, implementation) {
+  implementation.with = implementation
+  namespace[name] = implementation
+}
+
+function containerMetric({ environmentId, recordedAt }) {
+  return {
+    containerName: 'slipway-test-production',
+    containerType: 'app',
+    cpuPercent: 1,
+    memoryUsage: 10,
+    memoryLimit: 100,
+    memoryPercent: 10,
+    pids: 1,
+    recordedAt,
+    environment: environmentId
+  }
+}
+
+function span({ environmentId, startedAt }) {
+  return {
+    traceId: `trace-${startedAt}`,
+    spanId: `span-${startedAt}`,
+    name: 'GET /health',
+    duration: 1,
+    startedAt,
+    environment: String(environmentId)
+  }
+}
+
+function exception({ environmentId, occurredAt }) {
+  return {
+    exceptionType: 'Error',
+    message: 'Test error',
+    occurredAt,
+    environment: String(environmentId)
+  }
+}
+
+function metric({ environmentId, recordedAt }) {
+  return {
+    name: 'test.metric',
+    value: 1,
+    recordedAt,
+    environment: String(environmentId)
+  }
+}


### PR DESCRIPTION
## What changed

- separate Docker metric collection from retention and disk-health maintenance
- schedule non-overlapping observability maintenance through Quest
- move `ContainerMetric` into `observability.db` with a verified, restart-safe legacy migration
- prune container and application telemetry in configurable bounded batches
- add query-shaped SQLite indexes for environment, container, trace, and timestamp paths
- persist collector and retention success, failure, lag, duration, and row-count health
- expose that health through the Lookout API and one compact row in the existing Host disk card
- document retention defaults and production environment overrides

## Why

Retention and disk-health checks previously lived after Docker-dependent early returns. When Docker was unavailable or no Slipway containers were running, stale telemetry was not pruned and disk alerts did not run. Container metrics also lived in the application database while the rest of telemetry used the observability datastore.

## Impact

Observability housekeeping now continues independently of Docker availability, SQLite write locks stay bounded, existing metric history migrates safely, and operators can see whether collection and retention are healthy without adding another dashboard surface.

## Validation

- `npm run test:unit` — 126 passed
- `npm run test:functional` — 42 passed
- `npm run test:e2e` — 14 passed
- `npm run lint`
- `npm run check:consistency`
- explicit SQLite `EXPLAIN QUERY PLAN` assertions for the new indexes
- light and dark Lookout screenshots

Closes #237