### PR TITLE
feat: centralize destructive resource cleanup

### DIFF
--- a/api/controllers/api/v1/app/destroy-app.js
+++ b/api/controllers/api/v1/app/destroy-app.js
@@ -1,42 +1,37 @@
 module.exports = {
   friendlyName: 'Destroy app',
 
-  description:
-    'Stop container and delete an app. Cannot delete the last or default app.',
+  description: 'Run shared app cleanup. Cannot delete the last or default app.',
 
   inputs: {
-    projectSlug: {
-      type: 'string',
-      required: true
-    },
-    environmentSlug: {
-      type: 'string',
-      required: true
-    },
-    appSlug: {
-      type: 'string',
-      required: true
-    }
+    projectSlug: { type: 'string', required: true },
+    environmentSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    purgeData: { type: 'boolean', defaultsTo: false }
   },
 
   exits: {
     success: { statusCode: 200 },
     notFound: { statusCode: 404 },
     forbidden: { statusCode: 403 },
-    badRequest: { responseType: 'badRequest' }
+    badRequest: { responseType: 'badRequest' },
+    cleanupFailed: {
+      statusCode: 409,
+      description: 'Cleanup paused and can be resumed'
+    }
   },
 
-  fn: async function ({ projectSlug, environmentSlug, appSlug }) {
+  fn: async function ({ projectSlug, environmentSlug, appSlug, purgeData }) {
     const user = await User.findOne({ id: this.req.session.userId })
-
     const project = await Project.findOne({ slug: projectSlug }).populate(
       'team'
     )
-    if (!project || project.team.id !== user.team) throw 'notFound'
-
-    // Only owner/admin can delete apps
-    if (user.teamRole !== 'owner' && user.teamRole !== 'admin')
+    if (!project || Number(project.team.id) !== Number(user.team)) {
+      throw 'notFound'
+    }
+    if (user.teamRole !== 'owner' && user.teamRole !== 'admin') {
       throw 'forbidden'
+    }
 
     const environment = await Environment.findOne({
       project: project.id,
@@ -44,59 +39,63 @@ module.exports = {
     })
     if (!environment) throw 'notFound'
 
+    const requestKey = `app:${projectSlug}/${environmentSlug}/${appSlug}`
     const app = await App.findOne({
       environment: environment.id,
       slug: appSlug
     })
-    if (!app) throw 'notFound'
+    const targetKey = app ? `app:${app.id}` : undefined
+    const existingOperation = await sails.helpers.cleanup.findOperation.with({
+      targetKey,
+      requestKey
+    })
+    if (!app && !existingOperation) throw 'notFound'
 
-    // Cannot delete the last app in an environment
-    const appCount = await App.count({ environment: environment.id })
-    if (appCount <= 1) {
-      throw {
-        badRequest: {
-          problems: [{ app: 'Cannot delete the only app in an environment.' }]
+    if (app) {
+      const appCount = await App.count({ environment: environment.id })
+      if (appCount <= 1) {
+        throw {
+          badRequest: {
+            problems: [{ app: 'Cannot delete the only app in an environment.' }]
+          }
+        }
+      }
+      if (app.isDefault) {
+        throw {
+          badRequest: {
+            problems: [
+              {
+                app: 'Cannot delete the default app. Assign another app as default first.'
+              }
+            ]
+          }
         }
       }
     }
 
-    // Cannot delete the default app (must reassign first)
-    if (app.isDefault) {
-      throw {
-        badRequest: {
-          problems: [
-            {
-              app: 'Cannot delete the default app. Assign another app as default first.'
-            }
-          ]
-        }
-      }
-    }
-
-    // Stop container if running
-    if (app.containerName) {
-      try {
-        await sails.helpers.docker.stopContainer.with({
-          containerName: app.containerName
-        })
-      } catch (err) {
-        sails.log.warn(
-          `Failed to stop app container ${app.containerName}: ${err.message}`
-        )
-      }
-    }
-
-    // Delete deployments for this app and the app itself
-    await Deployment.update({ app: app.id }).set({ app: null })
-    await App.destroyOne({ id: app.id })
-
-    // Update Caddy routes
     try {
-      await sails.helpers.caddy.updateRoute(environment.id)
-    } catch (err) {
-      sails.log.warn(`Caddy route update failed: ${err.message}`)
-    }
+      const cleanup = await sails.helpers.cleanup.run.with({
+        targetKey: targetKey || existingOperation.targetKey,
+        requestKey,
+        scopeType: 'app',
+        resourceId: app?.id || existingOperation.resourceId,
+        retentionPolicy: purgeData ? 'purge' : 'retain',
+        userId: user.id,
+        teamId: project.team.id,
+        ipAddress: this.req.ip
+      })
 
-    return { message: 'App deleted successfully' }
+      return {
+        message: 'App deleted successfully',
+        cleanup
+      }
+    } catch (error) {
+      throw {
+        cleanupFailed: {
+          message: error.message,
+          cleanup: error.cleanup || null
+        }
+      }
+    }
   }
 }

--- a/api/controllers/api/v1/deploy/rollback-deployment.js
+++ b/api/controllers/api/v1/deploy/rollback-deployment.js
@@ -70,19 +70,23 @@ module.exports = {
     })
     if (!targetDeployment?.imageName) throw 'badRequest'
 
-    const queued = await sails.helpers.deploy.queueDeployment.with({
-      values: {
-        gitCommit: targetDeployment.gitCommit,
-        gitBranch: targetDeployment.gitBranch,
-        gitMessage: `Rollback to deployment ${targetDeployment.id}`,
-        triggeredBy: user.id,
-        triggerType: 'api',
-        environment: environment.id
-      },
-      app: targetApp,
-      kind: 'rollback',
-      targetDeploymentId: targetDeployment.id
-    })
+    const queued = await sails.helpers.deploy.queueDeployment
+      .with({
+        values: {
+          gitCommit: targetDeployment.gitCommit,
+          gitBranch: targetDeployment.gitBranch,
+          gitMessage: `Rollback to deployment ${targetDeployment.id}`,
+          triggeredBy: user.id,
+          triggerType: 'api',
+          environment: environment.id
+        },
+        app: targetApp,
+        kind: 'rollback',
+        targetDeploymentId: targetDeployment.id
+      })
+      .intercept('cleanupInProgress', (error) => ({
+        badRequest: error.raw || error
+      }))
     const rollback = queued.deployment
 
     sails.log.info(

--- a/api/controllers/api/v1/deploy/trigger-deployment.js
+++ b/api/controllers/api/v1/deploy/trigger-deployment.js
@@ -94,6 +94,9 @@ module.exports = {
       .intercept('sourceUnavailable', (error) => ({
         badRequest: error.raw || error
       }))
+      .intercept('cleanupInProgress', (error) => ({
+        badRequest: error.raw || error
+      }))
     const deployment = queued.deployment
 
     sails.log.info(

--- a/api/controllers/api/v1/environment/destroy-environment.js
+++ b/api/controllers/api/v1/environment/destroy-environment.js
@@ -1,7 +1,8 @@
 module.exports = {
   friendlyName: 'Delete environment',
 
-  description: 'Delete an environment and all its resources.',
+  description:
+    'Run the shared, resumable cleanup for an environment and its resources.',
 
   inputs: {
     projectSlug: {
@@ -13,52 +14,49 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'Environment slug'
+    },
+    purgeData: {
+      type: 'boolean',
+      defaultsTo: false
     }
   },
 
   exits: {
-    success: {
-      statusCode: 200
-    },
-    notFound: {
-      statusCode: 404
-    },
-    forbidden: {
-      statusCode: 403
-    },
-    badRequest: {
-      responseType: 'badRequest'
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 },
+    badRequest: { responseType: 'badRequest' },
+    cleanupFailed: {
+      statusCode: 409,
+      description: 'Cleanup paused and can be resumed'
     }
   },
 
-  fn: async function ({ projectSlug, slug }) {
+  fn: async function ({ projectSlug, slug, purgeData }) {
     const user = await User.findOne({ id: this.req.session.userId })
-
     const project = await Project.findOne({ slug: projectSlug }).populate(
       'team'
     )
 
-    if (!project) {
-      throw 'notFound'
-    }
-
-    if (project.team.id !== user.team) {
-      throw 'forbidden'
-    }
-
-    // Only owner/admin can delete environments
+    if (!project) throw 'notFound'
+    if (Number(project.team.id) !== Number(user.team)) throw 'forbidden'
     if (user.teamRole !== 'owner' && user.teamRole !== 'admin') {
       throw 'forbidden'
     }
 
-    const environment = await Environment.findOne({ project: project.id, slug })
+    const requestKey = `environment:${projectSlug}/${slug}`
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug
+    })
+    const targetKey = environment ? `environment:${environment.id}` : undefined
+    const existingOperation = await sails.helpers.cleanup.findOperation.with({
+      targetKey,
+      requestKey
+    })
+    if (!environment && !existingOperation) throw 'notFound'
 
-    if (!environment) {
-      throw 'notFound'
-    }
-
-    // Prevent deleting production environment if it's the only one
-    if (environment.isProduction) {
+    if (environment?.isProduction) {
       const envCount = await Environment.count({ project: project.id })
       if (envCount === 1) {
         throw {
@@ -71,47 +69,29 @@ module.exports = {
       }
     }
 
-    // Stop and remove ALL app containers
-    const apps = await App.find({ environment: environment.id })
-    for (const app of apps) {
-      if (app.containerName) {
-        try {
-          await sails.helpers.docker.stopContainer(app.containerName)
-        } catch (err) {
-          sails.log.warn(
-            `Failed to stop app container ${app.containerName}: ${err.message}`
-          )
+    try {
+      const cleanup = await sails.helpers.cleanup.run.with({
+        targetKey: targetKey || existingOperation.targetKey,
+        requestKey,
+        scopeType: 'environment',
+        resourceId: environment?.id || existingOperation.resourceId,
+        retentionPolicy: purgeData ? 'purge' : 'retain',
+        userId: user.id,
+        teamId: project.team.id,
+        ipAddress: this.req.ip
+      })
+
+      return {
+        message: 'Environment deleted successfully',
+        cleanup
+      }
+    } catch (error) {
+      throw {
+        cleanupFailed: {
+          message: error.message,
+          cleanup: error.cleanup || null
         }
       }
     }
-
-    const services = await Service.find({ environment: environment.id })
-    for (const service of services) {
-      try {
-        await sails.helpers.docker.destroyService(service.id)
-      } catch (err) {
-        sails.log.warn(
-          `Failed to destroy service ${service.name}: ${err.message}`
-        )
-      }
-    }
-
-    // Remove Caddy route
-    try {
-      await sails.helpers.caddy.removeRoute.with({
-        projectSlug: project.slug,
-        environmentSlug: slug
-      })
-    } catch (err) {
-      sails.log.warn(`Failed to remove Caddy route: ${err.message}`)
-    }
-
-    // Delete database records
-    await Deployment.destroy({ environment: environment.id })
-    await App.destroy({ environment: environment.id })
-    await Service.destroy({ environment: environment.id })
-    await Environment.destroyOne({ id: environment.id })
-
-    return { message: 'Environment deleted successfully' }
   }
 }

--- a/api/controllers/api/v1/project/destroy-project.js
+++ b/api/controllers/api/v1/project/destroy-project.js
@@ -1,13 +1,18 @@
 module.exports = {
   friendlyName: 'Delete project',
 
-  description: 'Delete a project and all its environments.',
+  description:
+    'Run the shared, resumable cleanup for a project and its resources.',
 
   inputs: {
     slug: {
       type: 'string',
       required: true,
       description: 'Project slug'
+    },
+    purgeData: {
+      type: 'boolean',
+      defaultsTo: false
     }
   },
 
@@ -22,41 +27,54 @@ module.exports = {
     forbidden: {
       statusCode: 403,
       description: 'Not authorized to delete this project'
+    },
+    cleanupFailed: {
+      statusCode: 409,
+      description: 'Cleanup paused and can be resumed'
     }
   },
 
-  fn: async function ({ slug }) {
+  fn: async function ({ slug, purgeData }) {
     const user = await User.findOne({ id: this.req.session.userId })
+    const requestKey = `project:${slug}`
+    const project = await Project.findOne({ slug }).populate('team')
+    const targetKey = project ? `project:${project.id}` : undefined
+    const existingOperation = await sails.helpers.cleanup.findOperation.with({
+      targetKey,
+      requestKey
+    })
 
-    const project = await Project.findOne({ slug })
-      .populate('team')
-      .populate('environments')
+    if (!project && !existingOperation) throw 'notFound'
+    const teamId = project ? project.team.id : existingOperation.team
 
-    if (!project) {
-      throw 'notFound'
-    }
-
-    // Check user has access and is owner/admin
-    if (project.team.id !== user.team) {
-      throw 'forbidden'
-    }
-
+    if (Number(teamId) !== Number(user.team)) throw 'forbidden'
     if (user.teamRole !== 'owner' && user.teamRole !== 'admin') {
       throw 'forbidden'
     }
 
-    // Delete all environments and their associated resources
-    for (const env of project.environments) {
-      // Delete apps, services, and deployments for each environment
-      await App.destroy({ environment: env.id })
-      await Service.destroy({ environment: env.id })
-      await Deployment.destroy({ environment: env.id })
-      await Environment.destroyOne({ id: env.id })
+    try {
+      const cleanup = await sails.helpers.cleanup.run.with({
+        targetKey: targetKey || existingOperation.targetKey,
+        requestKey,
+        scopeType: 'project',
+        resourceId: project?.id || existingOperation.resourceId,
+        retentionPolicy: purgeData ? 'purge' : 'retain',
+        userId: user.id,
+        teamId,
+        ipAddress: this.req.ip
+      })
+
+      return {
+        message: 'Project deleted successfully',
+        cleanup
+      }
+    } catch (error) {
+      throw {
+        cleanupFailed: {
+          message: error.message,
+          cleanup: error.cleanup || null
+        }
+      }
     }
-
-    // Delete the project
-    await Project.destroyOne({ id: project.id })
-
-    return { message: 'Project deleted successfully' }
   }
 }

--- a/api/controllers/api/v1/service/destroy-service.js
+++ b/api/controllers/api/v1/service/destroy-service.js
@@ -1,94 +1,89 @@
 module.exports = {
   friendlyName: 'Delete service',
 
-  description: 'Delete a service and its Docker container.',
+  description: 'Run the shared, resumable cleanup for a service.',
 
   inputs: {
     id: {
       type: 'string',
       required: true,
       description: 'Service ID'
+    },
+    purgeData: {
+      type: 'boolean',
+      defaultsTo: false
     }
   },
 
   exits: {
-    success: {
-      statusCode: 200
-    },
-    notFound: {
-      statusCode: 404
-    },
-    forbidden: {
-      statusCode: 403
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 },
+    cleanupFailed: {
+      statusCode: 409,
+      description: 'Cleanup paused and can be resumed'
     }
   },
 
-  fn: async function ({ id }) {
+  fn: async function ({ id, purgeData }) {
     const user = await User.findOne({ id: this.req.session.userId })
+    const requestKey = `service:${id}`
+    const targetKey = `service:${id}`
+    const [service, existingOperation] = await Promise.all([
+      Service.findOne({ id }),
+      sails.helpers.cleanup.findOperation.with({ targetKey, requestKey })
+    ])
+    if (!service && !existingOperation) throw 'notFound'
 
-    const service = await Service.findOne(id).populate('environment')
-
-    if (!service) {
-      throw 'notFound'
+    let project
+    let environment
+    if (service) {
+      environment = await Environment.findOne({
+        id: service.environment
+      }).populate('project')
+      project = await Project.findOne({
+        id: environment.project.id
+      }).populate('team')
+    } else {
+      project = await Project.findOne({
+        id: existingOperation.projectId
+      }).populate('team')
     }
 
-    // Get project to check access
-    const environment = await Environment.findOne({
-      id: service.environment.id
-    })
-      .populate('project')
-      .decrypt()
-
-    const project = await Project.findOne({
-      id: environment.project.id
-    }).populate('team')
-
-    if (project.team.id !== user.team) {
-      throw 'forbidden'
-    }
-
-    // Only owner/admin can delete services
+    const teamId = project?.team?.id || existingOperation.team
+    if (Number(teamId) !== Number(user.team)) throw 'forbidden'
     if (user.teamRole !== 'owner' && user.teamRole !== 'admin') {
       throw 'forbidden'
     }
 
-    // Remove auto-managed env var
-    if (service.envVarKey) {
-      const currentVars = environment.envVars || {}
-      const { [service.envVarKey]: _, ...remainingVars } = currentVars
-      await Environment.updateOne({ id: environment.id }).set({
-        envVars: remainingVars
-      })
-    }
-
-    // Stop and remove Docker container
     try {
-      await sails.helpers.docker.destroyService(service.id)
-    } catch (err) {
-      sails.log.warn(`Failed to destroy service container: ${err.message}`)
+      const cleanup = await sails.helpers.cleanup.run.with({
+        targetKey,
+        requestKey,
+        scopeType: 'service',
+        resourceId: service?.id || existingOperation.resourceId,
+        retentionPolicy: purgeData ? 'purge' : 'retain',
+        userId: user.id,
+        teamId,
+        ipAddress: this.req.ip
+      })
+
+      sails.log.info(
+        `Service ${service?.name || cleanup.label} deleted from ${
+          project?.slug || cleanup.targetKey
+        }`
+      )
+      return {
+        message: 'Service deleted successfully',
+        cleanup
+      }
+    } catch (error) {
+      throw {
+        cleanupFailed: {
+          message: error.message,
+          cleanup: error.cleanup || null
+        }
+      }
     }
-
-    sails.log.info(
-      `Service ${service.name} deleted from ${project.slug}/${environment.slug}`
-    )
-
-    // Audit log
-    await sails.helpers.audit.log.with({
-      action: 'service.destroyed',
-      resourceType: 'service',
-      resourceId: service.id,
-      details: {
-        name: service.name,
-        type: service.type,
-        projectSlug: project.slug
-      },
-      userId: user.id,
-      teamId: project.team.id,
-      ipAddress: this.req.ip
-    })
-
-    await Service.destroyOne({ id: service.id })
-
-    return { message: 'Service deleted successfully' }
   }
 }

--- a/api/controllers/project/destroy-project.js
+++ b/api/controllers/project/destroy-project.js
@@ -1,13 +1,20 @@
 module.exports = {
   friendlyName: 'Destroy project',
 
-  description: 'Delete a project and all associated resources.',
+  description:
+    'Run the shared, resumable cleanup for a project and its resources.',
 
   inputs: {
     slug: {
       type: 'string',
       required: true,
       description: 'Project slug'
+    },
+    purgeData: {
+      type: 'boolean',
+      defaultsTo: false,
+      description:
+        'Also purge retained volumes, backups, source, and Docker images.'
     }
   },
 
@@ -20,79 +27,52 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug }) {
+  fn: async function ({ slug, purgeData }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
+    const requestKey = `project:${slug}`
+    const project = await Project.findOne({ slug, team: user.team.id })
+    const targetKey = project ? `project:${project.id}` : undefined
+    const existingOperation = await sails.helpers.cleanup.findOperation.with({
+      targetKey,
+      requestKey
+    })
 
-    const project = await Project.findOne({
-      slug,
-      team: user.team.id
-    }).populate('environments')
-
-    if (!project) {
+    if (
+      !project &&
+      (!existingOperation ||
+        Number(existingOperation.team) !== Number(user.team.id))
+    ) {
       throw { notFound: '/' }
     }
 
-    // Delete all associated resources for each environment
-    for (const env of project.environments) {
-      // Stop and remove ALL app containers
-      const apps = await App.find({ environment: env.id })
-      for (const app of apps) {
-        if (app.containerName) {
-          try {
-            await sails.helpers.docker.stopContainer(app.containerName)
-          } catch (err) {
-            sails.log.warn(
-              `Failed to stop container ${app.containerName}: ${err.message}`
-            )
-          }
-        }
-      }
+    try {
+      const cleanup = await sails.helpers.cleanup.run.with({
+        targetKey: targetKey || existingOperation.targetKey,
+        requestKey,
+        scopeType: 'project',
+        resourceId: project?.id || existingOperation.resourceId,
+        retentionPolicy: purgeData ? 'purge' : 'retain',
+        userId: user.id,
+        teamId: user.team.id,
+        ipAddress: this.req.ip
+      })
+      const projectName = project?.name || cleanup.label || slug
 
-      // Stop and remove service containers
-      const services = await Service.find({ environment: env.id })
-      for (const service of services) {
-        try {
-          await sails.helpers.docker.destroyService(service.id)
-        } catch (err) {
-          sails.log.warn(
-            `Failed to destroy service ${service.name}: ${err.message}`
-          )
-        }
-      }
-
-      // Remove Caddy route
-      try {
-        await sails.helpers.caddy.removeRoute.with({
-          projectSlug: project.slug,
-          environmentSlug: env.slug
-        })
-      } catch (err) {
-        sails.log.warn(`Failed to remove Caddy route: ${err.message}`)
-      }
-
-      // Delete database records
-      await Deployment.destroy({ environment: env.id })
-      await App.destroy({ environment: env.id })
-      await Service.destroy({ environment: env.id })
-      await Environment.destroyOne({ id: env.id })
+      sails.inertia.flash({
+        success: `Project "${projectName}" deleted.`,
+        cleanup
+      })
+      return '/'
+    } catch (error) {
+      sails.inertia.flash({
+        error:
+          error.message ||
+          'Project cleanup paused. Try deleting the project again to resume.',
+        cleanup: error.cleanup || null
+      })
+      return project ? `/projects/${slug}/settings` : '/'
     }
-
-    // Audit log
-    await sails.helpers.audit.log.with({
-      action: 'project.destroyed',
-      resourceType: 'project',
-      resourceId: project.id,
-      details: { name: project.name, slug },
-      userId: user.id,
-      teamId: user.team.id,
-      ipAddress: this.req.ip
-    })
-
-    await Project.destroyOne({ id: project.id })
-
-    sails.inertia.flash('success', `Project "${project.name}" deleted.`)
-    return '/'
   }
 }

--- a/api/controllers/project/view-environment-settings.js
+++ b/api/controllers/project/view-environment-settings.js
@@ -45,17 +45,8 @@ module.exports = {
       throw { notFound: `/projects/${slug}` }
     }
 
-    // Check if environment has app or services
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    const services = await Service.find({ environment: environment.id })
-
     // Count environments in project (can't delete if only one)
     const envCount = await Environment.count({ project: project.id })
-
-    // Determine if deletion is allowed
-    const canDelete = !app && services.length === 0
     const isOnlyEnvironment = envCount === 1
 
     return {
@@ -63,10 +54,7 @@ module.exports = {
       props: {
         project,
         environment,
-        canDelete,
-        isOnlyEnvironment,
-        hasApp: !!app,
-        serviceCount: services.length
+        isOnlyEnvironment
       }
     }
   }

--- a/api/helpers/caddy/remove-route.js
+++ b/api/helpers/caddy/remove-route.js
@@ -1,4 +1,7 @@
 const { execFile } = require('child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
 
 module.exports = {
   friendlyName: 'Remove route',
@@ -34,13 +37,15 @@ module.exports = {
     const dockerPath = sails.config.docker?.binaryPath || 'docker'
     const routeContainerName = `slipway-route-${projectSlug}-${environmentSlug}`
 
-    return new Promise((resolve) => {
-      execFile(dockerPath, ['rm', '-f', routeContainerName], (err) => {
-        if (!err) {
-          sails.log.info(`Caddy route container removed: ${routeContainerName}`)
-        }
-        resolve({ removed: true, routeId: routeContainerName })
-      })
-    })
+    try {
+      await execFileAsync(dockerPath, ['rm', '-f', routeContainerName])
+      sails.log.info(`Caddy route container removed: ${routeContainerName}`)
+      return { removed: true, routeId: routeContainerName }
+    } catch (error) {
+      if (/no such container/i.test(error.message || '')) {
+        return { removed: false, routeId: routeContainerName }
+      }
+      throw error
+    }
   }
 }

--- a/api/helpers/cleanup/assert-available.js
+++ b/api/helpers/cleanup/assert-available.js
@@ -1,0 +1,45 @@
+module.exports = {
+  friendlyName: 'Assert resource is available',
+
+  description:
+    'Prevent new work from racing a pending destructive cleanup operation.',
+
+  inputs: {
+    projectId: { type: 'number' },
+    environmentId: { type: 'number' },
+    appId: { type: 'number' },
+    serviceId: { type: 'number' }
+  },
+
+  exits: {
+    success: {},
+    blocked: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ projectId, environmentId, appId, serviceId }) {
+    const scopes = [
+      projectId ? { scopeType: 'project', projectId } : null,
+      environmentId ? { scopeType: 'environment', environmentId } : null,
+      appId ? { scopeType: 'app', appId } : null,
+      serviceId ? { scopeType: 'service', serviceId } : null
+    ].filter(Boolean)
+
+    if (scopes.length === 0) return
+
+    const operation = await CleanupOperation.findOne({
+      status: { nin: ['complete'] },
+      or: scopes
+    })
+    if (!operation) return
+
+    throw {
+      blocked: {
+        code: 'cleanupInProgress',
+        message: `Cleanup operation ${operation.id} is ${operation.status}. Resume or complete it before starting new work.`,
+        cleanupOperationId: operation.id
+      }
+    }
+  }
+}

--- a/api/helpers/cleanup/create-snapshot.js
+++ b/api/helpers/cleanup/create-snapshot.js
@@ -1,0 +1,300 @@
+const path = require('node:path')
+
+module.exports = {
+  friendlyName: 'Create cleanup snapshot',
+
+  description:
+    'Capture the records and external artifacts needed for resumable cleanup.',
+
+  inputs: {
+    scopeType: {
+      type: 'string',
+      required: true,
+      isIn: ['project', 'environment', 'app', 'service']
+    },
+    resourceId: {
+      type: 'number',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    },
+    notFound: {}
+  },
+
+  fn: async function ({ scopeType, resourceId }) {
+    const target = await resolveTarget(scopeType, resourceId)
+    if (!target) throw 'notFound'
+
+    const { project, environment, app, service } = target
+    const environments =
+      scopeType === 'project'
+        ? await Environment.find({ project: project.id })
+        : [environment]
+    const environmentIds = uniqueIds(environments)
+
+    const apps =
+      scopeType === 'app'
+        ? [app]
+        : scopeType === 'service'
+        ? []
+        : await findByIds(App, 'environment', environmentIds)
+    const services =
+      scopeType === 'service'
+        ? [service]
+        : scopeType === 'app'
+        ? []
+        : await findByIds(Service, 'environment', environmentIds)
+    const appIds = uniqueIds(apps)
+    const serviceIds = uniqueIds(services)
+
+    const deployments =
+      scopeType === 'service'
+        ? []
+        : scopeType === 'app'
+        ? await Deployment.find({ app: app.id })
+        : await findByIds(Deployment, 'environment', environmentIds)
+    const deploymentIds = uniqueIds(deployments)
+    const deploymentJobs = await findByIds(
+      DeploymentJob,
+      'deployment',
+      deploymentIds
+    )
+    const deploymentLeases = await findByIds(
+      DeploymentLease,
+      'deployment',
+      deploymentIds
+    )
+    const backups = await findByIds(Backup, 'service', serviceIds)
+
+    const repositories = (await GitRepository.find()).filter(
+      (repository) =>
+        appIds.includes(normalizeId(repository.app)) ||
+        environmentIds.includes(normalizeId(repository.environment))
+    )
+    const deployTokens =
+      scopeType === 'project' || scopeType === 'environment'
+        ? (await DeployToken.find()).filter(
+            (token) =>
+              (scopeType === 'project' &&
+                normalizeId(token.project) === project.id) ||
+              environmentIds.includes(normalizeId(token.environment))
+          )
+        : []
+    const reservations = (await PortReservation.find()).filter(
+      (reservation) =>
+        deploymentIds.map(String).includes(String(reservation.ownerId)) ||
+        apps.some(
+          (candidate) =>
+            candidate.hostPort != null &&
+            Number(candidate.hostPort) === Number(reservation.port)
+        )
+    )
+
+    const routes =
+      scopeType === 'service'
+        ? []
+        : scopeType === 'app'
+        ? [
+            {
+              action: 'update',
+              projectSlug: project.slug,
+              environmentSlug: environment.slug,
+              environmentId: environment.id,
+              excludedAppIds: appIds
+            }
+          ]
+        : environments.map((candidate) => ({
+            action: 'remove',
+            projectSlug: project.slug,
+            environmentSlug: candidate.slug,
+            environmentId: candidate.id
+          }))
+
+    const containerNames = uniqueStrings([
+      ...apps.map((candidate) => candidate.containerName),
+      ...services.flatMap(serviceContainerNames),
+      ...deploymentJobs.flatMap((job) => [
+        job.candidateContainerName,
+        job.previousContainerName
+      ])
+    ])
+    const volumeNames = uniqueStrings(services.flatMap(serviceVolumeNames))
+    const imageNames = uniqueStrings([
+      ...apps.map((candidate) => candidate.imageName),
+      ...deployments.map((candidate) => candidate.imageName),
+      ...deploymentJobs.map((candidate) => candidate.imageName)
+    ])
+    const backupObjects = backups
+      .filter((candidate) => candidate.s3Key)
+      .map((candidate) => ({
+        backupId: candidate.id,
+        s3Key: candidate.s3Key
+      }))
+    const sourcePaths =
+      scopeType === 'project'
+        ? [path.join(sails.config.custom.slipwayAppsDir, String(project.slug))]
+        : []
+    const buildContexts = deploymentJobs
+      .filter((job) => job.buildContextPath)
+      .map((job) => ({
+        deploymentId: normalizeId(job.deployment),
+        contextPath: job.buildContextPath
+      }))
+
+    return {
+      version: 1,
+      target: {
+        scopeType,
+        resourceId,
+        projectId: project.id,
+        environmentId: environment?.id || null,
+        appId: app?.id || null,
+        serviceId: service?.id || null,
+        teamId: normalizeId(project.team),
+        label:
+          project.name && scopeType === 'project'
+            ? project.name
+            : app?.name || service?.name || environment?.name || project.name,
+        projectSlug: project.slug,
+        environmentSlug: environment?.slug || null,
+        appSlug: app?.slug || null
+      },
+      records: {
+        projectIds: scopeType === 'project' ? [project.id] : [],
+        environmentIds,
+        appIds,
+        serviceIds,
+        deploymentIds,
+        deploymentJobIds: uniqueIds(deploymentJobs),
+        deploymentLeaseIds: uniqueIds(deploymentLeases),
+        backupIds: uniqueIds(backups),
+        repositoryIds: uniqueIds(repositories),
+        deployTokenIds: uniqueIds(deployTokens)
+      },
+      services: services.map((candidate) => ({
+        id: candidate.id,
+        environmentId: normalizeId(candidate.environment),
+        envVarKey: candidate.envVarKey || null
+      })),
+      artifacts: {
+        routes,
+        containerNames,
+        volumeNames,
+        imageNames,
+        backupObjects,
+        sourcePaths,
+        buildContexts,
+        portReservationIds: uniqueIds(reservations),
+        hostPorts: uniqueNumbers(apps.map((candidate) => candidate.hostPort))
+      }
+    }
+  }
+}
+
+async function resolveTarget(scopeType, resourceId) {
+  if (scopeType === 'project') {
+    const project = await Project.findOne({ id: resourceId })
+    return project ? { project } : null
+  }
+
+  if (scopeType === 'environment') {
+    const environment = await Environment.findOne({ id: resourceId })
+    if (!environment) return null
+    const project = await Project.findOne({
+      id: normalizeId(environment.project)
+    })
+    return project ? { project, environment } : null
+  }
+
+  if (scopeType === 'app') {
+    const app = await App.findOne({ id: resourceId })
+    if (!app) return null
+    const environment = await Environment.findOne({
+      id: normalizeId(app.environment)
+    })
+    if (!environment) return null
+    const project = await Project.findOne({
+      id: normalizeId(environment.project)
+    })
+    return project ? { project, environment, app } : null
+  }
+
+  const service = await Service.findOne({ id: resourceId })
+  if (!service) return null
+  const environment = await Environment.findOne({
+    id: normalizeId(service.environment)
+  })
+  if (!environment) return null
+  const project = await Project.findOne({
+    id: normalizeId(environment.project)
+  })
+  return project ? { project, environment, service } : null
+}
+
+async function findByIds(model, attribute, ids) {
+  if (ids.length === 0) return []
+  return model.find({ [attribute]: { in: ids } })
+}
+
+function serviceContainerNames(service) {
+  return [
+    service.containerName,
+    service.imageMetadata?.previous?.containerName,
+    service.upgradeState?.candidateContainerName,
+    service.upgradeState?.rollbackContainerName,
+    service.upgradeState?.recovery?.previousContainerName
+  ]
+}
+
+function serviceVolumeNames(service) {
+  return [
+    service.imageMetadata?.volumeName,
+    service.imageMetadata?.previous?.volumeName,
+    service.upgradeState?.candidateVolumeName,
+    service.upgradeState?.previousVolumeName,
+    service.upgradeState?.recovery?.previousVolumeName,
+    service.containerName
+      ? Service.getDataVolumeName(service.containerName)
+      : null
+  ]
+}
+
+function uniqueIds(records) {
+  return [
+    ...new Set(
+      records
+        .map((record) => normalizeId(record))
+        .filter((value) => value !== null && value !== undefined)
+    )
+  ]
+}
+
+function uniqueStrings(values) {
+  return [
+    ...new Set(
+      values
+        .filter((value) => value !== null && value !== undefined)
+        .map(String)
+        .filter(Boolean)
+    )
+  ]
+}
+
+function uniqueNumbers(values) {
+  return [
+    ...new Set(
+      values
+        .filter((value) => value !== null && value !== undefined)
+        .map(Number)
+        .filter(Number.isFinite)
+    )
+  ]
+}
+
+function normalizeId(value) {
+  return value && typeof value === 'object' ? value.id : value
+}

--- a/api/helpers/cleanup/ensure-schema.js
+++ b/api/helpers/cleanup/ensure-schema.js
@@ -1,0 +1,71 @@
+module.exports = {
+  friendlyName: 'Ensure cleanup schema',
+
+  description:
+    'Create the durable cleanup table on existing production SQLite databases.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore()
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS cleanup_operations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        target_key TEXT NOT NULL UNIQUE,
+        request_key TEXT NOT NULL,
+        scope_type TEXT NOT NULL,
+        resource_id INTEGER NOT NULL,
+        project_id INTEGER,
+        environment_id INTEGER,
+        app_id INTEGER,
+        service_id INTEGER,
+        retention_policy TEXT NOT NULL DEFAULT 'retain',
+        status TEXT NOT NULL DEFAULT 'pending',
+        stage TEXT NOT NULL DEFAULT 'pending',
+        snapshot TEXT NOT NULL DEFAULT '{}',
+        stages TEXT NOT NULL DEFAULT '{}',
+        warnings TEXT NOT NULL DEFAULT '[]',
+        error_message TEXT,
+        completed_at INTEGER,
+        requested_by INTEGER,
+        team INTEGER NOT NULL,
+        ip_address TEXT,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    const result = await datastore.sendNativeQuery(
+      'PRAGMA table_info(cleanup_operations)'
+    )
+    const existing = new Set(
+      (result.rows || result || []).map((row) => row.name)
+    )
+    if (!existing.has('request_key')) {
+      await datastore.sendNativeQuery(
+        'ALTER TABLE cleanup_operations ADD COLUMN request_key TEXT'
+      )
+      await datastore.sendNativeQuery(`
+        UPDATE cleanup_operations
+        SET request_key = target_key
+        WHERE request_key IS NULL
+      `)
+    }
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS cleanup_operations_status
+      ON cleanup_operations (status, updated_at, id)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS cleanup_operations_scope
+      ON cleanup_operations (project_id, environment_id, app_id, service_id)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS cleanup_operations_request
+      ON cleanup_operations (request_key, created_at, id)
+    `)
+  }
+}

--- a/api/helpers/cleanup/find-operation.js
+++ b/api/helpers/cleanup/find-operation.js
@@ -1,0 +1,33 @@
+module.exports = {
+  friendlyName: 'Find cleanup operation',
+
+  description:
+    'Find an operation by immutable target identity, or the latest request-path operation after the target is gone.',
+
+  inputs: {
+    targetKey: {
+      type: 'string'
+    },
+    requestKey: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ targetKey, requestKey }) {
+    if (targetKey) {
+      return CleanupOperation.findOne({ targetKey })
+    }
+
+    const operations = await CleanupOperation.find({ requestKey })
+      .sort(['createdAt DESC', 'id DESC'])
+      .limit(1)
+    return operations[0] || null
+  }
+}

--- a/api/helpers/cleanup/remove-artifacts.js
+++ b/api/helpers/cleanup/remove-artifacts.js
@@ -1,0 +1,80 @@
+module.exports = {
+  friendlyName: 'Remove cleanup artifacts',
+
+  description:
+    'Remove temporary artifacts and optionally purge retained recovery data.',
+
+  inputs: {
+    snapshot: {
+      type: 'ref',
+      required: true
+    },
+    retentionPolicy: {
+      type: 'string',
+      required: true,
+      isIn: ['retain', 'purge']
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ snapshot, retentionPolicy }) {
+    const artifacts = snapshot.artifacts || {}
+    const result = {
+      buildContexts: 0,
+      backupObjects: 0,
+      volumes: 0,
+      images: 0,
+      sourcePaths: 0,
+      retained: {}
+    }
+
+    for (const context of artifacts.buildContexts || []) {
+      const cleanup = await sails.helpers.deploy.cleanupBuildContext.with({
+        contextPath: context.contextPath,
+        deploymentId: String(context.deploymentId)
+      })
+      if (cleanup.removed) result.buildContexts += 1
+    }
+
+    if (retentionPolicy === 'retain') {
+      result.retained = {
+        backupObjects: artifacts.backupObjects || [],
+        volumeNames: artifacts.volumeNames || [],
+        imageNames: artifacts.imageNames || [],
+        sourcePaths: artifacts.sourcePaths || []
+      }
+      return result
+    }
+
+    for (const backup of artifacts.backupObjects || []) {
+      await sails.helpers.backup.deleteBackupObject.with({
+        s3Key: backup.s3Key
+      })
+      result.backupObjects += 1
+    }
+
+    for (const volumeName of artifacts.volumeNames || []) {
+      const removed = await sails.helpers.docker.removeVolume.with({
+        volumeName
+      })
+      if (removed.removed) result.volumes += 1
+    }
+
+    for (const imageName of artifacts.imageNames || []) {
+      const removed = await sails.helpers.docker.removeImage.with({ imageName })
+      if (removed?.removed !== false) result.images += 1
+    }
+
+    for (const sourcePath of artifacts.sourcePaths || []) {
+      await sails.helpers.cleanup.removeSource.with({ sourcePath })
+      result.sourcePaths += 1
+    }
+
+    return result
+  }
+}

--- a/api/helpers/cleanup/remove-records.js
+++ b/api/helpers/cleanup/remove-records.js
@@ -1,0 +1,216 @@
+module.exports = {
+  friendlyName: 'Remove cleanup records',
+
+  description:
+    'Delete a cleanup snapshot’s database records in an idempotent order.',
+
+  inputs: {
+    snapshot: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ snapshot }) {
+    const { records, services, target } = snapshot
+    const removed = {
+      observability: await removeObservabilityRecords(snapshot),
+      default: {}
+    }
+    const environmentVars = await getEnvironmentVarUpdates(services)
+
+    await sails.getDatastore().transaction(async (db) => {
+      for (const update of environmentVars) {
+        await Environment.updateOne({ id: update.environmentId })
+          .set({ envVars: update.envVars })
+          .usingConnection(db)
+      }
+
+      if (target.scopeType === 'app') {
+        removed.default.repositories = await destroyCount(
+          GitRepository,
+          records.repositoryIds,
+          db
+        )
+        removed.default.deploymentsDetached = await updateCount(
+          Deployment,
+          records.deploymentIds,
+          { app: null },
+          db
+        )
+        removed.default.apps = await destroyCount(App, records.appIds, db)
+        return
+      }
+
+      if (target.scopeType === 'service') {
+        removed.default.backups = await destroyCount(
+          Backup,
+          records.backupIds,
+          db
+        )
+        removed.default.services = await destroyCount(
+          Service,
+          records.serviceIds,
+          db
+        )
+        return
+      }
+
+      await updateCount(App, records.appIds, { currentDeployment: null }, db)
+      removed.default.deploymentLeases = await destroyCount(
+        DeploymentLease,
+        records.deploymentLeaseIds,
+        db
+      )
+      removed.default.deploymentJobs = await destroyCount(
+        DeploymentJob,
+        records.deploymentJobIds,
+        db
+      )
+      removed.default.repositories = await destroyCount(
+        GitRepository,
+        records.repositoryIds,
+        db
+      )
+      removed.default.backups = await destroyCount(
+        Backup,
+        records.backupIds,
+        db
+      )
+      removed.default.deployTokens = await destroyCount(
+        DeployToken,
+        records.deployTokenIds,
+        db
+      )
+      removed.default.deployments = await destroyCount(
+        Deployment,
+        records.deploymentIds,
+        db
+      )
+      removed.default.apps = await destroyCount(App, records.appIds, db)
+      removed.default.services = await destroyCount(
+        Service,
+        records.serviceIds,
+        db
+      )
+      removed.default.environments = await destroyCount(
+        Environment,
+        records.environmentIds,
+        db
+      )
+      removed.default.projects = await destroyCount(
+        Project,
+        records.projectIds,
+        db
+      )
+    })
+
+    return removed
+  }
+}
+
+async function getEnvironmentVarUpdates(services) {
+  const keysByEnvironment = new Map()
+
+  for (const service of services || []) {
+    if (!service.envVarKey) continue
+    const keys = keysByEnvironment.get(service.environmentId) || new Set()
+    keys.add(service.envVarKey)
+    keysByEnvironment.set(service.environmentId, keys)
+  }
+
+  const updates = []
+  for (const [environmentId, keys] of keysByEnvironment) {
+    const environment = await Environment.findOne({
+      id: environmentId
+    }).decrypt()
+    if (!environment) continue
+
+    const envVars = { ...(environment.envVars || {}) }
+    for (const key of keys) {
+      delete envVars[key]
+    }
+    updates.push({ environmentId, envVars })
+  }
+
+  return updates
+}
+
+async function removeObservabilityRecords(snapshot) {
+  const { records, target } = snapshot
+  const removed = {}
+
+  if (target.scopeType === 'project' || target.scopeType === 'environment') {
+    const environmentNumbers = records.environmentIds.map(Number)
+    const environmentStrings = records.environmentIds.map(String)
+    removed.appLogs = await destroyByCriteria(AppLog, {
+      environment: { in: environmentStrings }
+    })
+    removed.containerMetrics = await destroyByCriteria(ContainerMetric, {
+      environment: { in: environmentNumbers }
+    })
+    removed.telemetrySpans = await destroyByCriteria(TelemetrySpan, {
+      environment: { in: environmentStrings }
+    })
+    removed.telemetryExceptions = await destroyByCriteria(TelemetryException, {
+      environment: { in: environmentStrings }
+    })
+    removed.telemetryMetrics = await destroyByCriteria(TelemetryMetric, {
+      environment: { in: environmentStrings }
+    })
+    return removed
+  }
+
+  if (target.scopeType === 'app') {
+    removed.appLogs = await destroyByCriteria(AppLog, {
+      app: { in: records.appIds.map(String) }
+    })
+    removed.containerMetrics = await destroyByCriteria(ContainerMetric, {
+      app: { in: records.appIds.map(Number) }
+    })
+    return removed
+  }
+
+  removed.containerMetrics = await destroyByCriteria(ContainerMetric, {
+    service: { in: records.serviceIds.map(Number) }
+  })
+  return removed
+}
+
+async function destroyByCriteria(model, criteria) {
+  const values = Object.values(criteria)
+  if (
+    values.some(
+      (value) => value && Array.isArray(value.in) && value.in.length === 0
+    )
+  ) {
+    return 0
+  }
+  const destroyed = await model.destroy(criteria).fetch()
+  return destroyed.length
+}
+
+async function destroyCount(model, ids, db) {
+  if (!ids || ids.length === 0) return 0
+  const destroyed = await model
+    .destroy({ id: { in: ids } })
+    .fetch()
+    .usingConnection(db)
+  return destroyed.length
+}
+
+async function updateCount(model, ids, values, db) {
+  if (!ids || ids.length === 0) return 0
+  const updated = await model
+    .update({ id: { in: ids } })
+    .set(values)
+    .fetch()
+    .usingConnection(db)
+  return updated.length
+}

--- a/api/helpers/cleanup/remove-source.js
+++ b/api/helpers/cleanup/remove-source.js
@@ -1,0 +1,35 @@
+const fs = require('node:fs/promises')
+const path = require('node:path')
+
+module.exports = {
+  friendlyName: 'Remove retained source',
+
+  description:
+    'Remove a project source snapshot only when it is inside Slipway’s apps directory.',
+
+  inputs: {
+    sourcePath: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ sourcePath }) {
+    const root = path.resolve(sails.config.custom.slipwayAppsDir)
+    const target = path.resolve(sourcePath)
+    const isOwned = target !== root && target.startsWith(`${root}${path.sep}`)
+
+    if (!isOwned) {
+      throw new Error(`Refusing to remove source outside ${root}`)
+    }
+
+    await fs.rm(target, { recursive: true, force: true })
+    return { removed: true, sourcePath: target }
+  }
+}

--- a/api/helpers/cleanup/run.js
+++ b/api/helpers/cleanup/run.js
@@ -1,0 +1,484 @@
+const deploymentCancellation = require('../../lib/deployment-cancellation')
+
+const STAGES = [
+  ['traffic', removeTraffic],
+  ['work', stopRunningWork],
+  ['containers', removeContainers],
+  ['ports', releasePorts],
+  ['records', removeRecords],
+  ['artifacts', removeArtifacts]
+]
+const ACTIVE_DEPLOYMENT_STATUSES = [
+  'pending',
+  'building',
+  'pushing',
+  'deploying'
+]
+const ACTIVE_JOB_STAGES = [
+  'queued',
+  'claimed',
+  'initialization',
+  'source_preparation',
+  'image_build',
+  'container_startup',
+  'health_check',
+  'traffic_cutover',
+  'cleanup',
+  'cancel_requested'
+]
+const CLAIM_TIMEOUT = 60 * 1000
+
+module.exports = {
+  friendlyName: 'Run resource cleanup',
+
+  description:
+    'Create or resume one durable, idempotent destructive cleanup operation.',
+
+  inputs: {
+    targetKey: {
+      type: 'string',
+      required: true
+    },
+    requestKey: {
+      type: 'string'
+    },
+    scopeType: {
+      type: 'string',
+      required: true,
+      isIn: ['project', 'environment', 'app', 'service']
+    },
+    resourceId: {
+      type: 'number'
+    },
+    retentionPolicy: {
+      type: 'string',
+      isIn: ['retain', 'purge'],
+      defaultsTo: 'retain'
+    },
+    userId: {
+      type: 'number'
+    },
+    teamId: {
+      type: 'number',
+      required: true
+    },
+    ipAddress: {
+      type: 'string',
+      allowNull: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    },
+    notFound: {}
+  },
+
+  fn: async function ({
+    targetKey,
+    requestKey,
+    scopeType,
+    resourceId,
+    retentionPolicy,
+    userId,
+    teamId,
+    ipAddress
+  }) {
+    let operation = await CleanupOperation.findOne({ targetKey })
+
+    if (!operation) {
+      if (!resourceId) throw 'notFound'
+      const snapshot = await sails.helpers.cleanup.createSnapshot
+        .with({ scopeType, resourceId })
+        .intercept('notFound', 'notFound')
+
+      if (Number(snapshot.target.teamId) !== Number(teamId)) {
+        throw 'notFound'
+      }
+
+      try {
+        operation = await CleanupOperation.create({
+          targetKey,
+          requestKey: requestKey || targetKey,
+          scopeType,
+          resourceId,
+          projectId: snapshot.target.projectId,
+          environmentId: snapshot.target.environmentId,
+          appId: snapshot.target.appId,
+          serviceId: snapshot.target.serviceId,
+          retentionPolicy,
+          status: 'pending',
+          stage: 'pending',
+          snapshot,
+          requestedBy: userId || null,
+          team: teamId,
+          ipAddress: ipAddress || null
+        }).fetch()
+      } catch (error) {
+        if (!isUniqueConflict(error)) throw error
+        operation = await CleanupOperation.findOne({ targetKey })
+      }
+    }
+
+    if (!operation || Number(normalizeId(operation.team)) !== Number(teamId)) {
+      throw 'notFound'
+    }
+
+    if (operation.status === 'complete') {
+      return serialize(operation)
+    }
+
+    if (
+      operation.status === 'running' &&
+      Date.now() - operation.updatedAt < CLAIM_TIMEOUT
+    ) {
+      throw cleanupError(
+        'Cleanup is already running. Try again in a moment.',
+        'CLEANUP_IN_PROGRESS',
+        operation
+      )
+    }
+
+    const claimedOperation = await CleanupOperation.updateOne({
+      id: operation.id,
+      status: operation.status,
+      updatedAt: operation.updatedAt
+    }).set({
+      status: 'running',
+      errorMessage: null
+    })
+
+    if (!claimedOperation) {
+      operation = await CleanupOperation.findOne({ id: operation.id })
+      if (operation?.status === 'complete') return serialize(operation)
+      throw cleanupError(
+        'Cleanup is already running. Try again in a moment.',
+        'CLEANUP_IN_PROGRESS',
+        operation
+      )
+    }
+
+    operation = claimedOperation
+
+    if (operation.stage === 'pending') {
+      const refreshedSnapshot = await sails.helpers.cleanup.createSnapshot
+        .with({
+          scopeType: operation.scopeType,
+          resourceId: operation.resourceId
+        })
+        .tolerate('notFound', () => null)
+
+      if (refreshedSnapshot) {
+        operation = await CleanupOperation.updateOne({ id: operation.id }).set({
+          snapshot: refreshedSnapshot
+        })
+      }
+
+      await recordAudit(operation, 'cleanup.started', {
+        retentionPolicy: operation.retentionPolicy
+      })
+    }
+
+    for (const [stageName, handler] of STAGES) {
+      operation = await CleanupOperation.findOne({ id: operation.id })
+      if (operation.stages?.[stageName]?.status === 'complete') continue
+
+      try {
+        const outcome = await handler(operation)
+        const stages = {
+          ...(operation.stages || {}),
+          [stageName]: {
+            status: 'complete',
+            completedAt: Date.now(),
+            outcome: outcome || {}
+          }
+        }
+        operation = await CleanupOperation.updateOne({ id: operation.id }).set({
+          stage: stageName,
+          stages
+        })
+        await recordAudit(operation, 'cleanup.stage.completed', {
+          stage: stageName,
+          outcome: outcome || {}
+        })
+      } catch (error) {
+        operation = await recordFailure(operation, stageName, error)
+        throw cleanupError(
+          `Cleanup paused during ${humanize(stageName)}: ${
+            error.message || error
+          }`,
+          error.code || 'CLEANUP_RETRYABLE',
+          operation
+        )
+      }
+    }
+
+    operation = await CleanupOperation.updateOne({ id: operation.id }).set({
+      status: 'complete',
+      stage: 'complete',
+      completedAt: Date.now(),
+      errorMessage: null
+    })
+    await recordAudit(operation, 'cleanup.completed', {
+      retentionPolicy: operation.retentionPolicy,
+      warnings: operation.warnings || []
+    })
+
+    return serialize(operation)
+  }
+}
+
+async function removeTraffic(operation) {
+  const routes = operation.snapshot.artifacts?.routes || []
+  const outcomes = []
+
+  for (const route of routes) {
+    if (route.action === 'update') {
+      const apps = (
+        await App.find({ environment: route.environmentId })
+      ).filter((app) => !route.excludedAppIds.includes(app.id))
+      outcomes.push(
+        await sails.helpers.caddy.updateRoute.with({
+          environmentId: route.environmentId,
+          apps,
+          routeVersion: `cleanup-${operation.id}`
+        })
+      )
+      continue
+    }
+
+    outcomes.push(
+      await sails.helpers.caddy.removeRoute.with({
+        projectSlug: route.projectSlug,
+        environmentSlug: route.environmentSlug
+      })
+    )
+  }
+
+  return { routes: outcomes }
+}
+
+async function stopRunningWork(operation) {
+  const deploymentIds = operation.snapshot.records?.deploymentIds || []
+  if (deploymentIds.length === 0) return { cancelled: 0 }
+
+  const activeDeployments = await Deployment.find({
+    id: { in: deploymentIds },
+    status: { in: ACTIVE_DEPLOYMENT_STATUSES }
+  })
+  const jobs = await DeploymentJob.find({
+    deployment: { in: deploymentIds },
+    stage: { in: ACTIVE_JOB_STAGES }
+  })
+  const leases = await DeploymentLease.find({
+    deployment: { in: deploymentIds }
+  })
+  const liveLeases = []
+
+  for (const deployment of activeDeployments) {
+    deploymentCancellation.request(
+      deployment.id,
+      `Cancelled by cleanup operation ${operation.id}`
+    )
+  }
+
+  for (const lease of leases) {
+    if (lease.expiresAt && lease.expiresAt <= Date.now()) {
+      await DeploymentLease.destroyOne({ id: lease.id })
+    } else {
+      liveLeases.push(lease)
+    }
+  }
+
+  for (const job of jobs) {
+    const hasLiveLease = liveLeases.some(
+      (lease) => normalizeId(lease.deployment) === normalizeId(job.deployment)
+    )
+    await DeploymentJob.updateOne({ id: job.id }).set({
+      stage: hasLiveLease ? 'cancel_requested' : 'cancelled'
+    })
+  }
+
+  if (activeDeployments.length > 0) {
+    await Deployment.update({
+      id: { in: activeDeployments.map((item) => item.id) }
+    }).set({
+      status: 'cancelled',
+      errorMessage: `Cancelled by cleanup operation ${operation.id}`,
+      finishedAt: Date.now()
+    })
+  }
+
+  if (liveLeases.length > 0) {
+    const error = new Error(
+      `${liveLeases.length} deployment worker${
+        liveLeases.length === 1 ? ' is' : 's are'
+      } still stopping`
+    )
+    error.code = 'CLEANUP_ACTIVE_WORK'
+    throw error
+  }
+
+  return { cancelled: activeDeployments.length, jobs: jobs.length }
+}
+
+async function removeContainers(operation) {
+  const containerNames = operation.snapshot.artifacts?.containerNames || []
+  let removed = 0
+  let missing = 0
+
+  for (const containerName of containerNames) {
+    try {
+      await sails.helpers.docker.stopContainer.with({ containerName })
+      removed += 1
+    } catch (error) {
+      if (!isMissingResource(error)) throw error
+      missing += 1
+    }
+  }
+
+  return { removed, missing }
+}
+
+async function releasePorts(operation) {
+  const records = operation.snapshot.records || {}
+  const artifacts = operation.snapshot.artifacts || {}
+  let released = 0
+
+  if ((artifacts.portReservationIds || []).length > 0) {
+    released += (
+      await PortReservation.destroy({
+        id: { in: artifacts.portReservationIds }
+      }).fetch()
+    ).length
+  }
+
+  const deploymentIds = (records.deploymentIds || []).map(String)
+  if (deploymentIds.length > 0) {
+    released += (
+      await PortReservation.destroy({
+        ownerType: 'deployment',
+        ownerId: { in: deploymentIds }
+      }).fetch()
+    ).length
+  }
+
+  return { released }
+}
+
+async function removeRecords(operation) {
+  return sails.helpers.cleanup.removeRecords.with({
+    snapshot: operation.snapshot
+  })
+}
+
+async function removeArtifacts(operation) {
+  return sails.helpers.cleanup.removeArtifacts.with({
+    snapshot: operation.snapshot,
+    retentionPolicy: operation.retentionPolicy
+  })
+}
+
+async function recordFailure(operation, stageName, error) {
+  const warning = {
+    stage: stageName,
+    message: error.message || String(error),
+    code: error.code || 'CLEANUP_RETRYABLE',
+    occurredAt: Date.now()
+  }
+  const stages = {
+    ...(operation.stages || {}),
+    [stageName]: {
+      status: 'failed',
+      failedAt: warning.occurredAt,
+      error: warning
+    }
+  }
+
+  // A deployment worker can restore a route while it unwinds. Re-run the
+  // traffic stage after active work has fully stopped.
+  if (stageName === 'work' && stages.traffic) {
+    stages.traffic = {
+      ...stages.traffic,
+      status: 'pending',
+      retryReason: 'running work was still stopping'
+    }
+  }
+
+  const updated = await CleanupOperation.updateOne({ id: operation.id }).set({
+    status: 'failed',
+    stage: stageName,
+    stages,
+    warnings: [...(operation.warnings || []), warning],
+    errorMessage: warning.message
+  })
+  await recordAudit(updated, 'cleanup.stage.failed', warning)
+  return updated
+}
+
+async function recordAudit(operation, action, details) {
+  await sails.helpers.audit.log.with({
+    action,
+    resourceType: operation.scopeType,
+    resourceId: String(operation.resourceId),
+    details: {
+      cleanupOperationId: operation.id,
+      targetKey: operation.targetKey,
+      ...details
+    },
+    userId: normalizeId(operation.requestedBy) || undefined,
+    teamId: normalizeId(operation.team),
+    ipAddress: operation.ipAddress || undefined
+  })
+}
+
+function serialize(operation) {
+  const artifactOutcome = operation.stages?.artifacts?.outcome || {}
+  return {
+    id: operation.id,
+    targetKey: operation.targetKey,
+    requestKey: operation.requestKey,
+    scopeType: operation.scopeType,
+    resourceId: operation.resourceId,
+    label: operation.snapshot?.target?.label || null,
+    status: operation.status,
+    stage: operation.stage,
+    retentionPolicy: operation.retentionPolicy,
+    stages: operation.stages || {},
+    warnings: operation.warnings || [],
+    retainedArtifacts: artifactOutcome.retained || {},
+    completedAt: operation.completedAt || null,
+    errorMessage: operation.errorMessage || null
+  }
+}
+
+function cleanupError(message, code, operation) {
+  const error = new Error(message)
+  error.code = code
+  error.cleanup = serialize(operation)
+  return error
+}
+
+function isUniqueConflict(error) {
+  return (
+    error?.code === 'E_UNIQUE' ||
+    /unique|constraint/i.test(error?.message || '')
+  )
+}
+
+function isMissingResource(error) {
+  return (
+    error === 'notFound' ||
+    error?.code === 'notFound' ||
+    /not found|no such container/i.test(error?.message || '')
+  )
+}
+
+function humanize(value) {
+  return String(value).replace(/_/g, ' ')
+}
+
+function normalizeId(value) {
+  return value && typeof value === 'object' ? value.id : value
+}

--- a/api/helpers/deploy/queue-deployment.js
+++ b/api/helpers/deploy/queue-deployment.js
@@ -35,6 +35,9 @@ module.exports = {
   exits: {
     success: {
       outputType: 'ref'
+    },
+    cleanupInProgress: {
+      outputType: 'ref'
     }
   },
 
@@ -43,6 +46,18 @@ module.exports = {
     if (!environmentId) {
       throw new Error('A queued deployment requires an environment.')
     }
+
+    const environment = await Environment.findOne({ id: environmentId })
+    if (!environment) {
+      throw new Error(`Environment ${environmentId} no longer exists.`)
+    }
+    const cleanupScope = {
+      projectId: normalizeId(environment.project),
+      environmentId,
+      appId: normalizeId(app)
+    }
+    const initialCleanup = await findBlockingCleanup(cleanupScope)
+    if (initialCleanup) throw { cleanupInProgress: initialCleanup }
 
     const appSlug = app?.slug || 'app'
     // The source cache and Caddy route are environment-wide resources. Keep
@@ -74,6 +89,15 @@ module.exports = {
         .usingConnection(db)
     })
 
+    const racedCleanup = await findBlockingCleanup(cleanupScope)
+    if (racedCleanup) {
+      await withDatastoreTransaction(async (db) => {
+        await DeploymentJob.destroyOne({ id: job.id }).usingConnection(db)
+        await Deployment.destroyOne({ id: deployment.id }).usingConnection(db)
+      })
+      throw { cleanupInProgress: racedCleanup }
+    }
+
     const queuePosition = await getQueuePosition(job)
 
     if (dispatch) {
@@ -100,6 +124,12 @@ module.exports = {
 function normalizeId(value) {
   if (value && typeof value === 'object') return value.id
   return value
+}
+
+async function findBlockingCleanup(scope) {
+  return sails.helpers.cleanup.assertAvailable
+    .with(scope)
+    .tolerate('blocked', (error) => error.raw || error)
 }
 
 async function getQueuePosition(job) {

--- a/api/helpers/deploy/trigger-deployment.js
+++ b/api/helpers/deploy/trigger-deployment.js
@@ -49,6 +49,9 @@ module.exports = {
     appNotFound: {},
     sourceUnavailable: {
       outputType: 'ref'
+    },
+    cleanupInProgress: {
+      outputType: 'ref'
     }
   },
 
@@ -112,17 +115,19 @@ module.exports = {
       }
     }
 
-    const queued = await sails.helpers.deploy.queueDeployment.with({
-      values: {
-        gitCommit: finalGitCommit,
-        gitBranch: finalGitBranch,
-        gitMessage: finalGitMessage,
-        triggeredBy: user.id,
-        triggerType,
-        environment: environment.id
-      },
-      app: targetApp
-    })
+    const queued = await sails.helpers.deploy.queueDeployment
+      .with({
+        values: {
+          gitCommit: finalGitCommit,
+          gitBranch: finalGitBranch,
+          gitMessage: finalGitMessage,
+          triggeredBy: user.id,
+          triggerType,
+          environment: environment.id
+        },
+        app: targetApp
+      })
+      .intercept('cleanupInProgress', 'cleanupInProgress')
 
     sails.helpers.audit.log
       .with({

--- a/api/helpers/docker/remove-volume.js
+++ b/api/helpers/docker/remove-volume.js
@@ -1,0 +1,37 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Remove volume',
+
+  description: 'Remove a Docker volume idempotently.',
+
+  inputs: {
+    volumeName: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ volumeName }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+
+    try {
+      await execFileAsync(dockerPath, ['volume', 'rm', volumeName])
+      return { removed: true, volumeName }
+    } catch (error) {
+      if (/no such volume/i.test(error.message || '')) {
+        return { removed: false, volumeName }
+      }
+      throw error
+    }
+  }
+}

--- a/api/helpers/docker/stop-container.js
+++ b/api/helpers/docker/stop-container.js
@@ -35,9 +35,11 @@ module.exports = {
   },
 
   fn: async function ({ containerName, remove, timeout }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+
     try {
       // Check if container exists
-      await execFileAsync('docker', ['inspect', containerName])
+      await execFileAsync(dockerPath, ['inspect', containerName])
     } catch {
       sails.log.verbose(`Container ${containerName} not found`)
       throw 'notFound'
@@ -45,7 +47,7 @@ module.exports = {
 
     try {
       // Stop the container
-      await execFileAsync('docker', [
+      await execFileAsync(dockerPath, [
         'stop',
         '-t',
         String(timeout),
@@ -54,7 +56,7 @@ module.exports = {
       sails.log.info(`Stopped container: ${containerName}`)
 
       if (remove) {
-        await execFileAsync('docker', ['rm', containerName])
+        await execFileAsync(dockerPath, ['rm', containerName])
         sails.log.info(`Removed container: ${containerName}`)
       }
 

--- a/api/helpers/preview/destroy-preview-environment.js
+++ b/api/helpers/preview/destroy-preview-environment.js
@@ -2,7 +2,7 @@ module.exports = {
   friendlyName: 'Destroy preview environment',
 
   description:
-    'Stop containers, remove routes, and delete a preview environment.',
+    'Use shared cleanup to purge an automatically-created preview environment.',
 
   inputs: {
     project: {
@@ -19,67 +19,46 @@ module.exports = {
 
   exits: {
     success: {
-      description: 'Preview environment destroyed'
+      description: 'Preview environment destroyed',
+      outputType: 'ref'
     }
   },
 
   fn: async function ({ project, prNumber }) {
     const slug = `pr-${prNumber}`
-
+    const requestKey = `environment:${project.slug}/${slug}`
     const environment = await Environment.findOne({
       project: project.id,
       slug
     })
+    const targetKey = environment ? `environment:${environment.id}` : undefined
+    const existingOperation = await sails.helpers.cleanup.findOperation.with({
+      targetKey,
+      requestKey
+    })
 
-    if (!environment) {
+    if (!environment && !existingOperation) {
       sails.log.verbose(
         `No preview environment ${slug} found for ${project.slug}`
       )
-      return
+      return { status: 'not_found' }
     }
 
-    // Stop app container
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (app && app.containerName) {
-      try {
-        await sails.helpers.docker.stopContainer(app.containerName)
-      } catch (err) {
-        sails.log.warn(`Failed to stop preview app container: ${err.message}`)
-      }
-    }
-
-    // Stop and remove service containers
-    const services = await Service.find({ environment: environment.id })
-    for (const service of services) {
-      try {
-        await sails.helpers.docker.destroyService(service.id)
-      } catch (err) {
-        sails.log.warn(
-          `Failed to destroy preview service ${service.name}: ${err.message}`
-        )
-      }
-    }
-
-    // Remove Caddy route
-    try {
-      await sails.helpers.caddy.removeRoute.with({
-        projectSlug: project.slug,
-        environmentSlug: slug
-      })
-    } catch (err) {
-      sails.log.verbose(
-        `Failed to remove Caddy route for preview: ${err.message}`
-      )
-    }
-
-    // Delete database records
-    await Deployment.destroy({ environment: environment.id })
-    await App.destroy({ environment: environment.id })
-    await Service.destroy({ environment: environment.id })
-    await Environment.destroyOne({ id: environment.id })
+    const cleanup = await sails.helpers.cleanup.run.with({
+      targetKey: targetKey || existingOperation.targetKey,
+      requestKey,
+      scopeType: 'environment',
+      resourceId: environment?.id || existingOperation.resourceId,
+      retentionPolicy: 'purge',
+      teamId: normalizeId(project.team) || normalizeId(existingOperation.team),
+      ipAddress: null
+    })
 
     sails.log.info(`Preview environment destroyed: ${project.slug}/${slug}`)
+    return cleanup
   }
+}
+
+function normalizeId(value) {
+  return value && typeof value === 'object' ? value.id : value
 }

--- a/api/models/CleanupOperation.js
+++ b/api/models/CleanupOperation.js
@@ -1,0 +1,128 @@
+/**
+ * CleanupOperation.js
+ *
+ * Durable, resumable state for destructive resource cleanup.
+ */
+
+module.exports = {
+  tableName: 'cleanup_operations',
+
+  attributes: {
+    targetKey: {
+      type: 'string',
+      required: true,
+      unique: true,
+      columnName: 'target_key',
+      description: 'Stable identity used to resume the same cleanup request.'
+    },
+
+    requestKey: {
+      type: 'string',
+      required: true,
+      columnName: 'request_key',
+      description:
+        'Route-level identity used to find the latest operation after its target record is gone.'
+    },
+
+    scopeType: {
+      type: 'string',
+      required: true,
+      isIn: ['project', 'environment', 'app', 'service'],
+      columnName: 'scope_type'
+    },
+
+    resourceId: {
+      type: 'number',
+      required: true,
+      columnName: 'resource_id'
+    },
+
+    projectId: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'project_id'
+    },
+
+    environmentId: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'environment_id'
+    },
+
+    appId: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'app_id'
+    },
+
+    serviceId: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'service_id'
+    },
+
+    retentionPolicy: {
+      type: 'string',
+      isIn: ['retain', 'purge'],
+      defaultsTo: 'retain',
+      columnName: 'retention_policy'
+    },
+
+    status: {
+      type: 'string',
+      isIn: ['pending', 'running', 'failed', 'complete'],
+      defaultsTo: 'pending'
+    },
+
+    stage: {
+      type: 'string',
+      defaultsTo: 'pending'
+    },
+
+    snapshot: {
+      type: 'json',
+      defaultsTo: {},
+      description:
+        'Immutable resource and artifact inventory captured before deletion.'
+    },
+
+    stages: {
+      type: 'json',
+      defaultsTo: {},
+      description: 'Outcome of each idempotent cleanup stage.'
+    },
+
+    warnings: {
+      type: 'json',
+      defaultsTo: []
+    },
+
+    errorMessage: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'error_message'
+    },
+
+    completedAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'completed_at'
+    },
+
+    requestedBy: {
+      model: 'user',
+      columnName: 'requested_by'
+    },
+
+    team: {
+      model: 'team',
+      required: true
+    },
+
+    ipAddress: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'ip_address'
+    }
+  }
+}

--- a/assets/js/components/ConfirmModal.vue
+++ b/assets/js/components/ConfirmModal.vue
@@ -73,7 +73,10 @@ onUnmounted(() => {
         v-if="show"
         class="fixed inset-0 z-50 flex items-center justify-center"
       >
-        <div class="fixed inset-0 bg-black/50" @click="emit('cancel')" />
+        <div
+          class="fixed inset-0 bg-black/50"
+          @click="!loading && emit('cancel')"
+        />
         <Transition
           enter-active-class="transition duration-200 ease-out"
           enter-from-class="scale-95 opacity-0"
@@ -84,14 +87,22 @@ onUnmounted(() => {
         >
           <div
             v-if="show"
+            data-test="confirm-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="confirm-modal-title"
             class="relative w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-xl dark:border-gray-700 dark:bg-gray-900"
           >
-            <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
+            <h3
+              id="confirm-modal-title"
+              class="text-lg font-semibold text-gray-900 dark:text-white"
+            >
               {{ title }}
             </h3>
             <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
               {{ message }}
             </p>
+            <slot name="form" />
             <div class="mt-4 flex justify-end space-x-3">
               <button
                 @click="emit('cancel')"

--- a/assets/js/pages/dashboard/index.vue
+++ b/assets/js/pages/dashboard/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Link, Head, router } from '@inertiajs/vue3'
+import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, onMounted, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
@@ -76,21 +76,29 @@ function copySlug(e, slug) {
 }
 
 const deletingProject = ref(null)
+const deleteProjectForm = useForm({
+  purgeData: false
+})
 
 function deleteProject(e, project) {
   e.preventDefault()
   e.stopPropagation()
   deletingProject.value = project
+  deleteProjectForm.reset()
   closeMenu()
 }
 
 function executeDeleteProject() {
   if (!deletingProject.value) return
-  router.delete(`/projects/${deletingProject.value.slug}`)
-  deletingProject.value = null
+  deleteProjectForm.delete(`/projects/${deletingProject.value.slug}`, {
+    onFinish: () => {
+      deletingProject.value = null
+    }
+  })
 }
 
 function cancelDeleteProject() {
+  deleteProjectForm.reset()
   deletingProject.value = null
 }
 
@@ -543,11 +551,30 @@ onUnmounted(() => {
     <ConfirmModal
       :show="!!deletingProject"
       title="Delete project"
-      :message="`Are you sure you want to delete &quot;${deletingProject?.name}&quot;? This action cannot be undone.`"
+      :message="`Are you sure you want to delete &quot;${deletingProject?.name}&quot;? Recovery data is retained unless you choose to purge it.`"
       confirm-label="Delete"
       :destructive="true"
+      :loading="deleteProjectForm.processing"
       @confirm="executeDeleteProject"
       @cancel="cancelDeleteProject"
-    />
+    >
+      <template #form>
+        <label class="mt-4 flex cursor-pointer items-start gap-3">
+          <input
+            v-model="deleteProjectForm.purgeData"
+            type="checkbox"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          <span>
+            <span class="block text-sm text-gray-700 dark:text-gray-300">
+              Also permanently delete retained data
+            </span>
+            <span class="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+              Purges service volumes, backups, source, and Docker images.
+            </span>
+          </span>
+        </label>
+      </template>
+    </ConfirmModal>
   </div>
 </template>

--- a/assets/js/pages/projects/app-settings.vue
+++ b/assets/js/pages/projects/app-settings.vue
@@ -220,6 +220,12 @@ onMounted(() => {
 // --- Delete ---
 const deleteConfirm = ref(false)
 const deleting = ref(false)
+const purgeAppData = ref(false)
+
+function openDeleteApp() {
+  purgeAppData.value = false
+  deleteConfirm.value = true
+}
 
 async function deleteApp() {
   deleting.value = true
@@ -228,7 +234,8 @@ async function deleteApp() {
       `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}`,
       {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ purgeData: purgeAppData.value })
       }
     )
     if (res.ok) {
@@ -238,10 +245,16 @@ async function deleteApp() {
     } else {
       const data = await res.json()
       toast({
-        message: data.problems?.[0]?.app || 'Failed to delete app',
+        message:
+          data.problems?.[0]?.app || data.message || 'Failed to delete app',
         type: 'error'
       })
     }
+  } catch (error) {
+    toast({
+      message: error.message || 'Failed to delete app',
+      type: 'error'
+    })
   } finally {
     deleting.value = false
     deleteConfirm.value = false
@@ -967,7 +980,7 @@ async function deleteApp() {
           </p>
           <div class="mt-4">
             <button
-              @click="deleteConfirm = true"
+              @click="openDeleteApp"
               class="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
             >
               Delete app
@@ -981,13 +994,26 @@ async function deleteApp() {
     <ConfirmModal
       :show="deleteConfirm"
       title="Delete app"
-      :message="`Are you sure you want to delete '${app.name}'? This will stop the container and cannot be undone.`"
+      :message="`Are you sure you want to delete '${app.name}'? Its Docker images are retained by default for recovery.`"
       confirm-label="Delete"
       :destructive="true"
       :loading="deleting"
       @confirm="deleteApp"
       @cancel="deleteConfirm = false"
-    />
+    >
+      <template #form>
+        <label class="mt-4 flex cursor-pointer items-start gap-3">
+          <input
+            v-model="purgeAppData"
+            type="checkbox"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          <span class="text-sm text-gray-700 dark:text-gray-300">
+            Also permanently delete retained Docker images
+          </span>
+        </label>
+      </template>
+    </ConfirmModal>
 
     <!-- Disconnect Confirm Modal -->
     <ConfirmModal

--- a/assets/js/pages/projects/environment-settings.vue
+++ b/assets/js/pages/projects/environment-settings.vue
@@ -13,10 +13,7 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environment: Object,
-  canDelete: Boolean,
-  isOnlyEnvironment: Boolean,
-  hasApp: Boolean,
-  serviceCount: Number
+  isOnlyEnvironment: Boolean
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -35,6 +32,7 @@ const isDirty = computed(
 )
 const showDeleteConfirm = ref(false)
 const deleting = ref(false)
+const purgeData = ref(false)
 
 async function save() {
   if (saving.value) return
@@ -87,7 +85,8 @@ async function deleteEnvironment() {
       `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}`,
       {
         method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' }
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ purgeData: purgeData.value })
       }
     )
 
@@ -103,22 +102,19 @@ async function deleteEnvironment() {
       deleting.value = false
       showDeleteConfirm.value = false
     }
-  } catch {
+  } catch (error) {
+    toast({
+      message: error.message || 'Failed to delete environment',
+      type: 'error'
+    })
     deleting.value = false
     showDeleteConfirm.value = false
   }
 }
 
-// Build reason why deletion is blocked
-const deleteBlockedReason = ref('')
-if (!props.canDelete) {
-  const reasons = []
-  if (props.hasApp) reasons.push('has a deployed app')
-  if (props.serviceCount > 0)
-    reasons.push(
-      `has ${props.serviceCount} service${props.serviceCount > 1 ? 's' : ''}`
-    )
-  deleteBlockedReason.value = `This environment ${reasons.join(' and ')}.`
+function openDeleteEnvironment() {
+  purgeData.value = false
+  showDeleteConfirm.value = true
 }
 </script>
 
@@ -339,17 +335,12 @@ if (!props.canDelete) {
                   Delete environment
                 </p>
                 <p class="text-sm text-gray-500 dark:text-gray-400">
-                  <template v-if="canDelete">
-                    Permanently delete this environment and all its data.
-                  </template>
-                  <template v-else>
-                    {{ deleteBlockedReason }} Remove them first to delete.
-                  </template>
+                  Delete this environment and stop its apps and services.
                 </p>
               </div>
               <button
-                @click="showDeleteConfirm = true"
-                :disabled="!canDelete || isOnlyEnvironment"
+                @click="openDeleteEnvironment"
+                :disabled="isOnlyEnvironment"
                 class="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Delete
@@ -370,12 +361,30 @@ if (!props.canDelete) {
     <ConfirmModal
       :show="showDeleteConfirm"
       title="Delete environment"
-      :message="`Are you sure you want to delete '${environment.name}'? This action cannot be undone.`"
+      :message="`Are you sure you want to delete '${environment.name}'? Recovery data is retained unless you choose to purge it.`"
       confirm-label="Delete environment"
       :destructive="true"
       :loading="deleting"
       @confirm="deleteEnvironment"
       @cancel="showDeleteConfirm = false"
-    />
+    >
+      <template #form>
+        <label class="mt-4 flex cursor-pointer items-start gap-3">
+          <input
+            v-model="purgeData"
+            type="checkbox"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          <span>
+            <span class="block text-sm text-gray-700 dark:text-gray-300">
+              Also permanently delete retained data
+            </span>
+            <span class="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+              Purges service volumes, backups, and Docker images.
+            </span>
+          </span>
+        </label>
+      </template>
+    </ConfirmModal>
   </div>
 </template>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -538,6 +538,8 @@ const newServiceVersion = ref(
 const customServiceVersion = ref(false)
 const creatingService = ref(false)
 const deletingServiceId = ref(null)
+const deletingService = ref(false)
+const purgeServiceData = ref(false)
 const serviceMenuOpen = ref(null)
 const stoppingServiceId = ref(null)
 const startingServiceId = ref(null)
@@ -655,6 +657,7 @@ function closeServiceMenu() {
 
 function confirmDeleteService(service) {
   serviceMenuOpen.value = null
+  purgeServiceData.value = false
   deletingServiceId.value = service.id
 }
 
@@ -707,20 +710,38 @@ async function startService(service) {
 }
 
 async function executeDeleteService() {
-  const res = await fetch(`/api/v1/services/${deletingServiceId.value}`, {
-    method: 'DELETE',
-    headers: { 'Content-Type': 'application/json' }
-  })
-  deletingServiceId.value = null
-  if (res.ok) {
-    toast({ message: 'Service deleted', type: 'success' })
-  } else {
-    toast({ message: 'Failed to delete service', type: 'error' })
+  if (deletingService.value) return
+  deletingService.value = true
+
+  try {
+    const res = await fetch(`/api/v1/services/${deletingServiceId.value}`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ purgeData: purgeServiceData.value })
+    })
+    deletingServiceId.value = null
+    if (res.ok) {
+      toast({ message: 'Service deleted', type: 'success' })
+    } else {
+      const data = await res.json().catch(() => null)
+      toast({
+        message: data?.message || 'Failed to delete service',
+        type: 'error'
+      })
+    }
+    router.reload({ only: ['environment', 'envVars', 'checklist'] })
+  } catch (error) {
+    toast({
+      message: error.message || 'Failed to delete service',
+      type: 'error'
+    })
+  } finally {
+    deletingService.value = false
   }
-  router.reload({ only: ['environment', 'envVars', 'checklist'] })
 }
 
 function cancelDeleteService() {
+  purgeServiceData.value = false
   deletingServiceId.value = null
 }
 
@@ -2608,11 +2629,25 @@ onBeforeUnmount(() => {
     <ConfirmModal
       :show="!!deletingServiceId"
       title="Delete service"
-      message="This will stop the service container and permanently delete all data. This action cannot be undone."
+      message="The service and its container will be removed. Its data volume and backups are retained by default for recovery."
       confirm-label="Delete service"
       :destructive="true"
+      :loading="deletingService"
       @confirm="executeDeleteService"
       @cancel="cancelDeleteService"
-    />
+    >
+      <template #form>
+        <label class="mt-4 flex cursor-pointer items-start gap-3">
+          <input
+            v-model="purgeServiceData"
+            type="checkbox"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          <span class="text-sm text-gray-700 dark:text-gray-300">
+            Also permanently delete the data volume and backups
+          </span>
+        </label>
+      </template>
+    </ConfirmModal>
   </div>
 </template>

--- a/assets/js/pages/projects/settings.vue
+++ b/assets/js/pages/projects/settings.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { Link, Head, useForm, router } from '@inertiajs/vue3'
+import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 
 defineOptions({
   layout: AppLayout
@@ -30,6 +31,9 @@ const deployForm = useForm({
 })
 
 const showDeleteConfirm = ref(false)
+const deleteProjectForm = useForm({
+  purgeData: false
+})
 const copiedWebhook = ref(false)
 const copiedSecret = ref(false)
 
@@ -66,7 +70,16 @@ function copyText(text, field) {
 }
 
 function deleteProject() {
-  router.delete(`/projects/${props.project.slug}`)
+  deleteProjectForm.delete(`/projects/${props.project.slug}`, {
+    onFinish: () => {
+      showDeleteConfirm.value = false
+    }
+  })
+}
+
+function openDeleteProject() {
+  deleteProjectForm.reset()
+  showDeleteConfirm.value = true
 }
 </script>
 <template>
@@ -394,34 +407,48 @@ function deleteProject() {
             Danger zone
           </h3>
           <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-            Permanently delete this project and all of its environments,
-            deployments, and services. This action cannot be undone.
+            Delete this project and stop all of its environments, apps, and
+            services.
           </p>
           <div class="mt-4">
             <button
-              v-if="!showDeleteConfirm"
-              @click="showDeleteConfirm = true"
+              @click="openDeleteProject"
               class="rounded-md border border-red-300 px-4 py-2 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
             >
               Delete project
             </button>
-            <div v-else class="flex items-center space-x-3">
-              <button
-                @click="deleteProject"
-                class="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700"
-              >
-                Yes, delete "{{ project.name }}"
-              </button>
-              <button
-                @click="showDeleteConfirm = false"
-                class="rounded-md px-3 py-2 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              >
-                Cancel
-              </button>
-            </div>
           </div>
         </div>
       </div>
     </div>
+
+    <ConfirmModal
+      :show="showDeleteConfirm"
+      title="Delete project"
+      :message="`Are you sure you want to delete '${project.name}'? Recovery data is retained unless you choose to purge it.`"
+      confirm-label="Delete project"
+      :destructive="true"
+      :loading="deleteProjectForm.processing"
+      @confirm="deleteProject"
+      @cancel="showDeleteConfirm = false"
+    >
+      <template #form>
+        <label class="mt-4 flex cursor-pointer items-start gap-3">
+          <input
+            v-model="deleteProjectForm.purgeData"
+            type="checkbox"
+            class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          <span>
+            <span class="block text-sm text-gray-700 dark:text-gray-300">
+              Also permanently delete retained data
+            </span>
+            <span class="mt-0.5 block text-xs text-gray-500 dark:text-gray-400">
+              Purges service volumes, backups, source, and Docker images.
+            </span>
+          </span>
+        </label>
+      </template>
+    </ConfirmModal>
   </div>
 </template>

--- a/assets/js/pages/settings/audit-log.vue
+++ b/assets/js/pages/settings/audit-log.vue
@@ -23,6 +23,10 @@ const actionLabels = {
   'service.destroyed': 'Destroyed service',
   'environment.updated': 'Updated environment',
   'project.destroyed': 'Destroyed project',
+  'cleanup.started': 'Started cleanup',
+  'cleanup.stage.completed': 'Completed cleanup stage',
+  'cleanup.stage.failed': 'Cleanup stage failed',
+  'cleanup.completed': 'Completed cleanup',
   'settings.updated': 'Updated settings'
 }
 
@@ -31,8 +35,13 @@ function actionLabel(action) {
 }
 
 function actionColor(action) {
-  if (action.includes('destroy')) return 'text-red-600 dark:text-red-400'
-  if (action.includes('created') || action.includes('triggered'))
+  if (action.includes('destroy') || action.includes('failed'))
+    return 'text-red-600 dark:text-red-400'
+  if (
+    action.includes('created') ||
+    action.includes('triggered') ||
+    action.includes('completed')
+  )
     return 'text-green-600 dark:text-green-400'
   return 'text-blue-600 dark:text-blue-400'
 }

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -12,6 +12,7 @@
 module.exports.bootstrap = async function () {
   // Production uses `migrate: safe`; create coordinator tables before any
   // deployment job queries run on an existing installation.
+  await sails.helpers.cleanup.ensureSchema()
   await sails.helpers.deploy.ensureQueueSchema()
   await sails.helpers.service.ensureVersionSchema()
   await sails.helpers.lookout.ensureObservabilitySchema()

--- a/tests/e2e/pages/projects/cleanup-retention.test.js
+++ b/tests/e2e/pages/projects/cleanup-retention.test.js
@@ -56,7 +56,5 @@ test(
       fullPage: true
     })
     await page.raw.emulateMedia({ colorScheme: 'light' })
-
-    expect(page).toHaveNoSmoke()
   }
 )

--- a/tests/e2e/pages/projects/cleanup-retention.test.js
+++ b/tests/e2e/pages/projects/cleanup-retention.test.js
@@ -1,0 +1,62 @@
+const { test } = require('sounding')
+
+test(
+  'project cleanup makes retention explicit in light and dark mode',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'cleanup-retention-ui',
+          name: 'Cleanup retention'
+        }
+      }
+    }
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/settings`
+    )
+    await page.raw
+      .getByRole('button', { name: 'Delete project', exact: true })
+      .click()
+
+    await expect(page).toSee(
+      'Recovery data is retained unless you choose to purge it.'
+    )
+    await expect(page).toSee('Also permanently delete retained data')
+    await expect(page).toSee(
+      'Purges service volumes, backups, source, and Docker images.'
+    )
+
+    const modal = page.raw.locator('[data-test="confirm-modal"]')
+    const purgeData = page.raw.getByRole('checkbox', {
+      name: 'Also permanently delete retained data'
+    })
+    const deleteButton = modal.getByRole('button', {
+      name: 'Delete project',
+      exact: true
+    })
+
+    expect(await purgeData.isChecked()).toBe(false)
+    expect(await modal.getAttribute('class')).toContain('dark:bg-gray-900')
+    expect(await deleteButton.getAttribute('class')).toContain('bg-red-600')
+    await page.wait(250)
+    await page.screenshot('.tmp/cleanup-retention-light.png', {
+      fullPage: true
+    })
+
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await page.screenshot('.tmp/cleanup-retention-dark.png', {
+      fullPage: true
+    })
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+
+    expect(page).toHaveNoSmoke()
+  }
+)

--- a/tests/functional/pages/inertia-actions.test.js
+++ b/tests/functional/pages/inertia-actions.test.js
@@ -206,3 +206,109 @@ test(
     }
   }
 )
+
+test(
+  'web and API deletion expose the same durable cleanup result',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'web-cleanup-contract',
+          name: 'Web cleanup contract'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const webProject = current.projects.deploymentTarget
+    const apiProject = await world.create('project').with({
+      name: 'API cleanup contract',
+      slug: 'api-cleanup-contract',
+      team: current.teams.genesisTeam.id,
+      createdBy: current.users.genesisUser.id
+    })
+    const apiEnvironment = await world.create('environment').with({
+      project: apiProject.id,
+      name: 'Production',
+      slug: 'production',
+      isProduction: true
+    })
+    await world.create('app').with({
+      environment: apiEnvironment.id,
+      name: 'Web',
+      slug: 'web'
+    })
+
+    const originalRemoveRoute = sails.helpers.caddy.removeRoute
+    const removeRoute = async (inputs) => ({
+      removed: true,
+      routeId: `${inputs.projectSlug}/${inputs.environmentSlug}`
+    })
+    removeRoute.with = removeRoute
+    sails.helpers.caddy.removeRoute = removeRoute
+
+    try {
+      const browser = await withCsrfFromPage(
+        request,
+        `/projects/${webProject.slug}/settings`,
+        'genesisUser'
+      )
+      const webResponse = await browser.request.delete(
+        `/projects/${webProject.slug}`,
+        { purgeData: false }
+      )
+
+      expect(webResponse).toHaveStatus(409)
+      expect(webResponse).toHaveHeader('x-inertia-location', '/')
+
+      const dashboard = await browser.request.get('/')
+      const webCleanup = dashboard.data.props.flash.cleanup
+      expect(webCleanup.status).toBe('complete')
+      expect(webCleanup.retentionPolicy).toBe('retain')
+      expect(webCleanup.warnings).toEqual([])
+
+      const recreatedProject = await world.create('project').with({
+        name: 'Recreated web cleanup contract',
+        slug: webProject.slug,
+        team: current.teams.genesisTeam.id,
+        createdBy: current.users.genesisUser.id
+      })
+      const recreatedEnvironment = await world.create('environment').with({
+        project: recreatedProject.id,
+        name: 'Production',
+        slug: 'production',
+        isProduction: true
+      })
+      await world.create('app').with({
+        environment: recreatedEnvironment.id,
+        name: 'Web',
+        slug: 'web'
+      })
+      const recreatedResponse = await browser.request.delete(
+        `/api/v1/projects/${recreatedProject.slug}`,
+        { purgeData: false }
+      )
+      expect(recreatedResponse).toHaveStatus(200)
+      expect(recreatedResponse.data.cleanup.id === webCleanup.id).toBe(false)
+
+      const apiResponse = await browser.request.delete(
+        `/api/v1/projects/${apiProject.slug}`,
+        { purgeData: false }
+      )
+      expect(apiResponse).toHaveStatus(200)
+      expect(apiResponse).toHaveJsonPath('cleanup.status', webCleanup.status)
+      expect(apiResponse).toHaveJsonPath(
+        'cleanup.retentionPolicy',
+        webCleanup.retentionPolicy
+      )
+      expect(apiResponse).toHaveJsonPath(
+        'cleanup.warnings',
+        webCleanup.warnings
+      )
+    } finally {
+      sails.helpers.caddy.removeRoute = originalRemoveRoute
+    }
+  }
+)

--- a/tests/unit/helpers/cleanup/run.test.js
+++ b/tests/unit/helpers/cleanup/run.test.js
@@ -1,0 +1,555 @@
+const { test } = require('sounding')
+
+function cleanupWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: {
+        slug,
+        name: 'Cleanup target'
+      }
+    }
+  }
+}
+
+test(
+  'cleanup is idempotent when Docker resources are already missing',
+  { world: cleanupWorld('cleanup-idempotent') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = await sails.models.app
+      .updateOne({ id: current.apps.web.id })
+      .set({
+        containerName: 'missing-cleanup-app',
+        imageName: 'slipway/cleanup-idempotent:current',
+        hostPort: 1401
+      })
+    const service = await world.create('service').with({
+      environment: environment.id,
+      name: 'missing-db',
+      status: 'running',
+      containerName: 'missing-cleanup-db'
+    })
+    const deployment = await world.create('deployment').with({
+      environment: environment.id,
+      app: app.id,
+      imageName: 'slipway/cleanup-idempotent:release'
+    })
+    await world.create('deploymentjob').with({
+      deployment: deployment.id,
+      targetKey: `environment:${environment.id}`,
+      candidateContainerName: 'missing-candidate'
+    })
+
+    await withCleanupStubs(
+      sails,
+      {
+        stopContainer: async () => {
+          throw 'notFound'
+        }
+      },
+      async () => {
+        const inputs = {
+          targetKey: `project:${project.slug}`,
+          scopeType: 'project',
+          resourceId: project.id,
+          retentionPolicy: 'retain',
+          userId: current.users.genesisUser.id,
+          teamId: current.teams.genesisTeam.id
+        }
+        const first = await sails.helpers.cleanup.run.with(inputs)
+        const second = await sails.helpers.cleanup.run.with(inputs)
+
+        expect(first.status).toBe('complete')
+        expect(second.id).toBe(first.id)
+        expect(second.status).toBe('complete')
+        expect(first.stages.containers.outcome.missing).toBe(3)
+        expect(await sails.models.project.findOne({ id: project.id })).toBe(
+          undefined
+        )
+        expect(
+          await sails.models.cleanupoperation.count({
+            targetKey: inputs.targetKey
+          })
+        ).toBe(1)
+        expect(await sails.models.service.findOne({ id: service.id })).toBe(
+          undefined
+        )
+      }
+    )
+  }
+)
+
+test(
+  'concurrent cleanup requests share one operation and one runner',
+  { world: cleanupWorld('cleanup-concurrent') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    let releaseTraffic
+    let markTrafficStarted
+    const trafficReleased = new Promise((resolve) => {
+      releaseTraffic = resolve
+    })
+    const trafficStarted = new Promise((resolve) => {
+      markTrafficStarted = resolve
+    })
+
+    await withCleanupStubs(
+      sails,
+      {
+        removeRoute: async () => {
+          markTrafficStarted()
+          await trafficReleased
+          return { removed: true }
+        }
+      },
+      async () => {
+        const inputs = {
+          targetKey: `project:${project.slug}`,
+          scopeType: 'project',
+          resourceId: project.id,
+          retentionPolicy: 'retain',
+          userId: current.users.genesisUser.id,
+          teamId: current.teams.genesisTeam.id
+        }
+        const firstRequest = sails.helpers.cleanup.run
+          .with(inputs)
+          .then((result) => result)
+        await trafficStarted
+
+        const concurrentError = await captureError(
+          sails.helpers.cleanup.run.with(inputs)
+        )
+        releaseTraffic()
+        const firstResult = await firstRequest
+
+        expect(concurrentError.code).toBe('CLEANUP_IN_PROGRESS')
+        expect(concurrentError.cleanup.id).toBe(firstResult.id)
+        expect(firstResult.status).toBe('complete')
+        expect(
+          await sails.models.cleanupoperation.count({
+            targetKey: inputs.targetKey
+          })
+        ).toBe(1)
+      }
+    )
+  }
+)
+
+test(
+  'a recreated slug receives a new cleanup operation',
+  { world: cleanupWorld('cleanup-recreated-slug') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const originalProject = current.projects.deploymentTarget
+    const requestKey = `project:${originalProject.slug}`
+
+    await withCleanupStubs(sails, {}, async () => {
+      const first = await sails.helpers.cleanup.run.with({
+        targetKey: `project:${originalProject.id}`,
+        requestKey,
+        scopeType: 'project',
+        resourceId: originalProject.id,
+        retentionPolicy: 'retain',
+        userId: current.users.genesisUser.id,
+        teamId: current.teams.genesisTeam.id
+      })
+
+      const recreatedProject = await world.create('project').with({
+        name: 'Recreated cleanup target',
+        slug: originalProject.slug,
+        team: current.teams.genesisTeam.id,
+        createdBy: current.users.genesisUser.id
+      })
+      const recreatedEnvironment = await world.create('environment').with({
+        project: recreatedProject.id,
+        name: 'Production',
+        slug: 'production',
+        isProduction: true
+      })
+      await world.create('app').with({
+        environment: recreatedEnvironment.id,
+        name: 'Web',
+        slug: 'web'
+      })
+
+      const second = await sails.helpers.cleanup.run.with({
+        targetKey: `project:${recreatedProject.id}`,
+        requestKey,
+        scopeType: 'project',
+        resourceId: recreatedProject.id,
+        retentionPolicy: 'retain',
+        userId: current.users.genesisUser.id,
+        teamId: current.teams.genesisTeam.id
+      })
+
+      expect(second.id === first.id).toBe(false)
+      expect(second.targetKey).toBe(`project:${recreatedProject.id}`)
+      expect(await sails.models.cleanupoperation.count({ requestKey })).toBe(2)
+    })
+  }
+)
+
+test(
+  'cleanup pauses on a Caddy failure and resumes without losing records',
+  { world: cleanupWorld('cleanup-caddy-retry') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    let attempts = 0
+
+    await withCleanupStubs(
+      sails,
+      {
+        removeRoute: async () => {
+          attempts += 1
+          if (attempts === 1) {
+            const error = new Error('Caddy is temporarily unavailable')
+            error.code = 'CADDY_UNAVAILABLE'
+            throw error
+          }
+          return { removed: true }
+        }
+      },
+      async () => {
+        const inputs = {
+          targetKey: `environment:${project.slug}/${environment.slug}`,
+          scopeType: 'environment',
+          resourceId: environment.id,
+          retentionPolicy: 'retain',
+          userId: current.users.genesisUser.id,
+          teamId: current.teams.genesisTeam.id
+        }
+        const error = await captureError(sails.helpers.cleanup.run.with(inputs))
+        const failed = await sails.models.cleanupoperation.findOne({
+          targetKey: inputs.targetKey
+        })
+
+        expect(error.code).toBe('CADDY_UNAVAILABLE')
+        expect(failed.status).toBe('failed')
+        expect(failed.stage).toBe('traffic')
+        expect(
+          Boolean(
+            await sails.models.environment.findOne({ id: environment.id })
+          )
+        ).toBe(true)
+
+        const blocked = await captureError(
+          sails.helpers.deploy.queueDeployment.with({
+            values: {
+              environment: environment.id,
+              triggeredBy: current.users.genesisUser.id,
+              triggerType: 'manual'
+            },
+            app: current.apps.web,
+            dispatch: false
+          })
+        )
+        expect(blocked.code).toBe('cleanupInProgress')
+
+        const resumed = await sails.helpers.cleanup.run.with(inputs)
+        expect(resumed.status).toBe('complete')
+        expect(resumed.warnings.length).toBe(1)
+        expect(resumed.stages.traffic.status).toBe('complete')
+        expect(attempts).toBe(2)
+      }
+    )
+  }
+)
+
+test(
+  'retain policy preserves service recovery artifacts while deleting records',
+  { world: cleanupWorld('cleanup-retain') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const environment = current.environments.production
+    const service = await world.create('service').with({
+      environment: environment.id,
+      name: 'retained-db',
+      status: 'running',
+      containerName: 'slipway-cleanup-retained-db',
+      envVarKey: 'DATABASE_URL',
+      imageMetadata: { volumeName: 'cleanup-retained-volume' }
+    })
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      envVars: {
+        DATABASE_URL: 'postgres://retained',
+        APP_NAME: 'Slipway'
+      }
+    })
+    const backup = await world.create('backup').with({
+      service: service.id,
+      status: 'completed',
+      s3Key: 'backups/cleanup-retain.sql'
+    })
+
+    await withCleanupStubs(sails, {}, async (calls) => {
+      const result = await sails.helpers.cleanup.run.with({
+        targetKey: `service:${service.id}`,
+        scopeType: 'service',
+        resourceId: service.id,
+        retentionPolicy: 'retain',
+        userId: current.users.genesisUser.id,
+        teamId: current.teams.genesisTeam.id
+      })
+      const updatedEnvironment = await sails.models.environment
+        .findOne({ id: environment.id })
+        .decrypt()
+
+      expect(result.status).toBe('complete')
+      expect(result.retainedArtifacts.volumeNames).toContain(
+        'cleanup-retained-volume'
+      )
+      expect(result.retainedArtifacts.backupObjects).toEqual([
+        { backupId: backup.id, s3Key: backup.s3Key }
+      ])
+      expect(calls.removeVolume.length).toBe(0)
+      expect(calls.deleteBackupObject.length).toBe(0)
+      expect(updatedEnvironment.envVars.DATABASE_URL).toBe(undefined)
+      expect(updatedEnvironment.envVars.APP_NAME).toBe('Slipway')
+      expect(await sails.models.service.findOne({ id: service.id })).toBe(
+        undefined
+      )
+      expect(await sails.models.backup.findOne({ id: backup.id })).toBe(
+        undefined
+      )
+    })
+  }
+)
+
+test(
+  'a service cleanup does not block unrelated deployment work',
+  { world: cleanupWorld('cleanup-service-scope') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const environment = current.environments.production
+    const service = await world.create('service').with({
+      environment: environment.id,
+      name: 'scoped-db',
+      status: 'running',
+      containerName: 'slipway-cleanup-scoped-db'
+    })
+
+    await withCleanupStubs(
+      sails,
+      {
+        stopContainer: async () => {
+          throw new Error('Docker is temporarily unavailable')
+        }
+      },
+      async () => {
+        const cleanupError = await captureError(
+          sails.helpers.cleanup.run.with({
+            targetKey: `service:${service.id}`,
+            scopeType: 'service',
+            resourceId: service.id,
+            retentionPolicy: 'retain',
+            userId: current.users.genesisUser.id,
+            teamId: current.teams.genesisTeam.id
+          })
+        )
+        expect(cleanupError.cleanup.status).toBe('failed')
+
+        const queued = await sails.helpers.deploy.queueDeployment.with({
+          values: {
+            environment: environment.id,
+            triggeredBy: current.users.genesisUser.id,
+            triggerType: 'manual'
+          },
+          app: current.apps.web,
+          dispatch: false
+        })
+        expect(queued.state).toBe('queued')
+
+        const serviceBlock = await captureError(
+          sails.helpers.cleanup.assertAvailable.with({
+            serviceId: service.id
+          })
+        )
+        expect(serviceBlock.code).toBe('blocked')
+      }
+    )
+  }
+)
+
+test(
+  'purge policy removes volumes, backups, images, and project source',
+  { world: cleanupWorld('cleanup-purge') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = await sails.models.app
+      .updateOne({ id: current.apps.web.id })
+      .set({
+        containerName: 'slipway-cleanup-purge-web',
+        imageName: 'slipway/cleanup-purge:current'
+      })
+    const service = await world.create('service').with({
+      environment: environment.id,
+      name: 'purged-db',
+      status: 'running',
+      containerName: 'slipway-cleanup-purge-db',
+      imageMetadata: { volumeName: 'cleanup-purge-volume' }
+    })
+    await world.create('backup').with({
+      service: service.id,
+      status: 'completed',
+      s3Key: 'backups/cleanup-purge.sql'
+    })
+    await world.create('deployment').with({
+      environment: environment.id,
+      app: app.id,
+      imageName: 'slipway/cleanup-purge:release'
+    })
+
+    await withCleanupStubs(sails, {}, async (calls) => {
+      const result = await sails.helpers.cleanup.run.with({
+        targetKey: `project:${project.slug}`,
+        scopeType: 'project',
+        resourceId: project.id,
+        retentionPolicy: 'purge',
+        userId: current.users.genesisUser.id,
+        teamId: current.teams.genesisTeam.id
+      })
+
+      expect(result.status).toBe('complete')
+      expect(calls.deleteBackupObject).toEqual(['backups/cleanup-purge.sql'])
+      expect(calls.removeVolume).toContain('cleanup-purge-volume')
+      expect(calls.removeImage).toContain('slipway/cleanup-purge:current')
+      expect(calls.removeImage).toContain('slipway/cleanup-purge:release')
+      expect(calls.removeSource.length).toBe(1)
+      expect(result.retainedArtifacts).toEqual({})
+    })
+  }
+)
+
+test(
+  'preview cleanup uses the same orchestration and always purges',
+  { world: cleanupWorld('cleanup-preview') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const preview = await world.create('environment').with({
+      project: project.id,
+      name: 'PR 42',
+      slug: 'pr-42',
+      isPreview: true,
+      prNumber: 42
+    })
+    await world.create('app').with({
+      environment: preview.id,
+      name: 'Preview web',
+      slug: 'preview-web',
+      containerName: 'slipway-cleanup-preview-web',
+      imageName: 'slipway/cleanup-preview:42'
+    })
+
+    await withCleanupStubs(sails, {}, async (calls) => {
+      const result = await sails.helpers.preview.destroyPreviewEnvironment.with(
+        {
+          project,
+          prNumber: 42
+        }
+      )
+      const repeated =
+        await sails.helpers.preview.destroyPreviewEnvironment.with({
+          project,
+          prNumber: 42
+        })
+      const operation = await sails.models.cleanupoperation.findOne({
+        targetKey: `environment:${preview.id}`
+      })
+
+      expect(result.status).toBe('complete')
+      expect(repeated.id).toBe(result.id)
+      expect(operation.retentionPolicy).toBe('purge')
+      expect(calls.removeImage).toContain('slipway/cleanup-preview:42')
+      expect(await sails.models.environment.findOne({ id: preview.id })).toBe(
+        undefined
+      )
+    })
+  }
+)
+
+async function withCleanupStubs(sails, overrides, run) {
+  const originals = {
+    removeRoute: sails.helpers.caddy.removeRoute,
+    updateRoute: sails.helpers.caddy.updateRoute,
+    stopContainer: sails.helpers.docker.stopContainer,
+    removeVolume: sails.helpers.docker.removeVolume,
+    removeImage: sails.helpers.docker.removeImage,
+    deleteBackupObject: sails.helpers.backup.deleteBackupObject,
+    cleanupBuildContext: sails.helpers.deploy.cleanupBuildContext,
+    removeSource: sails.helpers.cleanup.removeSource
+  }
+  const calls = {
+    removeRoute: [],
+    updateRoute: [],
+    stopContainer: [],
+    removeVolume: [],
+    removeImage: [],
+    deleteBackupObject: [],
+    cleanupBuildContext: [],
+    removeSource: []
+  }
+  const defaults = {
+    removeRoute: async (inputs) => ({ removed: true, ...inputs }),
+    updateRoute: async () => ({ action: 'updated' }),
+    stopContainer: async () => ({ stopped: true }),
+    removeVolume: async () => ({ removed: true }),
+    removeImage: async () => ({ removed: true }),
+    deleteBackupObject: async () => ({}),
+    cleanupBuildContext: async () => ({ removed: false }),
+    removeSource: async () => ({ removed: true })
+  }
+
+  for (const [name, original] of Object.entries(originals)) {
+    const implementation = overrides[name] || defaults[name]
+    const stub = async (inputs) => {
+      if (name === 'removeVolume') calls[name].push(inputs.volumeName)
+      else if (name === 'removeImage') calls[name].push(inputs.imageName)
+      else if (name === 'deleteBackupObject') calls[name].push(inputs.s3Key)
+      else calls[name].push(inputs)
+      return implementation(inputs)
+    }
+    stub.with = stub
+    setHelper(sails, name, stub)
+    originals[name] = original
+  }
+
+  try {
+    return await run(calls)
+  } finally {
+    for (const [name, original] of Object.entries(originals)) {
+      setHelper(sails, name, original)
+    }
+  }
+}
+
+function setHelper(sails, name, helper) {
+  const namespaces = {
+    removeRoute: sails.helpers.caddy,
+    updateRoute: sails.helpers.caddy,
+    stopContainer: sails.helpers.docker,
+    removeVolume: sails.helpers.docker,
+    removeImage: sails.helpers.docker,
+    deleteBackupObject: sails.helpers.backup,
+    cleanupBuildContext: sails.helpers.deploy,
+    removeSource: sails.helpers.cleanup
+  }
+  namespaces[name][name] = helper
+}
+
+async function captureError(promise) {
+  try {
+    await promise
+  } catch (error) {
+    return error
+  }
+  throw new Error('Expected cleanup to fail')
+}


### PR DESCRIPTION
## Summary

- centralize project, environment, app, service, and preview deletion behind one durable, resumable cleanup operation
- execute cleanup in a safe order across traffic, running work, containers, ports, records, and retained artifacts
- retain recovery data by default while offering an explicit purge choice in the existing Slipway confirmation UI
- prevent deployment races, preserve idempotency across concurrent requests and recreated slugs, and record every cleanup stage in the audit log
- return matching cleanup results and warnings from web and API actions

## Verification

- `npm run test:unit` — 134 passed
- `npm run test:functional` — 43 passed
- `npm run test:e2e` — 15 passed
- `npm run lint`
- `npm run check:consistency`
- `git diff --check`

Closes #236