### PR TITLE
fix: expand container environment references

### DIFF
--- a/api/helpers/docker/build-env-arguments.js
+++ b/api/helpers/docker/build-env-arguments.js
@@ -1,0 +1,155 @@
+const VARIABLE_PATTERN =
+  /\$(?:\{([A-Za-z_][A-Za-z0-9_]*)\}|([A-Za-z_][A-Za-z0-9_]*))/g
+const MAX_EXPANSION_DEPTH = 64
+const MAX_EXPANDED_VALUE_LENGTH = 1024 * 1024
+
+module.exports = {
+  friendlyName: 'Build Docker environment arguments',
+
+  description:
+    'Build shell-free Docker environment arguments with safe variable interpolation.',
+
+  sync: true,
+
+  inputs: {
+    envVars: {
+      type: 'ref',
+      defaultsTo: {},
+      description: 'Environment variables to pass to the container.'
+    },
+    runtimeValues: {
+      type: 'ref',
+      defaultsTo: {},
+      description:
+        'Slipway-owned runtime values available while expanding references.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: function ({ envVars, runtimeValues }) {
+    assertVariableMap(envVars, 'envVars')
+    assertVariableMap(runtimeValues, 'runtimeValues')
+
+    const envEntries = Object.entries(envVars)
+    const contextEntries = [
+      ...envEntries,
+      ...Object.entries(runtimeValues)
+    ].map(([key, value]) => [key, String(value)])
+    const escapedDollar = createEscapedDollarMarker(contextEntries)
+    const context = new Map(
+      contextEntries.map(([key, value]) => [
+        key,
+        protectEscapedDollars(value, escapedDollar)
+      ])
+    )
+    const resolved = new Map()
+    const args = []
+
+    for (const [key, value] of envEntries) {
+      const protectedValue = protectEscapedDollars(String(value), escapedDollar)
+      const expansion = expandTemplate({
+        template: protectedValue,
+        context,
+        resolved,
+        stack: new Set([key]),
+        depth: 0,
+        rootKey: key
+      })
+
+      args.push(
+        '-e',
+        `${key}=${restoreEscapedDollars(expansion.value, escapedDollar)}`
+      )
+    }
+
+    return args
+  }
+}
+
+function expandTemplate({
+  template,
+  context,
+  resolved,
+  stack,
+  depth,
+  rootKey
+}) {
+  let cyclic = false
+
+  const value = template.replace(
+    VARIABLE_PATTERN,
+    (reference, bracedName, bareName) => {
+      const name = bracedName || bareName
+
+      if (!context.has(name)) {
+        return reference
+      }
+
+      if (stack.has(name) || depth >= MAX_EXPANSION_DEPTH) {
+        cyclic = true
+        return reference
+      }
+
+      if (resolved.has(name)) {
+        return resolved.get(name)
+      }
+
+      const nextStack = new Set(stack)
+      nextStack.add(name)
+      const nested = expandTemplate({
+        template: context.get(name),
+        context,
+        resolved,
+        stack: nextStack,
+        depth: depth + 1,
+        rootKey
+      })
+
+      if (nested.cyclic) {
+        cyclic = true
+        return reference
+      }
+
+      resolved.set(name, nested.value)
+      return nested.value
+    }
+  )
+
+  if (value.length > MAX_EXPANDED_VALUE_LENGTH) {
+    throw new Error(
+      `Expanded value for environment variable "${rootKey}" exceeds the 1 MiB safety limit.`
+    )
+  }
+
+  return { value, cyclic }
+}
+
+function createEscapedDollarMarker(entries) {
+  const values = entries.map(([, value]) => value)
+  let marker = '\uE000SLIPWAY_ESCAPED_DOLLAR\uE001'
+
+  while (values.some((value) => value.includes(marker))) {
+    marker += '_'
+  }
+
+  return marker
+}
+
+function protectEscapedDollars(value, marker) {
+  return value.replace(/\$\$/g, marker)
+}
+
+function restoreEscapedDollars(value, marker) {
+  return value.split(marker).join('$')
+}
+
+function assertVariableMap(value, inputName) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${inputName} must be an object of environment variables.`)
+  }
+}

--- a/api/helpers/docker/build-image.js
+++ b/api/helpers/docker/build-image.js
@@ -96,7 +96,7 @@ module.exports = {
 
       args.push(contextPath)
 
-      sails.log.info(`Building image: ${dockerPath} ${args.join(' ')}`)
+      sails.log.info(`Building image: ${imageName}`)
 
       const buildProcess = spawn(dockerPath, args, {
         env: { ...process.env, DOCKER_BUILDKIT: '1' }

--- a/api/helpers/docker/run-container.js
+++ b/api/helpers/docker/run-container.js
@@ -128,7 +128,6 @@ module.exports = {
     args.push(imageName)
 
     sails.log.info(`Running container: ${containerName}`)
-    sails.log.verbose(`Command: docker ${args.join(' ')}`)
 
     if (deploymentId) {
       await Deployment.appendDeployLog(
@@ -185,7 +184,7 @@ module.exports = {
       if (signal?.aborted) {
         throw deploymentCancellation.cancellationError(signal, deploymentId)
       }
-      const errorMessage = error.message || String(error)
+      const errorMessage = sanitizeDockerError(error, args)
       sails.log.error(`Failed to run container: ${errorMessage}`)
 
       if (deploymentId) {
@@ -195,11 +194,50 @@ module.exports = {
         )
       }
 
-      throw error
+      const safeError = new Error(errorMessage)
+      if (error.code !== undefined) safeError.code = error.code
+      throw safeError
     }
   }
 }
 
 function normalizeHost(host) {
   return String(host || '0.0.0.0').trim() || '0.0.0.0'
+}
+
+function sanitizeDockerError(error, args) {
+  let message =
+    String(error.stderr || '').trim() ||
+    String(error.message || error || 'Docker failed to start the container.')
+  const environmentAssignments = []
+
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] !== '-e') continue
+
+    const assignment = String(args[index + 1] || '')
+    const separatorIndex = assignment.indexOf('=')
+    if (separatorIndex === -1) continue
+
+    environmentAssignments.push({
+      assignment,
+      key: assignment.slice(0, separatorIndex),
+      value: assignment.slice(separatorIndex + 1)
+    })
+    index += 1
+  }
+
+  for (const { assignment, key } of environmentAssignments) {
+    message = message.split(assignment).join(`${key}=<redacted>`)
+  }
+
+  const values = environmentAssignments
+    .map(({ value }) => value)
+    .filter(Boolean)
+    .sort((left, right) => right.length - left.length)
+
+  for (const value of values) {
+    message = message.split(value).join('<redacted>')
+  }
+
+  return message
 }

--- a/api/helpers/docker/run-container.js
+++ b/api/helpers/docker/run-container.js
@@ -103,10 +103,14 @@ module.exports = {
       portBindingArgument
     ]
 
-    // Add environment variables
-    for (const [key, value] of Object.entries(envVars)) {
-      args.push('-e', key + '=' + value)
-    }
+    // Add environment variables. PORT comes from Slipway's actual container
+    // contract, so references cannot drift from the mapped internal port.
+    args.push(
+      ...sails.helpers.docker.buildEnvArguments.with({
+        envVars,
+        runtimeValues: { PORT: port }
+      })
+    )
 
     // Add resource limits
     if (resourceLimits && resourceLimits.cpus) {

--- a/tests/unit/helpers/docker/build-env-arguments.test.js
+++ b/tests/unit/helpers/docker/build-env-arguments.test.js
@@ -150,7 +150,14 @@ test('runContainer gives Docker expanded environment arguments for its actual in
   const capturedArgumentsPath = path.join(temporaryDirectory, 'arguments.json')
   const previousDockerConfig = sails.config.docker
   const previousCapturePath = process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH
+  const previousFailureFlag = process.env.SLIPWAY_FAKE_DOCKER_SHOULD_FAIL
   const originalGetPortBinding = sails.helpers.docker.getPortBinding
+  const originalLoggers = {
+    error: sails.log.error,
+    info: sails.log.info,
+    verbose: sails.log.verbose
+  }
+  const logMessages = []
 
   await fs.writeFile(
     fakeDockerPath,
@@ -161,6 +168,11 @@ test('runContainer gives Docker expanded environment arguments for its actual in
       '  process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH,',
       '  JSON.stringify(process.argv.slice(2))',
       ')',
+      "if (process.env.SLIPWAY_FAKE_DOCKER_SHOULD_FAIL === 'true') {",
+      "  const secret = process.argv.find((value) => value.startsWith('SECRET_TOKEN='))",
+      '  process.stderr.write(`Docker rejected ${secret}\\n`)',
+      '  process.exit(1)',
+      '}',
       "process.stdout.write('0123456789abcdef\\n')"
     ].join('\n'),
     { mode: 0o755 }
@@ -171,6 +183,7 @@ test('runContainer gives Docker expanded environment arguments for its actual in
     binaryPath: fakeDockerPath
   }
   process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH = capturedArgumentsPath
+  delete process.env.SLIPWAY_FAKE_DOCKER_SHOULD_FAIL
   sails.helpers.docker.getPortBinding = {
     with: async ({ host, hostPort, containerPort }) => ({
       valid: true,
@@ -180,6 +193,9 @@ test('runContainer gives Docker expanded environment arguments for its actual in
       diagnostic: `${host}:${hostPort} -> ${containerPort}/tcp`
     })
   }
+  sails.log.error = (...values) => logMessages.push(values.join(' '))
+  sails.log.info = (...values) => logMessages.push(values.join(' '))
+  sails.log.verbose = (...values) => logMessages.push(values.join(' '))
 
   try {
     await sails.helpers.docker.runContainer.with({
@@ -190,7 +206,8 @@ test('runContainer gives Docker expanded environment arguments for its actual in
       host: '127.0.0.1',
       envVars: {
         PDF_BASE_URL: 'http://127.0.0.1:$PORT',
-        HEALTH_URL: 'http://127.0.0.1:${PORT}/health'
+        HEALTH_URL: 'http://127.0.0.1:${PORT}/health',
+        SECRET_TOKEN: 'should-reach-docker-but-never-logs'
       }
     })
 
@@ -201,16 +218,58 @@ test('runContainer gives Docker expanded environment arguments for its actual in
 
     expect(environmentArguments).toEqual([
       'PDF_BASE_URL=http://127.0.0.1:1337',
-      'HEALTH_URL=http://127.0.0.1:1337/health'
+      'HEALTH_URL=http://127.0.0.1:1337/health',
+      'SECRET_TOKEN=should-reach-docker-but-never-logs'
     ])
+    expect(logMessages.join('\n')).toMatch(
+      /Running container: example-app-test/
+    )
+    expect(logMessages.join('\n').includes('SECRET_TOKEN=')).toBe(false)
+    expect(
+      logMessages.join('\n').includes('should-reach-docker-but-never-logs')
+    ).toBe(false)
+
+    process.env.SLIPWAY_FAKE_DOCKER_SHOULD_FAIL = 'true'
+    let startupError
+    try {
+      await sails.helpers.docker.runContainer.with({
+        imageName: 'example/app:test',
+        containerName: 'example-app-failing',
+        port: 1337,
+        hostPort: 1401,
+        host: '127.0.0.1',
+        envVars: {
+          SHORT_SECRET: 'failure-secret',
+          SECRET_TOKEN: 'failure-secret-that-must-be-redacted'
+        }
+      })
+    } catch (error) {
+      startupError = error
+    }
+
+    expect(startupError).toBeDefined()
+    expect(startupError.message).toMatch(
+      /Docker rejected SECRET_TOKEN=<redacted>/
+    )
+    expect(startupError.message.includes('failure-secret')).toBe(false)
+    expect(logMessages.join('\n').includes('failure-secret')).toBe(false)
   } finally {
     sails.helpers.docker.getPortBinding = originalGetPortBinding
     sails.config.docker = previousDockerConfig
+    sails.log.error = originalLoggers.error
+    sails.log.info = originalLoggers.info
+    sails.log.verbose = originalLoggers.verbose
 
     if (previousCapturePath === undefined) {
       delete process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH
     } else {
       process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH = previousCapturePath
+    }
+
+    if (previousFailureFlag === undefined) {
+      delete process.env.SLIPWAY_FAKE_DOCKER_SHOULD_FAIL
+    } else {
+      process.env.SLIPWAY_FAKE_DOCKER_SHOULD_FAIL = previousFailureFlag
     }
 
     await fs.rm(temporaryDirectory, { recursive: true, force: true })

--- a/tests/unit/helpers/docker/build-env-arguments.test.js
+++ b/tests/unit/helpers/docker/build-env-arguments.test.js
@@ -1,0 +1,231 @@
+const fs = require('node:fs/promises')
+const os = require('node:os')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+test('Docker environment arguments expand runtime port references without mutating saved values', async ({
+  sails,
+  expect
+}) => {
+  const envVars = {
+    PDF_BASE_URL: 'http://127.0.0.1:$PORT',
+    HEALTH_URL: 'http://127.0.0.1:${PORT}/health',
+    NODE_ENV: 'production'
+  }
+  const original = { ...envVars }
+
+  const args = sails.helpers.docker.buildEnvArguments.with({
+    envVars,
+    runtimeValues: { PORT: 1337 }
+  })
+
+  expect(args).toEqual([
+    '-e',
+    'PDF_BASE_URL=http://127.0.0.1:1337',
+    '-e',
+    'HEALTH_URL=http://127.0.0.1:1337/health',
+    '-e',
+    'NODE_ENV=production'
+  ])
+  expect(envVars).toEqual(original)
+})
+
+test('Docker environment arguments resolve merged and nested references', async ({
+  sails,
+  expect
+}) => {
+  const args = sails.helpers.docker.buildEnvArguments.with({
+    envVars: {
+      HOST: 'app.internal',
+      ORIGIN: 'http://$HOST:${PORT}',
+      HEALTH_URL: '${ORIGIN}/health',
+      TELEMETRY_COPY: '$SLIPWAY_TELEMETRY_URL',
+      SLIPWAY_TELEMETRY_URL: 'http://slipway:1337/api/v1/telemetry/ingest'
+    },
+    runtimeValues: { PORT: 1337 }
+  })
+
+  expect(args).toEqual([
+    '-e',
+    'HOST=app.internal',
+    '-e',
+    'ORIGIN=http://app.internal:1337',
+    '-e',
+    'HEALTH_URL=http://app.internal:1337/health',
+    '-e',
+    'TELEMETRY_COPY=http://slipway:1337/api/v1/telemetry/ingest',
+    '-e',
+    'SLIPWAY_TELEMETRY_URL=http://slipway:1337/api/v1/telemetry/ingest'
+  ])
+})
+
+test('Docker environment arguments preserve unknown, escaped, cyclic, and shell-like values safely', async ({
+  sails,
+  expect
+}) => {
+  const args = sails.helpers.docker.buildEnvArguments.with({
+    envVars: {
+      UNKNOWN: '$NOT_CONFIGURED/${ALSO_MISSING}',
+      ESCAPED: 'literal=$$PORT resolved=$PORT',
+      FIRST: '$SECOND',
+      SECOND: '$FIRST',
+      SELF: 'prefix-$SELF-$PORT',
+      COMMAND_SUBSTITUTION: '$(touch /tmp/should-never-run)',
+      BACKTICKS: '`touch /tmp/should-never-run-either`',
+      NUMBER: 42,
+      ENABLED: true
+    },
+    runtimeValues: { PORT: 1337 }
+  })
+
+  expect(args).toEqual([
+    '-e',
+    'UNKNOWN=$NOT_CONFIGURED/${ALSO_MISSING}',
+    '-e',
+    'ESCAPED=literal=$PORT resolved=1337',
+    '-e',
+    'FIRST=$SECOND',
+    '-e',
+    'SECOND=$FIRST',
+    '-e',
+    'SELF=prefix-$SELF-1337',
+    '-e',
+    'COMMAND_SUBSTITUTION=$(touch /tmp/should-never-run)',
+    '-e',
+    'BACKTICKS=`touch /tmp/should-never-run-either`',
+    '-e',
+    'NUMBER=42',
+    '-e',
+    'ENABLED=true'
+  ])
+})
+
+test('Docker environment argument expansion stops deep and oversized reference graphs safely', async ({
+  sails,
+  expect
+}) => {
+  const deepReferences = {}
+  for (let index = 0; index < 70; index++) {
+    deepReferences[`VALUE_${index}`] = `$VALUE_${index + 1}`
+  }
+  deepReferences.VALUE_70 = 'resolved'
+
+  const deepArguments = sails.helpers.docker.buildEnvArguments.with({
+    envVars: deepReferences
+  })
+
+  expect(deepArguments[1]).toBe('VALUE_0=$VALUE_1')
+
+  const expandingReferences = { VALUE_0: 'xx' }
+  for (let index = 1; index <= 20; index++) {
+    expandingReferences[`VALUE_${index}`] = `$VALUE_${index - 1}$VALUE_${
+      index - 1
+    }`
+  }
+
+  let expansionError
+  try {
+    sails.helpers.docker.buildEnvArguments.with({
+      envVars: expandingReferences
+    })
+  } catch (error) {
+    expansionError = error
+  }
+
+  expect(expansionError).toBeDefined()
+  expect(expansionError.message).toMatch(
+    /Expanded value for environment variable "VALUE_20" exceeds the 1 MiB safety limit/
+  )
+})
+
+test('runContainer gives Docker expanded environment arguments for its actual internal port', async ({
+  sails,
+  expect
+}) => {
+  const temporaryDirectory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'slipway-docker-env-')
+  )
+  const fakeDockerPath = path.join(temporaryDirectory, 'docker')
+  const capturedArgumentsPath = path.join(temporaryDirectory, 'arguments.json')
+  const previousDockerConfig = sails.config.docker
+  const previousCapturePath = process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH
+  const originalGetPortBinding = sails.helpers.docker.getPortBinding
+
+  await fs.writeFile(
+    fakeDockerPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs')",
+      'fs.writeFileSync(',
+      '  process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH,',
+      '  JSON.stringify(process.argv.slice(2))',
+      ')',
+      "process.stdout.write('0123456789abcdef\\n')"
+    ].join('\n'),
+    { mode: 0o755 }
+  )
+
+  sails.config.docker = {
+    ...(previousDockerConfig || {}),
+    binaryPath: fakeDockerPath
+  }
+  process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH = capturedArgumentsPath
+  sails.helpers.docker.getPortBinding = {
+    with: async ({ host, hostPort, containerPort }) => ({
+      valid: true,
+      host,
+      hostPort,
+      containerPort,
+      diagnostic: `${host}:${hostPort} -> ${containerPort}/tcp`
+    })
+  }
+
+  try {
+    await sails.helpers.docker.runContainer.with({
+      imageName: 'example/app:test',
+      containerName: 'example-app-test',
+      port: 1337,
+      hostPort: 1400,
+      host: '127.0.0.1',
+      envVars: {
+        PDF_BASE_URL: 'http://127.0.0.1:$PORT',
+        HEALTH_URL: 'http://127.0.0.1:${PORT}/health'
+      }
+    })
+
+    const dockerArguments = JSON.parse(
+      await fs.readFile(capturedArgumentsPath, 'utf8')
+    )
+    const environmentArguments = collectEnvironmentArguments(dockerArguments)
+
+    expect(environmentArguments).toEqual([
+      'PDF_BASE_URL=http://127.0.0.1:1337',
+      'HEALTH_URL=http://127.0.0.1:1337/health'
+    ])
+  } finally {
+    sails.helpers.docker.getPortBinding = originalGetPortBinding
+    sails.config.docker = previousDockerConfig
+
+    if (previousCapturePath === undefined) {
+      delete process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH
+    } else {
+      process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH = previousCapturePath
+    }
+
+    await fs.rm(temporaryDirectory, { recursive: true, force: true })
+  }
+})
+
+function collectEnvironmentArguments(dockerArguments) {
+  const values = []
+
+  for (let index = 0; index < dockerArguments.length; index++) {
+    if (dockerArguments[index] === '-e') {
+      values.push(dockerArguments[index + 1])
+      index += 1
+    }
+  }
+
+  return values
+}

--- a/tests/unit/helpers/docker/build-image-cancellation.test.js
+++ b/tests/unit/helpers/docker/build-image-cancellation.test.js
@@ -15,6 +15,8 @@ test('docker image build terminates its process when the deployment is cancelled
   const readyPath = path.join(tempRoot, 'ready')
   const terminatedPath = path.join(tempRoot, 'terminated')
   const originalDockerPath = sails.config.docker?.binaryPath
+  const originalInfoLogger = sails.log.info
+  const logMessages = []
   fs.writeFileSync(
     dockerPath,
     [
@@ -32,6 +34,7 @@ test('docker image build terminates its process when the deployment is cancelled
   fs.chmodSync(dockerPath, 0o755)
   sails.config.docker = sails.config.docker || {}
   sails.config.docker.binaryPath = dockerPath
+  sails.log.info = (...values) => logMessages.push(values.join(' '))
 
   const controller = new AbortController()
   const cancellation = new Error('Cancelled by Builder')
@@ -44,6 +47,9 @@ test('docker image build terminates its process when the deployment is cancelled
       .with({
         contextPath: tempRoot,
         imageName: 'slipway/cancelled:latest',
+        buildArgs: {
+          NPM_TOKEN: 'should-reach-docker-but-never-logs'
+        },
         timeout: 10_000,
         signal: controller.signal
       })
@@ -56,6 +62,13 @@ test('docker image build terminates its process when the deployment is cancelled
 
     expect(buildError.code).toBe('DEPLOYMENT_CANCELLED')
     expect(fs.readFileSync(terminatedPath, 'utf8')).toBe('SIGTERM')
+    expect(logMessages.join('\n')).toMatch(
+      /Building image: slipway\/cancelled:latest/
+    )
+    expect(logMessages.join('\n').includes('NPM_TOKEN=')).toBe(false)
+    expect(
+      logMessages.join('\n').includes('should-reach-docker-but-never-logs')
+    ).toBe(false)
   } finally {
     if (!controller.signal.aborted) controller.abort(cancellation)
     if (build) await build
@@ -64,6 +77,7 @@ test('docker image build terminates its process when the deployment is cancelled
     } else {
       sails.config.docker.binaryPath = originalDockerPath
     }
+    sails.log.info = originalInfoLogger
     fs.rmSync(tempRoot, { recursive: true, force: true })
   }
 })


### PR DESCRIPTION
## Summary

- expand `$VAR` and `${VAR}` references from the final merged application environment before Docker starts a container
- make Slipway's actual internal `PORT` available as authoritative runtime interpolation context
- support nested references, `$$` literal-dollar escaping, unknown references, cycles, depth limits, and expansion-size limits without invoking a shell
- apply the behavior centrally to normal deployments and rollbacks through `docker.runContainer`
- prevent Docker environment values and build arguments from leaking through success or failure logs

## Root cause

Slipway passed environment values directly to `docker run` through `execFile`. Avoiding a shell is correct and protects against command injection, but it also means values such as `http://127.0.0.1:$PORT` were never interpolated. The same Docker argument arrays were reconstructed in logs, which could expose secret values.

## Impact

Applications can compose environment values safely from global, environment, app, telemetry, and Slipway runtime values. Existing values without references remain unchanged. Unknown or cyclic references remain literal rather than breaking startup, and failures retain useful Docker diagnostics with environment values redacted.

## Verification

- `npm run test:unit` — 139 passed
- `npm run test:functional` — 43 passed
- `npm run test:e2e` — 15 passed
- `npm run lint`
- `npm run check:consistency`
- focused Sounding trials execute the real container helper against a fake Docker binary and cover success, failure, escaping, cycles, excessive depth, expansion growth, overlapping secrets, and build-argument logging

No UI changed, so screenshots are not applicable.

Closes #226
