### PR TITLE
fix: prefer custom app domains everywhere

### DIFF
--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -89,8 +89,6 @@ module.exports = {
       }
     }
 
-    const { fullDomain, generatedDomain, domains } =
-      await Environment.resolveDomains(environment.id)
     const serverIp = await sails.helpers.getServerIp()
     let directAccess = null
     if (app.hostPort && app.routePath !== null) {
@@ -122,6 +120,11 @@ module.exports = {
       })
     }
     const directUrl = directAccess?.url || null
+    const { fullDomain, generatedDomain, domains, primaryUrl, accessUrls } =
+      await Environment.resolveAppUrls(environment.id, {
+        directUrl,
+        directHint: directAccess?.firewallHint || null
+      })
 
     const appWithHealth = { ...app, containerHealth }
     const deploymentHistory = await sails.helpers.deployment.getHistory.with({
@@ -206,7 +209,13 @@ module.exports = {
           serverIp,
           services
         },
-        app: { ...app, containerHealth, directUrl, directAccess },
+        app: {
+          ...app,
+          containerHealth,
+          directAccess,
+          primaryUrl,
+          accessUrls
+        },
         appEnvVars: decryptedApp.envVars || {},
         inheritedVars,
         deploymentHistory,

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -333,9 +333,6 @@ module.exports = {
       await updateDeployment({ status: 'running', finishedAt: Date.now() })
       await recordStage('complete')
 
-      const { fullDomain, generatedDomain } = await Environment.resolveDomains(
-        environment.id
-      )
       const directAccess = await sails.helpers.deploy.getDirectAccess.with({
         serverIp: await sails.helpers.getServerIp(),
         hostPort: deployHostPort,
@@ -344,24 +341,21 @@ module.exports = {
         portBinding: containerResult.portBinding
       })
       const directUrl = directAccess.url
+      const { accessUrls, primaryUrl } = await Environment.resolveAppUrls(
+        environment.id,
+        {
+          directUrl,
+          directHint: directAccess.firewallHint
+        }
+      )
       await Deployment.appendDeployLog(deploymentId, `Deployment complete.\n`)
-      if (fullDomain) {
+      for (const accessUrl of accessUrls) {
         await Deployment.appendDeployLog(
           deploymentId,
-          `  URL:       https://${fullDomain}\n`
-        )
-      }
-      if (generatedDomain && generatedDomain !== fullDomain) {
-        await Deployment.appendDeployLog(
-          deploymentId,
-          `  Fallback:  https://${generatedDomain}\n`
+          `  ${`${accessUrl.logLabel}:`.padEnd(11)}${accessUrl.value}\n`
         )
       }
       if (directUrl) {
-        await Deployment.appendDeployLog(
-          deploymentId,
-          `  Direct:    ${directUrl}\n`
-        )
         await Deployment.appendDeployLog(
           deploymentId,
           `  Network:   Container healthy; ${containerResult.portBinding.diagnostic}\n`
@@ -384,7 +378,7 @@ module.exports = {
 
       sails.log.info(
         `Deployment ${deploymentId} completed successfully${
-          directUrl ? ` — ${directUrl}` : ''
+          primaryUrl ? ` — ${primaryUrl}` : ''
         }`
       )
 

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -231,9 +231,6 @@ module.exports = {
       await updateDeployment({ status: 'running', finishedAt: Date.now() })
       await recordStage('complete')
 
-      const { fullDomain, generatedDomain } = await Environment.resolveDomains(
-        environment.id
-      )
       const directAccess = await sails.helpers.deploy.getDirectAccess.with({
         serverIp: await sails.helpers.getServerIp(),
         hostPort,
@@ -241,24 +238,18 @@ module.exports = {
         containerRunning: true,
         portBinding: containerResult.portBinding
       })
+      const { accessUrls } = await Environment.resolveAppUrls(environment.id, {
+        directUrl: directAccess.url,
+        directHint: directAccess.firewallHint
+      })
       await Deployment.appendDeployLog(rollbackId, `Rollback complete.\n`)
-      if (fullDomain) {
+      for (const accessUrl of accessUrls) {
         await Deployment.appendDeployLog(
           rollbackId,
-          `  URL:       https://${fullDomain}\n`
-        )
-      }
-      if (generatedDomain && generatedDomain !== fullDomain) {
-        await Deployment.appendDeployLog(
-          rollbackId,
-          `  Fallback:  https://${generatedDomain}\n`
+          `  ${`${accessUrl.logLabel}:`.padEnd(11)}${accessUrl.value}\n`
         )
       }
       if (directAccess.url) {
-        await Deployment.appendDeployLog(
-          rollbackId,
-          `  Direct:    ${directAccess.url}\n`
-        )
         await Deployment.appendDeployLog(
           rollbackId,
           `  Network:   Container healthy; ${containerResult.portBinding.diagnostic}\n`

--- a/api/hooks/custom/index.js
+++ b/api/hooks/custom/index.js
@@ -92,22 +92,30 @@ module.exports = function defineCustomHook(sails) {
                     'wildcardDomain'
                   )
                   const slipwayDomain = sails.config.custom.slipwayDomain
+                  const accessByEnvironment = new Map(
+                    await Promise.all(
+                      environments.map(async (environment) => {
+                        const project = projects.find(
+                          (candidate) => candidate.id === environment.project
+                        )
+                        const access = project
+                          ? await Environment.resolveAppUrls(
+                              { ...environment, project },
+                              { wildcardDomain, slipwayDomain }
+                            )
+                          : { primaryUrl: null }
+                        return [environment.id, access]
+                      })
+                    )
+                  )
                   return apps.map((app) => {
                     const env = environments.find(
                       (e) => e.id === app.environment
                     )
                     const project = projects.find((p) => p.id === env?.project)
-                    let domain = null
-                    if (env?.domain) {
-                      domain = env.domain
-                    } else if (project && env) {
-                      const subdomain = `${project.slug}-${env.slug}`
-                      domain = wildcardDomain
-                        ? `${subdomain}.${wildcardDomain}`
-                        : slipwayDomain
-                        ? `${subdomain}.${slipwayDomain}`
-                        : null
-                    }
+                    const url =
+                      accessByEnvironment.get(app.environment)?.primaryUrl ||
+                      null
                     return {
                       name: app.name,
                       slug: app.slug,
@@ -115,7 +123,7 @@ module.exports = function defineCustomHook(sails) {
                       projectSlug: project?.slug,
                       envName: env?.name,
                       envSlug: env?.slug,
-                      domain
+                      url
                     }
                   })
                 } catch (err) {

--- a/api/models/Environment.js
+++ b/api/models/Environment.js
@@ -140,10 +140,11 @@ module.exports = {
   /**
    * Resolve the primary, generated, and fallback domains for this environment.
    */
-  resolveDomains: async function (environmentId) {
-    const env = await Environment.findOne({ id: environmentId }).populate(
-      'project'
-    )
+  resolveDomains: async function (environmentOrId, options = {}) {
+    const env =
+      typeof environmentOrId === 'object' && environmentOrId !== null
+        ? environmentOrId
+        : await Environment.findOne({ id: environmentOrId }).populate('project')
     if (!env) {
       return {
         fullDomain: null,
@@ -159,13 +160,35 @@ module.exports = {
       domains.push(env.domain)
     }
 
-    const subdomain = `${env.project.slug}-${env.slug}`
+    const project =
+      env.project && typeof env.project === 'object'
+        ? env.project
+        : options.project || (await Project.findOne({ id: env.project }))
+    if (!project) {
+      return {
+        fullDomain: domains[0] || null,
+        generatedDomain: null,
+        domains
+      }
+    }
 
-    const wildcardDomain = await sails.helpers.setting.get('wildcardDomain')
+    const subdomain = `${project.slug}-${env.slug}`
+
+    const wildcardDomain = Object.prototype.hasOwnProperty.call(
+      options,
+      'wildcardDomain'
+    )
+      ? options.wildcardDomain
+      : await sails.helpers.setting.get('wildcardDomain')
     if (wildcardDomain) {
       generatedDomain = `${subdomain}.${wildcardDomain}`
     } else {
-      const slipwayDomain = sails.config.custom.slipwayDomain
+      const slipwayDomain = Object.prototype.hasOwnProperty.call(
+        options,
+        'slipwayDomain'
+      )
+        ? options.slipwayDomain
+        : sails.config.custom.slipwayDomain
       if (slipwayDomain) {
         generatedDomain = `${subdomain}.${slipwayDomain}`
       }
@@ -179,6 +202,51 @@ module.exports = {
       fullDomain: domains[0] || null,
       generatedDomain,
       domains
+    }
+  },
+
+  /**
+   * Resolve every user-facing URL for an app in canonical priority order.
+   *
+   * 1. Custom domain
+   * 2. Generated Slipway/wildcard domain
+   * 3. Verified raw IP:port URL
+   */
+  resolveAppUrls: async function (environmentOrId, options = {}) {
+    const { directUrl = null, directHint = null, ...domainOptions } = options
+    const resolved = await Environment.resolveDomains(
+      environmentOrId,
+      domainOptions
+    )
+
+    const accessUrls = resolved.domains.map((domain, index) => {
+      const isGenerated = domain === resolved.generatedDomain
+      return {
+        kind: isGenerated ? 'generated' : 'custom',
+        label: isGenerated ? 'Generated' : 'Custom',
+        display: domain,
+        value: `https://${domain}`,
+        href: `https://${domain}`,
+        logLabel: index === 0 ? 'URL' : 'Fallback'
+      }
+    })
+
+    if (directUrl && !accessUrls.some((entry) => entry.value === directUrl)) {
+      accessUrls.push({
+        kind: 'direct',
+        label: 'Direct',
+        display: directUrl.replace(/^https?:\/\//, ''),
+        value: directUrl,
+        href: directUrl,
+        hint: directHint,
+        logLabel: 'Direct'
+      })
+    }
+
+    return {
+      ...resolved,
+      primaryUrl: accessUrls[0]?.value || null,
+      accessUrls
     }
   },
 

--- a/assets/js/components/CommandPalette.vue
+++ b/assets/js/components/CommandPalette.vue
@@ -376,17 +376,17 @@ register({
   icon: 'clipboard',
   children: () =>
     navApps.value
-      .filter((app) => app.domain)
+      .filter((app) => app.url)
       .map((app) => ({
         id: `action.copy-url.${app.projectSlug}.${app.envSlug}.${app.slug}`,
         title: app.name,
-        subtitle: `https://${app.domain}`,
-        keywords: [app.slug, app.projectName, app.envName, app.domain],
+        subtitle: app.url,
+        keywords: [app.slug, app.projectName, app.envName, app.url],
         group: `${app.projectName} / ${app.envName}`,
         icon: 'clipboard',
         action: async () => {
           try {
-            await navigator.clipboard.writeText(`https://${app.domain}`)
+            await navigator.clipboard.writeText(app.url)
             toast({ message: `Copied URL for ${app.name}`, type: 'success' })
           } catch {
             toast({ message: 'Failed to copy URL', type: 'error' })

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -148,45 +148,7 @@ const domainDropdownOpen = ref(false)
 const copiedText = ref(null)
 const moreMenuOpen = ref(false)
 
-const accessUrls = computed(() => {
-  const list = []
-  if (props.environment.domain) {
-    list.push({
-      label: 'Custom',
-      display: props.environment.domain,
-      value: `https://${props.environment.domain}`,
-      href: `https://${props.environment.domain}`
-    })
-  }
-  if (
-    props.environment.generatedDomain &&
-    props.environment.generatedDomain !== props.environment.domain
-  ) {
-    list.push({
-      label: 'Generated',
-      display: props.environment.generatedDomain,
-      value: `https://${props.environment.generatedDomain}`,
-      href: `https://${props.environment.generatedDomain}`
-    })
-  } else if (!props.environment.domain && props.environment.generatedDomain) {
-    list.push({
-      label: 'Generated',
-      display: props.environment.generatedDomain,
-      value: `https://${props.environment.generatedDomain}`,
-      href: `https://${props.environment.generatedDomain}`
-    })
-  }
-  if (props.app.directUrl) {
-    list.push({
-      label: 'Direct',
-      display: props.app.directUrl.replace(/^https?:\/\//, ''),
-      value: props.app.directUrl,
-      href: props.app.directUrl,
-      hint: props.app.directAccess?.firewallHint
-    })
-  }
-  return list
-})
+const accessUrls = computed(() => props.app.accessUrls || [])
 
 const primaryAccessUrl = computed(() => accessUrls.value[0] || null)
 const hasMultipleAccessUrls = computed(() => accessUrls.value.length > 1)
@@ -813,6 +775,7 @@ onBeforeUnmount(() => {
             <!-- Domain display -->
             <div
               v-if="primaryAccessUrl"
+              data-test="app-access-urls"
               class="relative mt-1 inline-flex items-center"
             >
               <div class="group flex items-center gap-2">
@@ -859,6 +822,7 @@ onBeforeUnmount(() => {
                 </button>
                 <button
                   v-if="hasMultipleAccessUrls"
+                  data-test="app-access-urls-toggle"
                   @click.stop="domainDropdownOpen = !domainDropdownOpen"
                   class="rounded p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
                 >
@@ -884,12 +848,14 @@ onBeforeUnmount(() => {
               <!-- Domain dropdown -->
               <div
                 v-if="domainDropdownOpen && hasMultipleAccessUrls"
+                data-test="app-access-urls-menu"
                 @click.stop
                 class="absolute left-0 top-full z-20 mt-1.5 w-max rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
               >
                 <div
                   v-for="d in accessUrls"
                   :key="d.value"
+                  :data-test="`app-access-url-${d.kind}`"
                   class="group/item flex items-center gap-2 px-3 py-2"
                 >
                   <span

--- a/tests/e2e/pages/projects/direct-access.test.js
+++ b/tests/e2e/pages/projects/direct-access.test.js
@@ -37,3 +37,100 @@ test(
     expect(page).toHaveNoJavascriptErrors()
   }
 )
+
+test(
+  'custom domain stays primary ahead of generated and direct app URLs',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'app-url-priority',
+          name: 'App URL Priority'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const originalGetContainerStatus = sails.helpers.docker.getContainerStatus
+    const originalGetPortBinding = sails.helpers.docker.getPortBinding
+
+    const getContainerStatus = async () => ({
+      running: true,
+      health: 'healthy'
+    })
+    const getPortBinding = async () => ({
+      valid: true,
+      host: '0.0.0.0',
+      hostPort: 1340,
+      diagnostic: 'Published on 0.0.0.0:1340.'
+    })
+    getPortBinding.with = getPortBinding
+    sails.helpers.docker.getContainerStatus = getContainerStatus
+    sails.helpers.docker.getPortBinding = getPortBinding
+
+    try {
+      await sails.models.environment
+        .updateOne({ id: current.environments.production.id })
+        .set({ domain: 'app.example.com' })
+      await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+        status: 'running',
+        hostPort: 1340,
+        port: 1337,
+        containerName: `slipway-${current.key}-web`
+      })
+
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await page.inLightMode()
+      await page.goto(
+        `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/apps/${current.apps.web.slug}`
+      )
+
+      await page.wait('@app-access-urls')
+      const primaryUrl = await page.script(() =>
+        document
+          .querySelector('[data-test="app-access-urls"] a')
+          .textContent.trim()
+      )
+      expect(primaryUrl).toBe('app.example.com')
+
+      await page.click('@app-access-urls-toggle')
+      const orderedKinds = await page.script(() =>
+        Array.from(
+          document.querySelectorAll(
+            '[data-test="app-access-urls-menu"] [data-test^="app-access-url-"]'
+          )
+        ).map((element) =>
+          element.getAttribute('data-test').replace('app-access-url-', '')
+        )
+      )
+      expect(orderedKinds).toEqual(['custom', 'generated', 'direct'])
+      await page.screenshot('.tmp/issue-211-app-urls-light.png')
+
+      await page.click('@app-access-urls-toggle')
+      await page.key('ControlOrMeta+k')
+      await page.fill(
+        'input[placeholder="Type a command or search..."]',
+        'Copy App URL'
+      )
+      await page.click('Copy App URL')
+      await expect(page).toSee('https://app.example.com')
+      await page.key('Escape')
+      await page.key('Escape')
+
+      await page.inDarkMode()
+      await page.reload()
+      await page.click('@app-access-urls-toggle')
+      await page.screenshot('.tmp/issue-211-app-urls-dark.png')
+
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.helpers.docker.getContainerStatus = originalGetContainerStatus
+      sails.helpers.docker.getPortBinding = originalGetPortBinding
+    }
+  }
+)

--- a/tests/functional/pages/projects.test.js
+++ b/tests/functional/pages/projects.test.js
@@ -90,6 +90,41 @@ test(
 )
 
 test(
+  'app page uses the custom domain as the primary URL',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'custom-domain-priority',
+          name: 'Custom Domain Priority'
+        }
+      }
+    }
+  },
+  async ({ sails, world, visit, expect }) => {
+    const current = world.current
+    await sails.models.environment
+      .updateOne({ id: current.environments.production.id })
+      .set({ domain: 'app.example.com' })
+
+    const page = await visit.as('genesisUser')(
+      `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/apps/${current.apps.web.slug}`
+    )
+
+    expect(page).toHaveStatus(200)
+    expect(page).toBeInertiaPage('projects/app')
+    expect(page).toHaveInertiaProp('app.primaryUrl', 'https://app.example.com')
+    expect(page).toHaveInertiaProp(
+      'app.accessUrls.0.value',
+      'https://app.example.com'
+    )
+    expect(page).toHaveInertiaProp('app.accessUrls.0.kind', 'custom')
+    expect(page).toHaveInertiaProp('app.accessUrls.1.kind', 'generated')
+  }
+)
+
+test(
   'deployment history sorts before limiting and uses a stable cursor',
   {
     world: {

--- a/tests/unit/models/environment-access-urls.test.js
+++ b/tests/unit/models/environment-access-urls.test.js
@@ -1,0 +1,96 @@
+const { test } = require('sounding')
+
+test(
+  'app URLs keep custom, generated, and direct access in canonical order',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'canonical-app-urls',
+          name: 'Canonical App URLs'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const environment = await sails.models.environment
+      .updateOne({ id: current.environments.production.id })
+      .set({ domain: 'app.example.com' })
+
+    const resolved = await sails.models.environment.resolveAppUrls(
+      {
+        ...environment,
+        project: current.projects.deploymentTarget
+      },
+      {
+        wildcardDomain: 'apps.example.com',
+        slipwayDomain: null,
+        directUrl: 'http://203.0.113.10:1340',
+        directHint: 'Allow inbound TCP 1340.'
+      }
+    )
+
+    expect(resolved.primaryUrl).toBe('https://app.example.com')
+    expect(resolved.accessUrls).toEqual([
+      {
+        kind: 'custom',
+        label: 'Custom',
+        display: 'app.example.com',
+        value: 'https://app.example.com',
+        href: 'https://app.example.com',
+        logLabel: 'URL'
+      },
+      {
+        kind: 'generated',
+        label: 'Generated',
+        display: 'canonical-app-urls-production.apps.example.com',
+        value: 'https://canonical-app-urls-production.apps.example.com',
+        href: 'https://canonical-app-urls-production.apps.example.com',
+        logLabel: 'Fallback'
+      },
+      {
+        kind: 'direct',
+        label: 'Direct',
+        display: '203.0.113.10:1340',
+        value: 'http://203.0.113.10:1340',
+        href: 'http://203.0.113.10:1340',
+        hint: 'Allow inbound TCP 1340.',
+        logLabel: 'Direct'
+      }
+    ])
+  }
+)
+
+test(
+  'a verified direct URL becomes primary only when no domain is available',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'direct-url-fallback',
+          name: 'Direct URL Fallback'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const resolved = await sails.models.environment.resolveAppUrls(
+      {
+        ...current.environments.production,
+        project: current.projects.deploymentTarget
+      },
+      {
+        wildcardDomain: null,
+        slipwayDomain: null,
+        directUrl: 'http://203.0.113.10:1340'
+      }
+    )
+
+    expect(resolved.primaryUrl).toBe('http://203.0.113.10:1340')
+    expect(resolved.accessUrls.map((entry) => entry.kind)).toEqual(['direct'])
+  }
+)


### PR DESCRIPTION
## Summary

- centralize app URL selection as custom domain, generated domain, then verified direct access
- use the canonical URL contract in the app page, command palette, deployment logs, rollback logs, and worker completion messages
- preserve the existing compact UI while removing client-side URL reconstruction
- cover custom, generated, and direct fallback behavior with Sounding unit, Inertia, and browser trials

## Validation

- `npm run lint`
- `npm run check:consistency`
- `npm run test:unit` — 141 passed
- `npm run test:functional` — 44 passed
- `npm run test:e2e` — 16 passed

Fixes #211
