### PR TITLE
fix: replace overlay code editors with CodeMirror

### DIFF
--- a/assets/js/components/CodeEditor.vue
+++ b/assets/js/components/CodeEditor.vue
@@ -1,0 +1,387 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import {
+  defaultKeymap,
+  history,
+  historyKeymap,
+  indentWithTab
+} from '@codemirror/commands'
+import { javascript } from '@codemirror/lang-javascript'
+import { sql } from '@codemirror/lang-sql'
+import {
+  HighlightStyle,
+  StreamLanguage,
+  bracketMatching,
+  indentOnInput,
+  syntaxHighlighting
+} from '@codemirror/language'
+import { Compartment, EditorState } from '@codemirror/state'
+import {
+  EditorView,
+  drawSelection,
+  keymap,
+  placeholder as editorPlaceholder
+} from '@codemirror/view'
+import { tags } from '@lezer/highlight'
+
+const props = defineProps({
+  modelValue: { type: String, default: '' },
+  language: {
+    type: String,
+    default: 'plain',
+    validator: (value) => ['plain', 'javascript', 'sql', 'env'].includes(value)
+  },
+  placeholder: { type: String, default: '' },
+  ariaLabel: { type: String, default: 'Code editor' },
+  testId: { type: String, default: '' },
+  disabled: { type: Boolean, default: false },
+  submitOnModEnter: { type: Boolean, default: false },
+  height: {
+    type: String,
+    default: 'content',
+    validator: (value) => ['content', 'fill'].includes(value)
+  },
+  minHeight: { type: String, default: '5.25rem' },
+  maxHeight: { type: String, default: '' },
+  padding: {
+    type: String,
+    default: 'normal',
+    validator: (value) => ['normal', 'compact'].includes(value)
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'submit'])
+
+const editorHost = ref(null)
+const languageCompartment = new Compartment()
+const appearanceCompartment = new Compartment()
+const editableCompartment = new Compartment()
+let view
+let darkModeQuery
+let applyingExternalValue = false
+
+const editorStyle = computed(() => ({
+  '--code-editor-min-height': props.minHeight,
+  '--code-editor-max-height': props.maxHeight || 'none',
+  '--code-editor-padding': props.padding === 'compact' ? '0.75rem' : '1rem'
+}))
+
+const envLanguage = StreamLanguage.define({
+  startState: () => ({ beforeEquals: true }),
+  token(stream, state) {
+    if (stream.sol()) state.beforeEquals = true
+    if (stream.eatSpace()) return null
+
+    if (state.beforeEquals && stream.peek() === '#') {
+      stream.skipToEnd()
+      return 'comment'
+    }
+
+    if (
+      state.beforeEquals &&
+      stream.match(/[A-Za-z_][A-Za-z0-9_.-]*(?=\s*=)/)
+    ) {
+      return 'propertyName'
+    }
+
+    if (state.beforeEquals && stream.eat('=')) {
+      state.beforeEquals = false
+      return 'operator'
+    }
+
+    stream.skipToEnd()
+    return state.beforeEquals ? null : 'string'
+  }
+})
+
+function languageExtension(language) {
+  if (language === 'sql') return sql()
+  if (language === 'javascript') return javascript()
+  if (language === 'env') return envLanguage
+  return []
+}
+
+function editorTheme(isDark) {
+  const palette = isDark
+    ? {
+        text: '#f5f5f5',
+        caret: '#f5f5f5',
+        placeholder: '#525252',
+        selection: '#075985',
+        matchingBracket: '#404040'
+      }
+    : {
+        text: '#171717',
+        caret: '#171717',
+        placeholder: '#a3a3a3',
+        selection: '#bae6fd',
+        matchingBracket: '#e5e5e5'
+      }
+
+  return EditorView.theme(
+    {
+      '&': {
+        height: props.height === 'fill' ? '100%' : 'auto',
+        color: palette.text,
+        backgroundColor: 'transparent',
+        fontSize: '0.875rem'
+      },
+      '&.cm-focused': {
+        outline: 'none'
+      },
+      '.cm-scroller': {
+        minHeight: 'inherit',
+        maxHeight: 'inherit',
+        fontFamily:
+          'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
+        lineHeight: '1.5rem'
+      },
+      '.cm-content': {
+        minHeight: 'inherit',
+        padding: 'var(--code-editor-padding) 0',
+        caretColor: palette.caret
+      },
+      '.cm-line': {
+        padding: '0 var(--code-editor-padding)'
+      },
+      '.cm-cursor, .cm-dropCursor': {
+        borderLeftColor: palette.caret
+      },
+      '&.cm-focused > .cm-scroller > .cm-selectionLayer .cm-selectionBackground, .cm-selectionBackground, ::selection':
+        {
+          backgroundColor: `${palette.selection} !important`
+        },
+      '.cm-placeholder': {
+        color: palette.placeholder,
+        fontStyle: 'normal'
+      },
+      '.cm-matchingBracket': {
+        backgroundColor: palette.matchingBracket,
+        outline: 'none'
+      }
+    },
+    { dark: isDark }
+  )
+}
+
+function highlightStyle(language, isDark) {
+  const colors = isDark
+    ? {
+        text: '#f5f5f5',
+        comment: '#737373',
+        keyword: language === 'sql' ? '#f472b6' : '#c084fc',
+        string:
+          language === 'sql'
+            ? '#fbbf24'
+            : language === 'env'
+            ? '#d4d4d4'
+            : '#4ade80',
+        number: language === 'sql' ? '#c084fc' : '#fb923c',
+        name: language === 'env' ? '#fbbf24' : '#22d3ee',
+        punctuation: '#a3a3a3',
+        operator: language === 'env' ? '#525252' : '#a3a3a3'
+      }
+    : {
+        text: '#171717',
+        comment: '#a3a3a3',
+        keyword: language === 'sql' ? '#db2777' : '#9333ea',
+        string:
+          language === 'sql'
+            ? '#d97706'
+            : language === 'env'
+            ? '#404040'
+            : '#16a34a',
+        number: language === 'sql' ? '#9333ea' : '#ea580c',
+        name: language === 'env' ? '#d97706' : '#0891b2',
+        punctuation: '#737373',
+        operator: language === 'env' ? '#a3a3a3' : '#737373'
+      }
+
+  return HighlightStyle.define([
+    { tag: tags.comment, color: colors.comment },
+    { tag: tags.keyword, color: colors.keyword },
+    { tag: [tags.string, tags.special(tags.string)], color: colors.string },
+    { tag: [tags.number, tags.bool, tags.null], color: colors.number },
+    {
+      tag: [
+        tags.propertyName,
+        tags.function(tags.variableName),
+        tags.standard(tags.name),
+        tags.typeName
+      ],
+      color: colors.name
+    },
+    { tag: [tags.operator, tags.definitionOperator], color: colors.operator },
+    {
+      tag: [tags.punctuation, tags.bracket, tags.separator],
+      color: colors.punctuation
+    },
+    { tag: tags.content, color: colors.text }
+  ])
+}
+
+function appearanceExtension() {
+  const isDark = darkModeQuery?.matches ?? false
+  return [
+    editorTheme(isDark),
+    syntaxHighlighting(highlightStyle(props.language, isDark))
+  ]
+}
+
+function editableExtension() {
+  const attributes = {
+    'aria-label': props.ariaLabel,
+    'aria-disabled': String(props.disabled),
+    'aria-multiline': 'true',
+    autocapitalize: 'off',
+    autocomplete: 'off',
+    spellcheck: 'false'
+  }
+  if (props.testId) attributes['data-test'] = props.testId
+
+  return [
+    EditorState.readOnly.of(props.disabled),
+    EditorView.editable.of(!props.disabled),
+    EditorView.contentAttributes.of(attributes)
+  ]
+}
+
+function submitKeymap() {
+  if (!props.submitOnModEnter) return []
+  return [
+    {
+      key: 'Mod-Enter',
+      run() {
+        emit('submit')
+        return true
+      }
+    }
+  ]
+}
+
+function handleColorSchemeChange() {
+  if (!view) return
+  view.dispatch({
+    effects: appearanceCompartment.reconfigure(appearanceExtension())
+  })
+}
+
+onMounted(() => {
+  darkModeQuery = window.matchMedia('(prefers-color-scheme: dark)')
+  darkModeQuery.addEventListener('change', handleColorSchemeChange)
+
+  view = new EditorView({
+    parent: editorHost.value,
+    state: EditorState.create({
+      doc: props.modelValue,
+      extensions: [
+        history(),
+        drawSelection(),
+        indentOnInput(),
+        bracketMatching(),
+        EditorView.lineWrapping,
+        keymap.of([
+          ...submitKeymap(),
+          indentWithTab,
+          ...defaultKeymap,
+          ...historyKeymap
+        ]),
+        props.placeholder ? editorPlaceholder(props.placeholder) : [],
+        languageCompartment.of(languageExtension(props.language)),
+        appearanceCompartment.of(appearanceExtension()),
+        editableCompartment.of(editableExtension()),
+        EditorView.updateListener.of((update) => {
+          if (!update.docChanged || applyingExternalValue) return
+          emit('update:modelValue', update.state.doc.toString())
+        })
+      ]
+    })
+  })
+})
+
+watch(
+  () => props.modelValue,
+  (value) => {
+    if (!view || value === view.state.doc.toString()) return
+    applyingExternalValue = true
+    view.dispatch({
+      changes: { from: 0, to: view.state.doc.length, insert: value }
+    })
+    applyingExternalValue = false
+  }
+)
+
+watch(
+  () => props.language,
+  (language) => {
+    if (!view) return
+    view.dispatch({
+      effects: [
+        languageCompartment.reconfigure(languageExtension(language)),
+        appearanceCompartment.reconfigure(appearanceExtension())
+      ]
+    })
+  }
+)
+
+watch(
+  () => [props.disabled, props.ariaLabel, props.testId],
+  () => {
+    if (!view) return
+    view.dispatch({
+      effects: editableCompartment.reconfigure(editableExtension())
+    })
+  }
+)
+
+onBeforeUnmount(() => {
+  darkModeQuery?.removeEventListener('change', handleColorSchemeChange)
+  view?.destroy()
+})
+</script>
+
+<template>
+  <div
+    ref="editorHost"
+    data-code-editor
+    :data-test="testId ? `${testId}-container` : undefined"
+    :class="[
+      'code-editor min-w-0',
+      height === 'fill' ? 'code-editor--fill h-full' : 'code-editor--content'
+    ]"
+    :style="editorStyle"
+  ></div>
+</template>
+
+<style scoped>
+.code-editor--fill :deep(.cm-editor),
+.code-editor--fill :deep(.cm-scroller) {
+  height: 100%;
+}
+
+.code-editor--content :deep(.cm-editor),
+.code-editor--content :deep(.cm-scroller),
+.code-editor--content :deep(.cm-content) {
+  min-height: var(--code-editor-min-height);
+}
+
+.code-editor--content :deep(.cm-scroller) {
+  max-height: var(--code-editor-max-height);
+  overflow: auto;
+}
+
+.code-editor :deep(.cm-editor.cm-focused) {
+  outline: 1px solid var(--color-brand-200);
+  outline-offset: -1px;
+}
+
+.code-editor :deep(.cm-content:focus-visible) {
+  outline: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  .code-editor :deep(.cm-editor.cm-focused) {
+    outline-color: var(--color-brand-800);
+  }
+}
+</style>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -15,6 +15,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import CodeEditor from '@/components/CodeEditor.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
 import { highlightJSON } from '@/lib/highlightJSON'
 import { highlightJS } from '@/lib/highlightJS'
@@ -130,12 +131,6 @@ function showToast(message, type = 'success') {
 function dismissToast(id) {
   toasts.value = toasts.value.filter((t) => t.id !== id)
 }
-
-// SQL syntax highlighting (shared utility)
-const highlightedQuery = computed(() => highlightSQL(sqlQuery.value))
-
-// Helm JS syntax highlighting
-const highlightedHelmCode = computed(() => highlightJS(helmCode.value))
 
 // Format Helm output — try to parse as JSON for syntax highlighting, fall back to plain text
 const highlightedHelmOutput = computed(() => {
@@ -861,37 +856,29 @@ onUnmounted(() => {
         class="flex-1 overflow-hidden border-b border-gray-200 dark:border-gray-800"
       >
         <!-- SQL editor -->
-        <div v-if="consoleMode === 'sql'" class="relative h-full">
-          <pre
-            class="wrap-break-word pointer-events-none absolute inset-0 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm leading-6 text-gray-900 dark:text-gray-100"
-            aria-hidden="true"
-            v-html="highlightedQuery"
-          ></pre>
-          <textarea
-            v-model="sqlQuery"
-            class="absolute inset-0 h-full w-full resize-none bg-transparent p-4 font-mono text-sm leading-6 text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none dark:placeholder-gray-600 dark:caret-white"
-            placeholder="SELECT * FROM ..."
-            spellcheck="false"
-            @keydown.ctrl.enter="executeQuery"
-            @keydown.meta.enter="executeQuery"
-          ></textarea>
-        </div>
+        <CodeEditor
+          v-if="consoleMode === 'sql'"
+          v-model="sqlQuery"
+          language="sql"
+          aria-label="Bosun SQL query"
+          test-id="bosun-sql-editor"
+          height="fill"
+          submit-on-mod-enter
+          placeholder="SELECT * FROM ..."
+          @submit="executeQuery"
+        />
         <!-- Helm editor -->
-        <div v-else class="relative h-full">
-          <pre
-            class="wrap-break-word pointer-events-none absolute inset-0 overflow-auto whitespace-pre-wrap p-4 font-mono text-sm leading-6 text-gray-900 dark:text-gray-100"
-            aria-hidden="true"
-            v-html="highlightedHelmCode"
-          ></pre>
-          <textarea
-            v-model="helmCode"
-            class="absolute inset-0 h-full w-full resize-none bg-transparent p-4 font-mono text-sm leading-6 text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none dark:placeholder-gray-600 dark:caret-white"
-            placeholder="// Access Slipway models and helpers&#10;await User.find()"
-            spellcheck="false"
-            @keydown.ctrl.enter="executeHelm"
-            @keydown.meta.enter="executeHelm"
-          ></textarea>
-        </div>
+        <CodeEditor
+          v-else
+          v-model="helmCode"
+          language="javascript"
+          aria-label="Bosun Helm code"
+          test-id="bosun-helm-editor"
+          height="fill"
+          submit-on-mod-enter
+          placeholder="// Access Slipway models and helpers&#10;await User.find()"
+          @submit="executeHelm"
+        />
       </div>
 
       <!-- Actions bar -->

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -15,6 +15,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import CodeEditor from '@/components/CodeEditor.vue'
 import { useToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
@@ -393,29 +394,6 @@ const bulkMode = ref(_params.has('bulk'))
 const bulkText = ref('')
 
 const sortedVarKeys = computed(() => Object.keys(localVars).sort())
-
-const bulkHighlighted = computed(() => {
-  const text = bulkText.value || ''
-  return (
-    text
-      .split('\n')
-      .map((line) => {
-        const escaped = line
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-        if (escaped.trimStart().startsWith('#')) {
-          return `<span class="text-gray-500 dark:text-gray-600">${escaped}</span>`
-        }
-        const eqIdx = escaped.indexOf('=')
-        if (eqIdx === -1) return escaped
-        const key = escaped.slice(0, eqIdx)
-        const value = escaped.slice(eqIdx + 1)
-        return `<span class="text-amber-600 dark:text-amber-400">${key}</span><span class="text-gray-400 dark:text-gray-600">=</span><span class="text-gray-800 dark:text-gray-300">${value}</span>`
-      })
-      .join('\n') + '\n'
-  )
-})
 
 function enterBulkMode() {
   bulkText.value = sortedVarKeys.value
@@ -1425,21 +1403,14 @@ onBeforeUnmount(() => {
             <div v-show="envVarsOpen">
               <template v-if="bulkMode">
                 <div class="border-t border-gray-200 dark:border-gray-800">
-                  <div class="relative">
-                    <pre
-                      class="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-all bg-gray-50 px-4 py-4 font-mono text-sm leading-relaxed dark:bg-gray-950"
-                      aria-hidden="true"
-                      v-html="bulkHighlighted"
-                    ></pre>
-                    <textarea
-                      v-model="bulkText"
-                      rows="3"
-                      placeholder="KEY=value&#10;DATABASE_URL=postgres://localhost:5432/db&#10;# Comments are ignored"
-                      class="relative block w-full resize-none bg-transparent px-4 py-4 font-mono text-sm text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none dark:placeholder-gray-500 dark:caret-white"
-                      style="field-sizing: content"
-                      spellcheck="false"
-                    />
-                  </div>
+                  <CodeEditor
+                    v-model="bulkText"
+                    language="env"
+                    aria-label="Application environment variables"
+                    test-id="app-env-editor"
+                    class="bg-gray-50 dark:bg-gray-950"
+                    placeholder="KEY=value&#10;DATABASE_URL=postgres://localhost:5432/db&#10;# Comments are ignored"
+                  />
                   <div
                     class="flex items-center justify-between border-t border-gray-200 px-4 py-3 dark:border-gray-800"
                   >

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -13,6 +13,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import CodeEditor from '@/components/CodeEditor.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
 import { highlightJSON } from '@/lib/highlightJSON'
 import SlippyLoader from '@/components/SlippyLoader.vue'
@@ -262,11 +263,6 @@ function apiUrl(endpoint, extraParams = '') {
       : '')
   return `${apiBasePath.value}${endpoint}${queryPart}`
 }
-
-// SQL syntax highlighting (shared utility)
-const highlightedQuery = computed(() => {
-  return highlightSQL(query.value)
-})
 
 // Execute SQL query
 async function executeQuery() {
@@ -1460,23 +1456,16 @@ onUnmounted(() => {
         <div
           class="flex-1 overflow-hidden border-b border-gray-200 dark:border-gray-800"
         >
-          <div class="relative h-full">
-            <!-- Highlighted layer -->
-            <pre
-              class="pointer-events-none absolute inset-0 overflow-auto whitespace-pre-wrap break-words p-4 font-mono text-sm leading-6 text-gray-900 dark:text-gray-100"
-              aria-hidden="true"
-              v-html="highlightedQuery"
-            ></pre>
-            <!-- Textarea -->
-            <textarea
-              v-model="query"
-              class="absolute inset-0 h-full w-full resize-none bg-transparent p-4 font-mono text-sm leading-6 text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none dark:placeholder-gray-600 dark:caret-white"
-              :placeholder="defaultQuery"
-              spellcheck="false"
-              @keydown.ctrl.enter="executeQuery"
-              @keydown.meta.enter="executeQuery"
-            ></textarea>
-          </div>
+          <CodeEditor
+            v-model="query"
+            :language="isMongoDB ? 'javascript' : 'sql'"
+            :placeholder="defaultQuery"
+            aria-label="Database query"
+            test-id="dock-query-editor"
+            height="fill"
+            submit-on-mod-enter
+            @submit="executeQuery"
+          />
         </div>
 
         <!-- Actions bar -->
@@ -2504,24 +2493,16 @@ onUnmounted(() => {
 
           <!-- Paste mode -->
           <div v-if="importMode === 'paste'">
-            <div class="relative max-h-[400px] min-h-[200px] overflow-auto">
-              <!-- Highlighted layer -->
-              <pre
-                class="pointer-events-none absolute inset-0 overflow-hidden whitespace-pre-wrap break-words p-3 font-mono text-sm leading-6 text-gray-900 dark:text-gray-100"
-                aria-hidden="true"
-                v-html="
-                  highlightSQL(importSql) ||
-                  '<span class=\'text-gray-400 dark:text-gray-500\'>Paste your SQL statements here...</span>'
-                "
-              ></pre>
-              <!-- Textarea -->
-              <textarea
-                v-model="importSql"
-                class="field-sizing-content relative min-h-[200px] w-full resize-none bg-transparent p-3 font-mono text-sm leading-6 text-transparent placeholder-transparent caret-gray-900 focus:outline-none dark:caret-white"
-                placeholder="Paste your SQL statements here..."
-                spellcheck="false"
-              ></textarea>
-            </div>
+            <CodeEditor
+              v-model="importSql"
+              language="sql"
+              placeholder="Paste your SQL statements here..."
+              aria-label="SQL import"
+              test-id="dock-import-editor"
+              min-height="200px"
+              max-height="400px"
+              padding="compact"
+            />
           </div>
 
           <!-- Upload mode -->

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -14,6 +14,7 @@ import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import CodeEditor from '@/components/CodeEditor.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
 import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
@@ -310,29 +311,6 @@ const bulkHasChanges = computed(() => {
   if (keys.length !== currentKeys.length) return true
   return keys.some(
     (k, i) => k !== currentKeys[i] || vars[k] !== localVars[currentKeys[i]]
-  )
-})
-
-const bulkHighlighted = computed(() => {
-  const text = bulkText.value || ''
-  return (
-    text
-      .split('\n')
-      .map((line) => {
-        const escaped = line
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-        if (escaped.trimStart().startsWith('#')) {
-          return `<span class="text-gray-500 dark:text-gray-600">${escaped}</span>`
-        }
-        const eqIdx = escaped.indexOf('=')
-        if (eqIdx === -1) return escaped
-        const key = escaped.slice(0, eqIdx)
-        const value = escaped.slice(eqIdx + 1)
-        return `<span class="text-amber-600 dark:text-amber-400">${key}</span><span class="text-gray-400 dark:text-gray-600">=</span><span class="text-gray-800 dark:text-gray-300">${value}</span>`
-      })
-      .join('\n') + '\n'
   )
 })
 
@@ -2446,21 +2424,14 @@ onBeforeUnmount(() => {
             <div v-show="envVarsOpen">
               <template v-if="bulkMode">
                 <div class="border-t border-gray-200 dark:border-gray-800">
-                  <div class="relative">
-                    <pre
-                      class="pointer-events-none absolute inset-0 overflow-auto whitespace-pre-wrap break-all bg-gray-50 px-4 py-4 font-mono text-sm leading-relaxed dark:bg-gray-950"
-                      aria-hidden="true"
-                      v-html="bulkHighlighted"
-                    ></pre>
-                    <textarea
-                      v-model="bulkText"
-                      rows="3"
-                      placeholder="KEY=value&#10;DATABASE_URL=postgres://localhost:5432/db&#10;# Comments are ignored"
-                      class="relative block w-full resize-none bg-transparent px-4 py-4 font-mono text-sm leading-relaxed text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none dark:placeholder-gray-500 dark:caret-white"
-                      style="field-sizing: content"
-                      spellcheck="false"
-                    />
-                  </div>
+                  <CodeEditor
+                    v-model="bulkText"
+                    language="env"
+                    aria-label="Environment variables"
+                    test-id="environment-env-editor"
+                    class="bg-gray-50 dark:bg-gray-950"
+                    placeholder="KEY=value&#10;DATABASE_URL=postgres://localhost:5432/db&#10;# Comments are ignored"
+                  />
                   <div
                     class="flex items-center justify-between border-t border-gray-200 px-4 py-3 dark:border-gray-800"
                   >

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -3,7 +3,7 @@ import { Link, Head, usePage } from '@inertiajs/vue3'
 import { inject, ref, computed, onMounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
-import { highlightJS } from '@/lib/highlightJS'
+import CodeEditor from '@/components/CodeEditor.vue'
 
 defineOptions({
   layout: AppLayout
@@ -86,32 +86,6 @@ function clearExecutionOutput() {
   output.value = ''
   error.value = ''
 }
-
-function handleKeydown(e) {
-  // Cmd/Ctrl + Enter to run
-  if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-    e.preventDefault()
-    execute()
-  }
-  // Tab to insert spaces
-  if (e.key === 'Tab') {
-    e.preventDefault()
-    const target = e.target
-    const start = target.selectionStart
-    const end = target.selectionEnd
-    code.value =
-      code.value.substring(0, start) + '  ' + code.value.substring(end)
-    // Restore cursor position after Vue updates
-    requestAnimationFrame(() => {
-      target.selectionStart = target.selectionEnd = start + 2
-    })
-  }
-}
-
-// JavaScript syntax highlighting
-const highlightedCode = computed(() => {
-  return highlightJS(code.value)
-})
 
 // JSON/output syntax highlighting
 const highlightedOutput = computed(() => {
@@ -430,24 +404,17 @@ function highlightJSON(str) {
           class="relative min-h-0 min-w-0 flex-1 overflow-hidden bg-white dark:bg-gray-950"
         >
           <!-- Editor area -->
-          <div class="relative h-full overflow-auto">
-            <!-- Highlighted layer -->
-            <pre
-              class="pointer-events-none absolute inset-0 whitespace-pre-wrap break-words py-4 pl-4 pr-4 font-mono text-sm leading-6"
-              aria-hidden="true"
-              v-html="highlightedCode"
-            ></pre>
-            <!-- Textarea -->
-            <textarea
-              data-test="helm-editor"
-              v-model="code"
-              @keydown="handleKeydown"
-              :disabled="!isRunning"
-              spellcheck="false"
-              class="absolute inset-0 h-full w-full resize-none border-0 bg-transparent py-4 pl-4 pr-4 font-mono text-sm leading-6 text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none focus:ring-0 dark:placeholder-gray-600 dark:caret-gray-100"
-              placeholder="// Enter JavaScript code..."
-            ></textarea>
-          </div>
+          <CodeEditor
+            v-model="code"
+            language="javascript"
+            aria-label="Helm JavaScript"
+            test-id="helm-editor"
+            height="fill"
+            :disabled="!isRunning"
+            submit-on-mod-enter
+            placeholder="// Enter JavaScript code..."
+            @submit="execute"
+          />
         </div>
       </div>
 

--- a/assets/js/pages/settings/global-env.vue
+++ b/assets/js/pages/settings/global-env.vue
@@ -3,6 +3,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, reactive, computed, watch, onMounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import CodeEditor from '@/components/CodeEditor.vue'
 import { useToast } from '@/composables/toast'
 
 defineOptions({
@@ -127,29 +128,6 @@ const bulkHasChanges = computed(() => {
   if (keys.length !== currentKeys.length) return true
   return keys.some(
     (k, i) => k !== currentKeys[i] || vars[k] !== localVars[currentKeys[i]]
-  )
-})
-
-const bulkHighlighted = computed(() => {
-  const text = bulkText.value || ''
-  return (
-    text
-      .split('\n')
-      .map((line) => {
-        const escaped = line
-          .replace(/&/g, '&amp;')
-          .replace(/</g, '&lt;')
-          .replace(/>/g, '&gt;')
-        if (escaped.trimStart().startsWith('#')) {
-          return `<span class="text-gray-500 dark:text-gray-600">${escaped}</span>`
-        }
-        const eqIdx = escaped.indexOf('=')
-        if (eqIdx === -1) return escaped
-        const key = escaped.slice(0, eqIdx)
-        const value = escaped.slice(eqIdx + 1)
-        return `<span class="text-amber-600 dark:text-amber-400">${key}</span><span class="text-gray-400 dark:text-gray-600">=</span><span class="text-gray-800 dark:text-gray-300">${value}</span>`
-      })
-      .join('\n') + '\n'
   )
 })
 
@@ -468,21 +446,15 @@ onMounted(() => {
           <!-- Bulk edit mode -->
           <template v-if="bulkMode">
             <div class="border-t border-gray-200 dark:border-gray-800">
-              <div class="relative">
-                <pre
-                  class="pointer-events-none absolute inset-0 overflow-auto whitespace-pre-wrap break-all bg-gray-50 px-4 py-3 font-mono text-sm leading-relaxed dark:bg-gray-900"
-                  aria-hidden="true"
-                  v-html="bulkHighlighted"
-                ></pre>
-                <textarea
-                  v-model="bulkText"
-                  rows="3"
-                  placeholder="KEY=value&#10;R2_ACCESS_KEY=abc123&#10;# Comments are ignored"
-                  class="relative block w-full resize-none bg-transparent px-4 py-3 font-mono text-sm leading-relaxed text-transparent placeholder-gray-400 caret-gray-900 focus:outline-none dark:placeholder-gray-500 dark:caret-white"
-                  style="field-sizing: content"
-                  spellcheck="false"
-                />
-              </div>
+              <CodeEditor
+                v-model="bulkText"
+                language="env"
+                aria-label="Global environment variables"
+                test-id="global-env-editor"
+                class="bg-gray-50 dark:bg-gray-900"
+                placeholder="KEY=value&#10;R2_ACCESS_KEY=abc123&#10;# Comments are ignored"
+                padding="compact"
+              />
               <div
                 class="flex items-center justify-between border-t border-gray-200 px-4 py-3 dark:border-gray-800"
               >

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,14 @@
         "packages/*"
       ],
       "dependencies": {
+        "@codemirror/commands": "^6.10.4",
+        "@codemirror/lang-javascript": "^6.2.5",
+        "@codemirror/lang-sql": "^6.10.0",
+        "@codemirror/language": "^6.12.4",
+        "@codemirror/state": "^6.7.1",
+        "@codemirror/view": "^6.43.6",
         "@inertiajs/vue3": "^3.4.0",
+        "@lezer/highlight": "^1.2.3",
         "@sailscastshq/connect-sqlite": "^1.1.0",
         "@sailshq/connect-redis": "^6.1.3",
         "@sailshq/lodash": "^3.10.3",
@@ -127,6 +134,105 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-javascript": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+      "integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.6.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/javascript": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+      "integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+      "integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
       }
     },
     "node_modules/@emnapi/core": {
@@ -658,6 +764,47 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/javascript": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+      "integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.1.3",
+        "@lezer/lr": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.0.7",
@@ -3305,6 +3452,12 @@
       "peerDependencies": {
         "sails": ">=1"
       }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
     },
     "node_modules/cron-parser": {
       "version": "5.5.0",
@@ -8927,6 +9080,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,14 @@
     "packages/*"
   ],
   "dependencies": {
+    "@codemirror/commands": "^6.10.4",
+    "@codemirror/lang-javascript": "^6.2.5",
+    "@codemirror/lang-sql": "^6.10.0",
+    "@codemirror/language": "^6.12.4",
+    "@codemirror/state": "^6.7.1",
+    "@codemirror/view": "^6.43.6",
     "@inertiajs/vue3": "^3.4.0",
+    "@lezer/highlight": "^1.2.3",
     "@sailscastshq/connect-sqlite": "^1.1.0",
     "@sailshq/connect-redis": "^6.1.3",
     "@sailshq/lodash": "^3.10.3",

--- a/tests/e2e/pages/code-editors.test.js
+++ b/tests/e2e/pages/code-editors.test.js
@@ -1,0 +1,302 @@
+const { test } = require('sounding')
+
+const sqlExample = [
+  'SELECT id, email',
+  'FROM users',
+  'WHERE active = true',
+  'ORDER BY created_at DESC;'
+].join('\n')
+
+const javascriptExample = [
+  'const creators = await Creator.find({',
+  '  where: { isActive: true },',
+  '  limit: 20',
+  '})',
+  'return creators'
+].join('\n')
+
+const envExample = [
+  '# Runtime configuration',
+  'NODE_ENV=production',
+  'SESSION_SECRET=replace-me',
+  'LOG_LEVEL=info'
+].join('\n')
+
+async function verifyRealEditor({ page, expect, selector, value, ariaLabel }) {
+  await page.wait(selector)
+  await page.fill(selector, value)
+
+  const structure = await page.script((target) => {
+    const editor = document.querySelector(target)
+    const host = editor.closest('[data-code-editor]')
+
+    return {
+      tagName: editor.tagName,
+      contentEditable: editor.getAttribute('contenteditable'),
+      role: editor.getAttribute('role'),
+      ariaLabel: editor.getAttribute('aria-label'),
+      textareaCount: host.querySelectorAll('textarea').length,
+      overlayCount: host.querySelectorAll('pre').length,
+      wrapped: editor.classList.contains('cm-lineWrapping')
+    }
+  }, selector.replace('@', '[data-test="').concat('"]'))
+
+  expect(structure.tagName).toBe('DIV')
+  expect(structure.contentEditable).toBe('true')
+  expect(structure.role).toBe('textbox')
+  expect(structure.ariaLabel).toBe(ariaLabel)
+  expect(structure.textareaCount).toBe(0)
+  expect(structure.overlayCount).toBe(0)
+  expect(structure.wrapped).toBe(true)
+
+  await page.key('ControlOrMeta+a')
+  await page.key('ControlOrMeta+c')
+
+  expect(await page.script(() => window.getSelection().toString())).toBe(value)
+  expect(await page.script(() => navigator.clipboard.readText())).toBe(value)
+
+  await page.key('ArrowLeft')
+  await page.key('Shift+ArrowRight')
+  expect(await page.script(() => window.getSelection().toString())).toBe(
+    value[0]
+  )
+  await page.key('ArrowRight')
+}
+
+async function screenshotAroundEditor(page, selector, path) {
+  const editor = page.raw.locator(
+    selector.replace('@', '[data-test="').concat('"]')
+  )
+  await editor.evaluate((element) =>
+    element.scrollIntoView({ block: 'center', inline: 'nearest' })
+  )
+  await page.wait(100)
+  await page.screenshot(path)
+}
+
+test(
+  'Slipway code editors provide native selection and exact copy behavior everywhere',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'real-code-editors',
+          name: 'Real Code Editors'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const projectSlug = current.projects.deploymentTarget.slug
+    const environmentSlug = current.environments.production.slug
+    const appSlug = current.apps.web.slug
+
+    await sails.models.environment
+      .updateOne({ id: current.environments.production.id })
+      .set({
+        envVars: {
+          NODE_ENV: 'production',
+          SESSION_SECRET: 'environment-secret',
+          LOG_LEVEL: 'info'
+        }
+      })
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: null,
+      envVars: {
+        SAILS_ENV: 'production',
+        APP_FEATURES: 'content,quest',
+        CACHE_TTL: '300'
+      }
+    })
+    const database = await world.create('service').with({
+      name: 'primary-db',
+      type: 'postgresql',
+      version: '17',
+      status: 'running',
+      environment: current.environments.production.id,
+      internalHost: 'primary-db',
+      internalPort: 5432,
+      database: 'app',
+      username: 'slipway',
+      password: 'secret'
+    })
+    await sails.helpers.setting.set.with({
+      key: 'globalEnvVars',
+      value: JSON.stringify({
+        R2_ACCESS_KEY: 'global-access-key',
+        R2_BUCKET: 'slipway-backups',
+        SUPPORT_EMAIL: 'ops@example.com'
+      })
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await page.raw.route('**/dock/tables?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tables: [] })
+      })
+    })
+    await page.raw.route('**/dock/sql?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          columns: [],
+          rows: [],
+          rowCount: 0,
+          duration: 1
+        })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.raw
+      .context()
+      .grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.resize(1440, 900)
+    await page.inLightMode()
+
+    const dockPath = `/projects/${projectSlug}/environments/${environmentSlug}/dock/${database.id}`
+    await page.goto(dockPath)
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@dock-query-editor',
+      value: sqlExample,
+      ariaLabel: 'Database query'
+    })
+    await page.screenshot('.tmp/issue-212-dock-query-light.png')
+
+    const execution = page.raw.waitForRequest(
+      (request) =>
+        request.method() === 'POST' && request.url().includes('/dock/sql')
+    )
+    await page.key('ControlOrMeta+Enter')
+    expect((await execution).postDataJSON().query).toBe(sqlExample)
+
+    await page.inDarkMode()
+    await page.wait(350)
+    await page.screenshot('.tmp/issue-212-dock-query-dark.png')
+
+    await page.goto(`${dockPath}?import=1`)
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@dock-import-editor',
+      value: `${sqlExample}\n\nINSERT INTO audit_logs (event) VALUES ('ready');`,
+      ariaLabel: 'SQL import'
+    })
+    await page.screenshot('.tmp/issue-212-dock-import-dark.png')
+
+    await page.inLightMode()
+    await page.goto('/bosun?tab=console')
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@bosun-sql-editor',
+      value: sqlExample,
+      ariaLabel: 'Bosun SQL query'
+    })
+    await page.screenshot('.tmp/issue-212-bosun-sql-light.png')
+
+    await page.raw.getByRole('button', { name: 'Helm', exact: true }).click()
+    await page.inDarkMode()
+    await page.wait(350)
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@bosun-helm-editor',
+      value: javascriptExample,
+      ariaLabel: 'Bosun Helm code'
+    })
+    await page.screenshot('.tmp/issue-212-bosun-helm-dark.png')
+
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+    )
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@helm-editor',
+      value: javascriptExample,
+      ariaLabel: 'Helm JavaScript'
+    })
+    await page.screenshot('.tmp/issue-212-project-helm-light.png')
+    await page.inDarkMode()
+    await page.wait(350)
+    await page.screenshot('.tmp/issue-212-project-helm-dark.png')
+
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/apps/${appSlug}?bulk=1`
+    )
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@app-env-editor',
+      value: envExample,
+      ariaLabel: 'Application environment variables'
+    })
+    await screenshotAroundEditor(
+      page,
+      '@app-env-editor',
+      '.tmp/issue-212-app-env-light.png'
+    )
+
+    await page.inDarkMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}?bulk=1`
+    )
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@environment-env-editor',
+      value: envExample,
+      ariaLabel: 'Environment variables'
+    })
+    await screenshotAroundEditor(
+      page,
+      '@environment-env-editor',
+      '.tmp/issue-212-environment-env-dark.png'
+    )
+
+    await page.inLightMode()
+    await page.goto('/settings/global-env?bulk=1')
+    await verifyRealEditor({
+      page,
+      expect,
+      selector: '@global-env-editor',
+      value: envExample,
+      ariaLabel: 'Global environment variables'
+    })
+    await screenshotAroundEditor(
+      page,
+      '@global-env-editor',
+      '.tmp/issue-212-global-env-light.png'
+    )
+    await page.inDarkMode()
+    await page.wait(350)
+    await screenshotAroundEditor(
+      page,
+      '@global-env-editor',
+      '.tmp/issue-212-global-env-dark.png'
+    )
+
+    expect(page).toHaveNoSmoke()
+  }
+)


### PR DESCRIPTION
## Summary

- add one minimal shared CodeMirror editor with SQL, JavaScript, and environment-variable syntax support
- replace all eight transparent textarea overlays across Dock, Bosun, Helm, and environment settings
- preserve the existing Slipway layouts while adding real selection, wrapping, history, indentation, accessibility labels, system light/dark theming, and Mod-Enter submission
- add a Sounding browser trial that proves exact multiline selection and clipboard copy on every migrated surface

## Verification

- `npm run lint`
- `npm test` — 141 unit, 44 functional, and 17 browser trials passed
- 11 light/dark UI screenshots generated and visually reviewed

Closes #212