### PR TITLE
feat(dock): separate multi-statement SQL results

### DIFF
--- a/api/controllers/api/v1/dock/execute-sql.js
+++ b/api/controllers/api/v1/dock/execute-sql.js
@@ -1,3 +1,8 @@
+const {
+  getStatementPreview,
+  splitSqlStatements
+} = require('../../../../lib/dock-sql-results')
+
 module.exports = {
   friendlyName: 'Execute SQL',
 
@@ -75,7 +80,13 @@ module.exports = {
 
     const { service } = dbResult
 
-    // Security: Basic query validation
+    // Validate every statement so a dangerous command cannot hide later in a batch.
+    const queriesToValidate =
+      service.type === 'mongodb'
+        ? [query]
+        : splitSqlStatements(query, service.type).map((statement) =>
+            getStatementPreview(statement.sql, Number.MAX_SAFE_INTEGER)
+          )
     const dangerousPatterns =
       service.type === 'mongodb'
         ? [
@@ -86,8 +97,8 @@ module.exports = {
           ]
         : [/^DROP\s+DATABASE/i, /^DROP\s+SCHEMA/i, /^TRUNCATE\s+TABLE\s+pg_/i]
 
-    for (const pattern of dangerousPatterns) {
-      if (pattern.test(query)) {
+    for (const statement of queriesToValidate) {
+      if (dangerousPatterns.some((pattern) => pattern.test(statement))) {
         throw { badRequest: 'This query is not allowed for security reasons.' }
       }
     }

--- a/api/helpers/dock/execute-sql.js
+++ b/api/helpers/dock/execute-sql.js
@@ -1,12 +1,23 @@
-const { execFile } = require('child_process')
+const crypto = require('crypto')
+const { execFile, spawn } = require('child_process')
 const util = require('util')
+const {
+  getStatementCommand,
+  getStatementPreview,
+  parseMysqlResults,
+  parsePostgresResults,
+  splitSqlStatements
+} = require('../../lib/dock-sql-results')
+
 const execFileAsync = util.promisify(execFile)
+const maximumOutputBytes = 10 * 1024 * 1024
+const queryTimeout = 30000
 
 module.exports = {
   friendlyName: 'Execute SQL',
 
   description:
-    'Execute a SQL query against a database service via docker exec.',
+    'Execute a database query and return a labeled result for every statement.',
 
   inputs: {
     service: {
@@ -29,11 +40,8 @@ module.exports = {
 
   exits: {
     success: {
-      description: 'Query executed successfully',
+      description: 'Query execution completed',
       outputType: 'ref'
-    },
-    queryFailed: {
-      description: 'Query execution failed'
     }
   },
 
@@ -41,318 +49,408 @@ module.exports = {
     const dockerPath = sails.config.docker?.binaryPath || 'docker'
     const startTime = Date.now()
 
-    let args
-    let parseOutput
-
-    if (service.type === 'postgresql') {
-      // PostgreSQL: use psql with CSV output for reliable parsing
-      args = [
-        'exec',
-        '-i',
-        service.containerName,
-        'psql',
-        '-U',
-        service.username,
-        '-d',
-        service.database,
-        '-c',
-        query,
-        '--no-psqlrc',
-        '--csv'
-      ]
-
-      parseOutput = (stdout, stderr) =>
-        parsePostgresOutput(stdout, stderr, format)
-    } else if (service.type === 'mysql') {
-      // MySQL: use mysql client
-      args = [
-        'exec',
-        '-i',
-        service.containerName,
-        'mysql',
-        '-u',
-        service.username,
-        `-p${service.password}`,
-        service.database,
-        '-e',
-        query
-      ]
-
-      if (format === 'json') {
-        args.push('--batch') // Tab-separated output
-      }
-
-      parseOutput = (stdout, stderr) => parseMysqlOutput(stdout, stderr, format)
-    } else if (service.type === 'mongodb') {
-      // MongoDB: use mongosh with JSON output
-      // Connect to localhost inside container, authenticate against admin db
-      const mongoUri = `mongodb://${encodeURIComponent(
-        service.username
-      )}:${encodeURIComponent(service.password)}@localhost:27017/${
-        service.database
-      }?authSource=admin`
-
-      // Wrap query to output JSON, with error handling
-      const wrappedQuery = `
-        try {
-          var result = ${query};
-          print(JSON.stringify(result));
-        } catch (e) {
-          print(JSON.stringify({ __error: true, message: e.message }));
-        }
-      `.replace(/\n\s*/g, ' ')
-
-      args = [
-        'exec',
-        '-i',
-        service.containerName,
-        'mongosh',
-        mongoUri,
-        '--quiet',
-        '--eval',
-        wrappedQuery
-      ]
-
-      parseOutput = (stdout, stderr) => parseMongoOutput(stdout, stderr, format)
-    } else {
-      throw new Error(`Unsupported database type: ${service.type}`)
-    }
+    sails.log.verbose(`[dock] Executing query on ${service.containerName}`)
 
     try {
-      sails.log.verbose(`[dock] Executing SQL on ${service.containerName}`)
-
-      const { stdout, stderr } = await execFileAsync(dockerPath, args, {
-        timeout: 30000, // 30 second timeout
-        maxBuffer: 10 * 1024 * 1024, // 10MB buffer for large results
-        env: {
-          ...process.env,
-          PGPASSWORD: service.password // PostgreSQL password via env
-        }
-      })
-
-      const duration = Date.now() - startTime
-
-      const result = parseOutput(stdout, stderr)
-
-      return {
-        success: true,
-        ...result,
-        duration
+      if (service.type === 'postgresql') {
+        return await executePostgres({
+          dockerPath,
+          service,
+          query,
+          startTime
+        })
       }
+
+      if (service.type === 'mysql') {
+        return await executeMysql({
+          dockerPath,
+          service,
+          query,
+          startTime
+        })
+      }
+
+      if (service.type === 'mongodb') {
+        return await executeMongo({
+          dockerPath,
+          service,
+          query,
+          format,
+          startTime
+        })
+      }
+
+      throw new Error(`Unsupported database type: ${service.type}`)
     } catch (error) {
-      sails.log.error(`[dock] SQL execution failed: ${error.message}`)
-
-      // Extract useful error message
-      let errorMessage = error.message
-      if (error.stderr) {
-        errorMessage = error.stderr.trim()
+      sails.log.error(`[dock] Query execution failed: ${error.message}`)
+      const duration = Date.now() - startTime
+      const message = getProcessErrorMessage(error)
+      const statement = {
+        sql: query.trim(),
+        command: getStatementCommand(query),
+        preview: getStatementPreview(query)
+      }
+      const result = {
+        statementIndex: 0,
+        statementSql: statement.sql,
+        statementPreview: statement.preview,
+        commandTag: statement.command,
+        status: 'error',
+        duration,
+        rowCount: 0,
+        affected: null,
+        columns: [],
+        rows: [],
+        message,
+        error: message,
+        raw: ''
       }
 
-      return {
-        success: false,
-        error: errorMessage,
-        duration: Date.now() - startTime
-      }
+      return aggregateResults([result], duration, error.stderr)
     }
   }
 }
 
-/**
- * Parse PostgreSQL CSV output into structured format
- */
-function parsePostgresOutput(stdout, stderr, format) {
-  const output = stdout.trim()
+async function executePostgres({ dockerPath, service, query, startTime }) {
+  const statements = splitSqlStatements(query, 'postgresql')
+  if (statements.length === 0) return noStatementsResult(startTime)
 
-  if (!output) {
-    return { columns: [], rows: [], rowCount: 0 }
-  }
+  const marker = createMarker()
+  const args = [
+    'exec',
+    '-i',
+    service.containerName,
+    'psql',
+    '-U',
+    service.username,
+    '-d',
+    service.database,
+    '--no-psqlrc',
+    '--csv',
+    '-v',
+    'ON_ERROR_STOP=0',
+    '-c',
+    '\\timing on'
+  ]
 
-  // Check for non-SELECT queries (INSERT, UPDATE, DELETE)
-  // Use word boundary \b to avoid matching column names like "created_at"
-  if (output.match(/^(INSERT|UPDATE|DELETE|CREATE|ALTER|DROP)\b/i)) {
-    return {
-      message: output,
-      columns: [],
-      rows: [],
-      rowCount: 0
-    }
-  }
+  statements.forEach((statement, index) => {
+    args.push(
+      '-c',
+      `\\echo ${marker} START ${index}`,
+      '-c',
+      statement.sql,
+      '-c',
+      `\\echo ${marker} END ${index} :SQLSTATE :ROW_COUNT :LAST_ERROR_MESSAGE`
+    )
+  })
 
-  // Parse CSV output (--csv flag)
-  // Handle both \n and \r\n line endings
-  const lines = output.split(/\r?\n/).filter((line) => line.length > 0)
+  let stdout = ''
+  let stderr = ''
+  let processError = null
 
-  if (lines.length === 0) {
-    return { columns: [], rows: [], rowCount: 0 }
-  }
-
-  // First line is headers - trim any whitespace/carriage returns
-  const headerLine = lines[0].trim()
-
-  if (!headerLine) {
-    return { columns: [], rows: [], rowCount: 0 }
-  }
-
-  // Check if this looks like CSV (contains commas)
-  if (!headerLine.includes(',')) {
-    // Single column or non-CSV output
-    if (headerLine.match(/^[a-z_][a-z0-9_]*$/i)) {
-      // Looks like a single column name
-      return {
-        columns: [headerLine],
-        rows: lines
-          .slice(1)
-          .filter((l) => l.trim())
-          .map((l) => ({ [headerLine]: l.trim() || null })),
-        rowCount: lines.length - 1
+  try {
+    const output = await execFileAsync(dockerPath, args, {
+      timeout: queryTimeout,
+      maxBuffer: maximumOutputBytes,
+      env: {
+        ...process.env,
+        PGPASSWORD: service.password
       }
-    }
-    // Not CSV format - return as message
-    return {
-      message: output,
-      columns: [],
-      rows: [],
-      rowCount: 0
-    }
-  }
-
-  const columns = parseCSVLine(headerLine)
-
-  if (columns.length === 0) {
-    return {
-      message: output,
-      columns: [],
-      rows: [],
-      rowCount: 0
-    }
-  }
-
-  // Rest are data rows
-  const rows = []
-  for (let i = 1; i < lines.length; i++) {
-    const line = lines[i].trim()
-    if (!line) continue
-
-    const values = parseCSVLine(line)
-    const row = {}
-    columns.forEach((col, idx) => {
-      const val = values[idx]
-      // Handle empty strings as null for consistency
-      row[col] = val === '' ? null : val
     })
-    rows.push(row)
+    stdout = output.stdout
+    stderr = output.stderr
+  } catch (error) {
+    processError = error
+    stdout = error.stdout || ''
+    stderr = error.stderr || error.message
   }
 
-  return {
-    columns,
-    rows,
-    rowCount: rows.length
+  const duration = Date.now() - startTime
+  const results = parsePostgresResults({
+    stdout,
+    stderr,
+    statements,
+    marker,
+    totalDuration: duration
+  })
+
+  if (processError && results.every((result) => result.status === 'success')) {
+    throw processError
   }
+
+  return aggregateResults(results, duration, stderr)
 }
 
-/**
- * Parse a single CSV line, handling quoted fields
- */
-function parseCSVLine(line) {
-  const result = []
-  let current = ''
-  let inQuotes = false
+async function executeMysql({ dockerPath, service, query, startTime }) {
+  const statements = splitSqlStatements(query, 'mysql')
+  if (statements.length === 0) return noStatementsResult(startTime)
 
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i]
-    const nextChar = line[i + 1]
+  const marker = createMarker()
+  const timerVariable = `slipway_${marker
+    .replace(/[^A-Za-z0-9_]/g, '')
+    .toLowerCase()}_started_at`
+  const { payload, lineRanges } = buildMysqlPayload({
+    statements,
+    marker,
+    timerVariable
+  })
+  const args = [
+    'exec',
+    '-i',
+    service.containerName,
+    'mysql',
+    '-u',
+    service.username,
+    `-p${service.password}`,
+    service.database,
+    '--batch',
+    '--force'
+  ]
 
-    if (inQuotes) {
-      if (char === '"' && nextChar === '"') {
-        // Escaped quote
-        current += '"'
-        i++
-      } else if (char === '"') {
-        // End of quoted field
-        inQuotes = false
-      } else {
-        current += char
-      }
-    } else {
-      if (char === '"') {
-        // Start of quoted field
-        inQuotes = true
-      } else if (char === ',') {
-        // Field separator
-        result.push(current)
-        current = ''
-      } else {
-        current += char
-      }
-    }
-  }
+  let stdout = ''
+  let stderr = ''
+  let processError = null
 
-  // Don't forget the last field
-  result.push(current)
-
-  return result
-}
-
-/**
- * Parse MySQL output into structured format
- */
-function parseMysqlOutput(stdout, stderr, format) {
-  const output = stdout.trim()
-
-  if (!output) {
-    return { columns: [], rows: [], rowCount: 0 }
-  }
-
-  // Check for non-SELECT queries
-  if (output.match(/^Query OK/)) {
-    return {
-      message: output,
-      columns: [],
-      rows: [],
-      rowCount: 0
-    }
-  }
-
-  // Parse tab-separated output (--batch mode)
-  const lines = output.split('\n').filter((line) => line.trim())
-
-  if (lines.length === 0) {
-    return { columns: [], rows: [], rowCount: 0 }
-  }
-
-  // First line is headers
-  const columns = lines[0].split('\t')
-  const rows = lines.slice(1).map((line) => {
-    const values = line.split('\t')
-    const row = {}
-    columns.forEach((col, i) => {
-      row[col] = values[i] === 'NULL' ? null : values[i]
+  try {
+    const output = await execFileWithInput(dockerPath, args, payload, {
+      timeout: queryTimeout,
+      maxBuffer: maximumOutputBytes
     })
-    return row
+    stdout = output.stdout
+    stderr = output.stderr
+  } catch (error) {
+    processError = error
+    stdout = error.stdout || ''
+    stderr = error.stderr || error.message
+  }
+
+  const duration = Date.now() - startTime
+  const results = parseMysqlResults({
+    stdout,
+    stderr,
+    statements,
+    marker,
+    lineRanges,
+    totalDuration: duration
+  })
+
+  if (processError && results.every((result) => result.status === 'success')) {
+    throw processError
+  }
+
+  return aggregateResults(results, duration, stderr)
+}
+
+async function executeMongo({ dockerPath, service, query, format, startTime }) {
+  const mongoUri = `mongodb://${encodeURIComponent(
+    service.username
+  )}:${encodeURIComponent(service.password)}@localhost:27017/${
+    service.database
+  }?authSource=admin`
+  const wrappedQuery = `
+    try {
+      var result = ${query};
+      print(JSON.stringify(result));
+    } catch (e) {
+      print(JSON.stringify({ __error: true, message: e.message }));
+    }
+  `.replace(/\n\s*/g, ' ')
+  const { stdout, stderr } = await execFileAsync(
+    dockerPath,
+    [
+      'exec',
+      '-i',
+      service.containerName,
+      'mongosh',
+      mongoUri,
+      '--quiet',
+      '--eval',
+      wrappedQuery
+    ],
+    {
+      timeout: queryTimeout,
+      maxBuffer: maximumOutputBytes
+    }
+  )
+  const parsed = parseMongoOutput(stdout, stderr, format)
+  const duration = Date.now() - startTime
+  const error = parsed.error || null
+  const result = {
+    statementIndex: 0,
+    statementSql: query.trim(),
+    statementPreview: getStatementPreview(query),
+    commandTag: 'MONGODB',
+    status: error ? 'error' : 'success',
+    duration,
+    rowCount: parsed.rowCount,
+    affected: null,
+    columns: parsed.columns,
+    rows: parsed.rows,
+    message: error || parsed.message || null,
+    error,
+    raw: stdout.trim()
+  }
+
+  return aggregateResults([result], duration, stderr)
+}
+
+function buildMysqlPayload({ statements, marker, timerVariable }) {
+  const lines = []
+  const lineRanges = []
+
+  statements.forEach((statement, index) => {
+    lines.push(`SET @${timerVariable} = NOW(6);`)
+    lines.push(`SELECT '${marker}:start:${index}' AS __slipway_marker__;`)
+
+    const statementLines = statement.sql.split(/\r?\n/)
+    if (!statementLines.at(-1).trimEnd().endsWith(';')) {
+      statementLines[statementLines.length - 1] += ';'
+    }
+
+    const start = lines.length + 1
+    lines.push(...statementLines)
+    const end = lines.length
+    lineRanges.push({ start, end })
+
+    lines.push(
+      `SELECT '${marker}:end:${index}' AS __slipway_marker__, ROW_COUNT() AS __slipway_row_count__, ROUND(TIMESTAMPDIFF(MICROSECOND, @${timerVariable}, NOW(6)) / 1000, 3) AS __slipway_duration_ms__;`
+    )
   })
 
   return {
-    columns,
-    rows,
-    rowCount: rows.length
+    payload: `${lines.join('\n')}\n`,
+    lineRanges
   }
 }
 
-/**
- * Parse MongoDB mongosh JSON output into structured format
- */
-function parseMongoOutput(stdout, stderr, format) {
+function aggregateResults(results, duration, rawMessages = '') {
+  const firstResult = results[0] || {
+    columns: [],
+    rows: [],
+    rowCount: 0,
+    message: 'Query executed successfully'
+  }
+  const failedResult = results.find((result) => result.status === 'error')
+  const success = Boolean(results.length) && !failedResult
+
+  return {
+    success,
+    ...firstResult,
+    duration,
+    results,
+    error: failedResult?.error || undefined,
+    messages: String(rawMessages || '').trim()
+  }
+}
+
+function noStatementsResult(startTime) {
+  const message = 'No executable SQL statements were found.'
+
+  return {
+    success: false,
+    columns: [],
+    rows: [],
+    rowCount: 0,
+    duration: Date.now() - startTime,
+    results: [],
+    error: message,
+    message,
+    messages: ''
+  }
+}
+
+function createMarker() {
+  return `__SLIPWAY_RESULT_${crypto.randomBytes(12).toString('hex')}__`
+}
+
+function getProcessErrorMessage(error) {
+  return String(error.stderr || error.message || 'Query failed')
+    .trim()
+    .split(/\r?\n/)
+    .pop()
+}
+
+function execFileWithInput(command, args, input, options) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: options.env || process.env,
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    let stdout = ''
+    let stderr = ''
+    let outputBytes = 0
+    let settled = false
+    const timeout = setTimeout(() => {
+      const error = new Error(`Query timed out after ${options.timeout}ms`)
+      error.code = 'ETIMEDOUT'
+      child.kill('SIGTERM')
+      settle(error)
+    }, options.timeout)
+
+    function collect(chunk, stream) {
+      outputBytes += chunk.length
+      if (outputBytes > options.maxBuffer) {
+        const error = new Error('Query output exceeded the 10MB limit')
+        error.code = 'ERR_CHILD_PROCESS_STDIO_MAXBUFFER'
+        child.kill('SIGTERM')
+        settle(error)
+        return
+      }
+
+      if (stream === 'stdout') stdout += chunk.toString()
+      else stderr += chunk.toString()
+    }
+
+    function settle(error) {
+      if (settled) return
+      settled = true
+      clearTimeout(timeout)
+
+      if (error) {
+        error.stdout = stdout
+        error.stderr = stderr || error.stderr
+        reject(error)
+      } else {
+        resolve({ stdout, stderr })
+      }
+    }
+
+    child.stdout.on('data', (chunk) => collect(chunk, 'stdout'))
+    child.stderr.on('data', (chunk) => collect(chunk, 'stderr'))
+    child.on('error', settle)
+    child.on('close', (code, signal) => {
+      if (code === 0) {
+        settle()
+        return
+      }
+
+      const error = new Error(
+        signal
+          ? `Database client stopped with signal ${signal}`
+          : `Database client exited with code ${code}`
+      )
+      error.code = code
+      error.signal = signal
+      settle(error)
+    })
+
+    child.stdin.on('error', (error) => {
+      if (error.code !== 'EPIPE') settle(error)
+    })
+    child.stdin.end(input)
+  })
+}
+
+function parseMongoOutput(stdout) {
   const output = stdout.trim()
 
   if (!output) {
     return { columns: [], rows: [], rowCount: 0 }
   }
 
-  // Try to parse as JSON (our query wraps result in JSON.stringify)
   try {
     const data = JSON.parse(output)
 
-    // Check for wrapped error
     if (data && data.__error) {
       return {
         message: data.message || 'MongoDB query failed',
@@ -363,69 +461,34 @@ function parseMongoOutput(stdout, stderr, format) {
       }
     }
 
-    // Handle array results (find queries)
     if (Array.isArray(data)) {
       if (data.length === 0) {
         return { columns: [], rows: [], rowCount: 0 }
       }
 
-      // Extract columns from first document
-      const columns = Object.keys(data[0])
-
-      // Convert _id to string for display
-      const rows = data.map((doc) => {
-        const row = {}
-        columns.forEach((col) => {
-          const val = doc[col]
-          if (col === '_id' && val && typeof val === 'object') {
-            row[col] = val.$oid || JSON.stringify(val)
-          } else if (val && typeof val === 'object') {
-            row[col] = JSON.stringify(val)
-          } else {
-            row[col] = val
-          }
-        })
-        return row
-      })
-
-      return {
-        columns,
-        rows,
-        rowCount: rows.length
-      }
+      const columns = Array.from(
+        new Set(data.flatMap((document) => Object.keys(document)))
+      )
+      const rows = data.map((document) => normalizeMongoDocument(document))
+      return { columns, rows, rowCount: rows.length }
     }
 
-    // Handle single document result
     if (typeof data === 'object' && data !== null) {
-      const columns = Object.keys(data)
-      const row = {}
-      columns.forEach((col) => {
-        const val = data[col]
-        if (col === '_id' && val && typeof val === 'object') {
-          row[col] = val.$oid || JSON.stringify(val)
-        } else if (val && typeof val === 'object') {
-          row[col] = JSON.stringify(val)
-        } else {
-          row[col] = val
-        }
-      })
-
+      const row = normalizeMongoDocument(data)
       return {
-        columns,
+        columns: Object.keys(row),
         rows: [row],
         rowCount: 1
       }
     }
 
-    // Handle primitive results (count, etc)
     return {
       message: String(data),
       columns: [],
       rows: [],
       rowCount: 0
     }
-  } catch (e) {
-    // Not JSON - return as message
+  } catch {
     return {
       message: output,
       columns: [],
@@ -433,4 +496,20 @@ function parseMongoOutput(stdout, stderr, format) {
       rowCount: 0
     }
   }
+}
+
+function normalizeMongoDocument(document) {
+  const row = {}
+
+  Object.entries(document).forEach(([column, value]) => {
+    if (column === '_id' && value && typeof value === 'object') {
+      row[column] = value.$oid || JSON.stringify(value)
+    } else if (value && typeof value === 'object') {
+      row[column] = JSON.stringify(value)
+    } else {
+      row[column] = value
+    }
+  })
+
+  return row
 }

--- a/api/lib/dock-sql-results.js
+++ b/api/lib/dock-sql-results.js
@@ -1,0 +1,546 @@
+function splitSqlStatements(sql, dialect = 'postgresql') {
+  const statements = []
+  let buffer = ''
+  let state = 'normal'
+  let blockCommentDepth = 0
+  let dollarQuote = null
+  let quoteUsesBackslashEscapes = false
+
+  for (let index = 0; index < sql.length; index++) {
+    const character = sql[index]
+    const nextCharacter = sql[index + 1]
+    buffer += character
+
+    if (state === 'line-comment') {
+      if (character === '\n') state = 'normal'
+      continue
+    }
+
+    if (state === 'block-comment') {
+      if (character === '/' && nextCharacter === '*') {
+        blockCommentDepth++
+        buffer += nextCharacter
+        index++
+      } else if (character === '*' && nextCharacter === '/') {
+        blockCommentDepth--
+        buffer += nextCharacter
+        index++
+        if (blockCommentDepth === 0) state = 'normal'
+      }
+      continue
+    }
+
+    if (state === 'single-quote') {
+      if (character === "'" && nextCharacter === "'") {
+        buffer += nextCharacter
+        index++
+      } else if (
+        character === "'" &&
+        (!quoteUsesBackslashEscapes || !isBackslashEscaped(sql, index))
+      ) {
+        state = 'normal'
+      }
+      continue
+    }
+
+    if (state === 'double-quote') {
+      if (character === '"' && nextCharacter === '"') {
+        buffer += nextCharacter
+        index++
+      } else if (
+        character === '"' &&
+        (!quoteUsesBackslashEscapes || !isBackslashEscaped(sql, index))
+      ) {
+        state = 'normal'
+      }
+      continue
+    }
+
+    if (state === 'backtick') {
+      if (character === '`' && nextCharacter === '`') {
+        buffer += nextCharacter
+        index++
+      } else if (character === '`') {
+        state = 'normal'
+      }
+      continue
+    }
+
+    if (state === 'dollar-quote') {
+      if (sql.startsWith(dollarQuote, index)) {
+        buffer += dollarQuote.slice(1)
+        index += dollarQuote.length - 1
+        dollarQuote = null
+        state = 'normal'
+      }
+      continue
+    }
+
+    if (character === '-' && nextCharacter === '-') {
+      state = 'line-comment'
+      buffer += nextCharacter
+      index++
+      continue
+    }
+
+    if (dialect === 'mysql' && character === '#') {
+      state = 'line-comment'
+      continue
+    }
+
+    if (character === '/' && nextCharacter === '*') {
+      state = 'block-comment'
+      blockCommentDepth = 1
+      buffer += nextCharacter
+      index++
+      continue
+    }
+
+    if (character === "'") {
+      state = 'single-quote'
+      quoteUsesBackslashEscapes =
+        dialect === 'mysql' || hasPostgresEscapeStringPrefix(sql, index)
+      continue
+    }
+
+    if (character === '"') {
+      state = 'double-quote'
+      quoteUsesBackslashEscapes = dialect === 'mysql'
+      continue
+    }
+
+    if (character === '`') {
+      state = 'backtick'
+      continue
+    }
+
+    if (dialect === 'postgresql' && character === '$') {
+      const match = sql.slice(index).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/)
+      if (match) {
+        dollarQuote = match[0]
+        state = 'dollar-quote'
+        buffer += dollarQuote.slice(1)
+        index += dollarQuote.length - 1
+        continue
+      }
+    }
+
+    if (character === ';') {
+      pushStatement(statements, buffer)
+      buffer = ''
+    }
+  }
+
+  pushStatement(statements, buffer)
+  return statements
+}
+
+function pushStatement(statements, sql) {
+  const statementSql = sql.trim()
+  if (!statementSql || !stripSqlComments(statementSql).trim()) return
+
+  statements.push({
+    sql: statementSql,
+    command: getStatementCommand(statementSql),
+    preview: getStatementPreview(statementSql)
+  })
+}
+
+function stripSqlComments(sql) {
+  let index = 0
+
+  while (index < sql.length) {
+    while (/\s/.test(sql[index] || '')) index++
+
+    if (sql.startsWith('--', index) || sql[index] === '#') {
+      const lineEnd = sql.indexOf('\n', index)
+      index = lineEnd === -1 ? sql.length : lineEnd + 1
+      continue
+    }
+
+    if (sql.startsWith('/*', index)) {
+      let depth = 1
+      index += 2
+
+      while (index < sql.length && depth > 0) {
+        if (sql.startsWith('/*', index)) {
+          depth++
+          index += 2
+        } else if (sql.startsWith('*/', index)) {
+          depth--
+          index += 2
+        } else {
+          index++
+        }
+      }
+      continue
+    }
+
+    break
+  }
+
+  return sql.slice(index).trim()
+}
+
+function getStatementCommand(sql) {
+  const statement = stripSqlComments(sql)
+  const words = statement.match(/^[A-Za-z]+(?:\s+[A-Za-z]+)?/)
+  if (!words) return 'SQL'
+
+  const [firstWord, secondWord] = words[0].toUpperCase().split(/\s+/)
+  if (
+    secondWord &&
+    ['CREATE', 'ALTER', 'DROP', 'TRUNCATE', 'GRANT', 'REVOKE'].includes(
+      firstWord
+    )
+  ) {
+    return `${firstWord} ${secondWord}`
+  }
+
+  return firstWord
+}
+
+function getStatementPreview(sql, maximumLength = 72) {
+  const preview = stripSqlComments(sql)
+    .replace(/;\s*$/, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+
+  if (preview.length <= maximumLength) return preview
+  return `${preview.slice(0, maximumLength - 1).trimEnd()}…`
+}
+
+function isBackslashEscaped(sql, index) {
+  let backslashes = 0
+  for (let cursor = index - 1; cursor >= 0 && sql[cursor] === '\\'; cursor--) {
+    backslashes++
+  }
+  return backslashes % 2 === 1
+}
+
+function hasPostgresEscapeStringPrefix(sql, quoteIndex) {
+  const prefix = sql[quoteIndex - 1]
+  const beforePrefix = sql[quoteIndex - 2]
+  return (
+    (prefix === 'E' || prefix === 'e') &&
+    (!beforePrefix || !/[A-Za-z0-9_$]/.test(beforePrefix))
+  )
+}
+
+function parseCsvRecords(csv) {
+  const records = []
+  let record = []
+  let field = ''
+  let inQuotes = false
+
+  for (let index = 0; index < csv.length; index++) {
+    const character = csv[index]
+    const nextCharacter = csv[index + 1]
+
+    if (inQuotes) {
+      if (character === '"' && nextCharacter === '"') {
+        field += '"'
+        index++
+      } else if (character === '"') {
+        inQuotes = false
+      } else {
+        field += character
+      }
+      continue
+    }
+
+    if (character === '"') {
+      inQuotes = true
+    } else if (character === ',') {
+      record.push(field)
+      field = ''
+    } else if (character === '\n') {
+      record.push(field.replace(/\r$/, ''))
+      records.push(record)
+      record = []
+      field = ''
+    } else {
+      field += character
+    }
+  }
+
+  if (field || record.length) {
+    record.push(field.replace(/\r$/, ''))
+    records.push(record)
+  }
+
+  return records.filter(
+    (recordValues) =>
+      recordValues.length > 1 || (recordValues[0] || '').length > 0
+  )
+}
+
+function rowsFromRecords(records) {
+  if (records.length === 0) return { columns: [], rows: [] }
+
+  const columns = records[0]
+  const rows = records.slice(1).map((values) => {
+    const row = {}
+    columns.forEach((column, index) => {
+      row[column] =
+        values[index] === undefined || values[index] === ''
+          ? null
+          : values[index]
+    })
+    return row
+  })
+
+  return { columns, rows }
+}
+
+function parsePostgresResults({
+  stdout,
+  stderr,
+  statements,
+  marker,
+  totalDuration
+}) {
+  const results = []
+
+  for (let index = 0; index < statements.length; index++) {
+    const startMarker = `${marker} START ${index}`
+    const endMarker = `${marker} END ${index} `
+    const start = stdout.indexOf(startMarker)
+    const end = stdout.indexOf(endMarker, Math.max(0, start))
+
+    if (start === -1 || end === -1) {
+      results.push(
+        createIncompleteResult(statements[index], index, stderr, totalDuration)
+      )
+      continue
+    }
+
+    const outputStart = start + startMarker.length
+    const rawOutput = stdout
+      .slice(outputStart, end)
+      .replace(/^\r?\n/, '')
+      .trim()
+    const endOfLine = stdout.indexOf('\n', end)
+    const endLine = stdout.slice(
+      end,
+      endOfLine === -1 ? stdout.length : endOfLine
+    )
+    const metadata = endLine.slice(endMarker.length).trim()
+    const [sqlState = '00000', rowCountValue = '0', ...messageParts] =
+      metadata.split(' ')
+    const error = sqlState === '00000' ? null : messageParts.join(' ').trim()
+    const timing = rawOutput.match(
+      /(?:^|\r?\n)Time:\s+([0-9.]+)\s+ms(?:\s+\([^)]+\))?\s*$/i
+    )
+    const duration = timing ? Number(timing[1]) : null
+    const output = timing
+      ? rawOutput.slice(0, timing.index).trim()
+      : rawOutput.trim()
+    const commandTag = isPostgresCommandTag(output) ? output : null
+    const parsed = commandTag
+      ? { columns: [], rows: [] }
+      : rowsFromRecords(parseCsvRecords(output))
+    const reportedRowCount = Number.parseInt(rowCountValue, 10)
+    const rowCount = parsed.columns.length
+      ? parsed.rows.length
+      : Number.isFinite(reportedRowCount)
+      ? reportedRowCount
+      : 0
+    const status = error ? 'error' : 'success'
+
+    results.push({
+      statementIndex: index,
+      statementSql: statements[index].sql,
+      statementPreview: statements[index].preview,
+      commandTag: commandTag || statements[index].command,
+      status,
+      duration,
+      rowCount,
+      affected:
+        !parsed.columns.length && reportsAffectedRows(statements[index].command)
+          ? rowCount
+          : null,
+      columns: parsed.columns,
+      rows: parsed.rows,
+      message:
+        error || formatCommandMessage(statements[index].command, rowCount),
+      error,
+      sqlState,
+      raw: output
+    })
+  }
+
+  return results
+}
+
+function parseMysqlResults({
+  stdout,
+  stderr,
+  statements,
+  marker,
+  lineRanges,
+  totalDuration
+}) {
+  const lines = stdout.split(/\r?\n/)
+  const errors = parseMysqlErrors(stderr, lineRanges)
+
+  return statements.map((statement, index) => {
+    const startValue = `${marker}:start:${index}`
+    const endValue = `${marker}:end:${index}`
+    const startLine = lines.indexOf(startValue)
+    const endLine = lines.findIndex((line) => line.startsWith(`${endValue}\t`))
+    const statementError = errors.get(index) || null
+
+    if (startLine === -1 || endLine === -1 || endLine <= startLine) {
+      return createIncompleteResult(
+        statement,
+        index,
+        statementError?.message || stderr,
+        totalDuration
+      )
+    }
+
+    const metadata = lines[endLine].split('\t')
+    const affectedValue = Number.parseInt(metadata[1], 10)
+    const durationValue = Number.parseFloat(metadata[2])
+    const markerHeaderIndex = endLine - 1
+    const outputLines = lines
+      .slice(startLine + 1, markerHeaderIndex)
+      .filter((line) => line.length > 0)
+    const columns = outputLines.length ? outputLines[0].split('\t') : []
+    const rows = outputLines.slice(1).map((line) => {
+      const values = line.split('\t')
+      const row = {}
+      columns.forEach((column, valueIndex) => {
+        row[column] =
+          values[valueIndex] === 'NULL'
+            ? null
+            : decodeMysqlBatchValue(values[valueIndex])
+      })
+      return row
+    })
+    const rowCount = columns.length
+      ? rows.length
+      : Number.isFinite(affectedValue) && affectedValue > 0
+      ? affectedValue
+      : 0
+    const error = statementError?.message || null
+
+    return {
+      statementIndex: index,
+      statementSql: statement.sql,
+      statementPreview: statement.preview,
+      commandTag: statement.command,
+      status: error ? 'error' : 'success',
+      duration: Number.isFinite(durationValue) ? durationValue : null,
+      rowCount,
+      affected:
+        !columns.length && reportsAffectedRows(statement.command)
+          ? Math.max(0, affectedValue || 0)
+          : null,
+      columns,
+      rows,
+      message: error || formatCommandMessage(statement.command, rowCount),
+      error,
+      sqlState: statementError?.sqlState || '00000',
+      raw: outputLines.join('\n')
+    }
+  })
+}
+
+function parseMysqlErrors(stderr, lineRanges) {
+  const errors = new Map()
+  const pattern = /ERROR\s+(\d+)\s+\(([^)]+)\)\s+at line\s+(\d+):\s*([^\n]+)/g
+  let match
+
+  while ((match = pattern.exec(stderr))) {
+    const line = Number.parseInt(match[3], 10)
+    const statementIndex = lineRanges.findIndex(
+      (range) => line >= range.start && line <= range.end
+    )
+    if (statementIndex === -1) continue
+
+    errors.set(statementIndex, {
+      code: match[1],
+      sqlState: match[2],
+      message: match[4].trim()
+    })
+  }
+
+  return errors
+}
+
+function decodeMysqlBatchValue(value = '') {
+  return value.replace(/\\([0nt\\])/g, (match, character) => {
+    if (character === '0') return '\0'
+    if (character === 'n') return '\n'
+    if (character === 't') return '\t'
+    return '\\'
+  })
+}
+
+function isPostgresCommandTag(output) {
+  return /^(?:INSERT\s+\d+\s+\d+|UPDATE\s+\d+|DELETE\s+\d+|MERGE\s+\d+|SELECT\s+\d+|COPY\s+\d+|CREATE(?:\s+[A-Z]+)?|ALTER(?:\s+[A-Z]+)?|DROP(?:\s+[A-Z]+)?|TRUNCATE(?:\s+[A-Z]+)?|GRANT|REVOKE|COMMENT|VACUUM|ANALYZE|BEGIN|COMMIT|ROLLBACK|SET|RESET|DO)(?:\r?\n.*)?$/i.test(
+    output
+  )
+}
+
+function formatCommandMessage(command, affected) {
+  if (command === 'SELECT' || command === 'WITH' || command === 'SHOW') {
+    return null
+  }
+
+  if (
+    Number.isFinite(affected) &&
+    affected > 0 &&
+    ['INSERT', 'UPDATE', 'DELETE', 'MERGE', 'COPY'].includes(command)
+  ) {
+    return `${command} completed — ${affected} row${
+      affected === 1 ? '' : 's'
+    } affected`
+  }
+
+  return `${command} completed`
+}
+
+function reportsAffectedRows(command) {
+  return ['INSERT', 'UPDATE', 'DELETE', 'MERGE', 'COPY'].includes(command)
+}
+
+function createIncompleteResult(
+  statement,
+  statementIndex,
+  error,
+  totalDuration
+) {
+  const message = String(
+    error || 'The database client did not return a result.'
+  )
+    .trim()
+    .split(/\r?\n/)
+    .pop()
+
+  return {
+    statementIndex,
+    statementSql: statement.sql,
+    statementPreview: statement.preview,
+    commandTag: statement.command,
+    status: 'error',
+    duration: Number.isFinite(totalDuration) ? totalDuration : null,
+    rowCount: 0,
+    affected: null,
+    columns: [],
+    rows: [],
+    message,
+    error: message,
+    raw: ''
+  }
+}
+
+module.exports = {
+  getStatementCommand,
+  getStatementPreview,
+  parseMysqlResults,
+  parsePostgresResults,
+  splitSqlStatements
+}

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -101,6 +101,17 @@ const queryLoading = ref(false)
 const queryHistory = ref([])
 const resultView = ref('table') // 'table' or 'json'
 const showExportMenu = ref(false)
+const activeQueryResultIndex = ref(0)
+
+const queryResults = computed(() => {
+  if (!queryResult.value) return []
+  if (queryResult.value.results?.length) return queryResult.value.results
+  return [queryResult.value]
+})
+const activeQueryResult = computed(
+  () => queryResults.value[activeQueryResultIndex.value] || null
+)
+const hasMultipleQueryResults = computed(() => queryResults.value.length > 1)
 
 // Redis console state
 const redisCommand = ref('')
@@ -288,15 +299,25 @@ async function executeQuery() {
       return
     }
 
-    if (!res.ok || !data.success) {
+    if (data.results?.length) {
+      queryResult.value = data
+      const failedResultIndex = data.results.findIndex(
+        (result) => result.status === 'error'
+      )
+      activeQueryResultIndex.value =
+        failedResultIndex === -1 ? 0 : failedResultIndex
+      resultView.value = 'table'
+    } else if (!res.ok || !data.success) {
       queryError.value = data?.error || data?.message || text || 'Query failed'
     } else {
       queryResult.value = data
-      // Add to history
-      if (!queryHistory.value.includes(query.value)) {
-        queryHistory.value.unshift(query.value)
-        if (queryHistory.value.length > 20) queryHistory.value.pop()
-      }
+      activeQueryResultIndex.value = 0
+      resultView.value = 'table'
+    }
+
+    if (queryResult.value && !queryHistory.value.includes(query.value)) {
+      queryHistory.value.unshift(query.value)
+      if (queryHistory.value.length > 20) queryHistory.value.pop()
     }
   } catch (e) {
     queryError.value = e.message
@@ -784,16 +805,62 @@ function formatRowCount(count) {
   return count
 }
 
+function selectQueryResult(index) {
+  activeQueryResultIndex.value = index
+  showExportMenu.value = false
+}
+
+function handleQueryResultKeydown(event, index) {
+  let nextIndex = index
+
+  if (event.key === 'ArrowRight') {
+    nextIndex = (index + 1) % queryResults.value.length
+  } else if (event.key === 'ArrowLeft') {
+    nextIndex =
+      (index - 1 + queryResults.value.length) % queryResults.value.length
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = queryResults.value.length - 1
+  } else {
+    return
+  }
+
+  event.preventDefault()
+  selectQueryResult(nextIndex)
+  nextTick(() => {
+    document.getElementById(`dock-query-result-tab-${nextIndex}`)?.focus()
+  })
+}
+
+function queryResultAriaLabel(result, index) {
+  return `${index + 1}. ${
+    result.statementPreview || result.commandTag || 'SQL statement'
+  }. ${result.status || 'success'}`
+}
+
+function queryResultCountLabel(result) {
+  if (result.status === 'error') return 'Failed'
+  if (result.columns?.length) {
+    return `${result.rowCount} row${result.rowCount === 1 ? '' : 's'}`
+  }
+  if (result.affected !== null && result.affected !== undefined) {
+    return `${result.affected} row${result.affected === 1 ? '' : 's'} affected`
+  }
+  return result.commandTag || 'Completed'
+}
+
 // Export functions
 function exportAsJSON() {
-  if (!queryResult.value?.rows) return
-  const json = JSON.stringify(queryResult.value.rows, null, 2)
-  downloadFile(json, 'query-result.json', 'application/json')
+  if (!activeQueryResult.value?.rows) return
+  const json = JSON.stringify(activeQueryResult.value.rows, null, 2)
+  downloadFile(json, queryResultFilename('json'), 'application/json')
 }
 
 function exportAsCSV() {
-  if (!queryResult.value?.rows || !queryResult.value?.columns) return
-  const { columns, rows } = queryResult.value
+  if (!activeQueryResult.value?.rows || !activeQueryResult.value?.columns)
+    return
+  const { columns, rows } = activeQueryResult.value
   const csvLines = [columns.join(',')]
   for (const row of rows) {
     const values = columns.map((col) => {
@@ -808,7 +875,7 @@ function exportAsCSV() {
     })
     csvLines.push(values.join(','))
   }
-  downloadFile(csvLines.join('\n'), 'query-result.csv', 'text/csv')
+  downloadFile(csvLines.join('\n'), queryResultFilename('csv'), 'text/csv')
 }
 
 function downloadQueryResultAsJSON() {
@@ -822,15 +889,16 @@ function downloadQueryResultAsCSV() {
 }
 
 function copyAsJSON() {
-  if (!queryResult.value?.rows) return
-  const json = JSON.stringify(queryResult.value.rows, null, 2)
+  if (!activeQueryResult.value?.rows) return
+  const json = JSON.stringify(activeQueryResult.value.rows, null, 2)
   navigator.clipboard.writeText(json)
   showToast('Copied JSON to clipboard')
 }
 
 function copyAsCSV() {
-  if (!queryResult.value?.rows || !queryResult.value?.columns) return
-  const { columns, rows } = queryResult.value
+  if (!activeQueryResult.value?.rows || !activeQueryResult.value?.columns)
+    return
+  const { columns, rows } = activeQueryResult.value
   const csvLines = [columns.join(',')]
   for (const row of rows) {
     const values = columns.map((col) => {
@@ -846,6 +914,13 @@ function copyAsCSV() {
   }
   navigator.clipboard.writeText(csvLines.join('\n'))
   showToast('Copied CSV to clipboard')
+}
+
+function queryResultFilename(extension) {
+  const suffix = hasMultipleQueryResults.value
+    ? `-${activeQueryResultIndex.value + 1}`
+    : ''
+  return `query-result${suffix}.${extension}`
 }
 
 function downloadFile(content, filename, mimeType) {
@@ -1510,83 +1585,164 @@ onUnmounted(() => {
 
           <!-- Results -->
           <div v-else-if="queryResult" class="flex h-full min-h-0 flex-col">
-            <!-- Table view -->
             <div
-              v-if="
-                queryResult.columns &&
-                queryResult.columns.length > 0 &&
-                resultView === 'table'
-              "
-              class="flex-1 overflow-auto"
+              v-if="hasMultipleQueryResults"
+              role="tablist"
+              aria-label="Query results"
+              class="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-gray-200 px-2 py-1.5 dark:border-gray-800"
             >
-              <table class="min-w-full">
-                <thead class="sticky top-0">
-                  <tr
-                    class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900"
-                  >
-                    <th
-                      v-for="col in queryResult.columns"
-                      :key="col"
-                      class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400"
-                    >
-                      {{ col }}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr
-                    v-for="(row, i) in queryResult.rows"
-                    :key="i"
-                    class="border-b border-gray-100 hover:bg-gray-50 dark:border-gray-800/50 dark:hover:bg-gray-900/30"
-                  >
-                    <td
-                      v-for="col in queryResult.columns"
-                      :key="col"
-                      class="whitespace-nowrap px-4 py-2 font-mono text-sm text-gray-700 dark:text-gray-300"
-                    >
-                      <span
-                        v-if="row[col] === null"
-                        class="text-gray-400 dark:text-gray-600"
-                        >NULL</span
-                      >
-                      <span
-                        v-else-if="typeof row[col] === 'number'"
-                        class="text-purple-600 dark:text-purple-400"
-                        >{{ row[col] }}</span
-                      >
-                      <span
-                        v-else-if="typeof row[col] === 'boolean'"
-                        class="text-blue-600 dark:text-blue-400"
-                        >{{ row[col] }}</span
-                      >
-                      <span v-else>{{ row[col] }}</span>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
+              <button
+                v-for="(result, index) in queryResults"
+                :id="`dock-query-result-tab-${index}`"
+                :key="index"
+                role="tab"
+                :aria-selected="index === activeQueryResultIndex"
+                aria-controls="dock-query-result-panel"
+                :aria-label="queryResultAriaLabel(result, index)"
+                :tabindex="index === activeQueryResultIndex ? 0 : -1"
+                :data-test="`dock-query-result-${index + 1}`"
+                :title="result.statementSql"
+                :class="[
+                  'min-h-8 max-w-64 flex shrink-0 items-center gap-2 rounded-md px-2.5 py-1 text-left text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:focus-visible:ring-gray-600',
+                  index === activeQueryResultIndex
+                    ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
+                    : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-200'
+                ]"
+                @click="selectQueryResult(index)"
+                @keydown="handleQueryResultKeydown($event, index)"
+              >
+                <span
+                  v-if="result.status === 'error'"
+                  class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500"
+                  aria-hidden="true"
+                ></span>
+                <span class="shrink-0 font-medium tabular-nums">{{
+                  index + 1
+                }}</span>
+                <span class="truncate font-mono">
+                  {{
+                    result.statementPreview ||
+                    result.commandTag ||
+                    'SQL statement'
+                  }}
+                </span>
+              </button>
             </div>
 
-            <!-- JSON view -->
             <div
-              v-else-if="
-                queryResult.columns &&
-                queryResult.columns.length > 0 &&
-                resultView === 'json'
+              id="dock-query-result-panel"
+              data-test="dock-query-result-panel"
+              role="tabpanel"
+              :aria-labelledby="
+                hasMultipleQueryResults
+                  ? `dock-query-result-tab-${activeQueryResultIndex}`
+                  : undefined
               "
-              class="flex-1 overflow-auto p-4"
+              class="flex min-h-0 flex-1 flex-col"
             >
-              <pre
-                class="font-mono text-xs text-gray-700 dark:text-gray-300"
-                v-html="highlightJSON(queryResult.rows)"
-              ></pre>
-            </div>
+              <!-- Table view -->
+              <div
+                v-if="
+                  activeQueryResult.columns &&
+                  activeQueryResult.columns.length > 0 &&
+                  resultView === 'table'
+                "
+                class="flex-1 overflow-auto"
+              >
+                <table class="min-w-full">
+                  <caption class="sr-only">
+                    Query result
+                    {{
+                      activeQueryResultIndex + 1
+                    }}
+                    for
+                    {{
+                      activeQueryResult.statementPreview ||
+                      activeQueryResult.commandTag ||
+                      'SQL statement'
+                    }}
+                  </caption>
+                  <thead class="sticky top-0">
+                    <tr
+                      class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900"
+                    >
+                      <th
+                        v-for="col in activeQueryResult.columns"
+                        :key="col"
+                        scope="col"
+                        class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400"
+                      >
+                        {{ col }}
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr
+                      v-for="(row, i) in activeQueryResult.rows"
+                      :key="i"
+                      class="border-b border-gray-100 hover:bg-gray-50 dark:border-gray-800/50 dark:hover:bg-gray-900/30"
+                    >
+                      <td
+                        v-for="col in activeQueryResult.columns"
+                        :key="col"
+                        class="whitespace-nowrap px-4 py-2 font-mono text-sm text-gray-700 dark:text-gray-300"
+                      >
+                        <span
+                          v-if="row[col] === null"
+                          class="text-gray-400 dark:text-gray-600"
+                          >NULL</span
+                        >
+                        <span
+                          v-else-if="typeof row[col] === 'number'"
+                          class="text-purple-600 dark:text-purple-400"
+                          >{{ row[col] }}</span
+                        >
+                        <span
+                          v-else-if="typeof row[col] === 'boolean'"
+                          class="text-blue-600 dark:text-blue-400"
+                          >{{ row[col] }}</span
+                        >
+                        <span v-else>{{ row[col] }}</span>
+                      </td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
 
-            <!-- No columns (DDL result) -->
-            <div
-              v-else
-              class="flex flex-1 items-center justify-center text-sm text-gray-500 dark:text-gray-400"
-            >
-              {{ queryResult.message || 'Query executed successfully' }}
+              <!-- JSON view -->
+              <div
+                v-else-if="
+                  activeQueryResult.columns &&
+                  activeQueryResult.columns.length > 0 &&
+                  resultView === 'json'
+                "
+                class="flex-1 overflow-auto p-4"
+              >
+                <pre
+                  class="font-mono text-xs text-gray-700 dark:text-gray-300"
+                  v-html="highlightJSON(activeQueryResult.rows)"
+                ></pre>
+              </div>
+
+              <!-- Command or error result -->
+              <div
+                v-else
+                class="flex flex-1 items-center justify-center p-4 text-sm"
+              >
+                <p
+                  :class="
+                    activeQueryResult.status === 'error'
+                      ? 'font-mono text-red-600 dark:text-red-400'
+                      : 'text-gray-500 dark:text-gray-400'
+                  "
+                >
+                  {{
+                    activeQueryResult.message ||
+                    activeQueryResult.error ||
+                    'Query executed successfully'
+                  }}
+                </p>
+              </div>
             </div>
 
             <!-- Bottom status bar -->
@@ -1596,12 +1752,16 @@ onUnmounted(() => {
               <div class="flex items-center gap-4">
                 <!-- View toggle -->
                 <div
-                  v-if="queryResult.columns && queryResult.columns.length > 0"
+                  v-if="
+                    activeQueryResult.columns &&
+                    activeQueryResult.columns.length > 0
+                  "
                   class="flex overflow-hidden rounded-md border border-gray-300 dark:border-gray-700"
                 >
                   <Tooltip text="Table view" position="top">
                     <button
                       @click="resultView = 'table'"
+                      aria-label="Table view"
                       :class="[
                         'p-1.5',
                         resultView === 'table'
@@ -1627,6 +1787,7 @@ onUnmounted(() => {
                   <Tooltip text="JSON view" position="top">
                     <button
                       @click="resultView = 'json'"
+                      aria-label="JSON view"
                       :class="[
                         'border-l border-gray-300 px-1.5 py-1 font-mono text-sm font-bold dark:border-gray-700',
                         resultView === 'json'
@@ -1640,18 +1801,24 @@ onUnmounted(() => {
                 </div>
                 <!-- Row info -->
                 <span class="text-xs text-gray-500 dark:text-gray-400">
-                  {{ queryResult.rowCount }} row(s) •
-                  {{ queryResult.duration }}ms
+                  {{ queryResultCountLabel(activeQueryResult) }}
+                  <template v-if="activeQueryResult.duration != null">
+                    • {{ activeQueryResult.duration }}ms
+                  </template>
                 </span>
               </div>
               <!-- Actions -->
               <div
-                v-if="queryResult.columns && queryResult.columns.length > 0"
+                v-if="
+                  activeQueryResult.columns &&
+                  activeQueryResult.columns.length > 0
+                "
                 class="flex items-center gap-1"
               >
                 <Tooltip text="Re-run query" position="top">
                   <button
                     @click="executeQuery"
+                    aria-label="Re-run query"
                     class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                   >
                     <svg
@@ -1675,6 +1842,10 @@ onUnmounted(() => {
                 >
                   <button
                     @click="resultView === 'json' ? copyAsJSON() : copyAsCSV()"
+                    data-test="dock-copy-query-result"
+                    :aria-label="
+                      resultView === 'json' ? 'Copy as JSON' : 'Copy as CSV'
+                    "
                     class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                   >
                     <svg
@@ -1702,6 +1873,9 @@ onUnmounted(() => {
                   >
                     <button
                       @click="showExportMenu = !showExportMenu"
+                      :aria-label="
+                        resultView === 'json' ? 'Download JSON' : 'Download CSV'
+                      "
                       class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                     >
                       <svg

--- a/tests/e2e/pages/projects/dock-multi-results.test.js
+++ b/tests/e2e/pages/projects/dock-multi-results.test.js
@@ -1,0 +1,223 @@
+const { test } = require('sounding')
+
+const successfulQuery = [
+  'SELECT count(*) AS creators FROM creators;',
+  'SELECT count(*) AS teams FROM teams;'
+].join('\n')
+const partiallyFailedQuery = [
+  'DROP TABLE audit_events;',
+  'SELECT * FROM missing_table;'
+].join('\n')
+
+test(
+  'Dock keeps every SQL result labeled, navigable, and independently copyable',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'labeled-dock-results',
+          name: 'Labeled Dock Results'
+        }
+      }
+    }
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const database = await world.create('service').with({
+      name: 'primary-db',
+      type: 'postgresql',
+      version: '17',
+      status: 'running',
+      environment: current.environments.production.id,
+      internalHost: 'primary-db',
+      internalPort: 5432,
+      database: 'app',
+      username: 'slipway',
+      password: 'secret'
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await page.raw.route('**/dock/tables?**', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ tables: [] })
+      })
+    })
+    await page.raw.route('**/dock/sql?**', async (route) => {
+      const { query } = route.request().postDataJSON()
+      const response = query.includes('missing_table')
+        ? partiallyFailedResponse()
+        : successfulResponse()
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(response)
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.raw
+      .context()
+      .grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/environments/production/dock/${database.id}`
+    )
+
+    await page.fill('@dock-query-editor', successfulQuery)
+    await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
+    await page.wait('@dock-query-result-1')
+
+    const tabs = page.raw.getByRole('tab')
+    expect(await tabs.count()).toBe(2)
+    expect(await tabs.nth(0).getAttribute('aria-selected')).toBe('true')
+    await expect(page).toSee('24873')
+    await page.screenshot('.tmp/issue-213-multi-results-light.png')
+
+    await page.click('@dock-query-result-2')
+    await expect(page).toSee('154')
+    await page.click('@dock-copy-query-result')
+    expect(await page.script(() => navigator.clipboard.readText())).toBe(
+      'teams\n154'
+    )
+    await page.raw
+      .getByText('Copied CSV to clipboard')
+      .locator('..')
+      .getByRole('button')
+      .click()
+    await page.wait(350)
+
+    await page.raw.getByRole('tab').nth(0).focus()
+    await page.key('ArrowRight')
+    expect(await tabs.nth(1).getAttribute('aria-selected')).toBe('true')
+
+    await page.inDarkMode()
+    await page.fill('@dock-query-editor', partiallyFailedQuery)
+    await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
+    await page.wait(100)
+
+    expect(await tabs.count()).toBe(2)
+    expect(await tabs.nth(1).getAttribute('aria-selected')).toBe('true')
+    await expect(page).toSee('relation "missing_table" does not exist')
+    await page.screenshot('.tmp/issue-213-partial-failure-dark.png')
+
+    await page.click('@dock-query-result-1')
+    await expect(page).toSee('DROP TABLE completed')
+
+    await page.resize(390, 844)
+    await page.screenshot('.tmp/issue-213-multi-results-mobile-dark.png')
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+function successfulResponse() {
+  const results = [
+    queryResult({
+      statementIndex: 0,
+      statementSql: 'SELECT count(*) AS creators FROM creators;',
+      statementPreview: 'SELECT count(*) AS creators FROM creators',
+      duration: 2.4,
+      columns: ['creators'],
+      rows: [{ creators: 24873 }]
+    }),
+    queryResult({
+      statementIndex: 1,
+      statementSql: 'SELECT count(*) AS teams FROM teams;',
+      statementPreview: 'SELECT count(*) AS teams FROM teams',
+      duration: 1.8,
+      columns: ['teams'],
+      rows: [{ teams: 154 }]
+    })
+  ]
+
+  return {
+    success: true,
+    ...results[0],
+    duration: 5,
+    results,
+    messages: ''
+  }
+}
+
+function partiallyFailedResponse() {
+  const results = [
+    {
+      statementIndex: 0,
+      statementSql: 'DROP TABLE audit_events;',
+      statementPreview: 'DROP TABLE audit_events',
+      commandTag: 'DROP TABLE',
+      status: 'success',
+      duration: 3.1,
+      rowCount: 0,
+      affected: null,
+      columns: [],
+      rows: [],
+      message: 'DROP TABLE completed',
+      error: null,
+      raw: 'DROP TABLE'
+    },
+    {
+      statementIndex: 1,
+      statementSql: 'SELECT * FROM missing_table;',
+      statementPreview: 'SELECT * FROM missing_table',
+      commandTag: 'SELECT',
+      status: 'error',
+      duration: 1.2,
+      rowCount: 0,
+      affected: null,
+      columns: [],
+      rows: [],
+      message: 'relation "missing_table" does not exist',
+      error: 'relation "missing_table" does not exist',
+      sqlState: '42P01',
+      raw: ''
+    }
+  ]
+
+  return {
+    success: false,
+    ...results[0],
+    duration: 5,
+    results,
+    error: results[1].error,
+    messages: 'ERROR: relation "missing_table" does not exist'
+  }
+}
+
+function queryResult({
+  statementIndex,
+  statementSql,
+  statementPreview,
+  duration,
+  columns,
+  rows
+}) {
+  return {
+    statementIndex,
+    statementSql,
+    statementPreview,
+    commandTag: 'SELECT',
+    status: 'success',
+    duration,
+    rowCount: rows.length,
+    affected: null,
+    columns,
+    rows,
+    message: null,
+    error: null,
+    raw: ''
+  }
+}

--- a/tests/functional/api/dock.test.js
+++ b/tests/functional/api/dock.test.js
@@ -1,4 +1,5 @@
 const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
 
 test(
   'dock diff returns a stable error payload when static model source is missing',
@@ -53,6 +54,153 @@ test(
     } finally {
       sails.helpers.dock.getDatabaseService = originalGetDatabaseService
       sails.helpers.dock.getModelsStatic = originalGetModelsStatic
+    }
+  }
+)
+
+test(
+  'dock SQL returns labeled results for every statement',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'multi-results', name: 'Multi Results' }
+      }
+    }
+  },
+  async ({ expect, request, sails }) => {
+    const originalGetDatabaseService = sails.helpers.dock.getDatabaseService
+    const originalExecuteSql = sails.helpers.dock.executeSql
+    const results = [
+      {
+        statementIndex: 0,
+        statementSql: 'SELECT count(*) AS creators FROM creators;',
+        statementPreview: 'SELECT count(*) AS creators FROM creators',
+        commandTag: 'SELECT',
+        status: 'success',
+        duration: 2.5,
+        rowCount: 1,
+        affected: null,
+        columns: ['creators'],
+        rows: [{ creators: '42' }],
+        message: null,
+        error: null,
+        raw: 'creators\n42'
+      },
+      {
+        statementIndex: 1,
+        statementSql: 'DROP TABLE temporary_items;',
+        statementPreview: 'DROP TABLE temporary_items',
+        commandTag: 'DROP TABLE',
+        status: 'success',
+        duration: 1.25,
+        rowCount: 0,
+        affected: 0,
+        columns: [],
+        rows: [],
+        message: 'DROP TABLE completed',
+        error: null,
+        raw: 'DROP TABLE'
+      }
+    ]
+
+    sails.helpers.dock.getDatabaseService = async () => ({
+      service: {
+        id: 80,
+        type: 'postgresql',
+        containerName: 'primary-database'
+      }
+    })
+    sails.helpers.dock.executeSql = async () => ({
+      success: true,
+      ...results[0],
+      duration: 4,
+      results,
+      messages: ''
+    })
+
+    try {
+      const dashboard = await withCsrfFromPage(
+        request,
+        '/projects/multi-results/environments/production',
+        'genesisUser'
+      )
+      const response = await dashboard.request.post(
+        '/api/v1/projects/multi-results/dock/sql',
+        {
+          query: results.map((result) => result.statementSql).join('\n')
+        }
+      )
+
+      expect(response).toHaveStatus(200)
+      expect(response).toHaveJsonPath('success', true)
+      expect(response).toHaveJsonPath('results.0.statementIndex', 0)
+      expect(response).toHaveJsonPath(
+        'results.0.statementPreview',
+        'SELECT count(*) AS creators FROM creators'
+      )
+      expect(response).toHaveJsonPath('results.0.rows.0.creators', '42')
+      expect(response).toHaveJsonPath('results.1.commandTag', 'DROP TABLE')
+      expect(response).toHaveJsonPath(
+        'results.1.message',
+        'DROP TABLE completed'
+      )
+    } finally {
+      sails.helpers.dock.getDatabaseService = originalGetDatabaseService
+      sails.helpers.dock.executeSql = originalExecuteSql
+    }
+  }
+)
+
+test(
+  'dock SQL rejects a dangerous command hidden later in a batch',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'guarded-dock', name: 'Guarded Dock' }
+      }
+    }
+  },
+  async ({ expect, request, sails }) => {
+    const originalGetDatabaseService = sails.helpers.dock.getDatabaseService
+    const originalExecuteSql = sails.helpers.dock.executeSql
+    let executed = false
+
+    sails.helpers.dock.getDatabaseService = async () => ({
+      service: {
+        id: 81,
+        type: 'postgresql',
+        containerName: 'primary-database'
+      }
+    })
+    sails.helpers.dock.executeSql = async () => {
+      executed = true
+      return { success: true, results: [] }
+    }
+
+    try {
+      const dashboard = await withCsrfFromPage(
+        request,
+        '/projects/guarded-dock/environments/production',
+        'genesisUser'
+      )
+      const response = await dashboard.request.post(
+        '/api/v1/projects/guarded-dock/dock/sql',
+        {
+          query: [
+            'SELECT count(*) FROM creators;',
+            '/* never /* execute */ this */ DROP DATABASE slipway;'
+          ].join('\n')
+        }
+      )
+
+      expect(response).toHaveStatus(400)
+      expect(response).toHaveHeader('x-exit', 'badRequest')
+      expect(executed).toBe(false)
+    } finally {
+      sails.helpers.dock.getDatabaseService = originalGetDatabaseService
+      sails.helpers.dock.executeSql = originalExecuteSql
     }
   }
 )

--- a/tests/unit/helpers/dock/execute-sql-results.test.js
+++ b/tests/unit/helpers/dock/execute-sql-results.test.js
@@ -1,0 +1,271 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+
+const { test } = require('sounding')
+const { splitSqlStatements } = require('../../../../api/lib/dock-sql-results')
+
+test('PostgreSQL queries return one labeled result per SQL statement', async ({
+  sails,
+  expect
+}) => {
+  await withFakeDocker(sails, async () => {
+    const result = await sails.helpers.dock.executeSql.with({
+      service: databaseService('postgresql'),
+      query: [
+        "SELECT 'alpha;beta' AS value;",
+        'DROP TABLE temporary_items;',
+        'SELECT count(*) AS total FROM creators;',
+        'SELECT * FROM missing_items;'
+      ].join('\n')
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.results.map((entry) => entry.status)).toEqual([
+      'success',
+      'success',
+      'success',
+      'error'
+    ])
+    expect(result.results[0]).toEqual({
+      statementIndex: 0,
+      statementSql: "SELECT 'alpha;beta' AS value;",
+      statementPreview: "SELECT 'alpha;beta' AS value",
+      commandTag: 'SELECT',
+      status: 'success',
+      duration: 1.25,
+      rowCount: 1,
+      affected: null,
+      columns: ['value'],
+      rows: [{ value: 'alpha;beta' }],
+      message: null,
+      error: null,
+      sqlState: '00000',
+      raw: 'value\nalpha;beta'
+    })
+    expect(result.results[1].commandTag).toBe('DROP TABLE')
+    expect(result.results[1].message).toBe('DROP TABLE completed')
+    expect(result.results[2].rows).toEqual([{ total: '24873' }])
+    expect(result.results[3].statementIndex).toBe(3)
+    expect(result.results[3].sqlState).toBe('42P01')
+    expect(result.results[3].error).toBe(
+      'relation "missing_items" does not exist'
+    )
+  })
+})
+
+test('MySQL queries preserve successful results before a later error', async ({
+  sails,
+  expect
+}) => {
+  await withFakeDocker(sails, async () => {
+    const result = await sails.helpers.dock.executeSql.with({
+      service: databaseService('mysql'),
+      query: [
+        "SELECT 'north;west' AS region;",
+        'UPDATE creators SET active = 1 WHERE invited = 1;',
+        'SELECT * FROM missing_items;'
+      ].join('\n')
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.results.map((entry) => entry.status)).toEqual([
+      'success',
+      'success',
+      'error'
+    ])
+    expect(result.results[0].columns).toEqual(['region'])
+    expect(result.results[0].rows).toEqual([{ region: 'north;west' }])
+    expect(result.results[1].commandTag).toBe('UPDATE')
+    expect(result.results[1].affected).toBe(3)
+    expect(result.results[1].message).toBe('UPDATE completed — 3 rows affected')
+    expect(result.results[2].statementSql).toBe('SELECT * FROM missing_items;')
+    expect(result.results[2].sqlState).toBe('42S02')
+    expect(result.results[2].error).toBe(
+      "Table 'app.missing_items' doesn't exist"
+    )
+  })
+})
+
+test('SQL statement boundaries ignore comments, strings, and dollar-quoted bodies', async ({
+  sails,
+  expect
+}) => {
+  await withFakeDocker(sails, async () => {
+    const result = await sails.helpers.dock.executeSql.with({
+      service: databaseService('postgresql'),
+      query: [
+        '-- the semicolon below belongs to the function body',
+        'CREATE FUNCTION say_ready() RETURNS void AS $$',
+        'BEGIN',
+        "  PERFORM 'ready;still-ready';",
+        'END;',
+        '$$ LANGUAGE plpgsql;',
+        "SELECT 'done;really' AS value;"
+      ].join('\n')
+    })
+
+    expect(result.results.length).toBe(2)
+    expect(result.results[0].commandTag).toBe('CREATE FUNCTION')
+    expect(result.results[1].statementSql).toBe(
+      "SELECT 'done;really' AS value;"
+    )
+  })
+})
+
+test('PostgreSQL escape strings cannot hide a following statement', async ({
+  expect
+}) => {
+  const ordinaryString = splitSqlStatements(
+    String.raw`SELECT 'x\'; DROP DATABASE slipway;`,
+    'postgresql'
+  )
+  const escapeString = splitSqlStatements(
+    String.raw`SELECT E'x\';still-a-string' AS value; SELECT 1;`,
+    'postgresql'
+  )
+
+  expect(ordinaryString.map((statement) => statement.command)).toEqual([
+    'SELECT',
+    'DROP DATABASE'
+  ])
+  expect(escapeString.map((statement) => statement.command)).toEqual([
+    'SELECT',
+    'SELECT'
+  ])
+})
+
+test('comment-only SQL returns a useful error without invoking Docker', async ({
+  sails,
+  expect
+}) => {
+  const result = await sails.helpers.dock.executeSql.with({
+    service: databaseService('postgresql'),
+    query: '-- explain the next query here'
+  })
+
+  expect(result.success).toBe(false)
+  expect(result.results).toEqual([])
+  expect(result.error).toBe('No executable SQL statements were found.')
+})
+
+async function withFakeDocker(sails, callback) {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-dock-results-')
+  )
+  const dockerPath = path.join(tempRoot, 'docker')
+  const originalDockerPath = sails.config.docker?.binaryPath
+
+  fs.writeFileSync(dockerPath, fakeDockerSource())
+  fs.chmodSync(dockerPath, 0o755)
+  sails.config.docker = sails.config.docker || {}
+  sails.config.docker.binaryPath = dockerPath
+
+  try {
+    await callback()
+  } finally {
+    if (originalDockerPath === undefined) {
+      delete sails.config.docker.binaryPath
+    } else {
+      sails.config.docker.binaryPath = originalDockerPath
+    }
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+function databaseService(type) {
+  return {
+    type,
+    containerName: `${type}-database`,
+    username: 'slipway',
+    password: 'secret',
+    database: 'app'
+  }
+}
+
+function fakeDockerSource() {
+  return `#!/usr/bin/env node
+const args = process.argv.slice(2)
+
+if (args.includes('psql')) {
+  let sqlState = '00000'
+  let rowCount = '0'
+  let lastError = ''
+
+  for (let index = 0; index < args.length; index++) {
+    if (args[index] !== '-c') continue
+    const command = args[++index]
+
+    if (command === '\\\\timing on') continue
+    if (command.startsWith('\\\\echo ')) {
+      console.log(
+        command
+          .slice(6)
+          .replace(':SQLSTATE', sqlState)
+          .replace(':ROW_COUNT', rowCount)
+          .replace(':LAST_ERROR_MESSAGE', lastError)
+      )
+      continue
+    }
+
+    sqlState = '00000'
+    rowCount = '0'
+    if (command.includes("SELECT 'alpha;beta'")) {
+      rowCount = '1'
+      console.log('value')
+      console.log('alpha;beta')
+    } else if (command.startsWith('DROP TABLE')) {
+      console.log('DROP TABLE')
+    } else if (command.includes('count(*) AS total')) {
+      rowCount = '1'
+      console.log('total')
+      console.log('24873')
+    } else if (command.includes('missing_items')) {
+      sqlState = '42P01'
+      lastError = 'relation "missing_items" does not exist'
+      console.error('ERROR:  relation "missing_items" does not exist')
+    } else if (command.includes('CREATE FUNCTION')) {
+      console.log('CREATE FUNCTION')
+    } else if (command.includes("SELECT 'done;really'")) {
+      rowCount = '1'
+      console.log('value')
+      console.log('done;really')
+    }
+    console.log('Time: 1.250 ms')
+  }
+  process.exit(0)
+}
+
+let input = ''
+process.stdin.setEncoding('utf8')
+process.stdin.on('data', (chunk) => {
+  input += chunk
+})
+process.stdin.on('end', () => {
+  const marker = input.match(/(__SLIPWAY_RESULT_[a-f0-9]+__):start:0/)[1]
+  const missingLine =
+    input.split(/\\r?\\n/).findIndex((line) => line.includes('missing_items')) + 1
+
+  function boundary(index, output, affected, duration) {
+    console.log('__slipway_marker__')
+    console.log(marker + ':start:' + index)
+    if (output) console.log(output)
+    console.log(
+      '__slipway_marker__\\t__slipway_row_count__\\t__slipway_duration_ms__'
+    )
+    console.log(
+      marker + ':end:' + index + '\\t' + affected + '\\t' + duration
+    )
+  }
+
+  boundary(0, 'region\\nnorth;west', -1, 0.75)
+  boundary(1, '', 3, 1.5)
+  boundary(2, '', -1, 0.5)
+  console.error(
+    "ERROR 1146 (42S02) at line " +
+      missingLine +
+      ": Table 'app.missing_items' doesn't exist"
+  )
+})
+`
+}


### PR DESCRIPTION
## Summary

- preserve and label every PostgreSQL and MySQL statement result
- make partial failures inspectable without losing earlier successful results
- add a minimal accessible result navigator that appears only for multi-statement queries
- keep copy and export scoped to the selected result
- harden statement splitting and dangerous-query validation

## Verification

- npm run lint
- npm run check:consistency
- npm test (210 passing trials)
- light, dark, and mobile screenshots reviewed

Closes #213