### PR TITLE
feat(deployments): show status in browser favicon

### DIFF
--- a/assets/images/favicon-cancelled.svg
+++ b/assets/images/favicon-cancelled.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Slippy — cancelled deployment -->
+  <path
+    d="M7 17 C7 3 25 3 25 17 Z"
+    stroke="#0284c7"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path d="M7 17 C4 21 4 25 8 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M12 17 C11 21 10 25 13 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M20 17 C21 21 22 25 19 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M25 17 C28 21 28 25 24 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="13" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="19" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="25" cy="25" r="6" fill="#64748b" stroke="white" stroke-width="2"/>
+  <path d="M22.3 25h5.4" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/assets/images/favicon-deploying.svg
+++ b/assets/images/favicon-deploying.svg
@@ -1,0 +1,17 @@
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Slippy — active deployment -->
+  <path
+    d="M7 17 C7 3 25 3 25 17 Z"
+    stroke="#0284c7"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path d="M7 17 C4 21 4 25 8 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M12 17 C11 21 10 25 13 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M20 17 C21 21 22 25 19 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M25 17 C28 21 28 25 24 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="13" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="19" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="25" cy="25" r="6" fill="#f59e0b" stroke="white" stroke-width="2"/>
+</svg>

--- a/assets/images/favicon-failed.svg
+++ b/assets/images/favicon-failed.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Slippy — failed deployment -->
+  <path
+    d="M7 17 C7 3 25 3 25 17 Z"
+    stroke="#0284c7"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path d="M7 17 C4 21 4 25 8 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M12 17 C11 21 10 25 13 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M20 17 C21 21 22 25 19 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M25 17 C28 21 28 25 24 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="13" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="19" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="25" cy="25" r="6" fill="#ef4444" stroke="white" stroke-width="2"/>
+  <path d="m22.8 22.8 4.4 4.4m0-4.4-4.4 4.4" stroke="white" stroke-width="1.8" stroke-linecap="round"/>
+</svg>

--- a/assets/images/favicon-success.svg
+++ b/assets/images/favicon-success.svg
@@ -1,0 +1,18 @@
+<svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Slippy — successful deployment -->
+  <path
+    d="M7 17 C7 3 25 3 25 17 Z"
+    stroke="#0284c7"
+    stroke-width="2.5"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path d="M7 17 C4 21 4 25 8 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M12 17 C11 21 10 25 13 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M20 17 C21 21 22 25 19 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <path d="M25 17 C28 21 28 25 24 28" stroke="#0284c7" stroke-width="2.5" stroke-linecap="round"/>
+  <circle cx="13" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="19" cy="11" r="1.8" fill="#0284c7"/>
+  <circle cx="25" cy="25" r="6" fill="#10b981" stroke="white" stroke-width="2"/>
+  <path d="M22 25.2 24.2 27.2 28 22.9" stroke="white" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/assets/js/components/DeploymentToast.vue
+++ b/assets/js/components/DeploymentToast.vue
@@ -8,7 +8,7 @@ const props = defineProps({
   deployment: Object
 })
 
-const emit = defineEmits(['complete', 'dismiss'])
+const emit = defineEmits(['status-change', 'dismiss'])
 
 const status = ref(props.deployment.status)
 const startTime = ref(props.deployment.startedAt || Date.now())
@@ -141,6 +141,10 @@ const { close: closeStream, connect: connectToStream } = useEventSource(
     onMessage(data) {
       if (data.status) {
         status.value = data.status
+        emit('status-change', {
+          deploymentId: props.deployment.id,
+          status: data.status
+        })
         if (['running', 'failed', 'cancelled'].includes(data.status)) {
           closeStream()
           setTimeout(() => dismiss(), 5000)

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -2,6 +2,7 @@
 import { Link, usePage, router } from '@inertiajs/vue3'
 import { computed, ref, provide, onMounted, onUnmounted } from 'vue'
 import { useEventSource } from '@/composables/sse'
+import { createDeploymentFaviconManager } from '@/lib/deployment-favicon.mjs'
 import ToastContainer from '@/components/ToastContainer.vue'
 import UpdateBanner from '@/components/UpdateBanner.vue'
 import UpdateModal from '@/components/UpdateModal.vue'
@@ -117,6 +118,7 @@ function createNewTeam() {
 
 function logout() {
   userDropdownOpen.value = false
+  deploymentFavicon.reset()
   router.delete('/logout')
 }
 
@@ -187,6 +189,7 @@ const showUpdateModal = ref(false)
 
 // Active deployments tracking (SSE-based — no polling)
 const activeDeployments = ref([])
+const deploymentFavicon = createDeploymentFaviconManager()
 
 const { close: disconnectDeploymentStream } = useEventSource(
   loggedInUser ? '/api/v1/deployments/active/stream' : null,
@@ -194,6 +197,8 @@ const { close: disconnectDeploymentStream } = useEventSource(
     immediate: !!loggedInUser,
     onMessage(data) {
       if (data.deployments) {
+        deploymentFavicon.replaceActiveDeployments(data.deployments)
+
         // Only add new deployments, don't remove ones we're already tracking
         // (DeploymentToast handles its own lifecycle via per-deployment SSE)
         for (const dep of data.deployments) {
@@ -206,10 +211,25 @@ const { close: disconnectDeploymentStream } = useEventSource(
   }
 )
 
+function updateDeploymentStatus({ deploymentId, status }) {
+  const deployment = activeDeployments.value.find(
+    ({ id }) => String(id) === String(deploymentId)
+  )
+  if (deployment) deployment.status = status
+
+  deploymentFavicon.noteDeploymentStatus(deploymentId, status)
+}
+
 function dismissDeployment(deploymentId) {
   activeDeployments.value = activeDeployments.value.filter(
     (d) => d.id !== deploymentId
   )
+}
+
+function acknowledgeDeploymentFavicon() {
+  if (document.visibilityState === 'visible') {
+    deploymentFavicon.acknowledgeTerminalStates()
+  }
 }
 
 // Initialize on mount
@@ -225,10 +245,18 @@ onMounted(() => {
 
   // Listen for escape key to close dropdowns
   document.addEventListener('keydown', handleEscapeKey)
+  document.addEventListener('visibilitychange', acknowledgeDeploymentFavicon)
+  window.addEventListener('focus', acknowledgeDeploymentFavicon)
+  window.addEventListener('pagehide', deploymentFavicon.reset)
 })
 
 onUnmounted(() => {
+  disconnectDeploymentStream()
+  deploymentFavicon.destroy()
   document.removeEventListener('keydown', handleEscapeKey)
+  document.removeEventListener('visibilitychange', acknowledgeDeploymentFavicon)
+  window.removeEventListener('focus', acknowledgeDeploymentFavicon)
+  window.removeEventListener('pagehide', deploymentFavicon.reset)
 })
 </script>
 
@@ -1225,6 +1253,7 @@ onUnmounted(() => {
         v-for="deployment in activeDeployments"
         :key="'deploy-' + deployment.id"
         :deployment="deployment"
+        @status-change="updateDeploymentStatus"
         @dismiss="dismissDeployment"
       />
     </div>

--- a/assets/js/lib/deployment-favicon.mjs
+++ b/assets/js/lib/deployment-favicon.mjs
@@ -1,0 +1,222 @@
+export const DEPLOYMENT_FAVICON_STATES = Object.freeze({
+  idle: 'idle',
+  deploying: 'deploying',
+  success: 'success',
+  failed: 'failed',
+  cancelled: 'cancelled'
+})
+
+export const DEPLOYMENT_FAVICON_HREFS = Object.freeze({
+  idle: '/images/favicon.svg',
+  deploying: '/images/favicon-deploying.svg',
+  success: '/images/favicon-success.svg',
+  failed: '/images/favicon-failed.svg',
+  cancelled: '/images/favicon-cancelled.svg'
+})
+
+export const DEPLOYMENT_FAVICON_TERMINAL_DURATIONS = Object.freeze({
+  success: 10000,
+  failed: 12000,
+  cancelled: 12000
+})
+
+const ACTIVE_DEPLOYMENT_STATUSES = new Set([
+  'pending',
+  'building',
+  'pushing',
+  'deploying'
+])
+
+const TERMINAL_DEPLOYMENT_STATES = Object.freeze({
+  running: DEPLOYMENT_FAVICON_STATES.success,
+  failed: DEPLOYMENT_FAVICON_STATES.failed,
+  cancelled: DEPLOYMENT_FAVICON_STATES.cancelled
+})
+
+const TERMINAL_STATE_PRIORITY = Object.freeze({
+  success: 1,
+  cancelled: 2,
+  failed: 3
+})
+
+export function resolveDeploymentFaviconState({
+  activeStatuses = [],
+  terminalStates = []
+} = {}) {
+  if (activeStatuses.some((status) => isActiveDeploymentStatus(status))) {
+    return DEPLOYMENT_FAVICON_STATES.deploying
+  }
+
+  return terminalStates.reduce(
+    (highestPriorityState, state) =>
+      (TERMINAL_STATE_PRIORITY[state] || 0) >
+      (TERMINAL_STATE_PRIORITY[highestPriorityState] || 0)
+        ? state
+        : highestPriorityState,
+    DEPLOYMENT_FAVICON_STATES.idle
+  )
+}
+
+export function createDeploymentFaviconManager({
+  documentRef = typeof document === 'undefined' ? null : document,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  terminalDurations = DEPLOYMENT_FAVICON_TERMINAL_DURATIONS
+} = {}) {
+  let iconLink = null
+  let originalHref = null
+  let activeDeployments = new Map()
+  const terminalDeployments = new Map()
+  const terminalTimers = new Map()
+
+  function ensureIconLink() {
+    if (!documentRef) return null
+    if (iconLink) return iconLink
+
+    iconLink = documentRef.querySelector('link[rel~="icon"]')
+    if (!iconLink) {
+      iconLink = documentRef.createElement('link')
+      iconLink.setAttribute('rel', 'icon')
+      iconLink.setAttribute('type', 'image/svg+xml')
+      iconLink.setAttribute('sizes', 'any')
+      documentRef.head.appendChild(iconLink)
+    }
+
+    originalHref =
+      iconLink.getAttribute('href') || DEPLOYMENT_FAVICON_HREFS.idle
+
+    return iconLink
+  }
+
+  function getState() {
+    return resolveDeploymentFaviconState({
+      activeStatuses: [...activeDeployments.values()],
+      terminalStates: [...terminalDeployments.values()]
+    })
+  }
+
+  function render() {
+    const state = getState()
+    const link = ensureIconLink()
+    if (!link) return state
+
+    const href =
+      state === DEPLOYMENT_FAVICON_STATES.idle
+        ? originalHref || DEPLOYMENT_FAVICON_HREFS.idle
+        : DEPLOYMENT_FAVICON_HREFS[state]
+
+    link.setAttribute('href', href)
+    link.dataset.deploymentState = state
+
+    return state
+  }
+
+  function replaceActiveDeployments(deployments = []) {
+    activeDeployments = new Map(
+      deployments
+        .filter(
+          ({ id, status }) =>
+            isActiveDeploymentStatus(status) &&
+            !terminalDeployments.has(String(id))
+        )
+        .map(({ id, status }) => [String(id), status])
+    )
+
+    return render()
+  }
+
+  function noteDeploymentStatus(deploymentId, status) {
+    const id = String(deploymentId)
+
+    if (isActiveDeploymentStatus(status)) {
+      clearTerminalState(id)
+      activeDeployments.set(id, status)
+      return render()
+    }
+
+    const terminalState = TERMINAL_DEPLOYMENT_STATES[status]
+    if (!terminalState) return getState()
+
+    activeDeployments.delete(id)
+    terminalDeployments.set(id, terminalState)
+    scheduleTerminalReset(id, terminalState)
+
+    return render()
+  }
+
+  function scheduleTerminalReset(deploymentId, terminalState) {
+    clearTerminalTimer(deploymentId)
+
+    const duration = terminalDurations[terminalState]
+    if (!duration) {
+      clearTerminalState(deploymentId)
+      return
+    }
+
+    const timer = setTimeoutFn(() => {
+      terminalTimers.delete(deploymentId)
+      if (terminalDeployments.get(deploymentId) === terminalState) {
+        terminalDeployments.delete(deploymentId)
+      }
+      render()
+    }, duration)
+
+    terminalTimers.set(deploymentId, timer)
+  }
+
+  function clearTerminalTimer(deploymentId) {
+    const timer = terminalTimers.get(deploymentId)
+    if (timer === undefined) return
+
+    clearTimeoutFn(timer)
+    terminalTimers.delete(deploymentId)
+  }
+
+  function clearTerminalState(deploymentId) {
+    clearTerminalTimer(deploymentId)
+    terminalDeployments.delete(deploymentId)
+  }
+
+  function clearTerminalStates() {
+    terminalDeployments.clear()
+
+    for (const timer of terminalTimers.values()) {
+      clearTimeoutFn(timer)
+    }
+    terminalTimers.clear()
+  }
+
+  function acknowledgeTerminalStates() {
+    clearTerminalStates()
+
+    return render()
+  }
+
+  function reset() {
+    activeDeployments.clear()
+    clearTerminalStates()
+
+    return render()
+  }
+
+  function destroy() {
+    reset()
+    iconLink = null
+    originalHref = null
+  }
+
+  render()
+
+  return {
+    acknowledgeTerminalStates,
+    destroy,
+    getState,
+    noteDeploymentStatus,
+    replaceActiveDeployments,
+    reset
+  }
+}
+
+function isActiveDeploymentStatus(status) {
+  return ACTIVE_DEPLOYMENT_STATUSES.has(status)
+}

--- a/tests/e2e/pages/deployment-favicon.test.js
+++ b/tests/e2e/pages/deployment-favicon.test.js
@@ -1,0 +1,148 @@
+const { test } = require('sounding')
+
+test(
+  'browser tab favicon tracks active, terminal, aggregate, and logout states',
+  {
+    browser: true,
+    world: deploymentFaviconWorld('deployment-favicon-success')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const firstDeployment = await createDeployment(world, current, 'building')
+    const secondDeployment = await createDeployment(world, current, 'deploying')
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.goto('/')
+
+    expect(await waitForFavicon(page, 'deploying')).toBe(
+      '/images/favicon-deploying.svg'
+    )
+    expect(await faviconAssetsAreAvailable(page)).toBe(true)
+    await page.screenshot('.tmp/issue-214-deploying-light.png', {
+      fullPage: true
+    })
+
+    await acknowledgeFavicon(page)
+    expect(await faviconState(page)).toBe('deploying')
+
+    await sails.models.deployment.updateOne({ id: firstDeployment.id }).set({
+      status: 'running',
+      finishedAt: Date.now()
+    })
+
+    await page.raw
+      .locator('.pointer-events-none.fixed.bottom-4.right-4')
+      .getByText('Deployed', { exact: true })
+      .first()
+      .waitFor({ state: 'visible' })
+    expect(await faviconState(page)).toBe('deploying')
+
+    await sails.models.deployment.updateOne({ id: secondDeployment.id }).set({
+      status: 'running',
+      finishedAt: Date.now()
+    })
+
+    expect(await waitForFavicon(page, 'success')).toBe(
+      '/images/favicon-success.svg'
+    )
+    await acknowledgeFavicon(page)
+    expect(await waitForFavicon(page, 'idle')).toBe('/images/favicon.svg')
+
+    const failedDeployment = await createDeployment(world, current, 'building')
+    const activeDeployment = await createDeployment(world, current, 'deploying')
+
+    await waitForFavicon(page, 'deploying')
+
+    await sails.models.deployment.updateOne({ id: failedDeployment.id }).set({
+      status: 'failed',
+      finishedAt: Date.now(),
+      errorMessage: 'Build failed for favicon priority proof'
+    })
+    await page.raw
+      .locator('.pointer-events-none.fixed.bottom-4.right-4')
+      .getByText('Failed', { exact: true })
+      .waitFor({ state: 'visible' })
+
+    expect(await faviconState(page)).toBe('deploying')
+
+    await sails.models.deployment.updateOne({ id: activeDeployment.id }).set({
+      status: 'running',
+      finishedAt: Date.now()
+    })
+
+    expect(await waitForFavicon(page, 'failed')).toBe(
+      '/images/favicon-failed.svg'
+    )
+    await page.inDarkMode()
+    await page.screenshot('.tmp/issue-214-failed-dark.png', {
+      fullPage: true
+    })
+
+    await acknowledgeFavicon(page)
+    expect(await waitForFavicon(page, 'idle')).toBe('/images/favicon.svg')
+
+    await page.raw
+      .getByText(current.users.genesisUser.email, { exact: true })
+      .locator('..')
+      .click()
+    await page.raw.getByRole('button', { name: 'Sign out' }).click()
+
+    expect(await waitForFavicon(page, 'idle')).toBe('/images/favicon.svg')
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)
+
+function deploymentFaviconWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: {
+        slug,
+        name: 'Deployment Favicon'
+      }
+    }
+  }
+}
+
+async function createDeployment(world, current, status) {
+  return world.create('deployment').with({
+    status,
+    triggerType: 'manual',
+    environment: current.environments.production.id,
+    app: current.apps.web.id,
+    triggeredBy: current.users.genesisUser.id,
+    startedAt: Date.now() - 5000
+  })
+}
+
+async function waitForFavicon(page, state) {
+  const favicon = page.raw.locator(
+    `link[rel~="icon"][data-deployment-state="${state}"]`
+  )
+  await favicon.waitFor({ state: 'attached' })
+  return favicon.getAttribute('href')
+}
+
+async function faviconState(page) {
+  return page.raw
+    .locator('link[rel~="icon"]')
+    .getAttribute('data-deployment-state')
+}
+
+async function acknowledgeFavicon(page) {
+  await page.raw.evaluate(() => window.dispatchEvent(new Event('focus')))
+}
+
+async function faviconAssetsAreAvailable(page) {
+  return page.script(async () => {
+    const responses = await Promise.all(
+      ['deploying', 'success', 'failed', 'cancelled'].map((state) =>
+        fetch(`/images/favicon-${state}.svg`)
+      )
+    )
+
+    return responses.every((response) => response.ok)
+  })
+}

--- a/tests/e2e/pages/projects/dock-multi-results.test.js
+++ b/tests/e2e/pages/projects/dock-multi-results.test.js
@@ -65,9 +65,13 @@ test(
       })
     })
 
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
     await login.withPassword('genesisUser', page, {
       password: current.auth.genesisUserPassword
     })
+    await updateCheckFinished
     await page.raw
       .context()
       .grantPermissions(['clipboard-read', 'clipboard-write'])

--- a/tests/unit/assets/deployment-favicon.test.js
+++ b/tests/unit/assets/deployment-favicon.test.js
@@ -1,0 +1,238 @@
+const { test } = require('sounding')
+
+test('deployment favicon resolves aggregate state without hiding active work', async ({
+  expect
+}) => {
+  const { resolveDeploymentFaviconState } = await import(
+    '../../../assets/js/lib/deployment-favicon.mjs'
+  )
+
+  expect(resolveDeploymentFaviconState()).toBe('idle')
+  expect(
+    resolveDeploymentFaviconState({
+      activeStatuses: ['building'],
+      terminalStates: ['failed']
+    })
+  ).toBe('deploying')
+  expect(
+    resolveDeploymentFaviconState({
+      terminalStates: ['success', 'cancelled', 'failed']
+    })
+  ).toBe('failed')
+  expect(
+    resolveDeploymentFaviconState({
+      terminalStates: ['success', 'cancelled']
+    })
+  ).toBe('cancelled')
+})
+
+test('deployment favicon moves from active to success and restores the original icon', async ({
+  expect
+}) => {
+  const { createDeploymentFaviconManager } = await import(
+    '../../../assets/js/lib/deployment-favicon.mjs'
+  )
+  const documentRef = createFakeDocument('/images/custom-favicon.svg')
+  const timers = createFakeTimers()
+  const favicon = createDeploymentFaviconManager({
+    documentRef,
+    setTimeoutFn: timers.set,
+    clearTimeoutFn: timers.clear,
+    terminalDurations: {
+      success: 100,
+      failed: 120,
+      cancelled: 120
+    }
+  })
+
+  expect(documentRef.icon.getAttribute('href')).toBe(
+    '/images/custom-favicon.svg'
+  )
+  expect(documentRef.icon.dataset.deploymentState).toBe('idle')
+
+  favicon.replaceActiveDeployments([{ id: 7, status: 'building' }])
+  expect(favicon.getState()).toBe('deploying')
+  expect(documentRef.icon.getAttribute('href')).toBe(
+    '/images/favicon-deploying.svg'
+  )
+
+  favicon.noteDeploymentStatus(7, 'running')
+  expect(favicon.getState()).toBe('success')
+  expect(documentRef.icon.getAttribute('href')).toBe(
+    '/images/favicon-success.svg'
+  )
+
+  timers.runNext()
+  expect(favicon.getState()).toBe('idle')
+  expect(documentRef.icon.getAttribute('href')).toBe(
+    '/images/custom-favicon.svg'
+  )
+})
+
+test('deployment favicon keeps active work visible and preserves the most important terminal state', async ({
+  expect
+}) => {
+  const { createDeploymentFaviconManager } = await import(
+    '../../../assets/js/lib/deployment-favicon.mjs'
+  )
+  const documentRef = createFakeDocument()
+  const timers = createFakeTimers()
+  const favicon = createDeploymentFaviconManager({
+    documentRef,
+    setTimeoutFn: timers.set,
+    clearTimeoutFn: timers.clear,
+    terminalDurations: {
+      success: 100,
+      failed: 120,
+      cancelled: 120
+    }
+  })
+
+  favicon.replaceActiveDeployments([
+    { id: 1, status: 'deploying' },
+    { id: 2, status: 'building' }
+  ])
+  favicon.noteDeploymentStatus(1, 'failed')
+  expect(favicon.getState()).toBe('deploying')
+
+  favicon.replaceActiveDeployments([
+    { id: 1, status: 'building' },
+    { id: 2, status: 'building' }
+  ])
+  favicon.noteDeploymentStatus(2, 'running')
+  expect(favicon.getState()).toBe('failed')
+  expect(documentRef.icon.getAttribute('href')).toBe(
+    '/images/favicon-failed.svg'
+  )
+
+  timers.runByDelay(120)
+  expect(favicon.getState()).toBe('success')
+
+  timers.runByDelay(100)
+  expect(favicon.getState()).toBe('idle')
+})
+
+test('deployment favicon reset clears terminal timers and restores idle state', async ({
+  expect
+}) => {
+  const { createDeploymentFaviconManager } = await import(
+    '../../../assets/js/lib/deployment-favicon.mjs'
+  )
+  const documentRef = createFakeDocument()
+  const timers = createFakeTimers()
+  const favicon = createDeploymentFaviconManager({
+    documentRef,
+    setTimeoutFn: timers.set,
+    clearTimeoutFn: timers.clear
+  })
+
+  favicon.noteDeploymentStatus(9, 'cancelled')
+  expect(favicon.getState()).toBe('cancelled')
+  expect(timers.size()).toBe(1)
+
+  favicon.reset()
+  expect(favicon.getState()).toBe('idle')
+  expect(timers.size()).toBe(0)
+  expect(documentRef.icon.getAttribute('href')).toBe('/images/favicon.svg')
+})
+
+test('deployment favicon acknowledgement clears terminal results without hiding active work', async ({
+  expect
+}) => {
+  const { createDeploymentFaviconManager } = await import(
+    '../../../assets/js/lib/deployment-favicon.mjs'
+  )
+  const documentRef = createFakeDocument()
+  const timers = createFakeTimers()
+  const favicon = createDeploymentFaviconManager({
+    documentRef,
+    setTimeoutFn: timers.set,
+    clearTimeoutFn: timers.clear
+  })
+
+  favicon.replaceActiveDeployments([{ id: 10, status: 'deploying' }])
+  favicon.noteDeploymentStatus(9, 'failed')
+  expect(favicon.getState()).toBe('deploying')
+  expect(timers.size()).toBe(1)
+
+  favicon.acknowledgeTerminalStates()
+  expect(favicon.getState()).toBe('deploying')
+  expect(timers.size()).toBe(0)
+
+  favicon.replaceActiveDeployments([])
+  expect(favicon.getState()).toBe('idle')
+})
+
+function createFakeDocument(initialHref = '/images/favicon.svg') {
+  let icon = createFakeLink(initialHref)
+
+  return {
+    get icon() {
+      return icon
+    },
+    querySelector() {
+      return icon
+    },
+    createElement() {
+      return createFakeLink(null)
+    },
+    head: {
+      appendChild(element) {
+        icon = element
+      }
+    }
+  }
+}
+
+function createFakeLink(href) {
+  const attributes = new Map([
+    ['rel', 'icon'],
+    ['type', 'image/svg+xml']
+  ])
+  if (href) attributes.set('href', href)
+
+  return {
+    dataset: {},
+    getAttribute(name) {
+      return attributes.get(name) || null
+    },
+    setAttribute(name, value) {
+      attributes.set(name, value)
+    }
+  }
+}
+
+function createFakeTimers() {
+  let nextId = 1
+  const scheduled = new Map()
+
+  return {
+    set(callback, delay) {
+      const id = nextId++
+      scheduled.set(id, { callback, delay })
+      return id
+    },
+    clear(id) {
+      scheduled.delete(id)
+    },
+    runNext() {
+      const [id, timer] = scheduled.entries().next().value || []
+      if (!timer) return
+      scheduled.delete(id)
+      timer.callback()
+    },
+    runByDelay(delay) {
+      const match = [...scheduled.entries()].find(
+        ([, timer]) => timer.delay === delay
+      )
+      if (!match) return
+
+      const [id, timer] = match
+      scheduled.delete(id)
+      timer.callback()
+    },
+    size() {
+      return scheduled.size
+    }
+  }
+}

--- a/views/app.ejs
+++ b/views/app.ejs
@@ -7,7 +7,13 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
     />
-    <link rel="icon" type="image/svg+xml" href="/images/favicon.svg" />
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      sizes="any"
+      href="/images/favicon.svg"
+      data-deployment-state="idle"
+    />
     <%- shipwright.styles() %>
   </head>
   <body>


### PR DESCRIPTION
Closes #214

## Summary
- reflect aggregate deployment state in the browser favicon
- keep active work visible while briefly surfacing success, failure, and cancellation
- return to idle on timeout, tab acknowledgement, logout, or page teardown
- cover state resolution and the browser flow with Sounding

## Verification
- npm test (216 passed)
- npm run lint
- npm run check:consistency
- git diff --check