### PR TITLE
feat(bridge): add resource configuration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,14 @@ slipway slide
 
 Slipway includes integrated tools that work with your deployed Sails apps:
 
-| Tool        | What it does                                                                                                                          |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| **Helm**    | Production REPL — query models, run helpers, inspect config from the browser                                                          |
-| **Bridge**  | Auto-generated data management UI from your Waterline models                                                                          |
-| **Dock**    | SQL console, schema diff, and migration tool for your databases                                                                       |
-| **Quest**   | Job scheduler dashboard for [sails-hook-quest](https://docs.sailscasts.com/quest)                                                     |
-| **Content** | CMS for [sails-content](https://docs.sailscasts.com/content) markdown files                                                           |
-| **Lookout** | Infrastructure monitoring via [sails-hook-slipway](packages/hook) telemetry with [bounded retention](docs/observability-retention.md) |
+| Tool        | What it does                                                                                                                             |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| **Helm**    | Production REPL — query models, run helpers, inspect config from the browser                                                             |
+| **Bridge**  | Configurable data management UI from your Waterline models, with a [server-enforced resource contract](docs/bridge-resource-contract.md) |
+| **Dock**    | SQL console, schema diff, and migration tool for your databases                                                                          |
+| **Quest**   | Job scheduler dashboard for [sails-hook-quest](https://docs.sailscasts.com/quest)                                                        |
+| **Content** | CMS for [sails-content](https://docs.sailscasts.com/content) markdown files                                                              |
+| **Lookout** | Infrastructure monitoring via [sails-hook-slipway](packages/hook) telemetry with [bounded retention](docs/observability-retention.md)    |
 
 ## Requirements
 

--- a/api/controllers/project/bridge-bulk-delete.js
+++ b/api/controllers/project/bridge-bulk-delete.js
@@ -66,12 +66,44 @@ module.exports = {
     if (!Array.isArray(ids) || ids.length === 0) {
       throw { badRequest: { error: 'No records selected' } }
     }
+    if (ids.length > 500) {
+      throw {
+        badRequest: { error: 'Select no more than 500 records at a time.' }
+      }
+    }
+    if (
+      ids.some(
+        (id) =>
+          !['string', 'number'].includes(typeof id) ||
+          (typeof id === 'string' && id.length > 200)
+      )
+    ) {
+      throw { badRequest: { error: 'Record selection is invalid.' } }
+    }
 
-    // Execute bulk delete in container
+    let resource
+    try {
+      const loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: 'bulkDelete'
+      })
+      resource = loaded.resource
+    } catch (error) {
+      throw { badRequest: { error: error.message } }
+    }
+
+    const criteria = {
+      [resource.primaryKey]: { in: ids }
+    }
     const deleteCode = `
-      const deleted = await sails.models['${modelIdentity}'].destroy({ id: { in: ${JSON.stringify(
-      ids
-    )} } }).fetch();
+      const identity = ${JSON.stringify(resource.identity)};
+      const criteria = ${JSON.stringify(criteria)};
+      const model = sails.models[identity];
+      if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+      const deleted = await model.destroy(criteria).fetch();
       return { count: deleted.length };
     `
     const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(deleteCode)

--- a/api/controllers/project/bridge-create-record.js
+++ b/api/controllers/project/bridge-create-record.js
@@ -63,11 +63,32 @@ module.exports = {
       throw { badRequest: { error: 'App is not running' } }
     }
 
-    // Execute create in container
+    let loaded
+    let allowedValues
+    try {
+      loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: 'create'
+      })
+      allowedValues = await sails.helpers.bridge.allowResourceValues.with({
+        values,
+        resource: loaded.resource,
+        surface: 'create'
+      })
+    } catch (error) {
+      throw { badRequest: { error: error.message } }
+    }
+
+    // Execute the allowlisted create in the target container.
     const createCode = `
-      const record = await sails.models['${modelIdentity}'].create(${JSON.stringify(
-      values
-    )}).fetch();
+      const identity = ${JSON.stringify(loaded.resource.identity)};
+      const values = ${JSON.stringify(allowedValues)};
+      const model = sails.models[identity];
+      if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+      const record = await model.create(values).fetch();
       return { record };
     `
     const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(createCode)
@@ -84,15 +105,17 @@ module.exports = {
     let recordId
     try {
       const data = JSON.parse(result.output)
-      recordId = data.record?.id
+      recordId = data.record?.[loaded.resource.primaryKey]
     } catch {
       // Fallback to model list
     }
 
     // Redirect to the new record or model list
     const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    if (recordId) {
-      return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${recordId}`
+    if (recordId !== undefined && recordId !== null) {
+      return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${encodeURIComponent(
+        String(recordId)
+      )}`
     }
     return `/projects/${slug}${envPath}/bridge/${modelIdentity}`
   }

--- a/api/controllers/project/bridge-delete-record.js
+++ b/api/controllers/project/bridge-delete-record.js
@@ -62,11 +62,29 @@ module.exports = {
       throw { badRequest: { error: 'App is not running' } }
     }
 
-    // Execute delete in container
+    let resource
+    try {
+      const loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: 'delete'
+      })
+      resource = loaded.resource
+    } catch (error) {
+      throw { badRequest: { error: error.message } }
+    }
+
+    const criteria = {
+      [resource.primaryKey]: recordId
+    }
     const deleteCode = `
-      const record = await sails.models['${modelIdentity}'].destroyOne({ id: ${JSON.stringify(
-      recordId
-    )} });
+      const identity = ${JSON.stringify(resource.identity)};
+      const criteria = ${JSON.stringify(criteria)};
+      const model = sails.models[identity];
+      if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+      const record = await model.destroyOne(criteria);
       return { success: !!record };
     `
     const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(deleteCode)

--- a/api/controllers/project/bridge-update-record.js
+++ b/api/controllers/project/bridge-update-record.js
@@ -67,11 +67,35 @@ module.exports = {
       throw { badRequest: { error: 'App is not running' } }
     }
 
-    // Execute update in container
+    let loaded
+    let allowedValues
+    try {
+      loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: 'update'
+      })
+      allowedValues = await sails.helpers.bridge.allowResourceValues.with({
+        values,
+        resource: loaded.resource,
+        surface: 'edit'
+      })
+    } catch (error) {
+      throw { badRequest: { error: error.message } }
+    }
+
+    const criteria = {
+      [loaded.resource.primaryKey]: recordId
+    }
     const updateCode = `
-      const record = await sails.models['${modelIdentity}'].updateOne({ id: ${JSON.stringify(
-      recordId
-    )} }).set(${JSON.stringify(values)});
+      const identity = ${JSON.stringify(loaded.resource.identity)};
+      const criteria = ${JSON.stringify(criteria)};
+      const values = ${JSON.stringify(allowedValues)};
+      const model = sails.models[identity];
+      if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+      const record = await model.updateOne(criteria).set(values);
       return { record };
     `
     const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(updateCode)
@@ -86,6 +110,8 @@ module.exports = {
 
     // Redirect back to record view
     const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${recordId}`
+    return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${encodeURIComponent(
+      String(recordId)
+    )}`
   }
 }

--- a/api/controllers/project/view-bridge-create.js
+++ b/api/controllers/project/view-bridge-create.js
@@ -62,54 +62,19 @@ module.exports = {
 
     if (appRunning) {
       try {
-        const introspection = await sails.helpers.bridge.introspectModels(
-          app.containerName,
-          environment.id
-        )
-
-        if (introspection.error) {
-          error = introspection.error
-        } else {
-          modelMeta = introspection.models[modelIdentity]
-
-          if (!modelMeta) {
-            error = `Model "${modelIdentity}" not found.`
-          } else {
-            // Load association options for belongsTo relationships
-            const modelAssocs = (modelMeta.associations || []).filter(
-              (a) => a.type === 'model'
-            )
-            for (const assoc of modelAssocs) {
-              try {
-                const queryCode = `
-                  const records = await sails.models['${assoc.model}'].find({ limit: 100 });
-                  return records.map(r => ({
-                    id: r.id,
-                    label: r.name || r.title || r.email || \`#\${r.id}\`
-                  }));
-                `
-                const wrappedCode =
-                  await sails.helpers.bridge.buildSailsWrapper(queryCode)
-                const result = await sails.helpers.bridge.executeInContainer(
-                  app.containerName,
-                  wrappedCode
-                )
-
-                if (result.success) {
-                  try {
-                    assocOptions[assoc.alias] = JSON.parse(result.output)
-                  } catch {
-                    assocOptions[assoc.alias] = []
-                  }
-                } else {
-                  assocOptions[assoc.alias] = []
-                }
-              } catch {
-                assocOptions[assoc.alias] = []
-              }
-            }
-          }
-        }
+        const loaded = await sails.helpers.bridge.loadResource.with({
+          containerName: app.containerName,
+          environmentId: environment.id,
+          modelIdentity,
+          action: 'create'
+        })
+        modelMeta = loaded.resource
+        assocOptions = await sails.helpers.bridge.loadAssociationOptions.with({
+          containerName: app.containerName,
+          resources: loaded.contract.models,
+          resource: modelMeta,
+          surface: 'create'
+        })
       } catch (err) {
         error = err.message
       }

--- a/api/controllers/project/view-bridge-edit.js
+++ b/api/controllers/project/view-bridge-edit.js
@@ -67,85 +67,66 @@ module.exports = {
 
     if (appRunning) {
       try {
-        const introspection = await sails.helpers.bridge.introspectModels(
+        const loaded = await sails.helpers.bridge.loadResource.with({
+          containerName: app.containerName,
+          environmentId: environment.id,
+          modelIdentity,
+          action: 'update'
+        })
+        modelMeta = loaded.resource
+
+        const criteria = {
+          [modelMeta.primaryKey]: recordId
+        }
+        const fields = Array.from(
+          new Set([modelMeta.primaryKey, ...modelMeta.edit])
+        ).filter(
+          (field) =>
+            field === modelMeta.primaryKey ||
+            (!modelMeta.attributes[field].encrypt &&
+              !modelMeta.attributes[field].protect)
+        )
+        const queryCode = `
+          const identity = ${JSON.stringify(modelMeta.identity)};
+          const criteria = ${JSON.stringify(criteria)};
+          const fields = ${JSON.stringify(fields)};
+          const model = sails.models[identity];
+          if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+          const record = await model.findOne(criteria).select(fields);
+          return { record };
+        `
+        const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+          queryCode
+        )
+        const result = await sails.helpers.bridge.executeInContainer(
           app.containerName,
-          environment.id
+          wrappedCode
         )
 
-        if (introspection.error) {
-          error = introspection.error
-        } else {
-          modelMeta = introspection.models[modelIdentity]
-
-          if (!modelMeta) {
-            error = `Model "${modelIdentity}" not found.`
-          } else {
-            // Fetch the record
-            const queryCode = `
-              const record = await sails.models['${modelIdentity}'].findOne({ id: ${JSON.stringify(
-              recordId
-            )} });
-              return { record };
-            `
-            const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
-              queryCode
-            )
-            const result = await sails.helpers.bridge.executeInContainer(
-              app.containerName,
-              wrappedCode
-            )
-
-            if (result.success) {
-              try {
-                const data = JSON.parse(result.output)
-                record = data.record
-                if (!record) {
-                  error = `Record with ID "${recordId}" not found.`
-                }
-              } catch (e) {
-                error = 'Failed to parse record: ' + e.message
-              }
-            } else {
-              error = result.error || 'Failed to fetch record'
+        if (result.success) {
+          try {
+            const data = JSON.parse(result.output)
+            record = data.record
+            if (!record) {
+              error = `Record with ID "${recordId}" not found.`
             }
-
-            // Load association options for belongsTo relationships
-            if (!error) {
-              const modelAssocs = (modelMeta.associations || []).filter(
-                (a) => a.type === 'model'
-              )
-              for (const assoc of modelAssocs) {
-                try {
-                  const assocQueryCode = `
-                    const records = await sails.models['${assoc.model}'].find({ limit: 100 });
-                    return records.map(r => ({
-                      id: r.id,
-                      label: r.name || r.title || r.email || \`#\${r.id}\`
-                    }));
-                  `
-                  const assocWrappedCode =
-                    await sails.helpers.bridge.buildSailsWrapper(assocQueryCode)
-                  const assocResult =
-                    await sails.helpers.bridge.executeInContainer(
-                      app.containerName,
-                      assocWrappedCode
-                    )
-
-                  if (assocResult.success) {
-                    try {
-                      assocOptions[assoc.alias] = JSON.parse(assocResult.output)
-                    } catch {
-                      assocOptions[assoc.alias] = []
-                    }
-                  } else {
-                    assocOptions[assoc.alias] = []
-                  }
-                } catch {
-                  assocOptions[assoc.alias] = []
-                }
-              }
-            }
+          } catch (parseError) {
+            error = 'Failed to parse record: ' + parseError.message
           }
+        } else {
+          error = result.error || 'Failed to fetch record'
+        }
+
+        if (!error) {
+          assocOptions = await sails.helpers.bridge.loadAssociationOptions.with(
+            {
+              containerName: app.containerName,
+              resources: loaded.contract.models,
+              resource: modelMeta,
+              surface: 'edit'
+            }
+          )
         }
       } catch (err) {
         error = err.message

--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -26,7 +26,7 @@ module.exports = {
     },
     sort: {
       type: 'string',
-      defaultsTo: 'createdAt DESC'
+      defaultsTo: ''
     },
     search: {
       type: 'string',
@@ -86,100 +86,64 @@ module.exports = {
     let total = 0
     let totalPages = 0
     let error = null
+    let normalizedPage = page
+    let normalizedPerPage = perPage
+    let normalizedSort = sort
+    let normalizedSearch = search
 
     if (appRunning) {
       try {
-        // Get model introspection
-        const introspection = await sails.helpers.bridge.introspectModels(
+        const loaded = await sails.helpers.bridge.loadResource.with({
+          containerName: app.containerName,
+          environmentId: environment.id,
+          modelIdentity,
+          action: 'viewAny'
+        })
+        modelMeta = loaded.resource
+        const normalizedQuery =
+          await sails.helpers.bridge.normalizeResourceQuery.with({
+            resource: modelMeta,
+            page,
+            perPage,
+            sort,
+            search
+          })
+
+        normalizedPage = normalizedQuery.page
+        normalizedPerPage = normalizedQuery.perPage
+        normalizedSort = normalizedQuery.sort
+        normalizedSearch = normalizedQuery.search
+
+        const queryCode = `
+          const identity = ${JSON.stringify(modelMeta.identity)};
+          const where = ${JSON.stringify(normalizedQuery.where)};
+          const criteria = ${JSON.stringify(normalizedQuery.criteria)};
+          const model = sails.models[identity];
+          if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+          const total = await model.count(where);
+          const records = await model.find(criteria);
+          return { records, total };
+        `
+        const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+          queryCode
+        )
+        const result = await sails.helpers.bridge.executeInContainer(
           app.containerName,
-          environment.id
+          wrappedCode
         )
 
-        if (introspection.error) {
-          error = introspection.error
-        } else {
-          modelMeta = introspection.models[modelIdentity]
-
-          if (!modelMeta) {
-            error = `Model "${modelIdentity}" not found.`
-          } else {
-            // Fetch records
-            const pk = modelMeta.primaryKey || 'id'
-            const skip = (page - 1) * perPage
-
-            // Build query code
-            let queryCode
-            if (search) {
-              // Simple search: look for string fields containing the search term
-              const stringAttrs = Object.entries(modelMeta.attributes)
-                .filter(([, attr]) => attr.type === 'string' && !attr.encrypt)
-                .map(([name]) => name)
-
-              if (stringAttrs.length > 0) {
-                const orClauses = stringAttrs
-                  .map(
-                    (attr) =>
-                      `{ ${attr}: { contains: '${search.replace(
-                        /'/g,
-                        "\\'"
-                      )}' } }`
-                  )
-                  .join(', ')
-
-                queryCode = `
-                  const total = await sails.models['${modelIdentity}'].count({ or: [${orClauses}] });
-                  const records = await sails.models['${modelIdentity}'].find({
-                    where: { or: [${orClauses}] },
-                    skip: ${skip},
-                    limit: ${perPage},
-                    sort: '${sort}'
-                  });
-                  return { records, total };
-                `
-              } else {
-                queryCode = `
-                  const total = await sails.models['${modelIdentity}'].count();
-                  const records = await sails.models['${modelIdentity}'].find({
-                    skip: ${skip},
-                    limit: ${perPage},
-                    sort: '${sort}'
-                  });
-                  return { records, total };
-                `
-              }
-            } else {
-              queryCode = `
-                const total = await sails.models['${modelIdentity}'].count();
-                const records = await sails.models['${modelIdentity}'].find({
-                  skip: ${skip},
-                  limit: ${perPage},
-                  sort: '${sort}'
-                });
-                return { records, total };
-              `
-            }
-
-            const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
-              queryCode
-            )
-            const result = await sails.helpers.bridge.executeInContainer(
-              app.containerName,
-              wrappedCode
-            )
-
-            if (result.success) {
-              try {
-                const data = JSON.parse(result.output)
-                records = data.records || []
-                total = data.total || 0
-                totalPages = Math.ceil(total / perPage)
-              } catch (e) {
-                error = 'Failed to parse records: ' + e.message
-              }
-            } else {
-              error = result.error || 'Failed to fetch records'
-            }
+        if (result.success) {
+          try {
+            const data = JSON.parse(result.output)
+            records = data.records || []
+            total = data.total || 0
+            totalPages = Math.ceil(total / normalizedPerPage)
+          } catch (parseError) {
+            error = 'Failed to parse records: ' + parseError.message
           }
+        } else {
+          error = result.error || 'Failed to fetch records'
         }
       } catch (err) {
         error = err.message
@@ -205,10 +169,10 @@ module.exports = {
         records,
         total,
         totalPages,
-        currentPage: page,
-        perPage,
-        sort,
-        search,
+        currentPage: normalizedPage,
+        perPage: normalizedPerPage,
+        sort: normalizedSort,
+        search: normalizedSearch,
         error
       }
     }

--- a/api/controllers/project/view-bridge-record.js
+++ b/api/controllers/project/view-bridge-record.js
@@ -66,59 +66,47 @@ module.exports = {
 
     if (appRunning) {
       try {
-        // Get model introspection
-        const introspection = await sails.helpers.bridge.introspectModels(
+        const loaded = await sails.helpers.bridge.loadResource.with({
+          containerName: app.containerName,
+          environmentId: environment.id,
+          modelIdentity,
+          action: 'view'
+        })
+        modelMeta = loaded.resource
+
+        const criteria = {
+          [modelMeta.primaryKey]: recordId
+        }
+        const queryCode = `
+          const identity = ${JSON.stringify(modelMeta.identity)};
+          const criteria = ${JSON.stringify(criteria)};
+          const fields = ${JSON.stringify(modelMeta.show)};
+          const model = sails.models[identity];
+          if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+          const record = await model.findOne(criteria).select(fields);
+          return { record };
+        `
+        const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+          queryCode
+        )
+        const result = await sails.helpers.bridge.executeInContainer(
           app.containerName,
-          environment.id
+          wrappedCode
         )
 
-        if (introspection.error) {
-          error = introspection.error
-        } else {
-          modelMeta = introspection.models[modelIdentity]
-
-          if (!modelMeta) {
-            error = `Model "${modelIdentity}" not found.`
-          } else {
-            // Build populate clause for associations
-            const collectionAssocs = (modelMeta.associations || [])
-              .filter((a) => a.type === 'collection')
-              .map((a) => `'${a.alias}'`)
-
-            const populateChain =
-              collectionAssocs.length > 0
-                ? `.populate([${collectionAssocs.join(', ')}])`
-                : ''
-
-            // Fetch the record
-            const queryCode = `
-              const record = await sails.models['${modelIdentity}'].findOne({ id: ${JSON.stringify(
-              recordId
-            )} })${populateChain};
-              return { record };
-            `
-            const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
-              queryCode
-            )
-            const result = await sails.helpers.bridge.executeInContainer(
-              app.containerName,
-              wrappedCode
-            )
-
-            if (result.success) {
-              try {
-                const data = JSON.parse(result.output)
-                record = data.record
-                if (!record) {
-                  error = `Record with ID "${recordId}" not found.`
-                }
-              } catch (e) {
-                error = 'Failed to parse record: ' + e.message
-              }
-            } else {
-              error = result.error || 'Failed to fetch record'
+        if (result.success) {
+          try {
+            const data = JSON.parse(result.output)
+            record = data.record
+            if (!record) {
+              error = `Record with ID "${recordId}" not found.`
             }
+          } catch (parseError) {
+            error = 'Failed to parse record: ' + parseError.message
           }
+        } else {
+          error = result.error || 'Failed to fetch record'
         }
       } catch (err) {
         error = err.message

--- a/api/controllers/project/view-bridge.js
+++ b/api/controllers/project/view-bridge.js
@@ -66,22 +66,30 @@ module.exports = {
         if (introspection.error) {
           modelsError = introspection.error
         } else {
-          models = introspection.models || {}
+          models = Object.fromEntries(
+            Object.entries(introspection.models || {}).filter(
+              ([, resource]) =>
+                !resource.hidden && resource.actions?.viewAny !== false
+            )
+          )
 
           // Get record counts for all models
-          const identities = Object.keys(models)
-          if (identities.length > 0) {
+          const definitions = Object.entries(models).map(([key, resource]) => ({
+            key,
+            identity: resource.identity
+          }))
+          if (definitions.length > 0) {
             const countCode = `
+              const definitions = ${JSON.stringify(definitions)};
               const counts = {};
-              ${identities
-                .map(
-                  (id) => `
+              for (const definition of definitions) {
                 try {
-                  counts['${id}'] = await sails.models['${id}'].count();
-                } catch(e) { counts['${id}'] = 0; }
-              `
-                )
-                .join('\n')}
+                  counts[definition.key] =
+                    await sails.models[definition.identity].count();
+                } catch (error) {
+                  counts[definition.key] = 0;
+                }
+              }
               return counts;
             `
             const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
@@ -95,8 +103,8 @@ module.exports = {
             if (countResult.success) {
               try {
                 const counts = JSON.parse(countResult.output)
-                for (const id of identities) {
-                  models[id].count = counts[id] || 0
+                for (const definition of definitions) {
+                  models[definition.key].count = counts[definition.key] || 0
                 }
               } catch {
                 /* counts remain undefined */

--- a/api/helpers/bridge/allow-resource-values.js
+++ b/api/helpers/bridge/allow-resource-values.js
@@ -1,0 +1,117 @@
+module.exports = {
+  friendlyName: 'Allow Bridge resource values',
+
+  description:
+    'Allowlist a Bridge mutation payload against a normalized resource surface.',
+
+  inputs: {
+    values: {
+      type: 'ref',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    surface: {
+      type: 'string',
+      required: true,
+      isIn: ['create', 'edit']
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ values, resource, surface }) {
+    if (
+      !values ||
+      typeof values !== 'object' ||
+      Array.isArray(values) ||
+      ![Object.prototype, null].includes(Object.getPrototypeOf(values))
+    ) {
+      const error = new Error('Record values must be a plain object.')
+      error.code = 'INVALID_BRIDGE_VALUES'
+      throw error
+    }
+
+    const allowedFields = new Set(
+      (resource?.[surface] || []).filter((field) => {
+        const attribute = resource?.attributes?.[field]
+        return (
+          attribute &&
+          field !== resource.primaryKey &&
+          !attribute.protect &&
+          !attribute.autoCreatedAt &&
+          !attribute.autoUpdatedAt &&
+          attribute.field?.readOnly !== true
+        )
+      })
+    )
+    const allowedValues = {}
+    const rejectedFields = []
+    const unsafeMarkdownFields = []
+
+    for (const key of Object.keys(values)) {
+      if (
+        !allowedFields.has(key) ||
+        ['__proto__', 'constructor', 'prototype'].includes(key)
+      ) {
+        rejectedFields.push(key)
+        continue
+      }
+
+      const attribute = resource.attributes[key]
+      if (
+        attribute.field?.type === 'richtext' &&
+        attribute.field?.format?.toLowerCase() === 'markdown' &&
+        containsRawHtml(values[key])
+      ) {
+        unsafeMarkdownFields.push(key)
+        continue
+      }
+
+      allowedValues[key] = values[key]
+    }
+
+    if (rejectedFields.length > 0) {
+      const error = new Error(
+        `These fields are not available in Bridge: ${rejectedFields.join(
+          ', '
+        )}.`
+      )
+      error.code = 'BRIDGE_FIELD_NOT_ALLOWED'
+      error.fields = rejectedFields
+      throw error
+    }
+
+    if (unsafeMarkdownFields.length > 0) {
+      const error = new Error(
+        `Raw HTML is not allowed in Bridge Markdown fields: ${unsafeMarkdownFields.join(
+          ', '
+        )}.`
+      )
+      error.code = 'BRIDGE_MARKDOWN_HTML_NOT_ALLOWED'
+      error.fields = unsafeMarkdownFields
+      throw error
+    }
+
+    return allowedValues
+  }
+}
+
+function containsRawHtml(value) {
+  if (typeof value !== 'string') return false
+
+  const withoutAutolinks = value.replace(
+    /<[a-z][a-z\d+.-]{1,31}:[^<>\s]*>|<[a-z\d.!#$%&'*+/=?^_`{|}~-]+@[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?)+>/gi,
+    ''
+  )
+
+  return /<!--[\s\S]*?-->|<\/?[a-z][^<>]*>|<![A-Z][^>]*>|<\?[\s\S]*?\?>/i.test(
+    withoutAutolinks
+  )
+}

--- a/api/helpers/bridge/introspect-models.js
+++ b/api/helpers/bridge/introspect-models.js
@@ -1,10 +1,14 @@
-// Module-level cache: Map<environmentId, { data, expiresAt }>
+// Module-level cache: Map<environmentId:containerName, { data, expiresAt }>
 const cache = new Map()
 const CACHE_TTL = 10 * 60 * 1000 // 10 minutes
+const normalizeBridgeResourceContract = require('../../../packages/hook/lib/bridge/normalize-resource-contract')
 
 function clearCache(environmentId) {
   if (environmentId) {
-    cache.delete(environmentId)
+    const prefix = `${environmentId}:`
+    for (const key of cache.keys()) {
+      if (key.startsWith(prefix)) cache.delete(key)
+    }
   } else {
     cache.clear()
   }
@@ -39,9 +43,11 @@ module.exports = {
   },
 
   fn: async function ({ containerName, environmentId, skipCache }) {
+    const cacheKey = `${environmentId}:${containerName}`
+
     // Check cache
     if (!skipCache) {
-      const cached = cache.get(environmentId)
+      const cached = cache.get(cacheKey)
       if (cached && Date.now() < cached.expiresAt) {
         return cached.data
       }
@@ -59,11 +65,16 @@ module.exports = {
     }
 
     try {
-      const models = JSON.parse(result.output)
-      const data = { models }
+      const contract = JSON.parse(result.output)
+      const data = {
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources || {}
+      }
 
       // Store in cache
-      cache.set(environmentId, {
+      cache.set(cacheKey, {
         data,
         expiresAt: Date.now() + CACHE_TTL
       })
@@ -78,7 +89,11 @@ module.exports = {
 }
 
 function buildIntrospectionCode() {
+  const normalizeResourceContractSource =
+    normalizeBridgeResourceContract.toString()
+
   return `
+    const normalizeBridgeResourceContract = ${normalizeResourceContractSource};
     const models = {};
     for (const [identity, model] of Object.entries(sails.models)) {
       if (identity.startsWith('_') || !model.attributes) continue;
@@ -133,6 +148,7 @@ function buildIntrospectionCode() {
           isIn: attr.isIn || null,
           maxLength: attr.maxLength || null,
           encrypt: !!attr.encrypt,
+          protect: !!attr.protect,
           validations: {}
         };
 
@@ -145,6 +161,9 @@ function buildIntrospectionCode() {
       }
     }
 
-    return models;
+    return normalizeBridgeResourceContract({
+      models,
+      config: sails.config.slipway?.bridge || {}
+    });
   `
 }

--- a/api/helpers/bridge/load-association-options.js
+++ b/api/helpers/bridge/load-association-options.js
@@ -1,0 +1,112 @@
+module.exports = {
+  friendlyName: 'Load Bridge association options',
+
+  description:
+    'Load minimal labels and primary keys for configured belongs-to fields.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resources: {
+      type: 'ref',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    surface: {
+      type: 'string',
+      required: true,
+      isIn: ['create', 'edit']
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, resources, resource, surface }) {
+    const surfaceFields = new Set(resource[surface] || [])
+    const definitions = []
+
+    for (const association of resource.associations || []) {
+      if (
+        association.type !== 'model' ||
+        !surfaceFields.has(association.alias)
+      ) {
+        continue
+      }
+
+      const relatedResource = Object.prototype.hasOwnProperty.call(
+        resources,
+        association.model
+      )
+        ? resources[association.model]
+        : null
+      if (!relatedResource || relatedResource.hidden) continue
+
+      definitions.push({
+        alias: association.alias,
+        identity: relatedResource.identity,
+        primaryKey: relatedResource.primaryKey,
+        title: relatedResource.title
+      })
+    }
+
+    if (definitions.length === 0) return {}
+
+    const queryCode = `
+      const definitions = ${JSON.stringify(definitions)};
+      const options = {};
+
+      for (const definition of definitions) {
+        const model = sails.models[definition.identity];
+        if (!model) {
+          options[definition.alias] = [];
+          continue;
+        }
+
+        const fields = Array.from(new Set([
+          definition.primaryKey,
+          definition.title
+        ].filter(Boolean)));
+        const records = await model.find({ limit: 100 }).select(fields);
+        options[definition.alias] = records.map((record) => ({
+          id: record[definition.primaryKey],
+          label: record[definition.title] == null
+            ? '#' + record[definition.primaryKey]
+            : String(record[definition.title])
+        }));
+      }
+
+      return options;
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(queryCode)
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      const error = new Error(
+        result.error || 'Failed to load association options.'
+      )
+      error.code = 'BRIDGE_ASSOCIATION_OPTIONS_FAILED'
+      throw error
+    }
+
+    try {
+      return JSON.parse(result.output)
+    } catch (cause) {
+      const error = new Error('Failed to parse Bridge association options.')
+      error.code = 'BRIDGE_ASSOCIATION_OPTIONS_FAILED'
+      error.cause = cause
+      throw error
+    }
+  }
+}

--- a/api/helpers/bridge/load-resource.js
+++ b/api/helpers/bridge/load-resource.js
@@ -1,0 +1,69 @@
+module.exports = {
+  friendlyName: 'Load Bridge resource',
+
+  description:
+    'Load and authorize a normalized Bridge resource from a running app.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    environmentId: {
+      type: 'number',
+      required: true
+    },
+    modelIdentity: {
+      type: 'string',
+      required: true
+    },
+    action: {
+      type: 'string',
+      isIn: ['viewAny', 'view', 'create', 'update', 'delete', 'bulkDelete']
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, environmentId, modelIdentity, action }) {
+    const contract = await sails.helpers.bridge.introspectModels(
+      containerName,
+      environmentId
+    )
+
+    if (contract.error) {
+      const error = new Error(contract.error)
+      error.code = 'BRIDGE_INTROSPECTION_FAILED'
+      throw error
+    }
+
+    const hasResource = Object.prototype.hasOwnProperty.call(
+      contract.models || {},
+      modelIdentity
+    )
+    const resource = hasResource ? contract.models[modelIdentity] : null
+
+    if (!resource || resource.hidden) {
+      const error = new Error(
+        `Bridge resource "${modelIdentity}" was not found.`
+      )
+      error.code = 'BRIDGE_RESOURCE_NOT_FOUND'
+      throw error
+    }
+
+    if (action && resource.actions?.[action] === false) {
+      const error = new Error(
+        `${resource.singularLabel || modelIdentity} does not allow this action.`
+      )
+      error.code = 'BRIDGE_ACTION_NOT_ALLOWED'
+      error.action = action
+      throw error
+    }
+
+    return { contract, resource }
+  }
+}

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -1,0 +1,29 @@
+const normalizeBridgeResourceContract = require('../../../packages/hook/lib/bridge/normalize-resource-contract')
+
+module.exports = {
+  friendlyName: 'Normalize Bridge resource contract',
+
+  description:
+    'Merge Waterline metadata with a target app Bridge resource configuration.',
+
+  inputs: {
+    models: {
+      type: 'ref',
+      required: true
+    },
+    config: {
+      type: 'ref',
+      defaultsTo: {}
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ models, config }) {
+    return normalizeBridgeResourceContract({ models, config })
+  }
+}

--- a/api/helpers/bridge/normalize-resource-query.js
+++ b/api/helpers/bridge/normalize-resource-query.js
@@ -1,0 +1,96 @@
+module.exports = {
+  friendlyName: 'Normalize Bridge resource query',
+
+  description:
+    'Build safe Waterline pagination, search, selection, and sort criteria from a normalized Bridge resource.',
+
+  inputs: {
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    page: {
+      type: 'number',
+      defaultsTo: 1
+    },
+    perPage: {
+      type: 'number',
+      defaultsTo: 20
+    },
+    sort: {
+      type: 'string',
+      defaultsTo: ''
+    },
+    search: {
+      type: 'string',
+      defaultsTo: ''
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ resource, page, perPage, sort, search }) {
+    const safePage = Math.max(1, Math.floor(page || 1))
+    const safePerPage = Math.min(100, Math.max(1, Math.floor(perPage || 20)))
+    const primaryKey = resource.primaryKey || 'id'
+    const selectable = Array.from(
+      new Set([primaryKey, ...(resource.list || [])])
+    ).filter((field) => resource.attributes?.[field])
+    const sortable = new Set(
+      selectable.filter(
+        (field) => resource.attributes[field]?.field?.sortable !== false
+      )
+    )
+
+    let sortField = resource.sort?.field || primaryKey
+    let sortDirection = resource.sort?.direction || 'DESC'
+    const requestedSort = String(sort || '').trim()
+    if (requestedSort) {
+      const match = requestedSort.match(
+        /^([A-Za-z][A-Za-z0-9_]*)\s+(ASC|DESC)$/i
+      )
+      if (match && sortable.has(match[1])) {
+        sortField = match[1]
+        sortDirection = match[2].toUpperCase()
+      }
+    }
+
+    const searchValue = String(search || '')
+      .trim()
+      .slice(0, 200)
+    const searchFields = (resource.search || []).filter(
+      (field) =>
+        resource.attributes?.[field]?.type === 'string' &&
+        !resource.attributes[field].encrypt &&
+        !resource.attributes[field].protect
+    )
+    const where =
+      searchValue && searchFields.length > 0
+        ? {
+            or: searchFields.map((field) => ({
+              [field]: { contains: searchValue }
+            }))
+          }
+        : {}
+
+    return {
+      page: safePage,
+      perPage: safePerPage,
+      search: searchValue,
+      sort: `${sortField} ${sortDirection}`,
+      select: selectable,
+      where,
+      criteria: {
+        where,
+        skip: (safePage - 1) * safePerPage,
+        limit: safePerPage,
+        sort: `${sortField} ${sortDirection}`,
+        select: selectable
+      }
+    }
+  }
+}

--- a/assets/js/components/content/MarkdownEditor.vue
+++ b/assets/js/components/content/MarkdownEditor.vue
@@ -26,6 +26,39 @@ const props = defineProps({
   uploadUrl: {
     type: String,
     default: ''
+  },
+  variant: {
+    type: String,
+    default: 'document',
+    validator: (value) => ['document', 'field'].includes(value)
+  },
+  editorId: {
+    type: String,
+    default: 'content'
+  },
+  placeholder: {
+    type: String,
+    default: 'Start writing…'
+  },
+  ariaLabel: {
+    type: String,
+    default: 'Document body'
+  },
+  ariaLabelledby: {
+    type: String,
+    default: ''
+  },
+  ariaDescribedby: {
+    type: String,
+    default: ''
+  },
+  required: {
+    type: Boolean,
+    default: false
+  },
+  denyRawHtml: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -52,8 +85,35 @@ const uploadMessage = ref('')
 const uploadKind = ref('status')
 let uploadMessageTimeout
 
-const sourcePlaceholder =
-  'Write Markdown here. Visual mode becomes available when every construct can be preserved safely.'
+const isField = computed(() => props.variant === 'field')
+const sourcePlaceholder = computed(() =>
+  isField.value
+    ? 'Write Markdown…'
+    : 'Write Markdown here. Visual mode becomes available when every construct can be preserved safely.'
+)
+const compatibilityTitle = computed(() =>
+  isField.value
+    ? 'This value is safest in Markdown'
+    : 'This document is safest in Markdown'
+)
+const shouldShowCompatibilityWarning = computed(
+  () =>
+    compatibility.value.message &&
+    !(
+      props.denyRawHtml &&
+      compatibility.value.issues.some(({ code }) =>
+        ['html-comments', 'raw-html', 'mdx'].includes(code)
+      )
+    )
+)
+
+function elementId(suffix) {
+  return `${props.editorId}-${suffix}`
+}
+
+function testHandle(suffix) {
+  return `${props.editorId}-${suffix}`
+}
 
 const editor = useEditor({
   content: '',
@@ -84,7 +144,7 @@ const editor = useEditor({
       }
     }),
     Placeholder.configure({
-      placeholder: 'Start writing…'
+      placeholder: props.placeholder
     }),
     FileHandler.configure({
       allowedMimeTypes: [
@@ -110,8 +170,11 @@ const editor = useEditor({
   ],
   editorProps: {
     attributes: {
-      'aria-label': 'Document body',
-      'data-test': 'content-visual-editor',
+      'aria-label': props.ariaLabelledby ? undefined : props.ariaLabel,
+      'aria-labelledby': props.ariaLabelledby || undefined,
+      'aria-describedby': props.ariaDescribedby || undefined,
+      'aria-required': props.required ? 'true' : undefined,
+      'data-test': testHandle('visual-editor'),
       spellcheck: 'true'
     },
     transformPastedHTML: (html) =>
@@ -312,7 +375,7 @@ function openLinkEditor() {
   linkUrl.value = editor.value?.getAttributes('link').href || ''
   linkEditorOpen.value = true
   void nextTick(() => {
-    document.querySelector('[data-test="content-link-input"]')?.focus()
+    document.querySelector(`[data-test="${testHandle('link-input')}"]`)?.focus()
   })
 }
 
@@ -444,14 +507,22 @@ defineExpose({
 
 <template>
   <section
-    class="relative flex min-h-full flex-col"
-    aria-label="Content editor"
+    :class="[
+      'relative flex flex-col',
+      isField ? 'markdown-editor--field' : 'min-h-full'
+    ]"
+    :aria-label="isField ? undefined : 'Content editor'"
   >
     <div
-      v-if="mode === 'source' && compatibility.message"
-      data-test="content-source-warning"
+      v-if="mode === 'source' && shouldShowCompatibilityWarning"
+      :data-test="testHandle('source-warning')"
       role="note"
-      class="mx-auto mt-6 flex w-full max-w-3xl gap-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-950 dark:border-amber-900/70 dark:bg-amber-950/40 dark:text-amber-100"
+      :class="[
+        'flex w-full gap-3 rounded-lg text-sm text-amber-950 dark:text-amber-100',
+        isField
+          ? 'mb-3 bg-amber-50 px-3 py-2 dark:bg-amber-950/40'
+          : 'mx-auto mt-6 max-w-3xl border border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/70 dark:bg-amber-950/40'
+      ]"
     >
       <svg
         class="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
@@ -468,7 +539,7 @@ defineExpose({
         />
       </svg>
       <div>
-        <p class="font-medium">This document is safest in Markdown</p>
+        <p class="font-medium">{{ compatibilityTitle }}</p>
         <p class="mt-0.5 leading-5 text-amber-800 dark:text-amber-200">
           {{ compatibility.message }}
         </p>
@@ -480,27 +551,46 @@ defineExpose({
 
     <div
       v-show="mode === 'visual'"
-      class="mx-auto flex w-full max-w-3xl flex-1 px-5 pb-28 pt-10 sm:px-8 sm:pt-14"
+      :class="[
+        'flex w-full flex-1',
+        isField
+          ? 'focus-within:border-brand border-b border-dashed border-gray-200 px-1 py-2 dark:border-gray-700'
+          : 'mx-auto max-w-3xl px-5 pb-28 pt-10 sm:px-8 sm:pt-14'
+      ]"
     >
       <EditorContent
         :editor="editor"
-        class="content-editor-canvas min-h-[34rem] w-full"
+        :class="[
+          'content-editor-canvas w-full',
+          isField ? 'min-h-40' : 'min-h-[34rem]'
+        ]"
       />
     </div>
 
     <div
       v-if="mode === 'source'"
-      class="mx-auto flex w-full max-w-4xl flex-1 px-4 pb-24 pt-6 sm:px-8"
+      :class="[
+        'flex w-full flex-1',
+        isField
+          ? 'focus-within:border-brand border-b border-dashed border-gray-200 px-1 py-2 dark:border-gray-700'
+          : 'mx-auto max-w-4xl px-4 pb-24 pt-6 sm:px-8'
+      ]"
     >
-      <label class="sr-only" for="content-markdown-source"
-        >Markdown source</label
+      <label class="sr-only" :for="elementId('markdown-source')"
+        >{{ ariaLabel }} Markdown source</label
       >
       <textarea
-        id="content-markdown-source"
+        :id="elementId('markdown-source')"
         :value="sourceValue"
-        data-test="content-markdown-source"
-        class="min-h-[34rem] w-full resize-none bg-transparent px-1 py-4 font-mono text-[15px] leading-7 text-gray-800 outline-none placeholder:text-gray-400 focus-visible:ring-0 dark:text-gray-200 dark:placeholder:text-gray-600"
+        :data-test="testHandle('markdown-source')"
+        :class="[
+          'w-full resize-none bg-transparent px-1 font-mono text-[15px] leading-7 text-gray-800 outline-none placeholder:text-gray-400 focus-visible:ring-0 dark:text-gray-200 dark:placeholder:text-gray-600',
+          isField ? 'min-h-40 py-2' : 'min-h-[34rem] py-4'
+        ]"
         :placeholder="sourcePlaceholder"
+        :required="required"
+        :aria-labelledby="ariaLabelledby || undefined"
+        :aria-describedby="ariaDescribedby || undefined"
         spellcheck="false"
         @input="updateSource"
       ></textarea>
@@ -511,10 +601,10 @@ defineExpose({
       :editor="editor"
       :should-show="shouldShowTextMenu"
       :options="{ placement: 'top', offset: 10 }"
-      plugin-key="content-text-menu"
+      :plugin-key="elementId('text-menu')"
     >
       <div
-        data-test="content-format-menu"
+        :data-test="testHandle('format-menu')"
         class="flex items-center gap-0.5 rounded-lg bg-gray-900 p-1 text-white shadow-xl ring-1 ring-black/10 dark:bg-white dark:text-gray-900 dark:ring-white/10"
         role="toolbar"
         aria-label="Text formatting"
@@ -615,18 +705,18 @@ defineExpose({
           class="flex items-center gap-1"
           @submit.prevent="applyLink"
         >
-          <label class="sr-only" for="content-link-url">Link URL</label>
+          <label class="sr-only" :for="elementId('link-url')">Link URL</label>
           <input
-            id="content-link-url"
+            :id="elementId('link-url')"
             v-model="linkUrl"
-            data-test="content-link-input"
+            :data-test="testHandle('link-input')"
             type="text"
             inputmode="url"
             autocomplete="off"
             placeholder="https://"
             class="h-8 w-48 rounded-md border-0 bg-white/10 px-2 text-sm text-white outline-none placeholder:text-gray-400 focus:ring-1 focus:ring-white/50 dark:bg-gray-900/5 dark:text-gray-900 dark:placeholder:text-gray-500 dark:focus:ring-gray-900/30"
             :aria-invalid="Boolean(linkError)"
-            :aria-describedby="linkError ? 'content-link-error' : undefined"
+            :aria-describedby="linkError ? elementId('link-error') : undefined"
           />
           <button
             type="submit"
@@ -644,7 +734,7 @@ defineExpose({
           </button>
           <p
             v-if="linkError"
-            id="content-link-error"
+            :id="elementId('link-error')"
             class="sr-only"
             role="alert"
           >
@@ -659,16 +749,18 @@ defineExpose({
       :editor="editor"
       :should-show="shouldShowImageMenu"
       :options="{ placement: 'top', offset: 10 }"
-      plugin-key="content-image-menu"
+      :plugin-key="elementId('image-menu')"
     >
       <form
-        data-test="content-image-menu"
+        :data-test="testHandle('image-menu')"
         class="flex items-center gap-1 rounded-lg bg-gray-900 p-1 text-white shadow-xl ring-1 ring-black/10 dark:bg-white dark:text-gray-900 dark:ring-white/10"
         @submit.prevent="updateImageAlt"
       >
-        <label class="sr-only" for="content-image-alt">Image alt text</label>
+        <label class="sr-only" :for="elementId('image-alt')"
+          >Image alt text</label
+        >
         <input
-          id="content-image-alt"
+          :id="elementId('image-alt')"
           v-model="imageAlt"
           type="text"
           placeholder="Describe this image"
@@ -838,7 +930,48 @@ defineExpose({
   float: left;
   height: 0;
   color: var(--color-gray-400);
-  content: 'Start writing…';
+  content: attr(data-placeholder);
+}
+
+.markdown-editor--field :deep(.tiptap) {
+  min-height: 10rem;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+}
+
+.markdown-editor--field :deep(.tiptap p) {
+  margin: 0.65em 0;
+}
+
+.markdown-editor--field :deep(.tiptap h1) {
+  margin: 0.7em 0 0.4em;
+  font-size: 1.5rem;
+}
+
+.markdown-editor--field :deep(.tiptap h2) {
+  margin: 1.1em 0 0.45em;
+  font-size: 1.25rem;
+}
+
+.markdown-editor--field :deep(.tiptap h3) {
+  margin: 1em 0 0.4em;
+  font-size: 1.125rem;
+}
+
+.markdown-editor--field :deep(.tiptap h4) {
+  margin: 0.9em 0 0.35em;
+  font-size: 1rem;
+}
+
+.markdown-editor--field :deep(.tiptap ul),
+.markdown-editor--field :deep(.tiptap ol),
+.markdown-editor--field :deep(.tiptap blockquote),
+.markdown-editor--field :deep(.tiptap pre) {
+  margin: 0.9em 0;
+}
+
+.markdown-editor--field :deep(.tiptap hr) {
+  margin: 1.5rem auto;
 }
 
 @media (prefers-color-scheme: dark) {

--- a/assets/js/lib/content/markdown.mjs
+++ b/assets/js/lib/content/markdown.mjs
@@ -7,7 +7,8 @@ const UNSUPPORTED_MARKDOWN = [
   {
     code: 'raw-html',
     label: 'embedded HTML',
-    pattern: /(^|\n)\s*<\/?[a-z][^>\n]*>/i
+    pattern:
+      /<\/?[a-z][a-z\d-]*(?:\s[^<>]*?)?\s*\/?>|<![A-Z][^>]*>|<\?[\s\S]*?\?>/i
   },
   {
     code: 'footnotes',
@@ -46,6 +47,10 @@ const UNSUPPORTED_MARKDOWN = [
 const BLOCKED_PROTOCOL = /^[a-z][a-z\d+.-]*:/i
 const SAFE_LINK_PROTOCOLS = new Set(['http:', 'https:', 'mailto:', 'tel:'])
 const SAFE_IMAGE_PROTOCOLS = new Set(['http:', 'https:'])
+const MARKDOWN_AUTOLINK =
+  /<[a-z][a-z\d+.-]{1,31}:[^<>\s]*>|<[a-z\d.!#$%&'*+/=?^_`{|}~-]+@[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?)+>/gi
+const RAW_HTML =
+  /<!--[\s\S]*?-->|<\/?[a-z][^<>]*>|<![A-Z][^>]*>|<\?[\s\S]*?\?>/i
 
 export function inspectMarkdown(markdown = '') {
   const issues = UNSUPPORTED_MARKDOWN.filter(({ pattern }) =>
@@ -56,6 +61,10 @@ export function inspectMarkdown(markdown = '') {
     supported: issues.length === 0,
     issues
   }
+}
+
+export function containsRawHtml(markdown = '') {
+  return RAW_HTML.test(String(markdown).replace(MARKDOWN_AUTOLINK, ''))
 }
 
 export function normalizeMarkdownBoundary(markdown = '') {

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -5,6 +5,8 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
+import { containsRawHtml } from '@/lib/content/markdown.mjs'
 
 defineOptions({
   layout: AppLayout
@@ -30,25 +32,39 @@ const { toasts, toast, dismiss } = createToast()
 
 const isEdit = computed(() => props.mode === 'edit')
 
+function encodePathSegment(value) {
+  return encodeURIComponent(String(value))
+}
+
+function displayIdentifier(value) {
+  const identifier = String(value ?? '')
+  if (identifier.length <= 24) return identifier
+  return `${identifier.slice(0, 10)}…${identifier.slice(-6)}`
+}
+
 // Form state
 const formValues = ref({})
 const formErrors = ref({})
 const form = useForm({ values: {} })
+const richTextEditors = ref({})
+const richTextModes = ref({})
+const richTextCompatibility = ref({})
 
 // Initialize form values from props
 onMounted(() => {
   if (!props.modelMeta) return
 
   const values = {}
-  for (const [name, attr] of Object.entries(props.modelMeta.attributes)) {
-    if (attr.autoIncrement) continue
-    if (attr.type === 'boolean') values[name] = attr.defaultsTo ?? false
+  const surface = isEdit.value ? props.modelMeta.edit : props.modelMeta.create
+  for (const name of surface || []) {
+    const attr = props.modelMeta.attributes[name]
+    if (!attr) continue
+    const defaultValue = attr.field?.default ?? attr.defaultsTo
+    if (attr.type === 'boolean') values[name] = defaultValue ?? false
     else if (attr.type === 'json')
       values[name] =
-        attr.defaultsTo !== undefined
-          ? JSON.stringify(attr.defaultsTo, null, 2)
-          : ''
-    else values[name] = attr.defaultsTo ?? ''
+        defaultValue !== undefined ? JSON.stringify(defaultValue, null, 2) : ''
+    else values[name] = defaultValue ?? ''
   }
 
   // Load record values in edit mode
@@ -73,34 +89,67 @@ onMounted(() => {
 // Editable fields
 const editableFields = computed(() => {
   if (!props.modelMeta) return []
-  const fields = []
+  const surface = isEdit.value ? props.modelMeta.edit : props.modelMeta.create
 
-  for (const [name, attr] of Object.entries(props.modelMeta.attributes)) {
-    // Skip auto-generated fields
-    if (attr.autoIncrement) continue
-    if (name === 'id') continue // Primary key
-    if (!isEdit.value && (attr.autoCreatedAt || attr.autoUpdatedAt)) continue
+  return (surface || [])
+    .map((name) => {
+      const attribute = props.modelMeta.attributes[name]
+      if (!attribute) return null
+      const association = (props.modelMeta.associations || []).find(
+        (candidate) => candidate.type === 'model' && candidate.alias === name
+      )
 
-    fields.push({
-      name,
-      attr,
-      readOnly: attr.autoCreatedAt || attr.autoUpdatedAt
+      return {
+        name,
+        attr: association
+          ? {
+              ...attribute,
+              isBelongsTo: true,
+              relatedModel: association.model
+            }
+          : attribute,
+        readOnly:
+          attribute.field?.readOnly === true ||
+          attribute.autoCreatedAt ||
+          attribute.autoUpdatedAt
+      }
     })
-  }
-
-  // Add model associations (belongsTo)
-  for (const assoc of props.modelMeta.associations || []) {
-    if (assoc.type !== 'model') continue
-    const attr = props.modelMeta.attributes[assoc.alias]
-    fields.push({
-      name: assoc.alias,
-      attr: { ...attr, isBelongsTo: true, relatedModel: assoc.model },
-      readOnly: false
-    })
-  }
-
-  return fields
+    .filter(Boolean)
 })
+
+function hasRequiredValue(field) {
+  if (field.readOnly || !field.attr.required) return true
+
+  const value = formValues.value[field.name]
+  if (isEdit.value && field.attr.encrypt && value === '') return true
+  if (inputType(field) === 'toggle') return typeof value === 'boolean'
+  if (inputType(field) === 'number') {
+    return (
+      value !== '' &&
+      value !== null &&
+      value !== undefined &&
+      Number.isFinite(Number(value))
+    )
+  }
+  if (inputType(field) === 'json') {
+    if (typeof value !== 'string' || value.trim() === '') return false
+    try {
+      JSON.parse(value)
+      return true
+    } catch {
+      return false
+    }
+  }
+  if (typeof value === 'string') return value.trim().length > 0
+  return value !== null && value !== undefined
+}
+
+const isFormReady = computed(
+  () =>
+    editableFields.value.every(hasRequiredValue) &&
+    editableFields.value.every((field) => !richTextSecurityError(field)) &&
+    Object.keys(formErrors.value).length === 0
+)
 
 // Rich text field names (detect by name pattern)
 const richTextPatterns = [
@@ -121,6 +170,20 @@ function inputType(field) {
   const name = field.name.toLowerCase()
 
   if (attr.isBelongsTo) return 'belongsTo'
+  if (
+    [
+      'text',
+      'email',
+      'password',
+      'number',
+      'select',
+      'toggle',
+      'json',
+      'richtext'
+    ].includes(attr.field?.type)
+  ) {
+    return attr.field.type
+  }
   if (attr.encrypt) return 'password'
   if (attr.isEmail) return 'email'
   if (attr.isIn && attr.isIn.length > 0) return 'select'
@@ -137,21 +200,87 @@ function inputType(field) {
   return 'text'
 }
 
+function isMarkdownRichText(field) {
+  return (
+    inputType(field) === 'richtext' &&
+    field.attr.field?.format?.toLowerCase() === 'markdown'
+  )
+}
+
+function richTextEditorId(field) {
+  return `bridge-${props.modelIdentity}-${field.name}`.replace(
+    /[^a-zA-Z0-9_-]/g,
+    '-'
+  )
+}
+
+function richTextLabelId(field) {
+  return `${richTextEditorId(field)}-label`
+}
+
+function richTextHelpId(field) {
+  return fieldDescription(field) ? `${richTextEditorId(field)}-help` : undefined
+}
+
+function richTextErrorId(field) {
+  return `${richTextEditorId(field)}-error`
+}
+
+function richTextDescribedBy(field) {
+  return (
+    [
+      richTextHelpId(field),
+      richTextSecurityError(field) && richTextErrorId(field)
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined
+  )
+}
+
+function richTextSecurityError(field) {
+  if (!isMarkdownRichText(field)) return ''
+  if (!containsRawHtml(formValues.value[field.name] || '')) return ''
+  return 'Raw HTML is not allowed in Bridge Markdown fields.'
+}
+
+function registerRichTextEditor(field, editor) {
+  if (editor) richTextEditors.value[field.name] = editor
+  else delete richTextEditors.value[field.name]
+}
+
+function updateRichTextMode(field, mode) {
+  richTextModes.value[field.name] = mode
+}
+
+function updateRichTextCompatibility(field, compatibility) {
+  richTextCompatibility.value[field.name] = compatibility
+}
+
+function toggleRichTextMode(field) {
+  const nextMode =
+    richTextModes.value[field.name] === 'source' ? 'visual' : 'source'
+  richTextEditors.value[field.name]?.setMode(nextMode)
+}
+
+function canUseRichTextVisual(field) {
+  return richTextCompatibility.value[field.name]?.supported !== false
+}
+
 // Get field description based on type/validations
 function fieldDescription(field) {
-  const attr = field.attr
-  const parts = []
+  return field.attr.field?.help || ''
+}
 
-  if (attr.type) parts.push(attr.type)
-  if (attr.columnType && attr.columnType !== attr.type)
-    parts.push(attr.columnType)
-  if (attr.encrypt) parts.push('encrypted')
-  if (attr.unique) parts.push('unique')
-  if (attr.maxLength) parts.push(`max ${attr.maxLength} chars`)
-  if (attr.isBelongsTo) parts.push(`belongs to ${attr.relatedModel}`)
-  if (attr.isIn) parts.push(`options: ${attr.isIn.join(', ')}`)
+function fieldLabel(field) {
+  return field.attr.label || field.name
+}
 
-  return parts.join(' \u00b7 ')
+function fieldPlaceholder(field, fallback = '') {
+  return field.attr.field?.placeholder || fallback
+}
+
+function selectOptions(field) {
+  return field.attr.field?.options || field.attr.isIn || []
 }
 
 // JSON validation
@@ -170,6 +299,11 @@ function validateJson(name) {
 }
 
 function handleSubmit() {
+  if (!isFormReady.value) {
+    toast({ message: 'Complete the required fields first.', type: 'error' })
+    return
+  }
+
   if (Object.keys(formErrors.value).length > 0) {
     toast({ message: 'Please fix validation errors.', type: 'error' })
     return
@@ -205,7 +339,11 @@ function handleSubmit() {
 
   form.values = values
   const actionUrl = isEdit.value
-    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${props.recordId}/update`
+    ? `/projects/${props.project.slug}/environments/${
+        props.environment.slug
+      }/bridge/${props.modelIdentity}/${encodePathSegment(
+        props.recordId
+      )}/update`
     : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/create`
 
   form.post(actionUrl, {
@@ -228,13 +366,17 @@ function modelUrl() {
   return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}`
 }
 function recordUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${props.recordId}`
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/${encodePathSegment(props.recordId)}`
 }
 </script>
 
 <template>
   <Head
-    :title="`${isEdit ? 'Edit' : 'Create'} ${modelIdentity} - Bridge | Slipway`"
+    :title="`${isEdit ? 'Edit' : 'Create'} ${
+      modelMeta?.singularLabel || modelIdentity
+    } - Bridge | Slipway`"
   ></Head>
   <ToastContainer :toasts="toasts" @dismiss="dismiss" />
 
@@ -333,7 +475,7 @@ function recordUrl() {
         </button>
         <nav class="flex items-center space-x-2 text-sm sm:hidden">
           <Link :href="modelUrl()" class="text-gray-500 dark:text-gray-400">{{
-            modelIdentity
+            modelMeta?.label || modelIdentity
           }}</Link>
           <span class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white">{{
@@ -363,11 +505,11 @@ function recordUrl() {
           <Link
             :href="modelUrl()"
             class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >{{ modelIdentity }}</Link
+            >{{ modelMeta?.label || modelIdentity }}</Link
           >
           <span class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white">{{
-            isEdit ? `#${recordId}` : 'new'
+            isEdit ? displayIdentifier(recordId) : 'new'
           }}</span>
         </nav>
       </div>
@@ -400,31 +542,29 @@ function recordUrl() {
       </div>
 
       <!-- Form -->
-      <div v-else-if="modelMeta" class="mx-auto max-w-2xl">
+      <div v-else-if="modelMeta" class="mx-auto max-w-xl">
         <!-- Description -->
         <div class="mb-6">
           <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
             {{ isEdit ? 'Edit' : 'Create' }}
-            {{ modelMeta.globalId || modelIdentity }}
+            {{ modelMeta.singularLabel || modelIdentity }}
           </h1>
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
             {{
               isEdit
-                ? `Editing record #${recordId}`
-                : `Add a new record to ${modelMeta.tableName || modelIdentity}`
+                ? `Update this ${(
+                    modelMeta.singularLabel || modelIdentity
+                  ).toLowerCase()}`
+                : `Add a new ${(
+                    modelMeta.singularLabel || modelIdentity
+                  ).toLowerCase()}`
             }}
           </p>
         </div>
 
-        <form @submit.prevent="handleSubmit">
-          <div class="rounded-lg border border-gray-200 dark:border-gray-800">
-            <div
-              v-for="(field, index) in editableFields"
-              :key="field.name"
-              :class="
-                index > 0 ? 'border-t border-gray-200 dark:border-gray-800' : ''
-              "
-            >
+        <form @submit.prevent="handleSubmit" class="space-y-7">
+          <div class="space-y-7">
+            <div v-for="field in editableFields" :key="field.name">
               <!-- Simple fields (text, email, password, number, select) -->
               <div
                 v-if="
@@ -437,13 +577,13 @@ function recordUrl() {
                     'belongsTo'
                   ].includes(inputType(field))
                 "
-                class="flex items-center gap-4 px-4 py-3"
+                class="space-y-2"
               >
                 <label
                   :for="field.name"
-                  class="w-40 shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300"
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
-                  {{ field.name }}
+                  {{ fieldLabel(field) }}
                   <span v-if="field.attr.required" class="text-red-500">*</span>
                 </label>
                 <div class="flex-1">
@@ -457,11 +597,14 @@ function recordUrl() {
                     :required="field.attr.required"
                     :maxlength="field.attr.maxLength || undefined"
                     :placeholder="
-                      field.attr.defaultsTo !== undefined
-                        ? String(field.attr.defaultsTo)
-                        : ''
+                      fieldPlaceholder(
+                        field,
+                        field.attr.defaultsTo !== undefined
+                          ? String(field.attr.defaultsTo)
+                          : ''
+                      )
                     "
-                    class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   />
                   <!-- Email -->
                   <input
@@ -471,8 +614,8 @@ function recordUrl() {
                     type="email"
                     :disabled="field.readOnly"
                     :required="field.attr.required"
-                    placeholder="email@example.com"
-                    class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                    :placeholder="fieldPlaceholder(field, 'email@example.com')"
+                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   />
                   <!-- Password -->
                   <input
@@ -481,8 +624,13 @@ function recordUrl() {
                     v-model="formValues[field.name]"
                     type="password"
                     :disabled="field.readOnly"
-                    :placeholder="isEdit ? 'Leave blank to keep current' : ''"
-                    class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                    :placeholder="
+                      fieldPlaceholder(
+                        field,
+                        isEdit ? 'Leave blank to keep current' : ''
+                      )
+                    "
+                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   />
                   <!-- Number -->
                   <input
@@ -492,8 +640,8 @@ function recordUrl() {
                     type="number"
                     :disabled="field.readOnly"
                     :required="field.attr.required"
-                    placeholder="0"
-                    class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                    :placeholder="fieldPlaceholder(field, '0')"
+                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   />
                   <!-- Select (isIn) -->
                   <select
@@ -502,11 +650,11 @@ function recordUrl() {
                     v-model="formValues[field.name]"
                     :disabled="field.readOnly"
                     :required="field.attr.required"
-                    class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white"
+                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white"
                   >
                     <option value="">Select...</option>
                     <option
-                      v-for="opt in field.attr.isIn"
+                      v-for="opt in selectOptions(field)"
                       :key="opt"
                       :value="opt"
                     >
@@ -519,7 +667,7 @@ function recordUrl() {
                     :id="field.name"
                     v-model="formValues[field.name]"
                     :disabled="field.readOnly"
-                    class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white"
+                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white"
                   >
                     <option value="">None</option>
                     <option
@@ -530,23 +678,29 @@ function recordUrl() {
                       {{ opt.label }}
                     </option>
                   </select>
+                  <p
+                    v-if="fieldDescription(field)"
+                    class="mt-1.5 text-xs text-gray-400 dark:text-gray-500"
+                  >
+                    {{ fieldDescription(field) }}
+                  </p>
                 </div>
               </div>
 
               <!-- Toggle (boolean) -->
-              <div
-                v-else-if="inputType(field) === 'toggle'"
-                class="flex items-center gap-4 px-4 py-3"
-              >
+              <div v-else-if="inputType(field) === 'toggle'" class="space-y-3">
                 <label
                   :for="field.name"
-                  class="w-40 shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300"
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
-                  {{ field.name }}
+                  {{ fieldLabel(field) }}
                 </label>
                 <div class="flex items-center gap-3">
                   <button
+                    :id="field.name"
                     type="button"
+                    role="switch"
+                    :aria-checked="Boolean(formValues[field.name])"
                     :disabled="field.readOnly"
                     @click="formValues[field.name] = !formValues[field.name]"
                     :class="[
@@ -572,16 +726,85 @@ function recordUrl() {
                 </div>
               </div>
 
-              <!-- Rich text / Long text -->
+              <!-- Markdown-backed rich text -->
+              <div v-else-if="isMarkdownRichText(field)" class="space-y-2">
+                <div class="flex items-center justify-between gap-3">
+                  <span
+                    :id="richTextLabelId(field)"
+                    class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >
+                    {{ fieldLabel(field) }}
+                    <span v-if="field.attr.required" class="text-red-500"
+                      >*</span
+                    >
+                  </span>
+                  <button
+                    type="button"
+                    :data-test="`${richTextEditorId(field)}-mode-toggle`"
+                    :aria-label="`Edit ${fieldLabel(field)} as ${
+                      richTextModes[field.name] === 'source'
+                        ? 'Visual'
+                        : 'Markdown'
+                    }`"
+                    :disabled="
+                      richTextModes[field.name] === 'source' &&
+                      !canUseRichTextVisual(field)
+                    "
+                    class="text-xs font-medium text-gray-400 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-500 dark:hover:text-white"
+                    @click="toggleRichTextMode(field)"
+                  >
+                    {{
+                      richTextModes[field.name] === 'source'
+                        ? 'Visual'
+                        : 'Markdown'
+                    }}
+                  </button>
+                </div>
+                <MarkdownEditor
+                  :ref="(editor) => registerRichTextEditor(field, editor)"
+                  v-model="formValues[field.name]"
+                  variant="field"
+                  :editor-id="richTextEditorId(field)"
+                  :placeholder="
+                    fieldPlaceholder(field, 'Write your content here...')
+                  "
+                  :aria-label="fieldLabel(field)"
+                  :aria-labelledby="richTextLabelId(field)"
+                  :aria-describedby="richTextDescribedBy(field)"
+                  :required="field.attr.required"
+                  deny-raw-html
+                  @mode-change="updateRichTextMode(field, $event)"
+                  @compatibility-change="
+                    updateRichTextCompatibility(field, $event)
+                  "
+                />
+                <p
+                  v-if="richTextSecurityError(field)"
+                  :id="richTextErrorId(field)"
+                  class="text-xs text-red-600 dark:text-red-400"
+                  role="alert"
+                >
+                  {{ richTextSecurityError(field) }}
+                </p>
+                <p
+                  v-if="fieldDescription(field)"
+                  :id="richTextHelpId(field)"
+                  class="mt-1.5 text-xs text-gray-400 dark:text-gray-500"
+                >
+                  {{ fieldDescription(field) }}
+                </p>
+              </div>
+
+              <!-- Long text -->
               <div
                 v-else-if="inputType(field) === 'richtext'"
-                class="px-4 py-3"
+                class="space-y-2"
               >
                 <label
                   :for="field.name"
                   class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
-                  {{ field.name }}
+                  {{ fieldLabel(field) }}
                   <span v-if="field.attr.required" class="text-red-500">*</span>
                 </label>
                 <textarea
@@ -589,19 +812,27 @@ function recordUrl() {
                   v-model="formValues[field.name]"
                   :disabled="field.readOnly"
                   :required="field.attr.required"
-                  placeholder="Write your content here..."
-                  class="focus:border-brand w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                  :placeholder="
+                    fieldPlaceholder(field, 'Write your content here...')
+                  "
+                  class="focus:border-brand min-h-28 w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   style="field-sizing: content"
                 ></textarea>
+                <p
+                  v-if="fieldDescription(field)"
+                  class="mt-1.5 text-xs text-gray-400 dark:text-gray-500"
+                >
+                  {{ fieldDescription(field) }}
+                </p>
               </div>
 
               <!-- JSON -->
-              <div v-else-if="inputType(field) === 'json'" class="px-4 py-3">
+              <div v-else-if="inputType(field) === 'json'" class="space-y-2">
                 <label
                   :for="field.name"
                   class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
                 >
-                  {{ field.name }}
+                  {{ fieldLabel(field) }}
                   <span class="ml-1 text-xs font-normal text-gray-400"
                     >JSON</span
                   >
@@ -611,8 +842,8 @@ function recordUrl() {
                   v-model="formValues[field.name]"
                   :disabled="field.readOnly"
                   @blur="validateJson(field.name)"
-                  placeholder="{}"
-                  class="focus:border-brand w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                  :placeholder="fieldPlaceholder(field, '{}')"
+                  class="focus:border-brand min-h-28 w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-2 font-mono text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   style="field-sizing: content"
                 ></textarea>
                 <p
@@ -624,25 +855,26 @@ function recordUrl() {
               </div>
 
               <!-- Fallback -->
-              <div v-else class="flex items-center gap-4 px-4 py-3">
+              <div v-else class="space-y-2">
                 <label
                   :for="field.name"
-                  class="w-40 shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300"
-                  >{{ field.name }}</label
+                  class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >{{ fieldLabel(field) }}</label
                 >
                 <input
                   :id="field.name"
                   v-model="formValues[field.name]"
                   type="text"
                   :disabled="field.readOnly"
-                  class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                  :placeholder="fieldPlaceholder(field)"
+                  class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                 />
               </div>
             </div>
           </div>
 
           <!-- Actions -->
-          <div class="mt-6 flex items-center justify-end gap-3">
+          <div class="flex items-center justify-end gap-3 pt-1">
             <Link
               :href="isEdit ? recordUrl() : modelUrl()"
               class="rounded-md px-4 py-2 text-sm font-medium text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
@@ -651,8 +883,15 @@ function recordUrl() {
             </Link>
             <button
               type="submit"
-              :disabled="form.processing"
-              class="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+              :disabled="form.processing || !isFormReady"
+              :title="
+                !isFormReady
+                  ? isEdit
+                    ? 'Complete the required fields to save this record'
+                    : 'Complete the required fields to create this record'
+                  : undefined
+              "
+              class="inline-flex items-center rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               <SlippyLoader
                 v-if="form.processing"

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -39,12 +39,85 @@ const selectedIds = ref(new Set())
 const selectAll = ref(false)
 const deleteModal = ref({ show: false, recordId: null })
 const bulkDeleteModal = ref({ show: false })
+const openActionMenu = ref(null)
+
+const hasRecordActions = computed(() => {
+  const actions = props.modelMeta?.actions || {}
+  return (
+    actions.view !== false ||
+    actions.update !== false ||
+    actions.delete !== false
+  )
+})
+
+function encodePathSegment(value) {
+  return encodeURIComponent(String(value))
+}
+
+function recordKey(record) {
+  return String(record[props.modelMeta.primaryKey])
+}
+
+function displayIdentifier(value) {
+  const identifier = String(value ?? '')
+  if (identifier.length <= 24) return identifier
+  return `${identifier.slice(0, 10)}…${identifier.slice(-6)}`
+}
+
+function actionLabel(record) {
+  const titleField = props.modelMeta?.title
+  const title = titleField ? record[titleField] : null
+  return String(title || displayIdentifier(record[props.modelMeta.primaryKey]))
+}
+
+function toggleActionMenu(record) {
+  const key = recordKey(record)
+  openActionMenu.value = openActionMenu.value === key ? null : key
+}
+
+function closeActionMenu() {
+  openActionMenu.value = null
+}
+
+function handleActionMenuKeydown(event) {
+  const items = Array.from(
+    event.currentTarget.querySelectorAll('[role="menuitem"]')
+  )
+  const currentIndex = items.indexOf(document.activeElement)
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    closeActionMenu()
+    event.currentTarget.previousElementSibling?.focus()
+    return
+  }
+
+  let nextIndex
+  if (event.key === 'ArrowDown') {
+    nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+  } else if (event.key === 'ArrowUp') {
+    nextIndex =
+      currentIndex < 0
+        ? items.length - 1
+        : (currentIndex - 1 + items.length) % items.length
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = items.length - 1
+  } else {
+    return
+  }
+
+  event.preventDefault()
+  items[nextIndex]?.focus()
+}
 
 // Forms for delete actions
 const deleteForm = useForm({})
 const bulkDeleteForm = useForm({ ids: [] })
 
 function openDeleteModal(record) {
+  closeActionMenu()
   deleteModal.value = {
     show: true,
     recordId: record[props.modelMeta.primaryKey],
@@ -71,7 +144,10 @@ function navigateWithParams(updates) {
 
   // Clean up defaults
   if (params.page === 1) delete params.page
-  if (params.sort === 'createdAt DESC') delete params.sort
+  const defaultSort = props.modelMeta
+    ? `${props.modelMeta.sort.field} ${props.modelMeta.sort.direction}`
+    : ''
+  if (params.sort === defaultSort) delete params.sort
   if (!params.search) delete params.search
 
   const query = new URLSearchParams(params).toString()
@@ -86,32 +162,7 @@ function navigateWithParams(updates) {
 // Visible columns
 const visibleColumns = computed(() => {
   if (!props.modelMeta) return []
-  const attrs = props.modelMeta.attributes
-  const pk = props.modelMeta.primaryKey
-  const cols = [pk]
-
-  const candidates = Object.entries(attrs).filter(([name, attr]) => {
-    if (name === pk) return false
-    if (attr.autoCreatedAt || attr.autoUpdatedAt || attr.autoIncrement)
-      return false
-    if (attr.encrypt) return false
-    return true
-  })
-
-  candidates.sort((a, b) => {
-    const order = { string: 0, number: 1, boolean: 2, json: 3, ref: 4 }
-    return (order[a[1].type] ?? 5) - (order[b[1].type] ?? 5)
-  })
-
-  for (const [name] of candidates.slice(0, 5)) {
-    cols.push(name)
-  }
-
-  if (attrs.createdAt && !cols.includes('createdAt')) {
-    cols.push('createdAt')
-  }
-
-  return cols
+  return props.modelMeta.list || []
 })
 
 // Sort handling
@@ -119,6 +170,7 @@ const sortAttr = computed(() => sortValue.value.split(' ')[0])
 const sortDir = computed(() => sortValue.value.split(' ')[1] || 'ASC')
 
 function toggleSort(attr) {
+  if (props.modelMeta?.attributes[attr]?.field?.sortable === false) return
   let newSort
   if (sortAttr.value === attr) {
     newSort = `${attr} ${sortDir.value === 'ASC' ? 'DESC' : 'ASC'}`
@@ -127,6 +179,10 @@ function toggleSort(attr) {
   }
   sortValue.value = newSort
   navigateWithParams({ sort: newSort, page: 1 })
+}
+
+function fieldLabel(name) {
+  return props.modelMeta?.attributes[name]?.label || name
 }
 
 // Selection
@@ -192,7 +248,11 @@ function isTimestamp(attrName) {
 // Delete single record
 function confirmDelete() {
   deleteForm.post(
-    `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${deleteModal.value.recordId}/delete`,
+    `/projects/${props.project.slug}/environments/${
+      props.environment.slug
+    }/bridge/${props.modelIdentity}/${encodePathSegment(
+      deleteModal.value.recordId
+    )}/delete`,
     {
       preserveScroll: true,
       onSuccess: () => {
@@ -248,10 +308,14 @@ function bridgeUrl() {
   return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
 }
 function recordUrl(id) {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${id}`
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/${encodePathSegment(id)}`
 }
 function editUrl(id) {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${id}/edit`
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/${encodePathSegment(id)}/edit`
 }
 function createUrl() {
   return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/new`
@@ -259,10 +323,16 @@ function createUrl() {
 </script>
 
 <template>
-  <Head :title="`${modelIdentity} - Bridge | Slipway`"></Head>
+  <Head
+    :title="`${modelMeta?.label || modelIdentity} - Bridge | Slipway`"
+  ></Head>
   <ToastContainer :toasts="toasts" @dismiss="dismiss" />
 
-  <div class="flex h-full flex-col">
+  <div
+    class="flex h-full flex-col"
+    @click="closeActionMenu"
+    @keydown.esc="closeActionMenu"
+  >
     <!-- Header -->
     <div
       class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6"
@@ -361,7 +431,7 @@ function createUrl() {
           >
           <span class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white">{{
-            modelIdentity
+            modelMeta?.label || modelIdentity
           }}</span>
         </nav>
         <nav class="hidden items-center space-x-2 text-sm sm:flex">
@@ -392,7 +462,7 @@ function createUrl() {
           >
           <span class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white">{{
-            modelIdentity
+            modelMeta?.label || modelIdentity
           }}</span>
         </nav>
       </div>
@@ -403,6 +473,7 @@ function createUrl() {
       <div class="mx-auto flex max-w-6xl items-center justify-between">
         <div class="flex items-center space-x-3">
           <input
+            v-if="(modelMeta?.search || []).length > 0"
             v-model="searchInput"
             type="text"
             placeholder="Search records..."
@@ -417,7 +488,9 @@ function createUrl() {
             leave-to-class="opacity-0"
           >
             <div
-              v-if="selectedIds.size > 0"
+              v-if="
+                selectedIds.size > 0 && modelMeta?.actions?.bulkDelete !== false
+              "
               class="flex items-center space-x-2"
             >
               <span class="text-xs text-gray-500 dark:text-gray-400"
@@ -452,6 +525,7 @@ function createUrl() {
             >{{ total.toLocaleString() }} records</span
           >
           <Link
+            v-if="modelMeta?.actions?.create !== false"
             :href="createUrl()"
             prefetch
             class="inline-flex items-center rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
@@ -495,14 +569,17 @@ function createUrl() {
         <!-- Table -->
         <div
           v-else-if="modelMeta"
-          class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+          class="rounded-lg border border-gray-200 dark:border-gray-800"
         >
           <table class="w-full text-left text-sm">
             <thead
               class="border-b border-gray-200 bg-gray-50/50 dark:border-gray-800 dark:bg-gray-900/50"
             >
               <tr>
-                <th class="w-10 px-4 py-2">
+                <th
+                  v-if="modelMeta?.actions?.bulkDelete !== false"
+                  class="w-10 px-4 py-2"
+                >
                   <input
                     type="checkbox"
                     :checked="selectAll"
@@ -514,10 +591,15 @@ function createUrl() {
                   v-for="col in visibleColumns"
                   :key="col"
                   @click="toggleSort(col)"
-                  class="cursor-pointer select-none whitespace-nowrap px-4 py-2 text-xs font-medium uppercase tracking-wider text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                  :class="[
+                    'select-none whitespace-nowrap px-4 py-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400',
+                    modelMeta.attributes[col]?.field?.sortable === false
+                      ? ''
+                      : 'cursor-pointer hover:text-gray-900 dark:hover:text-white'
+                  ]"
                 >
                   <span class="flex items-center space-x-1">
-                    <span>{{ col }}</span>
+                    <span>{{ fieldLabel(col) }}</span>
                     <svg
                       v-if="sortAttr === col"
                       class="h-3.5 w-3.5"
@@ -542,7 +624,9 @@ function createUrl() {
                     </svg>
                   </span>
                 </th>
-                <th class="w-20 px-4 py-2"></th>
+                <th v-if="hasRecordActions" class="w-12 px-4 py-2">
+                  <span class="sr-only">Actions</span>
+                </th>
               </tr>
             </thead>
             <tbody
@@ -551,7 +635,11 @@ function createUrl() {
             >
               <tr>
                 <td
-                  :colspan="visibleColumns.length + 2"
+                  :colspan="
+                    visibleColumns.length +
+                    (modelMeta?.actions?.bulkDelete !== false ? 1 : 0) +
+                    (hasRecordActions ? 1 : 0)
+                  "
                   class="px-4 py-12 text-center text-sm text-gray-500 dark:text-gray-400"
                 >
                   {{ search ? 'No matching records.' : 'No records yet.' }}
@@ -563,11 +651,14 @@ function createUrl() {
               class="divide-y divide-gray-200 bg-white dark:divide-gray-800 dark:bg-gray-950"
             >
               <tr
-                v-for="record in records"
+                v-for="(record, recordIndex) in records"
                 :key="record[modelMeta.primaryKey]"
-                class="hover:bg-gray-50 dark:hover:bg-gray-900/30"
+                class="group hover:bg-gray-50 dark:hover:bg-gray-900/30"
               >
-                <td class="px-4 py-2">
+                <td
+                  v-if="modelMeta?.actions?.bulkDelete !== false"
+                  class="px-4 py-2"
+                >
                   <input
                     type="checkbox"
                     :checked="selectedIds.has(record[modelMeta.primaryKey])"
@@ -605,83 +696,82 @@ function createUrl() {
                     null
                   </span>
                   <Link
-                    v-else-if="col === modelMeta.primaryKey"
+                    v-else-if="
+                      col === modelMeta.primaryKey &&
+                      modelMeta.actions?.view !== false
+                    "
                     :href="recordUrl(record[col])"
+                    :title="String(record[col])"
                     class="font-medium text-gray-900 hover:underline dark:text-white"
                   >
-                    {{ record[col] }}
+                    {{ displayIdentifier(record[col]) }}
                   </Link>
                   <span v-else class="text-gray-700 dark:text-gray-300">
                     {{ formatCell(record[col], col) }}
                   </span>
                 </td>
-                <td class="px-4 py-2">
-                  <div class="flex items-center justify-end space-x-1">
-                    <Link
-                      :href="recordUrl(record[modelMeta.primaryKey])"
-                      prefetch
-                      class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-white"
-                      title="View"
-                    >
-                      <svg
-                        class="h-4 w-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-                        />
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z"
-                        />
-                      </svg>
-                    </Link>
-                    <Link
-                      :href="editUrl(record[modelMeta.primaryKey])"
-                      prefetch
-                      class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-900 dark:hover:bg-gray-800 dark:hover:text-white"
-                      title="Edit"
-                    >
-                      <svg
-                        class="h-4 w-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-                        />
-                      </svg>
-                    </Link>
+                <td v-if="hasRecordActions" class="px-4 py-2">
+                  <div class="relative flex justify-end" @click.stop>
                     <button
-                      @click="openDeleteModal(record)"
-                      class="rounded p-1 text-gray-400 hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-900/20 dark:hover:text-red-400"
-                      title="Delete"
+                      type="button"
+                      class="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
+                      :aria-label="`Actions for ${actionLabel(record)}`"
+                      aria-haspopup="menu"
+                      :aria-expanded="openActionMenu === recordKey(record)"
+                      @click="toggleActionMenu(record)"
                     >
                       <svg
                         class="h-4 w-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
+                        fill="currentColor"
+                        viewBox="0 0 20 20"
+                        aria-hidden="true"
                       >
                         <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+                          d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"
                         />
                       </svg>
                     </button>
+
+                    <div
+                      v-if="openActionMenu === recordKey(record)"
+                      role="menu"
+                      :class="[
+                        'absolute right-0 z-20 w-36 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900',
+                        recordIndex >= records.length - 2
+                          ? 'bottom-full mb-1'
+                          : 'top-full mt-1'
+                      ]"
+                      @keydown="handleActionMenuKeydown"
+                    >
+                      <Link
+                        v-if="modelMeta.actions?.view !== false"
+                        :href="recordUrl(record[modelMeta.primaryKey])"
+                        prefetch
+                        role="menuitem"
+                        class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+                        @click="closeActionMenu"
+                      >
+                        View record
+                      </Link>
+                      <Link
+                        v-if="modelMeta.actions?.update !== false"
+                        :href="editUrl(record[modelMeta.primaryKey])"
+                        prefetch
+                        role="menuitem"
+                        class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+                        @click="closeActionMenu"
+                      >
+                        Edit record
+                      </Link>
+                      <button
+                        v-if="modelMeta.actions?.delete !== false"
+                        @click="openDeleteModal(record)"
+                        role="menuitem"
+                        class="flex w-full px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 focus:bg-red-50 focus:outline-none dark:text-red-400 dark:hover:bg-red-900/20 dark:focus:bg-red-900/20"
+                      >
+                        Delete record
+                      </button>
+                    </div>
                   </div>
                 </td>
               </tr>

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -29,25 +29,50 @@ const { toasts, toast, dismiss } = createToast()
 const deleteModal = ref({ show: false })
 const deleteForm = useForm({})
 
+function encodePathSegment(value) {
+  return encodeURIComponent(String(value))
+}
+
+function displayIdentifier(value) {
+  const identifier = String(value ?? '')
+  if (identifier.length <= 24) return identifier
+  return `${identifier.slice(0, 10)}…${identifier.slice(-6)}`
+}
+
+function relatedIdentifier(record) {
+  if (!record) return ''
+  return record.id ?? record[Object.keys(record)[0]]
+}
+
 // Categorize attributes
 const regularAttrs = computed(() => {
   if (!props.modelMeta) return []
-  return Object.entries(props.modelMeta.attributes).filter(
-    ([, attr]) => !attr.model
-  )
+  return (props.modelMeta.show || [])
+    .map((name) => [name, props.modelMeta.attributes[name]])
+    .filter(([, attr]) => attr && !attr.model)
 })
 
 const modelAssociations = computed(() => {
   if (!props.modelMeta) return []
-  return (props.modelMeta.associations || []).filter((a) => a.type === 'model')
+  const visibleFields = new Set(props.modelMeta.show || [])
+  return (props.modelMeta.associations || []).filter(
+    (association) =>
+      association.type === 'model' && visibleFields.has(association.alias)
+  )
 })
 
 const collectionAssociations = computed(() => {
   if (!props.modelMeta) return []
+  const visibleFields = new Set(props.modelMeta.show || [])
   return (props.modelMeta.associations || []).filter(
-    (a) => a.type === 'collection'
+    (association) =>
+      association.type === 'collection' && visibleFields.has(association.alias)
   )
 })
+
+function fieldLabel(name) {
+  return props.modelMeta?.attributes[name]?.label || name
+}
 
 function formatValue(value, attr) {
   if (value === null || value === undefined)
@@ -94,7 +119,11 @@ function collectionCount(alias) {
 
 function confirmDelete() {
   deleteForm.post(
-    `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${props.recordId}/delete`,
+    `/projects/${props.project.slug}/environments/${
+      props.environment.slug
+    }/bridge/${props.modelIdentity}/${encodePathSegment(
+      props.recordId
+    )}/delete`,
     {
       onSuccess: () => {
         toast({ message: 'Record deleted.', type: 'success' })
@@ -116,15 +145,23 @@ function modelUrl() {
   return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}`
 }
 function editUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${props.recordId}/edit`
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/${encodePathSegment(props.recordId)}/edit`
 }
 function relatedRecordUrl(model, id) {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${model}/${id}`
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${model}/${encodePathSegment(id)}`
 }
 </script>
 
 <template>
-  <Head :title="`${modelIdentity} #${recordId} - Bridge | Slipway`"></Head>
+  <Head
+    :title="`${
+      modelMeta?.singularLabel || modelIdentity
+    } ${recordId} - Bridge | Slipway`"
+  ></Head>
   <ToastContainer :toasts="toasts" @dismiss="dismiss" />
 
   <div class="flex h-full flex-col">
@@ -222,11 +259,13 @@ function relatedRecordUrl(model, id) {
         </button>
         <nav class="flex items-center space-x-2 text-sm sm:hidden">
           <Link :href="modelUrl()" class="text-gray-500 dark:text-gray-400">{{
-            modelIdentity
+            modelMeta?.label || modelIdentity
           }}</Link>
           <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white"
-            >#{{ recordId }}</span
+          <span
+            class="max-w-40 truncate font-medium text-gray-900 dark:text-white"
+            :title="String(recordId)"
+            >{{ displayIdentifier(recordId) }}</span
           >
         </nav>
         <nav class="hidden items-center space-x-2 text-sm sm:flex">
@@ -252,16 +291,19 @@ function relatedRecordUrl(model, id) {
           <Link
             :href="modelUrl()"
             class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >{{ modelIdentity }}</Link
+            >{{ modelMeta?.label || modelIdentity }}</Link
           >
           <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white"
-            >#{{ recordId }}</span
+          <span
+            class="max-w-48 truncate font-medium text-gray-900 dark:text-white"
+            :title="String(recordId)"
+            >{{ displayIdentifier(recordId) }}</span
           >
         </nav>
       </div>
       <div v-if="record" class="flex items-center space-x-2">
         <Link
+          v-if="modelMeta?.actions?.update !== false"
           :href="editUrl()"
           class="inline-flex items-center rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
         >
@@ -281,6 +323,7 @@ function relatedRecordUrl(model, id) {
           Edit
         </Link>
         <button
+          v-if="modelMeta?.actions?.delete !== false"
           @click="deleteModal.show = true"
           class="inline-flex items-center rounded-md border border-red-200 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
         >
@@ -330,9 +373,16 @@ function relatedRecordUrl(model, id) {
 
       <!-- Record detail -->
       <div v-else-if="record && modelMeta" class="p-4 sm:p-6">
-        <div class="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        <div
+          :class="[
+            'mx-auto grid max-w-6xl grid-cols-1 gap-6',
+            collectionAssociations.length > 0 ? 'lg:grid-cols-3' : ''
+          ]"
+        >
           <!-- Left: Attributes -->
-          <div class="lg:col-span-2">
+          <div
+            :class="collectionAssociations.length > 0 ? 'lg:col-span-2' : ''"
+          >
             <div
               class="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
             >
@@ -353,7 +403,7 @@ function relatedRecordUrl(model, id) {
                   <dt
                     class="w-40 shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400"
                   >
-                    {{ name }}
+                    {{ fieldLabel(name) }}
                   </dt>
                   <dd
                     class="min-w-0 flex-1 text-sm text-gray-900 dark:text-white"
@@ -409,7 +459,7 @@ function relatedRecordUrl(model, id) {
                   <dt
                     class="w-40 shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400"
                   >
-                    {{ assoc.alias }}
+                    {{ fieldLabel(assoc.alias) }}
                     <span
                       class="block text-xs font-normal text-gray-400 dark:text-gray-500"
                       >→ {{ assoc.model }}</span
@@ -429,7 +479,8 @@ function relatedRecordUrl(model, id) {
                       :href="relatedRecordUrl(assoc.model, record[assoc.alias])"
                       class="font-medium text-gray-900 hover:underline dark:text-white"
                     >
-                      {{ assoc.model }} #{{ record[assoc.alias] }}
+                      {{ assoc.model }}
+                      {{ displayIdentifier(record[assoc.alias]) }}
                     </Link>
                   </dd>
                 </div>
@@ -438,7 +489,7 @@ function relatedRecordUrl(model, id) {
           </div>
 
           <!-- Right: Collection associations -->
-          <div class="space-y-4">
+          <div v-if="collectionAssociations.length > 0" class="space-y-4">
             <div
               v-for="assoc in collectionAssociations"
               :key="assoc.alias"
@@ -478,12 +529,13 @@ function relatedRecordUrl(model, id) {
                     :href="
                       relatedRecordUrl(
                         assoc.collection,
-                        related.id || related[Object.keys(related)[0]]
+                        relatedIdentifier(related)
                       )
                     "
+                    :title="String(relatedIdentifier(related))"
                     class="text-sm font-medium text-gray-900 hover:underline dark:text-white"
                   >
-                    #{{ related.id || related[Object.keys(related)[0]] }}
+                    {{ displayIdentifier(relatedIdentifier(related)) }}
                   </Link>
                   <span
                     v-if="related.name || related.title || related.email"
@@ -493,16 +545,6 @@ function relatedRecordUrl(model, id) {
                   </span>
                 </li>
               </ul>
-            </div>
-
-            <!-- Empty state for no associations -->
-            <div
-              v-if="collectionAssociations.length === 0"
-              class="rounded-xl border border-dashed border-gray-200 px-4 py-8 text-center dark:border-gray-800"
-            >
-              <p class="text-xs text-gray-400 dark:text-gray-500">
-                No collection associations
-              </p>
             </div>
           </div>
         </div>

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -22,26 +22,10 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 // Search
 const searchQuery = ref('')
 
-// Settings modal
-const settingsModalOpen = ref(false)
-const selectedModel = ref(null)
-
-function openSettings(model, e) {
-  e.preventDefault()
-  e.stopPropagation()
-  selectedModel.value = model
-  settingsModalOpen.value = true
-}
-
-function closeSettings() {
-  settingsModalOpen.value = false
-  selectedModel.value = null
-}
-
 // Sorted model list
 const modelList = computed(() => {
-  return Object.values(props.models || {}).sort((a, b) =>
-    a.identity.localeCompare(b.identity)
+  return Object.values(props.models || {}).sort(
+    (a, b) => a.group.localeCompare(b.group) || a.label.localeCompare(b.label)
   )
 })
 
@@ -51,23 +35,17 @@ const filteredModels = computed(() => {
   const query = searchQuery.value.toLowerCase()
   return modelList.value.filter(
     (model) =>
+      model.label.toLowerCase().includes(query) ||
+      model.singularLabel.toLowerCase().includes(query) ||
+      model.group.toLowerCase().includes(query) ||
       model.identity.toLowerCase().includes(query) ||
       (model.globalId && model.globalId.toLowerCase().includes(query)) ||
       (model.tableName && model.tableName.toLowerCase().includes(query))
   )
 })
 
-// Stats
+// Resource count
 const totalModels = computed(() => modelList.value.length)
-const totalRecords = computed(() => {
-  return modelList.value.reduce((sum, m) => sum + (m.count || 0), 0)
-})
-const totalAttributes = computed(() => {
-  return modelList.value.reduce(
-    (sum, m) => sum + Object.keys(m.attributes || {}).length,
-    0
-  )
-})
 
 function attrCount(model) {
   return Object.keys(model.attributes || {}).length
@@ -83,13 +61,6 @@ function bridgeModelUrl(identity) {
 
 function refresh() {
   router.reload({ only: ['models', 'modelsError'] })
-}
-
-// Format large numbers
-function formatNumber(num) {
-  if (num >= 1000000) return (num / 1000000).toFixed(1) + 'M'
-  if (num >= 1000) return (num / 1000).toFixed(1) + 'K'
-  return num.toLocaleString()
 }
 </script>
 
@@ -357,56 +328,39 @@ function formatNumber(num) {
             </svg>
           </div>
           <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">
-            No models found
+            No resources available
           </h3>
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            Your app doesn't have any Waterline models.
+            No Waterline resources are currently exposed to Bridge.
           </p>
         </div>
       </div>
 
       <!-- Models dashboard -->
       <div v-else class="mx-auto max-w-6xl px-4 py-6 sm:px-8">
-        <!-- Toolbar: Search + Stats -->
+        <!-- Toolbar -->
         <div class="mb-4 flex items-center justify-between">
           <input
             v-model="searchQuery"
             type="text"
-            placeholder="Search models..."
+            placeholder="Search resources..."
             class="w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 dark:focus:border-gray-600 sm:w-64"
           />
-          <div class="hidden items-center gap-6 text-sm sm:flex">
-            <div class="flex items-center gap-2">
-              <span class="text-gray-500 dark:text-gray-400">Models</span>
-              <span
-                class="font-medium tabular-nums text-gray-900 dark:text-white"
-                >{{ totalModels }}</span
-              >
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="text-gray-500 dark:text-gray-400">Records</span>
-              <span
-                class="font-medium tabular-nums text-gray-900 dark:text-white"
-                >{{ formatNumber(totalRecords) }}</span
-              >
-            </div>
-            <div class="flex items-center gap-2">
-              <span class="text-gray-500 dark:text-gray-400">Attributes</span>
-              <span
-                class="font-medium tabular-nums text-gray-900 dark:text-white"
-                >{{ totalAttributes }}</span
-              >
-            </div>
-          </div>
+          <span
+            class="hidden text-xs tabular-nums text-gray-500 dark:text-gray-400 sm:block"
+          >
+            {{ totalModels }}
+            {{ totalModels === 1 ? 'resource' : 'resources' }}
+          </span>
         </div>
 
-        <!-- Models table -->
+        <!-- Resources table -->
         <div class="rounded-lg border border-gray-200 dark:border-gray-800">
           <!-- Table Header -->
           <div
             class="grid grid-cols-12 gap-4 rounded-t-lg border-b border-gray-200 bg-gray-50/50 px-6 py-2 text-xs font-medium text-gray-500 dark:border-gray-800 dark:bg-gray-900/50"
           >
-            <div class="col-span-5">Model</div>
+            <div class="col-span-5">Resource</div>
             <div class="col-span-2 text-right">Records</div>
             <div class="col-span-2 text-right">Attributes</div>
             <div class="col-span-2 text-right">Associations</div>
@@ -449,10 +403,10 @@ function formatNumber(num) {
                     <div
                       class="font-medium text-gray-900 underline decoration-gray-300 decoration-dashed underline-offset-2 hover:text-gray-700 dark:text-white dark:decoration-gray-600 dark:hover:text-gray-300"
                     >
-                      {{ model.globalId || model.identity }}
+                      {{ model.label }}
                     </div>
                     <div class="text-xs text-gray-500 dark:text-gray-500">
-                      {{ model.tableName || model.identity }}
+                      {{ model.group }}
                     </div>
                   </div>
                 </Link>
@@ -478,10 +432,10 @@ function formatNumber(num) {
                 <span v-else class="text-gray-300 dark:text-gray-700">—</span>
               </div>
               <div class="col-span-1 flex items-center justify-end">
-                <button
-                  @click="openSettings(model, $event)"
-                  class="rounded p-1 text-gray-400 opacity-0 transition-opacity hover:bg-gray-100 hover:text-gray-600 group-hover:opacity-100 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-                  title="Model settings"
+                <Link
+                  :href="bridgeModelUrl(model.identity)"
+                  class="rounded p-1 text-gray-400 opacity-0 transition-opacity group-hover:opacity-100 dark:text-gray-500"
+                  :aria-label="`Open ${model.label}`"
                 >
                   <svg
                     class="h-4 w-4"
@@ -492,17 +446,11 @@ function formatNumber(num) {
                     <path
                       stroke-linecap="round"
                       stroke-linejoin="round"
-                      stroke-width="1.5"
-                      d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-                    />
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="1.5"
-                      d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                      stroke-width="2"
+                      d="m9 18 6-6-6-6"
                     />
                   </svg>
-                </button>
+                </Link>
               </div>
             </div>
 
@@ -511,245 +459,11 @@ function formatNumber(num) {
               v-if="filteredModels.length === 0"
               class="px-6 py-8 text-center text-sm text-gray-500"
             >
-              No models found matching "{{ searchQuery }}"
+              No resources found matching "{{ searchQuery }}"
             </div>
           </div>
         </div>
       </div>
     </div>
-
-    <!-- Settings Modal -->
-    <Teleport to="body">
-      <Transition
-        enter-active-class="transition duration-200 ease-out"
-        enter-from-class="opacity-0"
-        enter-to-class="opacity-100"
-        leave-active-class="transition duration-150 ease-in"
-        leave-from-class="opacity-100"
-        leave-to-class="opacity-0"
-      >
-        <div
-          v-if="settingsModalOpen"
-          class="fixed inset-0 z-50 flex items-center justify-center p-4"
-        >
-          <div
-            class="fixed inset-0 bg-black/50 backdrop-blur-sm"
-            @click="closeSettings"
-          />
-          <Transition
-            enter-active-class="transition duration-200 ease-out"
-            enter-from-class="scale-95 opacity-0"
-            enter-to-class="scale-100 opacity-100"
-            leave-active-class="transition duration-150 ease-in"
-            leave-from-class="scale-100 opacity-100"
-            leave-to-class="scale-95 opacity-0"
-          >
-            <div
-              v-if="settingsModalOpen && selectedModel"
-              class="relative flex max-h-[85vh] w-full max-w-lg flex-col overflow-hidden rounded-2xl border border-gray-200 bg-white shadow-2xl dark:border-gray-800 dark:bg-gray-900"
-            >
-              <!-- Modal header -->
-              <div
-                class="shrink-0 border-b border-gray-200 px-6 py-4 dark:border-gray-800"
-              >
-                <div class="flex items-center justify-between">
-                  <div class="flex items-center gap-3">
-                    <div
-                      class="flex h-10 w-10 items-center justify-center rounded-xl bg-gray-100 dark:bg-gray-800"
-                    >
-                      <svg
-                        class="h-5 w-5 text-gray-600 dark:text-gray-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="1.5"
-                          d="M4 7v10c0 2.21 3.582 4 8 4s8-1.79 8-4V7M4 7c0 2.21 3.582 4 8 4s8-1.79 8-4M4 7c0-2.21 3.582-4 8-4s8 1.79 8 4"
-                        />
-                      </svg>
-                    </div>
-                    <div>
-                      <h3
-                        class="text-lg font-semibold text-gray-900 dark:text-white"
-                      >
-                        {{ selectedModel.globalId || selectedModel.identity }}
-                      </h3>
-                      <p class="text-sm text-gray-500 dark:text-gray-400">
-                        Model Settings
-                      </p>
-                    </div>
-                  </div>
-                  <button
-                    @click="closeSettings"
-                    class="rounded-lg p-2 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-                  >
-                    <svg
-                      class="h-5 w-5"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-              </div>
-
-              <!-- Modal body -->
-              <div class="flex-1 overflow-y-auto p-6">
-                <!-- Model info -->
-                <div class="mb-6 grid grid-cols-3 gap-4">
-                  <div class="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
-                    <p
-                      class="text-xs font-medium text-gray-500 dark:text-gray-400"
-                    >
-                      Records
-                    </p>
-                    <p
-                      class="mt-1 text-lg font-semibold tabular-nums text-gray-900 dark:text-white"
-                    >
-                      {{ (selectedModel.count || 0).toLocaleString() }}
-                    </p>
-                  </div>
-                  <div class="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
-                    <p
-                      class="text-xs font-medium text-gray-500 dark:text-gray-400"
-                    >
-                      Attributes
-                    </p>
-                    <p
-                      class="mt-1 text-lg font-semibold tabular-nums text-gray-900 dark:text-white"
-                    >
-                      {{ attrCount(selectedModel) }}
-                    </p>
-                  </div>
-                  <div class="rounded-lg bg-gray-50 p-3 dark:bg-gray-800/50">
-                    <p
-                      class="text-xs font-medium text-gray-500 dark:text-gray-400"
-                    >
-                      Associations
-                    </p>
-                    <p
-                      class="mt-1 text-lg font-semibold tabular-nums text-gray-900 dark:text-white"
-                    >
-                      {{ assocCount(selectedModel) }}
-                    </p>
-                  </div>
-                </div>
-
-                <!-- Settings options -->
-                <div class="space-y-4">
-                  <div>
-                    <label
-                      class="text-sm font-medium text-gray-900 dark:text-white"
-                      >Display Columns</label
-                    >
-                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                      Select which columns to display in the table view.
-                    </p>
-                    <div class="mt-3 flex flex-wrap gap-2">
-                      <span
-                        v-for="attr in Object.keys(
-                          selectedModel.attributes || {}
-                        )"
-                        :key="attr"
-                        class="inline-flex items-center gap-1.5 rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300"
-                      >
-                        {{ attr }}
-                      </span>
-                    </div>
-                  </div>
-
-                  <div
-                    class="border-t border-gray-200 pt-4 dark:border-gray-800"
-                  >
-                    <label
-                      class="text-sm font-medium text-gray-900 dark:text-white"
-                      >Primary Display Field</label
-                    >
-                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                      Choose the field to use as the main identifier in lists.
-                    </p>
-                    <select
-                      class="mt-3 block w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-                    >
-                      <option value="">Auto-detect</option>
-                      <option
-                        v-for="attr in Object.keys(
-                          selectedModel.attributes || {}
-                        )"
-                        :key="attr"
-                        :value="attr"
-                      >
-                        {{ attr }}
-                      </option>
-                    </select>
-                  </div>
-
-                  <div
-                    class="border-t border-gray-200 pt-4 dark:border-gray-800"
-                  >
-                    <label
-                      class="text-sm font-medium text-gray-900 dark:text-white"
-                      >Default Sort</label
-                    >
-                    <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-                      Set the default sorting for this model.
-                    </p>
-                    <div class="mt-3 flex gap-3">
-                      <select
-                        class="block flex-1 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-                      >
-                        <option value="createdAt">createdAt</option>
-                        <option
-                          v-for="attr in Object.keys(
-                            selectedModel.attributes || {}
-                          )"
-                          :key="attr"
-                          :value="attr"
-                        >
-                          {{ attr }}
-                        </option>
-                      </select>
-                      <select
-                        class="block w-32 rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500 dark:border-gray-700 dark:bg-gray-800 dark:text-white"
-                      >
-                        <option value="DESC">Descending</option>
-                        <option value="ASC">Ascending</option>
-                      </select>
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              <!-- Modal footer -->
-              <div
-                class="flex shrink-0 items-center justify-end gap-3 border-t border-gray-200 bg-gray-50/50 px-6 py-4 dark:border-gray-800 dark:bg-gray-900/50"
-              >
-                <button
-                  @click="closeSettings"
-                  class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
-                >
-                  Cancel
-                </button>
-                <button
-                  class="rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
-                >
-                  Save Settings
-                </button>
-              </div>
-            </div>
-          </Transition>
-        </div>
-      </Transition>
-    </Teleport>
   </div>
 </template>

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -1,0 +1,180 @@
+# Bridge resource contract
+
+Bridge works without configuration by discovering the Waterline models in a
+running Sails application. Applications that need a curated administration
+surface can define a versioned resource contract in `config/slipway.js`.
+
+```js
+module.exports.slipway = {
+  bridge: {
+    schemaVersion: 1,
+    resources: {
+      course: {
+        label: 'Courses',
+        singularLabel: 'Course',
+        group: 'Content',
+        title: 'title',
+        search: ['title'],
+        list: ['title', 'published', 'createdAt'],
+        show: [
+          'id',
+          'title',
+          'description',
+          'thumbnailUrl',
+          'published',
+          'creator'
+        ],
+        create: [
+          'title',
+          'description',
+          'thumbnailUrl',
+          'published',
+          'creator'
+        ],
+        edit: ['title', 'description', 'thumbnailUrl', 'published', 'creator'],
+        filters: ['published'],
+        sort: {
+          field: 'createdAt',
+          direction: 'DESC'
+        },
+        actions: {
+          bulkDelete: false
+        },
+        fields: {
+          description: {
+            label: 'Course description',
+            type: 'richtext',
+            format: 'markdown',
+            help: 'The public course description.'
+          },
+          thumbnailUrl: {
+            label: 'Thumbnail',
+            type: 'upload',
+            upload: {
+              kind: 'image',
+              storage: 'bridge',
+              directory: 'courses/thumbnails',
+              store: 'url'
+            }
+          }
+        }
+      },
+
+      auditLog: false
+    }
+  }
+}
+```
+
+## Discovery
+
+`discover` defaults to `true`. Configured resources are merged with discovered
+Waterline metadata while unconfigured models continue to use sensible
+defaults.
+
+Set `discover: false` when Bridge should expose only explicitly configured
+resources:
+
+```js
+module.exports.slipway = {
+  bridge: {
+    schemaVersion: 1,
+    discover: false,
+    resources: {
+      course: {
+        group: 'Content'
+      }
+    }
+  }
+}
+```
+
+A resource can also be removed from Bridge with `false` or `hidden: true`.
+
+## Server enforcement
+
+The contract is an authorization boundary, not presentation-only metadata.
+Slipway validates the resource and requested action before executing a Bridge
+operation. List, show, create, and edit field lists are enforced on the server:
+
+- list queries select only `list` fields;
+- record queries select only `show` or `edit` fields;
+- create and update payloads reject fields absent from their configured
+  surface;
+- hidden resources and disabled actions cannot be reached by calling the
+  endpoint directly;
+- sort and search inputs are validated and serialized as data before entering
+  the target app container.
+
+Unknown resources, fields, actions, and resource options fail closed so a typo
+cannot silently expose the wrong surface.
+
+## Field options
+
+Every field may define serializable UI metadata:
+
+| Option        | Purpose                                      |
+| ------------- | -------------------------------------------- |
+| `label`       | Human-readable field name                    |
+| `type`        | Explicit field renderer                      |
+| `format`      | Stored value format, such as `markdown`      |
+| `help`        | Short guidance shown with the field          |
+| `placeholder` | Empty input hint                             |
+| `readOnly`    | Render without submitting changes            |
+| `sortable`    | Allow or prevent table sorting               |
+| `options`     | Values for a select-style field              |
+| `default`     | Bridge form default                          |
+| `currency`    | Currency display and hydration metadata      |
+| `relation`    | Relationship display metadata                |
+| `upload`      | Upload constraints and canonical URL storage |
+
+Set `type: 'richtext'` and `format: 'markdown'` to use Bridge's TipTap editor:
+
+- the stored model value remains Markdown;
+- Markdown shortcuts such as `## ` and `- ` format as the editor types;
+- selecting text opens the minimal bold, italic, link, strikethrough, and
+  inline-code menu;
+- the **Markdown** control exposes the source directly; and
+- unsupported Markdown stays in source mode rather than being silently
+  rewritten.
+
+Bridge only activates the visual editor for the explicit `markdown` format.
+Inferred long-text fields and rich-text fields with another format continue to
+use a multiline input.
+
+Raw HTML is denied by default and requires no additional field option. The form
+blocks the save with an inline error, and the server repeats the check before
+executing the mutation in the target app. Normal Markdown and autolinks continue
+to work. Applications must still sanitize the HTML produced by their Markdown
+renderer because stored content remains untrusted at the rendering boundary.
+
+Uploads, currency hydration, and other specialized renderers build on the same
+field contract in their respective Bridge features.
+
+## Upload configuration boundary
+
+Upload fields describe behavior only. Never put R2 or S3 credentials in
+`config/slipway.js`, because the normalized resource contract is safe to send
+to the Bridge UI.
+
+Bridge storage credentials use `BRIDGE_`-prefixed environment variables. The
+upload field engine will resolve the effective values from the current app
+first, then its environment, then instance-global defaults. This lets one app
+use its own R2 bucket while other apps inherit a shared provider configuration.
+
+The R2 provider contract is:
+
+```text
+BRIDGE_STORAGE_PROVIDER=r2
+BRIDGE_R2_ACCESS_KEY=...
+BRIDGE_R2_SECRET_KEY=...
+BRIDGE_R2_BUCKET=...
+BRIDGE_R2_ENDPOINT=https://ACCOUNT_ID.r2.cloudflarestorage.com
+BRIDGE_R2_PUBLIC_URL=https://cdn.example.com
+BRIDGE_R2_REGION=auto
+```
+
+The planned upload flow returns the canonical public URL and a short-lived,
+server-verifiable upload receipt. The model mutation stores the URL, while the
+receipt prevents a client from claiming an arbitrary object was uploaded by
+Bridge.

--- a/packages/hook/lib/bridge/normalize-resource-contract.js
+++ b/packages/hook/lib/bridge/normalize-resource-contract.js
@@ -1,0 +1,529 @@
+'use strict'
+
+/**
+ * Normalize Waterline metadata and `sails.config.slipway.bridge` into the
+ * serializable contract consumed by every Bridge surface.
+ *
+ * Keep this function dependency-free. Slipway embeds its source in the
+ * compatibility introspector while sails-hook-slipway can call it directly.
+ */
+module.exports = function normalizeBridgeResourceContract({
+  models,
+  config = {}
+}) {
+  const SCHEMA_VERSION = 1
+  const RESOURCE_ACTIONS = [
+    'viewAny',
+    'view',
+    'create',
+    'update',
+    'delete',
+    'bulkDelete'
+  ]
+  const RESOURCE_OPTION_KEYS = [
+    'label',
+    'singularLabel',
+    'group',
+    'title',
+    'search',
+    'list',
+    'show',
+    'create',
+    'edit',
+    'filters',
+    'sort',
+    'hidden',
+    'actions',
+    'fields'
+  ]
+  const FIELD_OPTION_KEYS = [
+    'label',
+    'type',
+    'format',
+    'help',
+    'placeholder',
+    'readOnly',
+    'sortable',
+    'options',
+    'default',
+    'currency',
+    'relation',
+    'upload'
+  ]
+
+  if (!isPlainObject(models)) {
+    throw new Error(
+      'Bridge requires an object of introspected Waterline models.'
+    )
+  }
+  if (!isPlainObject(config)) {
+    throw new Error('sails.config.slipway.bridge must be an object.')
+  }
+
+  const requestedVersion = config.schemaVersion ?? SCHEMA_VERSION
+  if (requestedVersion !== SCHEMA_VERSION) {
+    throw new Error(
+      `Unsupported Bridge resource schema version "${requestedVersion}". ` +
+        `This Slipway release supports version ${SCHEMA_VERSION}.`
+    )
+  }
+
+  if (config.resources !== undefined && !isPlainObject(config.resources)) {
+    throw new Error('sails.config.slipway.bridge.resources must be an object.')
+  }
+  if (config.discover !== undefined && typeof config.discover !== 'boolean') {
+    throw new Error('sails.config.slipway.bridge.discover must be a boolean.')
+  }
+
+  const configuredResources = config.resources || {}
+  const discover = config.discover !== false
+  const identities = discover
+    ? Array.from(
+        new Set([...Object.keys(models), ...Object.keys(configuredResources)])
+      )
+    : Object.keys(configuredResources)
+  const resources = {}
+
+  for (const identity of identities) {
+    const model = models[identity]
+    const rawResource = configuredResources[identity]
+
+    if (!model) {
+      throw new Error(
+        `Bridge resource "${identity}" does not match a loaded Waterline model.`
+      )
+    }
+    if (
+      rawResource !== undefined &&
+      rawResource !== false &&
+      !isPlainObject(rawResource)
+    ) {
+      throw new Error(
+        `Bridge resource "${identity}" must be an object or false.`
+      )
+    }
+
+    if (isPlainObject(rawResource)) {
+      rejectUnknownKeys(
+        rawResource,
+        RESOURCE_OPTION_KEYS,
+        `Bridge resource "${identity}"`
+      )
+    }
+
+    resources[identity] = normalizeResource(
+      identity,
+      model,
+      rawResource === false ? { hidden: true } : rawResource || {},
+      rawResource !== undefined
+    )
+  }
+
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    discover,
+    configured: Object.keys(configuredResources).length > 0,
+    resources
+  }
+
+  function normalizeResource(identity, model, raw, configured) {
+    for (const option of ['label', 'singularLabel', 'group']) {
+      assertOptionalString(
+        raw[option],
+        `Bridge resource "${identity}".${option}`
+      )
+    }
+    assertOptionalBoolean(raw.hidden, `Bridge resource "${identity}".hidden`)
+
+    const attributes = normalizeAttributes(
+      identity,
+      model.attributes || {},
+      raw
+    )
+    const fieldNames = Object.keys(attributes)
+    const primaryKey = model.primaryKey || 'id'
+    const visibleFields = fieldNames.filter(
+      (name) => !attributes[name].encrypt && !attributes[name].protect
+    )
+    const writableFields = fieldNames.filter((name) => {
+      const attribute = attributes[name]
+      return (
+        name !== primaryKey &&
+        !attribute.protect &&
+        !attribute.autoCreatedAt &&
+        !attribute.autoUpdatedAt &&
+        attribute.field?.readOnly !== true
+      )
+    })
+    const defaultList = inferListFields(primaryKey, visibleFields, attributes)
+    const defaultTitle = inferTitleField(primaryKey, visibleFields)
+    const defaultSearch = visibleFields.filter(
+      (name) => attributes[name].type === 'string' && !attributes[name].encrypt
+    )
+    const defaultSortField = attributes.createdAt ? 'createdAt' : primaryKey
+    const label = readString(raw.label) || pluralizeLabel(humanize(identity))
+    const singularLabel =
+      readString(raw.singularLabel) || singularizeLabel(label)
+
+    const resource = {
+      identity: model.identity || identity,
+      globalId: model.globalId,
+      tableName: model.tableName || identity,
+      primaryKey,
+      label,
+      singularLabel,
+      group: readString(raw.group) || 'Resources',
+      title: normalizeFieldName(
+        identity,
+        'title',
+        raw.title ?? defaultTitle,
+        visibleFields
+      ),
+      search: normalizeFieldList(
+        identity,
+        'search',
+        raw.search ?? defaultSearch,
+        visibleFields
+      ),
+      list: normalizeFieldList(
+        identity,
+        'list',
+        raw.list ?? defaultList,
+        visibleFields
+      ),
+      show: normalizeFieldList(
+        identity,
+        'show',
+        raw.show ?? visibleFields,
+        visibleFields
+      ),
+      create: normalizeFieldList(
+        identity,
+        'create',
+        raw.create ?? writableFields,
+        writableFields
+      ),
+      edit: normalizeFieldList(
+        identity,
+        'edit',
+        raw.edit ?? writableFields,
+        writableFields
+      ),
+      filters: normalizeFieldList(
+        identity,
+        'filters',
+        raw.filters ?? [],
+        visibleFields
+      ),
+      sort: normalizeSort(identity, raw.sort, defaultSortField, visibleFields),
+      hidden: raw.hidden === true,
+      configured,
+      actions: normalizeActions(identity, raw.actions),
+      attributes,
+      associations: Array.isArray(model.associations)
+        ? model.associations.map((association) => ({ ...association }))
+        : []
+    }
+
+    if (!resource.list.includes(primaryKey)) {
+      resource.list.unshift(primaryKey)
+    }
+    if (!resource.show.includes(primaryKey)) {
+      resource.show.unshift(primaryKey)
+    }
+
+    return resource
+  }
+
+  function normalizeAttributes(identity, rawAttributes, rawResource) {
+    if (!isPlainObject(rawAttributes)) {
+      throw new Error(
+        `Waterline metadata for "${identity}" has invalid attributes.`
+      )
+    }
+    if (
+      rawResource.fields !== undefined &&
+      !isPlainObject(rawResource.fields)
+    ) {
+      throw new Error(`Bridge resource "${identity}".fields must be an object.`)
+    }
+
+    const fieldOptions = rawResource.fields || {}
+    for (const name of Object.keys(fieldOptions)) {
+      if (!Object.prototype.hasOwnProperty.call(rawAttributes, name)) {
+        throw new Error(
+          `Bridge resource "${identity}".fields references unknown field "${name}".`
+        )
+      }
+      if (!isPlainObject(fieldOptions[name])) {
+        throw new Error(`Bridge field "${identity}.${name}" must be an object.`)
+      }
+      rejectUnknownKeys(
+        fieldOptions[name],
+        FIELD_OPTION_KEYS,
+        `Bridge field "${identity}.${name}"`
+      )
+      for (const option of ['label', 'type', 'format', 'help', 'placeholder']) {
+        assertOptionalString(
+          fieldOptions[name][option],
+          `Bridge field "${identity}.${name}".${option}`
+        )
+      }
+      for (const option of ['readOnly', 'sortable']) {
+        assertOptionalBoolean(
+          fieldOptions[name][option],
+          `Bridge field "${identity}.${name}".${option}`
+        )
+      }
+      if (
+        fieldOptions[name].options !== undefined &&
+        !Array.isArray(fieldOptions[name].options)
+      ) {
+        throw new Error(
+          `Bridge field "${identity}.${name}".options must be an array.`
+        )
+      }
+      for (const option of ['relation', 'upload']) {
+        if (
+          fieldOptions[name][option] !== undefined &&
+          !isPlainObject(fieldOptions[name][option])
+        ) {
+          throw new Error(
+            `Bridge field "${identity}.${name}".${option} must be an object.`
+          )
+        }
+      }
+    }
+
+    const attributes = {}
+    for (const [name, attribute] of Object.entries(rawAttributes)) {
+      const rawField = fieldOptions[name] || {}
+      const safeField = {}
+
+      for (const key of FIELD_OPTION_KEYS) {
+        if (rawField[key] !== undefined) {
+          safeField[key] = cloneSerializable(
+            rawField[key],
+            `${identity}.${name}`
+          )
+        }
+      }
+
+      attributes[name] = {
+        ...attribute,
+        label: readString(rawField.label) || humanize(name),
+        field: safeField
+      }
+    }
+    return attributes
+  }
+
+  function normalizeActions(identity, rawActions) {
+    if (rawActions !== undefined && !isPlainObject(rawActions)) {
+      throw new Error(
+        `Bridge resource "${identity}".actions must be an object.`
+      )
+    }
+
+    rejectUnknownKeys(
+      rawActions || {},
+      RESOURCE_ACTIONS,
+      `Bridge resource "${identity}".actions`
+    )
+
+    const actions = {}
+    for (const action of RESOURCE_ACTIONS) {
+      const value = rawActions?.[action]
+      if (value !== undefined && typeof value !== 'boolean') {
+        throw new Error(
+          `Bridge action "${identity}.${action}" must be a boolean.`
+        )
+      }
+      actions[action] = value !== false
+    }
+    return actions
+  }
+
+  function normalizeSort(identity, rawSort, defaultField, fieldNames) {
+    if (rawSort !== undefined && !isPlainObject(rawSort)) {
+      throw new Error(`Bridge resource "${identity}".sort must be an object.`)
+    }
+
+    const field = normalizeFieldName(
+      identity,
+      'sort.field',
+      rawSort?.field ?? defaultField,
+      fieldNames
+    )
+    const direction = String(rawSort?.direction || 'DESC').toUpperCase()
+    if (!['ASC', 'DESC'].includes(direction)) {
+      throw new Error(
+        `Bridge resource "${identity}".sort.direction must be ASC or DESC.`
+      )
+    }
+    return { field, direction }
+  }
+
+  function normalizeFieldList(identity, surface, value, fieldNames) {
+    if (!Array.isArray(value)) {
+      throw new Error(
+        `Bridge resource "${identity}".${surface} must be an array of field names.`
+      )
+    }
+
+    const unique = []
+    for (const entry of value) {
+      const field = normalizeFieldName(identity, surface, entry, fieldNames)
+      if (!unique.includes(field)) unique.push(field)
+    }
+    return unique
+  }
+
+  function normalizeFieldName(identity, surface, value, fieldNames) {
+    if (typeof value !== 'string' || value.trim() === '') {
+      throw new Error(
+        `Bridge resource "${identity}".${surface} must reference a field name.`
+      )
+    }
+    const field = value.trim()
+    if (!fieldNames.includes(field)) {
+      throw new Error(
+        `Bridge resource "${identity}".${surface} references unknown field "${field}".`
+      )
+    }
+    return field
+  }
+
+  function inferListFields(primaryKey, visibleFields, attributes) {
+    const preferred = [
+      'name',
+      'title',
+      'email',
+      'status',
+      'slug',
+      'type',
+      'role',
+      'createdAt'
+    ]
+    const result = []
+
+    if (visibleFields.includes(primaryKey)) result.push(primaryKey)
+    for (const name of preferred) {
+      if (
+        visibleFields.includes(name) &&
+        !result.includes(name) &&
+        result.length < 6
+      ) {
+        result.push(name)
+      }
+    }
+    for (const name of visibleFields) {
+      const type = attributes[name]?.type
+      if (
+        !result.includes(name) &&
+        !['json', 'ref'].includes(type) &&
+        result.length < 6
+      ) {
+        result.push(name)
+      }
+    }
+    return result
+  }
+
+  function inferTitleField(primaryKey, visibleFields) {
+    return (
+      ['name', 'title', 'email', 'slug'].find((name) =>
+        visibleFields.includes(name)
+      ) || (visibleFields.includes(primaryKey) ? primaryKey : visibleFields[0])
+    )
+  }
+
+  function humanize(value) {
+    return String(value)
+      .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+      .replace(/[_-]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+      .replace(/\b\w/g, (character) => character.toUpperCase())
+  }
+
+  function pluralizeLabel(label) {
+    if (/(s|x|z|ch|sh)$/i.test(label)) return `${label}es`
+    if (/[^aeiou]y$/i.test(label)) return `${label.slice(0, -1)}ies`
+    return `${label}s`
+  }
+
+  function singularizeLabel(label) {
+    if (/ies$/i.test(label)) return `${label.slice(0, -3)}y`
+    if (/(ches|shes|xes|zes)$/i.test(label)) return label.slice(0, -2)
+    if (/s$/i.test(label) && !/ss$/i.test(label)) return label.slice(0, -1)
+    return label
+  }
+
+  function cloneSerializable(value, path) {
+    assertSerializable(value, path)
+    try {
+      return JSON.parse(JSON.stringify(value))
+    } catch {
+      throw new Error(`Bridge field option "${path}" must be serializable.`)
+    }
+  }
+
+  function assertSerializable(value, path, seen = new Set()) {
+    if (
+      typeof value === 'function' ||
+      typeof value === 'symbol' ||
+      typeof value === 'bigint' ||
+      value === undefined
+    ) {
+      throw new Error(`Bridge field option "${path}" must be serializable.`)
+    }
+    if (!value || typeof value !== 'object') return
+    if (seen.has(value)) {
+      throw new Error(`Bridge field option "${path}" must be serializable.`)
+    }
+
+    seen.add(value)
+    for (const [key, nestedValue] of Object.entries(value)) {
+      assertSerializable(nestedValue, `${path}.${key}`, seen)
+    }
+    seen.delete(value)
+  }
+
+  function rejectUnknownKeys(value, allowedKeys, path) {
+    const unknownKeys = Object.keys(value).filter(
+      (key) => !allowedKeys.includes(key)
+    )
+    if (unknownKeys.length > 0) {
+      throw new Error(
+        `${path} contains unsupported option "${unknownKeys[0]}".`
+      )
+    }
+  }
+
+  function assertOptionalString(value, path) {
+    if (
+      value !== undefined &&
+      (typeof value !== 'string' || value.trim() === '')
+    ) {
+      throw new Error(`${path} must be a non-empty string.`)
+    }
+  }
+
+  function assertOptionalBoolean(value, path) {
+    if (value !== undefined && typeof value !== 'boolean') {
+      throw new Error(`${path} must be a boolean.`)
+    }
+  }
+
+  function readString(value) {
+    return typeof value === 'string' && value.trim() ? value.trim() : null
+  }
+
+  function isPlainObject(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value))
+      return false
+    const prototype = Object.getPrototypeOf(value)
+    return prototype === Object.prototype || prototype === null
+  }
+}

--- a/tests/e2e/pages/code-editors.test.js
+++ b/tests/e2e/pages/code-editors.test.js
@@ -74,6 +74,14 @@ async function screenshotAroundEditor(page, selector, path) {
   await page.screenshot(path)
 }
 
+async function navigateAfterUpdateCheck(page, target) {
+  const updateCheckFinished = page.raw.waitForResponse(
+    '**/api/v1/system/check-update'
+  )
+  await page.goto(target)
+  await updateCheckFinished
+}
+
 test(
   'Slipway code editors provide native selection and exact copy behavior everywhere',
   {
@@ -161,9 +169,13 @@ test(
       })
     })
 
+    const loginUpdateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
     await login.withPassword('genesisUser', page, {
       password: current.auth.genesisUserPassword
     })
+    await loginUpdateCheckFinished
     await page.raw
       .context()
       .grantPermissions(['clipboard-read', 'clipboard-write'])
@@ -171,7 +183,7 @@ test(
     await page.inLightMode()
 
     const dockPath = `/projects/${projectSlug}/environments/${environmentSlug}/dock/${database.id}`
-    await page.goto(dockPath)
+    await navigateAfterUpdateCheck(page, dockPath)
     await verifyRealEditor({
       page,
       expect,
@@ -192,7 +204,7 @@ test(
     await page.wait(350)
     await page.screenshot('.tmp/issue-212-dock-query-dark.png')
 
-    await page.goto(`${dockPath}?import=1`)
+    await navigateAfterUpdateCheck(page, `${dockPath}?import=1`)
     await verifyRealEditor({
       page,
       expect,
@@ -203,7 +215,7 @@ test(
     await page.screenshot('.tmp/issue-212-dock-import-dark.png')
 
     await page.inLightMode()
-    await page.goto('/bosun?tab=console')
+    await navigateAfterUpdateCheck(page, '/bosun?tab=console')
     await verifyRealEditor({
       page,
       expect,
@@ -226,7 +238,8 @@ test(
     await page.screenshot('.tmp/issue-212-bosun-helm-dark.png')
 
     await page.inLightMode()
-    await page.goto(
+    await navigateAfterUpdateCheck(
+      page,
       `/projects/${projectSlug}/environments/${environmentSlug}/helm`
     )
     await verifyRealEditor({
@@ -242,7 +255,8 @@ test(
     await page.screenshot('.tmp/issue-212-project-helm-dark.png')
 
     await page.inLightMode()
-    await page.goto(
+    await navigateAfterUpdateCheck(
+      page,
       `/projects/${projectSlug}/environments/${environmentSlug}/apps/${appSlug}?bulk=1`
     )
     await verifyRealEditor({
@@ -259,7 +273,8 @@ test(
     )
 
     await page.inDarkMode()
-    await page.goto(
+    await navigateAfterUpdateCheck(
+      page,
       `/projects/${projectSlug}/environments/${environmentSlug}?bulk=1`
     )
     await verifyRealEditor({
@@ -276,7 +291,7 @@ test(
     )
 
     await page.inLightMode()
-    await page.goto('/settings/global-env?bulk=1')
+    await navigateAfterUpdateCheck(page, '/settings/global-env?bulk=1')
     await verifyRealEditor({
       page,
       expect,

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -1,0 +1,562 @@
+const fs = require('fs')
+const path = require('path')
+
+const { test } = require('sounding')
+
+test(
+  'Bridge renders the target app resource contract in the existing Slipway UI',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-contract-ui',
+          name: 'Bridge Contract UI'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const screenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-216-resource-contract'
+    )
+
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: resourceMetadata(),
+      config: resourceConfig()
+    })
+    const courseRecordId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80211'
+    const createdCourseRecordId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80212'
+    const records = [
+      {
+        id: courseRecordId,
+        title: 'Build a production Sails app',
+        published: true,
+        createdAt: Date.UTC(2026, 6, 21, 9, 30)
+      },
+      {
+        id: '018f2a5c-7b34-7f8a-9c12-4a73b9d80210',
+        title: 'Own the deployment path',
+        published: true,
+        createdAt: Date.UTC(2026, 6, 18, 15, 10)
+      },
+      {
+        id: '018f2a5c-7b34-7f8a-9c12-4a73b9d8020f',
+        title: 'A legible cloud on one server',
+        published: false,
+        createdAt: Date.UTC(2026, 6, 12, 11, 5)
+      }
+    ]
+    const record = {
+      id: courseRecordId,
+      title: 'Build a production Sails app',
+      description:
+        'A practical path from a Waterline model to a calm production release.',
+      thumbnailUrl: 'https://cdn.example.com/courses/production-sails.webp',
+      published: true,
+      creator: 7
+    }
+    let persistedCourseRecord = record
+    let createdValues
+    let updatedValues
+
+    await sails.models.app
+      .updateOne({ id: app.id })
+      .set({ status: 'running', containerName: 'bridge-contract-ui-web' })
+
+    sails.helpers.bridge.introspectModels = async () => ({
+      schemaVersion: contract.schemaVersion,
+      discover: contract.discover,
+      configured: contract.configured,
+      models: contract.resources
+    })
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-contract-ui-web')
+
+      if (code.includes('const counts = {};')) {
+        return successfulResult({
+          course: records.length,
+          user: 1
+        })
+      }
+      if (code.includes('const options = {};')) {
+        return successfulResult({
+          creator: [{ id: 7, label: 'Ada Lovelace' }]
+        })
+      }
+      if (code.includes('const total = await model.count(where);')) {
+        return successfulResult({
+          records,
+          total: records.length
+        })
+      }
+      if (code.includes('await model.create(values).fetch();')) {
+        createdValues = readEmbeddedValue(code, 'values')
+        persistedCourseRecord = {
+          id: createdCourseRecordId,
+          ...createdValues
+        }
+        return successfulResult({ record: persistedCourseRecord })
+      }
+      if (code.includes('await model.updateOne(criteria).set(values);')) {
+        updatedValues = readEmbeddedValue(code, 'values')
+        persistedCourseRecord = {
+          ...persistedCourseRecord,
+          ...updatedValues
+        }
+        return successfulResult({ record: persistedCourseRecord })
+      }
+      if (code.includes('const record = await model.findOne(criteria)')) {
+        if (code.includes('const identity = "user";')) {
+          return successfulResult({
+            record: {
+              id: 7,
+              fullName: 'Ada Lovelace',
+              email: 'ada@example.com'
+            }
+          })
+        }
+        const criteria = readEmbeddedValue(code, 'criteria')
+        return successfulResult({
+          record:
+            criteria.id === createdCourseRecordId
+              ? persistedCourseRecord
+              : record
+        })
+      }
+
+      return {
+        success: false,
+        output: '',
+        error: 'Unexpected Bridge query in UI trial.'
+      }
+    }
+
+    try {
+      await page.raw.route('**/api/v1/system/check-update', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ updateAvailable: false })
+        })
+      })
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await page.raw.waitForURL((url) => !url.pathname.startsWith('/login'), {
+        timeout: 10000
+      })
+      await page.raw.setViewportSize({ width: 1440, height: 900 })
+
+      const bridgePath = `/projects/${project.slug}/environments/${environment.slug}/bridge`
+      const coursePath = `${bridgePath}/course`
+
+      await page.goto(bridgePath)
+      await page.wait('text=Courses')
+      await expect(page).toSee('Content')
+      await expect(page).toSee('People')
+      await expect(page).toSee('2 resources')
+      expect(await page.raw.getByText('Model Settings').count()).toBe(0)
+      await page.screenshot(path.join(screenshotRoot, 'resources-light.png'), {
+        fullPage: true
+      })
+
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(path.join(screenshotRoot, 'resources-dark.png'), {
+        fullPage: true
+      })
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+
+      await page.goto(coursePath)
+      await page.wait('text=Build a production Sails app')
+      await expect(page).toSee('Course title')
+      expect(await page.raw.locator('input[type="checkbox"]').count()).toBe(0)
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-list-light.png'),
+        {
+          fullPage: true
+        }
+      )
+
+      const actionsButton = page.raw.getByRole('button', {
+        name: 'Actions for Build a production Sails app'
+      })
+      expect(await actionsButton.count()).toBe(1)
+      await actionsButton.click()
+      await expect(page).toSee('View record')
+      await expect(page).toSee('Edit record')
+      await expect(page).toSee('Delete record')
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-actions-light.png'),
+        {
+          fullPage: true
+        }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-actions-dark.png'),
+        {
+          fullPage: true
+        }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw.keyboard.press('Escape')
+
+      await page.goto(`${coursePath}/new`)
+      await page.wait('text=Create Course')
+      await expect(page).toSee('Course description')
+      await expect(page).toSee('Thumbnail')
+      await expect(page).toSee('Creator')
+      const createRecordButton = page.raw.getByRole('button', {
+        name: 'Create record'
+      })
+      expect(await createRecordButton.isDisabled()).toBe(true)
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-create-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.getByLabel('Course title').fill('Ship a durable course')
+      expect(await createRecordButton.isEnabled()).toBe(true)
+
+      const descriptionEditor = page.raw.locator(
+        '[data-test="bridge-course-description-visual-editor"]'
+      )
+      expect(await descriptionEditor.count()).toBe(1)
+      expect(await descriptionEditor.getAttribute('aria-labelledby')).toBe(
+        'bridge-course-description-label'
+      )
+
+      await descriptionEditor.click()
+      await page.raw.keyboard.type('## ')
+      await page.raw.keyboard.type('Ship with confidence')
+      expect(await descriptionEditor.locator('h2').textContent()).toBe(
+        'Ship with confidence'
+      )
+      await page.raw.keyboard.press('Enter')
+      await page.raw.keyboard.type('Boring releases are good.')
+      await page.raw.keyboard.press('Shift+Home')
+      expect(
+        (await page.script(() => window.getSelection().toString())).includes(
+          'Boring releases are good.'
+        )
+      ).toBe(true)
+      await page.wait('@bridge-course-description-format-menu')
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-richtext-light.png'),
+        { fullPage: true }
+      )
+
+      await page.raw.getByRole('button', { name: 'Bold', exact: true }).click()
+      await page.raw
+        .getByRole('button', {
+          name: 'Edit Course description as Markdown'
+        })
+        .click()
+      const descriptionSource = page.raw.locator(
+        '[data-test="bridge-course-description-markdown-source"]'
+      )
+      expect(await descriptionSource.inputValue()).toContain(
+        '**Boring releases are good.**'
+      )
+      const createdMarkdown = await descriptionSource.inputValue()
+      await descriptionSource.fill(
+        `${createdMarkdown}\n\n<script>alert('unsafe')</script>`
+      )
+      await expect(page).toSee(
+        'Raw HTML is not allowed in Bridge Markdown fields.'
+      )
+      expect(await createRecordButton.isDisabled()).toBe(true)
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-richtext-html-blocked.png'),
+        { fullPage: true }
+      )
+      await descriptionSource.fill(createdMarkdown)
+      expect(await createRecordButton.isEnabled()).toBe(true)
+
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.wait(100)
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-richtext-source-dark.png'),
+        { fullPage: true }
+      )
+
+      await page.raw
+        .getByRole('button', {
+          name: 'Edit Course description as Visual'
+        })
+        .click()
+      await page.raw.keyboard.press('Shift+Home')
+      await page.wait('@bridge-course-description-format-menu')
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-richtext-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+
+      await createRecordButton.click()
+      await page.raw.waitForURL(
+        (url) => url.pathname.endsWith(`/${createdCourseRecordId}`),
+        { timeout: 10000 }
+      )
+      expect(createdValues.description).toBe(createdMarkdown)
+      await expect(page).toSee('Ship a durable course')
+
+      await page.goto(`${coursePath}/${createdCourseRecordId}/edit`)
+      await page.wait('text=Edit Course')
+      await page.raw
+        .getByRole('button', {
+          name: 'Edit Course description as Markdown'
+        })
+        .click()
+      const persistedDescriptionSource = page.raw.locator(
+        '[data-test="bridge-course-description-markdown-source"]'
+      )
+      expect(await persistedDescriptionSource.inputValue()).toBe(
+        createdMarkdown
+      )
+      const updatedMarkdown = `${createdMarkdown}\n\nA safe production update.`
+      await persistedDescriptionSource.fill(updatedMarkdown)
+      await page.raw
+        .getByRole('button', {
+          name: 'Edit Course description as Visual'
+        })
+        .click()
+
+      await page.raw.setViewportSize({ width: 390, height: 844 })
+      expect(
+        await page.script(
+          () => document.documentElement.scrollWidth <= window.innerWidth
+        )
+      ).toBe(true)
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-richtext-mobile.png'),
+        { fullPage: true }
+      )
+      await page.raw.getByRole('button', { name: 'Save changes' }).click()
+      await page.raw.waitForURL(
+        (url) => url.pathname.endsWith(`/${createdCourseRecordId}`),
+        { timeout: 10000 }
+      )
+      expect(updatedValues.description).toBe(updatedMarkdown)
+
+      await page.raw.setViewportSize({ width: 1440, height: 900 })
+      await page.goto(`${coursePath}/${createdCourseRecordId}/edit`)
+      await page.wait('text=Edit Course')
+      await page.raw
+        .getByRole('button', {
+          name: 'Edit Course description as Markdown'
+        })
+        .click()
+      expect(
+        await page.raw
+          .locator('[data-test="bridge-course-description-markdown-source"]')
+          .inputValue()
+      ).toBe(updatedMarkdown)
+
+      await page.goto(`${coursePath}/${courseRecordId}`)
+      await page.wait('text=A practical path')
+      await expect(page).toSee('Course description')
+      await expect(page).toSee('Thumbnail')
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(screenshotRoot, 'course-record-dark.png'),
+        {
+          fullPage: true
+        }
+      )
+
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.goto(`${bridgePath}/user/7`)
+      await page.wait('text=Ada Lovelace')
+      await expect(page).toSee('ada@example.com')
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
+}
+
+function resourceConfig() {
+  return {
+    schemaVersion: 1,
+    resources: {
+      course: {
+        label: 'Courses',
+        singularLabel: 'Course',
+        group: 'Content',
+        title: 'title',
+        search: ['title'],
+        list: ['title', 'published', 'createdAt'],
+        show: [
+          'id',
+          'title',
+          'description',
+          'thumbnailUrl',
+          'published',
+          'creator'
+        ],
+        create: [
+          'title',
+          'description',
+          'thumbnailUrl',
+          'published',
+          'creator'
+        ],
+        edit: ['title', 'description', 'thumbnailUrl', 'published', 'creator'],
+        sort: {
+          field: 'createdAt',
+          direction: 'DESC'
+        },
+        actions: {
+          bulkDelete: false
+        },
+        fields: {
+          title: {
+            label: 'Course title',
+            placeholder: 'A clear, specific course title'
+          },
+          description: {
+            label: 'Course description',
+            type: 'richtext',
+            format: 'markdown',
+            help: 'The public description shown on the course page.'
+          },
+          thumbnailUrl: {
+            label: 'Thumbnail',
+            type: 'upload',
+            placeholder: 'https://cdn.example.com/courses/thumbnail.webp',
+            upload: {
+              kind: 'image',
+              storage: 'bridge',
+              directory: 'courses/thumbnails',
+              store: 'url'
+            }
+          },
+          creator: {
+            label: 'Creator'
+          }
+        }
+      },
+      user: {
+        label: 'People',
+        singularLabel: 'Person',
+        group: 'People',
+        title: 'fullName',
+        search: ['fullName', 'email'],
+        list: ['fullName', 'email'],
+        show: ['id', 'fullName', 'email'],
+        create: ['fullName', 'email'],
+        edit: ['fullName', 'email'],
+        actions: {
+          delete: false,
+          bulkDelete: false
+        }
+      }
+    }
+  }
+}
+
+function resourceMetadata() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'course',
+      primaryKey: 'id',
+      attributes: {
+        id: {
+          type: 'string',
+          required: true
+        },
+        title: {
+          type: 'string',
+          required: true
+        },
+        description: {
+          type: 'string',
+          columnType: 'text'
+        },
+        thumbnailUrl: {
+          type: 'string'
+        },
+        published: {
+          type: 'boolean',
+          defaultsTo: false
+        },
+        createdAt: {
+          type: 'number',
+          autoCreatedAt: true
+        },
+        updatedAt: {
+          type: 'number',
+          autoUpdatedAt: true
+        },
+        creator: {
+          type: 'number',
+          model: 'user'
+        }
+      },
+      associations: [
+        {
+          alias: 'creator',
+          type: 'model',
+          model: 'user'
+        }
+      ]
+    },
+    user: {
+      identity: 'user',
+      globalId: 'User',
+      tableName: 'users',
+      primaryKey: 'id',
+      attributes: {
+        id: {
+          type: 'number',
+          autoIncrement: true
+        },
+        fullName: {
+          type: 'string',
+          required: true
+        },
+        email: {
+          type: 'string',
+          isEmail: true,
+          required: true
+        },
+        createdAt: {
+          type: 'number',
+          autoCreatedAt: true
+        }
+      },
+      associations: []
+    }
+  }
+}

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -296,8 +296,6 @@ test(
           name: 'Edit Course description as Visual'
         })
         .click()
-      await page.raw.keyboard.press('Shift+Home')
-      await page.wait('@bridge-course-description-format-menu')
       await page.raw.emulateMedia({ colorScheme: 'dark' })
       await page.screenshot(
         path.join(screenshotRoot, 'course-richtext-dark.png'),

--- a/tests/unit/content/markdown-editor.test.js
+++ b/tests/unit/content/markdown-editor.test.js
@@ -53,7 +53,7 @@ test('Content Manager keeps unsupported Markdown in source mode', async ({
 test('Content Manager rejects unsafe links and image sources', async ({
   expect
 }) => {
-  const { normalizeImageUrl, normalizeLinkUrl } = await import(
+  const { containsRawHtml, normalizeImageUrl, normalizeLinkUrl } = await import(
     '../../../assets/js/lib/content/markdown.mjs'
   )
 
@@ -73,6 +73,15 @@ test('Content Manager rejects unsafe links and image sources', async ({
   expect(normalizeImageUrl('https://cdn.test/cover.webp')).toBe(
     'https://cdn.test/cover.webp'
   )
+
+  expect(containsRawHtml('A normal **Markdown** paragraph.')).toBe(false)
+  expect(containsRawHtml('Visit <https://sailsjs.com>.')).toBe(false)
+  expect(containsRawHtml('Email <hello@sailsjs.com>.')).toBe(false)
+  expect(containsRawHtml('Two is < three.')).toBe(false)
+  expect(containsRawHtml('Before <script>alert(1)</script> after.')).toBe(true)
+  expect(containsRawHtml('<svg/onload=alert(1)>')).toBe(true)
+  expect(containsRawHtml('<FeatureCard title="Slipway" />')).toBe(true)
+  expect(containsRawHtml('<!-- hidden markup -->')).toBe(true)
 })
 
 function createMarkdownEditor(content) {

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -1,0 +1,481 @@
+const { test } = require('sounding')
+
+test('Bridge derives a usable resource contract with zero config', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {}
+  })
+
+  expect(contract.schemaVersion).toBe(1)
+  expect(contract.discover).toBe(true)
+  expect(contract.configured).toBe(false)
+  expect(contract.resources.course.label).toBe('Courses')
+  expect(contract.resources.course.singularLabel).toBe('Course')
+  expect(contract.resources.course.title).toBe('title')
+  expect(contract.resources.course.list).toEqual([
+    'id',
+    'title',
+    'createdAt',
+    'description',
+    'thumbnailUrl',
+    'published'
+  ])
+  expect(contract.resources.course.show).toEqual([
+    'id',
+    'title',
+    'description',
+    'thumbnailUrl',
+    'published',
+    'createdAt',
+    'updatedAt',
+    'creator'
+  ])
+  expect(contract.resources.course.create).toEqual([
+    'title',
+    'description',
+    'thumbnailUrl',
+    'published',
+    'password',
+    'creator'
+  ])
+})
+
+test('Bridge merges a partial resource config over discovered metadata', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          label: 'Learning paths',
+          group: 'Content',
+          search: ['title'],
+          list: ['title', 'published']
+        },
+        auditLog: false
+      }
+    }
+  })
+
+  expect(contract.resources.course.label).toBe('Learning paths')
+  expect(contract.resources.course.singularLabel).toBe('Learning path')
+  expect(contract.resources.course.group).toBe('Content')
+  expect(contract.resources.course.list).toEqual(['id', 'title', 'published'])
+  expect(contract.resources.course.create).toEqual([
+    'title',
+    'description',
+    'thumbnailUrl',
+    'published',
+    'password',
+    'creator'
+  ])
+  expect(contract.resources.auditLog.hidden).toBe(true)
+})
+
+test('Bridge represents a fully configured content resource', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      schemaVersion: 1,
+      discover: false,
+      resources: {
+        course: {
+          label: 'Courses',
+          singularLabel: 'Course',
+          group: 'Content',
+          title: 'title',
+          search: ['title'],
+          list: ['title', 'published'],
+          show: ['id', 'title', 'description', 'published', 'creator'],
+          create: [
+            'title',
+            'description',
+            'thumbnailUrl',
+            'published',
+            'creator'
+          ],
+          edit: [
+            'title',
+            'description',
+            'thumbnailUrl',
+            'published',
+            'creator'
+          ],
+          filters: ['published'],
+          sort: { field: 'title', direction: 'ASC' },
+          actions: {
+            bulkDelete: false
+          },
+          fields: {
+            description: {
+              label: 'Course description',
+              type: 'richtext',
+              format: 'markdown'
+            },
+            thumbnailUrl: {
+              label: 'Thumbnail',
+              type: 'upload',
+              upload: {
+                kind: 'image',
+                storage: 'bridge',
+                directory: 'courses/thumbnails',
+                store: 'url'
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const resource = contract.resources.course
+  expect(Object.keys(contract.resources)).toEqual(['course'])
+  expect(resource.sort).toEqual({ field: 'title', direction: 'ASC' })
+  expect(resource.actions).toEqual({
+    viewAny: true,
+    view: true,
+    create: true,
+    update: true,
+    delete: true,
+    bulkDelete: false
+  })
+  expect(resource.attributes.description.field).toEqual({
+    label: 'Course description',
+    type: 'richtext',
+    format: 'markdown'
+  })
+  expect(resource.attributes.thumbnailUrl.field.upload).toEqual({
+    kind: 'image',
+    storage: 'bridge',
+    directory: 'courses/thumbnails',
+    store: 'url'
+  })
+})
+
+test('Bridge rejects unknown fields and unsupported config options', async ({
+  sails,
+  expect
+}) => {
+  let unknownFieldError
+  let unknownOptionError
+
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            list: ['title', 'missing']
+          }
+        }
+      }
+    })
+  } catch (error) {
+    unknownFieldError = error
+  }
+
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            magic: true
+          }
+        }
+      }
+    })
+  } catch (error) {
+    unknownOptionError = error
+  }
+
+  expect(unknownFieldError.message).toBe(
+    'Bridge resource "course".list references unknown field "missing".'
+  )
+  expect(unknownOptionError.message).toBe(
+    'Bridge resource "course" contains unsupported option "magic".'
+  )
+})
+
+test('Bridge query normalization treats sort and search as data', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          search: ['title'],
+          list: ['title', 'published'],
+          sort: { field: 'title', direction: 'ASC' }
+        }
+      }
+    }
+  })
+
+  const query = await sails.helpers.bridge.normalizeResourceQuery.with({
+    resource: contract.resources.course,
+    page: -4,
+    perPage: 5000,
+    sort: "title ASC'; process.exit(1); //",
+    search: "Robert'); throw new Error('nope"
+  })
+
+  expect(query.page).toBe(1)
+  expect(query.perPage).toBe(100)
+  expect(query.sort).toBe('title ASC')
+  expect(query.select).toEqual(['id', 'title', 'published'])
+  expect(query.where).toEqual({
+    or: [
+      {
+        title: {
+          contains: "Robert'); throw new Error('nope"
+        }
+      }
+    ]
+  })
+})
+
+test('Bridge rejects forged mutation fields before container execution', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          create: ['title', 'published']
+        }
+      }
+    }
+  })
+  let receivedError
+
+  try {
+    await sails.helpers.bridge.allowResourceValues.with({
+      resource: contract.resources.course,
+      surface: 'create',
+      values: {
+        title: 'Safe title',
+        isAdmin: true
+      }
+    })
+  } catch (error) {
+    receivedError = error
+  }
+
+  expect(receivedError.code).toBe('BRIDGE_FIELD_NOT_ALLOWED')
+  expect(receivedError.fields).toEqual(['isAdmin'])
+})
+
+test('Bridge denies raw HTML in Markdown fields by default', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          create: ['title', 'description'],
+          fields: {
+            description: {
+              type: 'richtext',
+              format: 'markdown'
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const safeValues = await sails.helpers.bridge.allowResourceValues.with({
+    resource: contract.resources.course,
+    surface: 'create',
+    values: {
+      title: 'A safe course',
+      description:
+        '## Ship calmly\n\nRead <https://sailsjs.com> and keep **building**.'
+    }
+  })
+  expect(safeValues.description).toContain('**building**')
+
+  for (const description of [
+    'Before <script>alert(1)</script> after.',
+    '<svg/onload=alert(1)>',
+    '<FeatureCard title="Slipway" />',
+    '<!-- hidden markup -->'
+  ]) {
+    let receivedError
+
+    try {
+      await sails.helpers.bridge.allowResourceValues.with({
+        resource: contract.resources.course,
+        surface: 'create',
+        values: {
+          title: 'Unsafe course',
+          description
+        }
+      })
+    } catch (error) {
+      receivedError = error
+    }
+
+    expect(receivedError.code).toBe('BRIDGE_MARKDOWN_HTML_NOT_ALLOWED')
+    expect(receivedError.fields).toEqual(['description'])
+  }
+})
+
+test('Bridge resource loading rejects hidden and disabled resources server-side', async ({
+  sails,
+  expect
+}) => {
+  const originalIntrospectModels = sails.helpers.bridge.introspectModels
+  sails.helpers.bridge.introspectModels = async () => ({
+    models: {
+      course: {
+        identity: 'course',
+        singularLabel: 'Course',
+        hidden: false,
+        actions: {
+          update: false
+        }
+      },
+      auditLog: {
+        identity: 'auditLog',
+        singularLabel: 'Audit log',
+        hidden: true,
+        actions: {}
+      }
+    }
+  })
+
+  let disabledActionError
+  let hiddenResourceError
+  let prototypeResourceError
+
+  try {
+    try {
+      await sails.helpers.bridge.loadResource.with({
+        containerName: 'app',
+        environmentId: 1,
+        modelIdentity: 'course',
+        action: 'update'
+      })
+    } catch (error) {
+      disabledActionError = error
+    }
+
+    try {
+      await sails.helpers.bridge.loadResource.with({
+        containerName: 'app',
+        environmentId: 1,
+        modelIdentity: 'auditLog',
+        action: 'view'
+      })
+    } catch (error) {
+      hiddenResourceError = error
+    }
+
+    try {
+      await sails.helpers.bridge.loadResource.with({
+        containerName: 'app',
+        environmentId: 1,
+        modelIdentity: '__proto__',
+        action: 'view'
+      })
+    } catch (error) {
+      prototypeResourceError = error
+    }
+  } finally {
+    sails.helpers.bridge.introspectModels = originalIntrospectModels
+  }
+
+  expect(disabledActionError.code).toBe('BRIDGE_ACTION_NOT_ALLOWED')
+  expect(hiddenResourceError.code).toBe('BRIDGE_RESOURCE_NOT_FOUND')
+  expect(prototypeResourceError.code).toBe('BRIDGE_RESOURCE_NOT_FOUND')
+})
+
+function modelMetadata() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'course',
+      primaryKey: 'id',
+      attributes: {
+        id: {
+          type: 'number',
+          autoIncrement: true
+        },
+        title: {
+          type: 'string',
+          required: true
+        },
+        description: {
+          type: 'string',
+          columnType: 'text'
+        },
+        thumbnailUrl: {
+          type: 'string'
+        },
+        published: {
+          type: 'boolean',
+          defaultsTo: false
+        },
+        password: {
+          type: 'string',
+          encrypt: true
+        },
+        internalNotes: {
+          type: 'string',
+          protect: true
+        },
+        createdAt: {
+          type: 'number',
+          autoCreatedAt: true
+        },
+        updatedAt: {
+          type: 'number',
+          autoUpdatedAt: true
+        },
+        creator: {
+          type: 'string',
+          model: 'user'
+        }
+      },
+      associations: [
+        {
+          alias: 'creator',
+          type: 'model',
+          model: 'user'
+        }
+      ]
+    },
+    auditLog: {
+      identity: 'auditLog',
+      globalId: 'AuditLog',
+      tableName: 'audit_log',
+      primaryKey: 'id',
+      attributes: {
+        id: {
+          type: 'string'
+        },
+        event: {
+          type: 'string'
+        }
+      },
+      associations: []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add a versioned Bridge resource contract with safe zero-configuration discovery
- enforce resource actions, field surfaces, sorting, search, and mutations on the server
- add the minimal TipTap Markdown field, durable validation, opaque primary-key handling, and polished light, dark, and mobile states
- deny raw HTML in Bridge Markdown fields by default at both the browser and server boundaries
- document the contract and its security model

## Impact

Bridge can now serve as a production-grade, Sails-native resource manager. Applications can opt into labels, surfaces, relationships, and field renderers while the server remains the authorization boundary.

## Validation

- `npm run lint`
- `npm run check:consistency`
- `npm test` — 159 unit, 46 functional, and 20 browser trials
- focused Bridge and Content Manager browser regression trials
- Markdown create, reload, edit, and reload persistence journey

Closes #216
