### PR TITLE
feat(bridge): enforce field and action authorization

### DIFF
--- a/api/controllers/project/bridge-bulk-delete.js
+++ b/api/controllers/project/bridge-bulk-delete.js
@@ -83,11 +83,17 @@ module.exports = {
 
     let resource
     try {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
       const loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
         modelIdentity,
-        action: 'bulkDelete'
+        action: 'bulkDelete',
+        actor
       })
       resource = loaded.resource
     } catch (error) {

--- a/api/controllers/project/bridge-create-record.js
+++ b/api/controllers/project/bridge-create-record.js
@@ -66,11 +66,17 @@ module.exports = {
     let loaded
     let allowedValues
     try {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
       loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
         modelIdentity,
-        action: 'create'
+        action: 'create',
+        actor
       })
       allowedValues = await sails.helpers.bridge.allowResourceValues.with({
         values,

--- a/api/controllers/project/bridge-delete-record.js
+++ b/api/controllers/project/bridge-delete-record.js
@@ -65,18 +65,21 @@ module.exports = {
     let resource
     let normalizedRecordId
     try {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
       const loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
         modelIdentity,
-        action: 'delete'
+        action: 'delete',
+        actor,
+        recordId
       })
       resource = loaded.resource
-      normalizedRecordId = await sails.helpers.bridge.normalizeIdentifier.with({
-        value: recordId,
-        resource,
-        label: `${resource.singularLabel} identifier`
-      })
+      normalizedRecordId = loaded.recordId
     } catch (error) {
       throw { badRequest: { error: error.message } }
     }

--- a/api/controllers/project/bridge-update-record.js
+++ b/api/controllers/project/bridge-update-record.js
@@ -69,30 +69,31 @@ module.exports = {
 
     let loaded
     let allowedValues
-    let normalizedRecordId
     try {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
       loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
         modelIdentity,
-        action: 'update'
+        action: 'update',
+        actor,
+        recordId
       })
       allowedValues = await sails.helpers.bridge.allowResourceValues.with({
         values,
         resource: loaded.resource,
         surface: 'edit'
       })
-      normalizedRecordId = await sails.helpers.bridge.normalizeIdentifier.with({
-        value: recordId,
-        resource: loaded.resource,
-        label: `${loaded.resource.singularLabel} identifier`
-      })
     } catch (error) {
       throw { badRequest: { error: error.message } }
     }
 
     const criteria = {
-      [loaded.resource.primaryKey]: normalizedRecordId
+      [loaded.resource.primaryKey]: loaded.recordId
     }
     const updateCode = `
       const identity = ${JSON.stringify(loaded.resource.identity)};

--- a/api/controllers/project/view-bridge-create.js
+++ b/api/controllers/project/view-bridge-create.js
@@ -62,11 +62,17 @@ module.exports = {
 
     if (appRunning) {
       try {
+        const actor = await sails.helpers.bridge.buildActor.with({
+          user,
+          project,
+          environment
+        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
           modelIdentity,
-          action: 'create'
+          action: 'create',
+          actor
         })
         modelMeta = loaded.resource
         assocOptions = await sails.helpers.bridge.loadAssociationOptions.with({

--- a/api/controllers/project/view-bridge-edit.js
+++ b/api/controllers/project/view-bridge-edit.js
@@ -67,22 +67,23 @@ module.exports = {
 
     if (appRunning) {
       try {
+        const actor = await sails.helpers.bridge.buildActor.with({
+          user,
+          project,
+          environment
+        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
           modelIdentity,
-          action: 'update'
+          action: 'update',
+          actor,
+          recordId
         })
         modelMeta = loaded.resource
 
-        const normalizedRecordId =
-          await sails.helpers.bridge.normalizeIdentifier.with({
-            value: recordId,
-            resource: modelMeta,
-            label: `${modelMeta.singularLabel} identifier`
-          })
         const criteria = {
-          [modelMeta.primaryKey]: normalizedRecordId
+          [modelMeta.primaryKey]: loaded.recordId
         }
         const fields = Array.from(
           new Set([modelMeta.primaryKey, ...modelMeta.edit])
@@ -113,7 +114,11 @@ module.exports = {
         if (result.success) {
           try {
             const data = JSON.parse(result.output)
-            record = data.record
+            record = await sails.helpers.bridge.redactResourceRecords.with({
+              records: data.record,
+              resource: modelMeta,
+              surface: 'edit'
+            })
             if (!record) {
               error = `Record with ID "${recordId}" not found.`
             }

--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -93,11 +93,17 @@ module.exports = {
 
     if (appRunning) {
       try {
+        const actor = await sails.helpers.bridge.buildActor.with({
+          user,
+          project,
+          environment
+        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
           modelIdentity,
-          action: 'viewAny'
+          action: 'viewAny',
+          actor
         })
         modelMeta = loaded.resource
         const normalizedQuery =
@@ -136,7 +142,11 @@ module.exports = {
         if (result.success) {
           try {
             const data = JSON.parse(result.output)
-            records = data.records || []
+            records = await sails.helpers.bridge.redactResourceRecords.with({
+              records: data.records || [],
+              resource: modelMeta,
+              surface: 'list'
+            })
             total = data.total || 0
             totalPages = Math.ceil(total / normalizedPerPage)
           } catch (parseError) {

--- a/api/controllers/project/view-bridge-record.js
+++ b/api/controllers/project/view-bridge-record.js
@@ -66,22 +66,23 @@ module.exports = {
 
     if (appRunning) {
       try {
+        const actor = await sails.helpers.bridge.buildActor.with({
+          user,
+          project,
+          environment
+        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
           modelIdentity,
-          action: 'view'
+          action: 'view',
+          actor,
+          recordId
         })
         modelMeta = loaded.resource
 
-        const normalizedRecordId =
-          await sails.helpers.bridge.normalizeIdentifier.with({
-            value: recordId,
-            resource: modelMeta,
-            label: `${modelMeta.singularLabel} identifier`
-          })
         const criteria = {
-          [modelMeta.primaryKey]: normalizedRecordId
+          [modelMeta.primaryKey]: loaded.recordId
         }
         const queryCode = `
           const identity = ${JSON.stringify(modelMeta.identity)};
@@ -104,7 +105,11 @@ module.exports = {
         if (result.success) {
           try {
             const data = JSON.parse(result.output)
-            record = data.record
+            record = await sails.helpers.bridge.redactResourceRecords.with({
+              records: data.record,
+              resource: modelMeta,
+              surface: 'show'
+            })
             if (!record) {
               error = `Record with ID "${recordId}" not found.`
             }

--- a/api/controllers/project/view-bridge.js
+++ b/api/controllers/project/view-bridge.js
@@ -58,6 +58,11 @@ module.exports = {
 
     if (appRunning) {
       try {
+        const actor = await sails.helpers.bridge.buildActor.with({
+          user,
+          project,
+          environment
+        })
         const introspection = await sails.helpers.bridge.introspectModels(
           app.containerName,
           environment.id
@@ -66,8 +71,14 @@ module.exports = {
         if (introspection.error) {
           modelsError = introspection.error
         } else {
+          const authorizedModels =
+            await sails.helpers.bridge.authorizeResourceActions.with({
+              containerName: app.containerName,
+              resources: introspection.models || {},
+              actor
+            })
           models = Object.fromEntries(
-            Object.entries(introspection.models || {}).filter(
+            Object.entries(authorizedModels).filter(
               ([, resource]) =>
                 !resource.hidden && resource.actions?.viewAny !== false
             )

--- a/api/helpers/bridge/authorize-resource-actions.js
+++ b/api/helpers/bridge/authorize-resource-actions.js
@@ -1,0 +1,186 @@
+module.exports = {
+  friendlyName: 'Authorize Bridge resource actions',
+
+  description:
+    'Resolve effective Bridge actions through the target application authorization helper.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resources: {
+      type: 'ref',
+      required: true
+    },
+    actor: {
+      type: 'ref'
+    },
+    recordId: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, resources, actor, recordId }) {
+    const effectiveResources = cloneResources(resources)
+    const requests = []
+
+    for (const [key, resource] of Object.entries(effectiveResources)) {
+      const helperIdentity = resource.authorization?.helper
+      if (!helperIdentity) continue
+      if (!isSafeHelperIdentity(helperIdentity)) {
+        const error = new Error(
+          `Bridge resource "${
+            resource.identity || key
+          }" has an invalid authorization helper.`
+        )
+        error.code = 'BRIDGE_AUTHORIZATION_FAILED'
+        throw error
+      }
+
+      for (const [action, enabled] of Object.entries(resource.actions || {})) {
+        if (enabled !== true) continue
+        if (!isSafeIdentifier(action)) {
+          const error = new Error(
+            `Bridge resource "${
+              resource.identity || key
+            }" has an invalid action.`
+          )
+          error.code = 'BRIDGE_AUTHORIZATION_FAILED'
+          throw error
+        }
+        requests.push({
+          key,
+          action,
+          helperIdentity,
+          resource: {
+            identity: resource.identity,
+            primaryKey: resource.primaryKey,
+            label: resource.label,
+            singularLabel: resource.singularLabel
+          }
+        })
+      }
+    }
+
+    if (requests.length === 0) return effectiveResources
+    if (!actor || typeof actor !== 'object' || Array.isArray(actor)) {
+      const error = new Error(
+        'Bridge authorization requires an authenticated actor.'
+      )
+      error.code = 'BRIDGE_AUTHORIZATION_FAILED'
+      throw error
+    }
+
+    const authorizationCode = `
+      const requests = ${JSON.stringify(requests)};
+      const actor = ${JSON.stringify(actor)};
+      const recordId = ${JSON.stringify(recordId)};
+      const decisions = Object.create(null);
+
+      function resolveHelper(identity) {
+        let helper = sails.helpers;
+        for (const segment of identity.split('.')) {
+          helper = helper && helper[segment];
+        }
+        if (!helper || typeof helper.with !== 'function') {
+          throw new Error(
+            'Configured Bridge authorization helper "' +
+              identity +
+              '" is unavailable.'
+          );
+        }
+        return helper;
+      }
+
+      for (const request of requests) {
+        const helper = resolveHelper(request.helperIdentity);
+        const inputs = {
+          actor,
+          action: request.action,
+          resource: request.resource
+        };
+        if (recordId !== undefined && recordId !== null) {
+          inputs.recordId = recordId;
+        }
+
+        const result = await helper.with(inputs);
+        decisions[request.key] = decisions[request.key] || {};
+        decisions[request.key][request.action] =
+          result === true ||
+          (
+            result &&
+            typeof result === 'object' &&
+            result.allowed === true
+          );
+      }
+
+      return decisions;
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+      authorizationCode
+    )
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      const error = new Error(
+        result.error || 'Target app Bridge authorization failed.'
+      )
+      error.code = 'BRIDGE_AUTHORIZATION_FAILED'
+      throw error
+    }
+
+    let decisions
+    try {
+      decisions = JSON.parse(result.output)
+    } catch (cause) {
+      const error = new Error(
+        'Failed to parse the target app Bridge authorization result.'
+      )
+      error.code = 'BRIDGE_AUTHORIZATION_FAILED'
+      error.cause = cause
+      throw error
+    }
+
+    for (const request of requests) {
+      effectiveResources[request.key].actions[request.action] =
+        decisions?.[request.key]?.[request.action] === true
+    }
+
+    return effectiveResources
+  }
+}
+
+function cloneResources(resources) {
+  if (!resources || typeof resources !== 'object' || Array.isArray(resources)) {
+    const error = new Error('Bridge resources must be an object.')
+    error.code = 'BRIDGE_AUTHORIZATION_FAILED'
+    throw error
+  }
+
+  return JSON.parse(JSON.stringify(resources))
+}
+
+function isSafeIdentifier(value) {
+  return (
+    typeof value === 'string' &&
+    /^[A-Za-z][A-Za-z0-9]*$/.test(value) &&
+    !['__proto__', 'constructor', 'prototype'].includes(value)
+  )
+}
+
+function isSafeHelperIdentity(value) {
+  return (
+    typeof value === 'string' &&
+    value.split('.').every((part) => isSafeIdentifier(part))
+  )
+}

--- a/api/helpers/bridge/build-actor.js
+++ b/api/helpers/bridge/build-actor.js
@@ -1,0 +1,44 @@
+module.exports = {
+  friendlyName: 'Build Bridge actor',
+
+  description:
+    'Build the small, serializable actor context passed to target app authorization helpers.',
+
+  inputs: {
+    user: {
+      type: 'ref',
+      required: true
+    },
+    project: {
+      type: 'ref',
+      required: true
+    },
+    environment: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ user, project, environment }) {
+    const teamId =
+      user.team && typeof user.team === 'object' ? user.team.id : user.team
+
+    return {
+      id: String(user.id),
+      email: user.email,
+      fullName: user.fullName,
+      role: user.teamRole || 'member',
+      teamId: String(teamId),
+      projectId: String(project.id),
+      projectSlug: project.slug,
+      environmentId: String(environment.id),
+      environmentSlug: environment.slug
+    }
+  }
+}

--- a/api/helpers/bridge/load-resource.js
+++ b/api/helpers/bridge/load-resource.js
@@ -18,8 +18,13 @@ module.exports = {
       required: true
     },
     action: {
-      type: 'string',
-      isIn: ['viewAny', 'view', 'create', 'update', 'delete', 'bulkDelete']
+      type: 'string'
+    },
+    actor: {
+      type: 'ref'
+    },
+    recordId: {
+      type: 'ref'
     }
   },
 
@@ -29,7 +34,14 @@ module.exports = {
     }
   },
 
-  fn: async function ({ containerName, environmentId, modelIdentity, action }) {
+  fn: async function ({
+    containerName,
+    environmentId,
+    modelIdentity,
+    action,
+    actor,
+    recordId
+  }) {
     const contract = await sails.helpers.bridge.introspectModels(
       containerName,
       environmentId
@@ -45,7 +57,7 @@ module.exports = {
       contract.models || {},
       modelIdentity
     )
-    const resource = hasResource ? contract.models[modelIdentity] : null
+    let resource = hasResource ? contract.models[modelIdentity] : null
 
     if (!resource || resource.hidden) {
       const error = new Error(
@@ -55,7 +67,41 @@ module.exports = {
       throw error
     }
 
-    if (action && resource.actions?.[action] === false) {
+    if (
+      action &&
+      (!/^[A-Za-z][A-Za-z0-9]*$/.test(action) ||
+        ['__proto__', 'constructor', 'prototype'].includes(action))
+    ) {
+      const error = new Error(`Bridge action "${action}" is invalid.`)
+      error.code = 'BRIDGE_ACTION_NOT_ALLOWED'
+      error.action = action
+      throw error
+    }
+
+    let normalizedRecordId
+    if (recordId !== undefined && recordId !== null) {
+      normalizedRecordId = await sails.helpers.bridge.normalizeIdentifier.with({
+        value: recordId,
+        resource,
+        label: `${resource.singularLabel || modelIdentity} identifier`
+      })
+    }
+
+    const effective = await sails.helpers.bridge.authorizeResourceActions.with({
+      containerName,
+      resources: { resource },
+      actor,
+      ...(normalizedRecordId !== undefined
+        ? { recordId: normalizedRecordId }
+        : {})
+    })
+    resource = effective.resource
+
+    if (
+      action &&
+      (!Object.prototype.hasOwnProperty.call(resource.actions || {}, action) ||
+        resource.actions[action] !== true)
+    ) {
       const error = new Error(
         `${resource.singularLabel || modelIdentity} does not allow this action.`
       )
@@ -64,6 +110,18 @@ module.exports = {
       throw error
     }
 
-    return { contract, resource }
+    return {
+      contract: {
+        ...contract,
+        models: {
+          ...contract.models,
+          [modelIdentity]: resource
+        }
+      },
+      resource,
+      ...(normalizedRecordId !== undefined
+        ? { recordId: normalizedRecordId }
+        : {})
+    }
   }
 }

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -34,7 +34,7 @@ module.exports = {
  */
 function normalizeBridgeResourceContract({ models, config = {} }) {
   const SCHEMA_VERSION = 1
-  const RESOURCE_ACTIONS = [
+  const DEFAULT_RESOURCE_ACTIONS = [
     'viewAny',
     'view',
     'create',
@@ -42,6 +42,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'delete',
     'bulkDelete'
   ]
+  const FIELD_VISIBILITY_SURFACES = ['list', 'show', 'create', 'edit', 'filter']
   const RESOURCE_OPTION_KEYS = [
     'label',
     'singularLabel',
@@ -56,6 +57,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'sort',
     'hidden',
     'actions',
+    'authorization',
     'fields'
   ]
   const FIELD_OPTION_KEYS = [
@@ -68,6 +70,8 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'sortable',
     'options',
     'default',
+    'sensitive',
+    'visibility',
     'currency',
     'relation',
     'upload'
@@ -170,8 +174,27 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       raw
     )
     const fieldNames = Object.keys(attributes)
-    const visibleFields = fieldNames.filter(
+    const readableFields = fieldNames.filter(
       (name) => !attributes[name].encrypt && !attributes[name].protect
+    )
+    const allowedListFields = readableFields.filter(
+      (name) =>
+        name === primaryKey || isAllowedOnSurface(attributes[name], 'list')
+    )
+    const allowedShowFields = readableFields.filter(
+      (name) =>
+        name === primaryKey || isAllowedOnSurface(attributes[name], 'show')
+    )
+    const allowedFilterFields = readableFields.filter((name) =>
+      isAllowedOnSurface(attributes[name], 'filter')
+    )
+    const defaultListFields = allowedListFields.filter(
+      (name) =>
+        name === primaryKey || isVisibleByDefault(attributes[name], 'list')
+    )
+    const defaultShowFields = allowedShowFields.filter(
+      (name) =>
+        name === primaryKey || isVisibleByDefault(attributes[name], 'show')
     )
     const requiresPrimaryKeyInput = needsPrimaryKeyInput(attributes[primaryKey])
     const writableCreateFields = fieldNames.filter((name) => {
@@ -181,16 +204,42 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         !attribute.autoCreatedAt &&
         !attribute.autoUpdatedAt &&
         attribute.field?.readOnly !== true &&
+        isAllowedOnSurface(attribute, 'create') &&
         (name !== primaryKey || requiresPrimaryKeyInput)
       )
     })
-    const writableEditFields = writableCreateFields.filter(
-      (name) => name !== primaryKey
+    const writableEditFields = fieldNames.filter((name) => {
+      const attribute = attributes[name]
+      return (
+        name !== primaryKey &&
+        !attribute.protect &&
+        !attribute.autoCreatedAt &&
+        !attribute.autoUpdatedAt &&
+        attribute.field?.readOnly !== true &&
+        isAllowedOnSurface(attribute, 'edit')
+      )
+    })
+    const defaultCreateFields = writableCreateFields.filter((name) =>
+      isVisibleByDefault(attributes[name], 'create')
     )
-    const defaultList = inferListFields(primaryKey, visibleFields, attributes)
-    const defaultTitle = inferTitleField(primaryKey, visibleFields)
-    const defaultSearch = visibleFields.filter(
+    const defaultEditFields = writableEditFields.filter((name) =>
+      isVisibleByDefault(attributes[name], 'edit')
+    )
+    const explicitlyListedFields = allowedListFields.filter(
+      (name) => attributes[name].field?.visibility?.list === true
+    )
+    const defaultList = Array.from(
+      new Set([
+        ...inferListFields(primaryKey, defaultListFields, attributes),
+        ...explicitlyListedFields
+      ])
+    )
+    const defaultTitle = inferTitleField(primaryKey, defaultShowFields)
+    const defaultSearch = defaultListFields.filter(
       (name) => attributes[name].type === 'string' && !attributes[name].encrypt
+    )
+    const defaultFilters = allowedFilterFields.filter(
+      (name) => attributes[name].field?.visibility?.filter === true
     )
     const defaultSortField = attributes.createdAt ? 'createdAt' : primaryKey
     const label = readString(raw.label) || pluralizeLabel(humanize(identity))
@@ -209,48 +258,54 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         identity,
         'title',
         raw.title ?? defaultTitle,
-        visibleFields
+        allowedShowFields
       ),
       search: normalizeFieldList(
         identity,
         'search',
         raw.search ?? defaultSearch,
-        visibleFields
+        allowedListFields
       ),
       list: normalizeFieldList(
         identity,
         'list',
         raw.list ?? defaultList,
-        visibleFields
+        allowedListFields
       ),
       show: normalizeFieldList(
         identity,
         'show',
-        raw.show ?? visibleFields,
-        visibleFields
+        raw.show ?? defaultShowFields,
+        allowedShowFields
       ),
       create: normalizeFieldList(
         identity,
         'create',
-        raw.create ?? writableCreateFields,
+        raw.create ?? defaultCreateFields,
         writableCreateFields
       ),
       edit: normalizeFieldList(
         identity,
         'edit',
-        raw.edit ?? writableEditFields,
+        raw.edit ?? defaultEditFields,
         writableEditFields
       ),
       filters: normalizeFieldList(
         identity,
         'filters',
-        raw.filters ?? [],
-        visibleFields
+        raw.filters ?? defaultFilters,
+        allowedFilterFields
       ),
-      sort: normalizeSort(identity, raw.sort, defaultSortField, visibleFields),
+      sort: normalizeSort(
+        identity,
+        raw.sort,
+        defaultSortField,
+        allowedListFields
+      ),
       hidden: raw.hidden === true,
       configured,
       actions: normalizeActions(identity, raw.actions),
+      authorization: normalizeAuthorization(identity, raw.authorization),
       attributes,
       associations
     }
@@ -320,6 +375,11 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
           `Bridge field "${identity}.${name}".${option}`
         )
       }
+      assertOptionalBoolean(
+        fieldOptions[name].sensitive,
+        `Bridge field "${identity}.${name}".sensitive`
+      )
+      validateFieldVisibility(identity, name, fieldOptions[name].visibility)
       if (
         fieldOptions[name].options !== undefined &&
         !Array.isArray(fieldOptions[name].options)
@@ -369,6 +429,11 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
           ? { type: association.primaryKeyType }
           : {}),
         label: readString(rawField.label) || humanize(name),
+        sensitive:
+          attribute.protect === true ||
+          attribute.encrypt === true ||
+          rawField.sensitive === true ||
+          (rawField.sensitive !== false && hasSensitiveName(name)),
         field: safeField
       }
     }
@@ -457,14 +522,18 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       )
     }
 
-    rejectUnknownKeys(
-      rawActions || {},
-      RESOURCE_ACTIONS,
-      `Bridge resource "${identity}".actions`
-    )
+    for (const action of Object.keys(rawActions || {})) {
+      if (!isSafeIdentifier(action)) {
+        throw new Error(
+          `Bridge action "${identity}.${action}" must use a safe action name.`
+        )
+      }
+    }
 
     const actions = {}
-    for (const action of RESOURCE_ACTIONS) {
+    for (const action of Array.from(
+      new Set([...DEFAULT_RESOURCE_ACTIONS, ...Object.keys(rawActions || {})])
+    )) {
       const value = rawActions?.[action]
       if (value !== undefined && typeof value !== 'boolean') {
         throw new Error(
@@ -474,6 +543,92 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       actions[action] = value !== false
     }
     return actions
+  }
+
+  function normalizeAuthorization(identity, rawAuthorization) {
+    if (rawAuthorization === undefined) return null
+
+    const authorization =
+      typeof rawAuthorization === 'string'
+        ? { helper: rawAuthorization }
+        : rawAuthorization
+    if (!isPlainObject(authorization)) {
+      throw new Error(
+        `Bridge resource "${identity}".authorization must be a helper identity or an object.`
+      )
+    }
+    rejectUnknownKeys(
+      authorization,
+      ['helper'],
+      `Bridge resource "${identity}".authorization`
+    )
+    if (!isSafeHelperIdentity(authorization.helper)) {
+      throw new Error(
+        `Bridge resource "${identity}".authorization.helper must be a safe Sails helper identity.`
+      )
+    }
+    return { helper: authorization.helper }
+  }
+
+  function validateFieldVisibility(identity, name, visibility) {
+    if (visibility === undefined) return
+    if (!isPlainObject(visibility)) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".visibility must be an object.`
+      )
+    }
+    rejectUnknownKeys(
+      visibility,
+      FIELD_VISIBILITY_SURFACES,
+      `Bridge field "${identity}.${name}".visibility`
+    )
+    for (const surface of FIELD_VISIBILITY_SURFACES) {
+      assertOptionalBoolean(
+        visibility[surface],
+        `Bridge field "${identity}.${name}".visibility.${surface}`
+      )
+    }
+  }
+
+  function isAllowedOnSurface(attribute, surface) {
+    return attribute.field?.visibility?.[surface] !== false
+  }
+
+  function isVisibleByDefault(attribute, surface) {
+    const configuredVisibility = attribute.field?.visibility?.[surface]
+    if (configuredVisibility !== undefined) return configuredVisibility
+    return attribute.sensitive !== true
+  }
+
+  function hasSensitiveName(name) {
+    const normalized = String(name)
+      .replace(/[^A-Za-z0-9]/g, '')
+      .toLowerCase()
+    if (
+      ['emailchangecandidate', 'plancode', 'subscriptioncode'].includes(
+        normalized
+      )
+    ) {
+      return true
+    }
+    return /(password|passwd|passphrase|secret|token|apikey|privatekey|signingkey|credential|totp|otp|recoverycode|backupcode|verificationcode|authcode)/.test(
+      normalized
+    )
+  }
+
+  function isSafeIdentifier(value) {
+    return (
+      typeof value === 'string' &&
+      /^[A-Za-z][A-Za-z0-9]*$/.test(value) &&
+      !['__proto__', 'constructor', 'prototype'].includes(value)
+    )
+  }
+
+  function isSafeHelperIdentity(value) {
+    return (
+      typeof value === 'string' &&
+      value.split('.').every((part) => isSafeIdentifier(part))
+    )
   }
 
   function normalizeSort(identity, rawSort, defaultField, fieldNames) {

--- a/api/helpers/bridge/redact-resource-records.js
+++ b/api/helpers/bridge/redact-resource-records.js
@@ -1,0 +1,54 @@
+module.exports = {
+  friendlyName: 'Redact Bridge resource records',
+
+  description:
+    'Strip record properties that are outside the normalized Bridge field surface.',
+
+  inputs: {
+    records: {
+      type: 'ref',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    surface: {
+      type: 'string',
+      required: true,
+      isIn: ['list', 'show', 'edit']
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ records, resource, surface }) {
+    const allowedFields = new Set(resource[surface] || [])
+    if (surface === 'edit' && resource.primaryKey) {
+      allowedFields.add(resource.primaryKey)
+    }
+
+    const redact = (record) => {
+      if (!record || typeof record !== 'object' || Array.isArray(record)) {
+        return record
+      }
+
+      const safeRecord = {}
+      for (const field of allowedFields) {
+        if (
+          !['__proto__', 'constructor', 'prototype'].includes(field) &&
+          Object.prototype.hasOwnProperty.call(record, field)
+        ) {
+          safeRecord[field] = record[field]
+        }
+      }
+      return safeRecord
+    }
+
+    return Array.isArray(records) ? records.map(redact) : redact(records)
+  }
+}

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -40,6 +40,9 @@ module.exports.slipway = {
         actions: {
           bulkDelete: false
         },
+        authorization: {
+          helper: 'bridge.authorize'
+        },
         fields: {
           description: {
             label: 'Course description',
@@ -99,10 +102,14 @@ operation. List, show, create, and edit field lists are enforced on the server:
 
 - list queries select only `list` fields;
 - record queries select only `show` or `edit` fields;
+- parsed records are redacted again before they become Inertia props;
 - create and update payloads reject fields absent from their configured
   surface;
 - hidden resources and disabled actions cannot be reached by calling the
   endpoint directly;
+- target app authorization helpers resolve the effective actions for the
+  current actor, and denied actions are rejected by the same server path that
+  hides them in the UI;
 - sort and search inputs are validated and serialized as data before entering
   the target app container.
 
@@ -113,20 +120,114 @@ cannot silently expose the wrong surface.
 
 Every field may define serializable UI metadata:
 
-| Option        | Purpose                                      |
-| ------------- | -------------------------------------------- |
-| `label`       | Human-readable field name                    |
-| `type`        | Explicit field renderer                      |
-| `format`      | Stored value format, such as `markdown`      |
-| `help`        | Short guidance shown with the field          |
-| `placeholder` | Empty input hint                             |
-| `readOnly`    | Render without submitting changes            |
-| `sortable`    | Allow or prevent table sorting               |
-| `options`     | Values for a select-style field              |
-| `default`     | Literal form default or primary-key helper   |
-| `currency`    | Currency display and hydration metadata      |
-| `relation`    | Relationship display metadata                |
-| `upload`      | Upload constraints and canonical URL storage |
+| Option        | Purpose                                                |
+| ------------- | ------------------------------------------------------ |
+| `label`       | Human-readable field name                              |
+| `type`        | Explicit field renderer                                |
+| `format`      | Stored value format, such as `markdown`                |
+| `help`        | Short guidance shown with the field                    |
+| `placeholder` | Empty input hint                                       |
+| `readOnly`    | Render without submitting changes                      |
+| `sortable`    | Allow or prevent table sorting                         |
+| `options`     | Values for a select-style field                        |
+| `default`     | Literal form default or primary-key helper             |
+| `sensitive`   | Mark an additional field as hidden by default          |
+| `visibility`  | Per-surface `list`, `show`, `create`, `edit`, `filter` |
+| `currency`    | Currency display and hydration metadata                |
+| `relation`    | Relationship display metadata                          |
+| `upload`      | Upload constraints and canonical URL storage           |
+
+Sensitive names such as password, token, secret, API key, credential, recovery
+code, `emailChangeCandidate`, `planCode`, and `subscriptionCode` are omitted
+from every generated surface. Encrypted and protected fields receive the same
+safe treatment.
+
+An explicit resource array is an opt-in. Field-level visibility is useful when
+the resource should mostly use generated defaults:
+
+```js
+fields: {
+  internalNote: {
+    sensitive: true,
+    visibility: {
+      show: true,
+      edit: true
+    }
+  },
+  githubAccessToken: {
+    visibility: {
+      list: false,
+      show: false,
+      create: false,
+      edit: false,
+      filter: false
+    }
+  }
+}
+```
+
+Setting a surface to `false` is a hard deny for that surface, including forged
+payloads. Setting it to `true` explicitly opts a sensitive-name field into that
+surface. Protected values are never readable through Bridge.
+
+## Target app authorization
+
+Static `actions` remain useful for permanently disabling operations. Add an
+authorization helper when the decision depends on the signed-in actor:
+
+```js
+course: {
+  authorization: {
+    helper: 'bridge.authorize'
+  }
+}
+```
+
+The helper runs inside the target Sails application. It receives `actor`,
+`action`, `resource`, and `recordId` when a record is in scope. It must return
+`true` (or `{ allowed: true }`) to allow the action; falsey values, missing
+helpers, malformed results, and helper errors fail closed.
+
+```js
+// api/helpers/bridge/authorize.js
+const levels = {
+  user: 0,
+  editor: 1,
+  admin: 2
+}
+
+module.exports = {
+  friendlyName: 'Authorize Bridge',
+
+  inputs: {
+    actor: { type: 'ref', required: true },
+    action: { type: 'string', required: true },
+    resource: { type: 'ref', required: true },
+    recordId: { type: 'ref' }
+  },
+
+  fn: async function ({ actor, action }) {
+    const user = await User.findOne({ email: actor.email })
+    if (!user) return false
+
+    const requiredLevel = ['update', 'delete', 'bulkDelete'].includes(action)
+      ? levels.admin
+      : levels.editor
+
+    return (levels[user.role] ?? -1) >= requiredLevel
+  }
+}
+```
+
+This matches the current Nexus split: editors can discover, read, and create;
+admins can also update and delete. The actor contains a small Slipway identity
+context (`id`, `email`, `fullName`, team role, and current project/environment
+identifiers). The target app remains responsible for mapping that identity to
+its own user and roles.
+
+Custom action names may be declared in `actions`. They pass through the same
+authorization helper even when their executor is supplied by a later Bridge
+feature.
 
 Set `type: 'richtext'` and `format: 'markdown'` to use Bridge's TipTap editor:
 

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -31,9 +31,13 @@ test(
     const identifierScreenshotRoot = path.resolve(
       '.tmp/screenshots/issue-217-uuid-identifiers'
     )
+    const authorizationScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-218-bridge-authorization'
+    )
 
     fs.mkdirSync(screenshotRoot, { recursive: true })
     fs.mkdirSync(identifierScreenshotRoot, { recursive: true })
+    fs.mkdirSync(authorizationScreenshotRoot, { recursive: true })
 
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: resourceMetadata(),
@@ -89,6 +93,19 @@ test(
     sails.helpers.bridge.executeInContainer = async (containerName, code) => {
       expect(containerName).toBe('bridge-contract-ui-web')
 
+      if (code.includes('const decisions = Object.create(null);')) {
+        const requests = readEmbeddedValue(code, 'requests')
+        const decisions = {}
+        for (const request of requests) {
+          decisions[request.key] = decisions[request.key] || {}
+          decisions[request.key][request.action] = [
+            'viewAny',
+            'view',
+            'create'
+          ].includes(request.action)
+        }
+        return successfulResult(decisions)
+      }
       if (code.includes('const counts = {};')) {
         return successfulResult({
           course: records.length,
@@ -135,7 +152,12 @@ test(
             record: {
               id: creatorId,
               fullName: 'Ada Lovelace',
-              email: 'ada@example.com'
+              email: 'ada@example.com',
+              githubAccessToken: 'gho_never-render-this',
+              emailChangeCandidate: 'private-candidate@example.com',
+              planCode: 'private-plan',
+              subscriptionCode: 'private-subscription',
+              unexpectedSerializerValue: 'never-render-this-either'
             }
           })
         }
@@ -411,6 +433,33 @@ test(
       await page.goto(`${bridgePath}/user/${creatorId}`)
       await page.wait('text=Ada Lovelace')
       await expect(page).toSee('ada@example.com')
+      await expect(page).not.toSee('gho_never-render-this')
+      await expect(page).not.toSee('private-candidate@example.com')
+      await expect(page).not.toSee('private-plan')
+      await expect(page).not.toSee('private-subscription')
+      expect(
+        await page.raw.getByRole('link', { name: 'Edit', exact: true }).count()
+      ).toBe(0)
+      expect(
+        await page.raw
+          .getByRole('button', { name: 'Delete', exact: true })
+          .count()
+      ).toBe(0)
+      await page.screenshot(
+        path.join(
+          authorizationScreenshotRoot,
+          'editor-record-redacted-light.png'
+        ),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(
+          authorizationScreenshotRoot,
+          'editor-record-redacted-dark.png'
+        ),
+        { fullPage: true }
+      )
     } finally {
       sails.helpers.bridge.introspectModels = originalIntrospectModels
       sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
@@ -507,11 +556,10 @@ function resourceConfig() {
         title: 'fullName',
         search: ['fullName', 'email'],
         list: ['fullName', 'email'],
-        show: ['id', 'fullName', 'email'],
-        create: ['fullName', 'email'],
-        edit: ['fullName', 'email'],
+        authorization: {
+          helper: 'bridge.authorize'
+        },
         actions: {
-          delete: false,
           bulkDelete: false
         }
       }
@@ -587,6 +635,18 @@ function resourceMetadata() {
           type: 'string',
           isEmail: true,
           required: true
+        },
+        githubAccessToken: {
+          type: 'string'
+        },
+        emailChangeCandidate: {
+          type: 'string'
+        },
+        planCode: {
+          type: 'string'
+        },
+        subscriptionCode: {
+          type: 'string'
         },
         createdAt: {
           type: 'number',

--- a/tests/functional/pages/bridge-authorization.test.js
+++ b/tests/functional/pages/bridge-authorization.test.js
@@ -1,0 +1,97 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'Bridge rejects a forged sensitive field before target app execution',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-forged-sensitive-field',
+          name: 'Bridge forged sensitive field'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    let executionCount = 0
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: {
+        user: {
+          identity: 'user',
+          globalId: 'User',
+          tableName: 'users',
+          primaryKey: 'id',
+          attributes: {
+            id: {
+              type: 'number',
+              autoIncrement: true
+            },
+            fullName: {
+              type: 'string',
+              required: true
+            },
+            email: {
+              type: 'string',
+              required: true,
+              isEmail: true
+            },
+            githubAccessToken: {
+              type: 'string'
+            }
+          },
+          associations: []
+        }
+      },
+      config: {}
+    })
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-forged-sensitive-field-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources
+      })
+      sails.helpers.bridge.executeInContainer = async () => {
+        executionCount += 1
+        return {
+          success: false,
+          output: '',
+          error: 'A rejected payload must not reach the target app.',
+          exitCode: 1
+        }
+      }
+
+      const createPath = `/projects/${project.slug}/environments/${environment.slug}/bridge/user/new`
+      const createRecordPath = `/projects/${project.slug}/environments/${environment.slug}/bridge/user/create`
+      const browser = await withCsrfFromPage(request, createPath, 'genesisUser')
+      const response = await browser.request.post(createRecordPath, {
+        values: {
+          fullName: 'Forged administrator',
+          email: 'forged@example.com',
+          githubAccessToken: 'gho_forged'
+        }
+      })
+
+      expect(response).toHaveStatus(400)
+      expect(response).toHaveHeader('x-exit', 'badRequest')
+      expect(executionCount).toBe(0)
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -38,7 +38,6 @@ test('Bridge derives a usable resource contract with zero config', async ({
     'description',
     'thumbnailUrl',
     'published',
-    'password',
     'creator'
   ])
 })
@@ -125,7 +124,6 @@ test('Bridge merges a partial resource config over discovered metadata', async (
     'description',
     'thumbnailUrl',
     'published',
-    'password',
     'creator'
   ])
   expect(contract.resources.auditLog.hidden).toBe(true)
@@ -564,6 +562,199 @@ test('Bridge rejects forged mutation fields before container execution', async (
   expect(receivedError.fields).toEqual(['isAdmin'])
 })
 
+test('Bridge hides sensitive fields by default and honors per-surface visibility', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: sensitiveModelMetadata(),
+    config: {
+      resources: {
+        user: {
+          fields: {
+            emailChangeCandidate: {
+              visibility: {
+                show: true
+              }
+            },
+            internalNote: {
+              sensitive: true,
+              visibility: {
+                edit: true
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+  const user = contract.resources.user
+
+  expect(user.list).toEqual(['id', 'email', 'fullName', 'postalCode'])
+  expect(user.show).toEqual([
+    'id',
+    'fullName',
+    'email',
+    'emailChangeCandidate',
+    'postalCode'
+  ])
+  expect(user.create).toEqual(['fullName', 'email', 'postalCode'])
+  expect(user.edit).toEqual(['fullName', 'email', 'internalNote', 'postalCode'])
+  expect(user.search).toEqual(['fullName', 'email', 'postalCode'])
+  expect(user.attributes.githubAccessToken.sensitive).toBe(true)
+  expect(user.attributes.planCode.sensitive).toBe(true)
+  expect(user.attributes.subscriptionCode.sensitive).toBe(true)
+  expect(user.attributes.postalCode.sensitive).toBe(false)
+
+  const redactedList = await sails.helpers.bridge.redactResourceRecords.with({
+    records: [
+      {
+        id: 7,
+        fullName: 'Editor',
+        email: 'editor@example.com',
+        postalCode: '101001',
+        githubAccessToken: 'gho_secret',
+        planCode: 'enterprise',
+        unexpected: 'serializer leak'
+      }
+    ],
+    resource: user,
+    surface: 'list'
+  })
+  expect(redactedList).toEqual([
+    {
+      id: 7,
+      fullName: 'Editor',
+      email: 'editor@example.com',
+      postalCode: '101001'
+    }
+  ])
+
+  let forgedFieldError
+  try {
+    await sails.helpers.bridge.allowResourceValues.with({
+      resource: user,
+      surface: 'edit',
+      values: {
+        fullName: 'Forged editor',
+        githubAccessToken: 'gho_forged'
+      }
+    })
+  } catch (error) {
+    forgedFieldError = error
+  }
+
+  expect(forgedFieldError.code).toBe('BRIDGE_FIELD_NOT_ALLOWED')
+  expect(forgedFieldError.fields).toEqual(['githubAccessToken'])
+})
+
+test('Bridge resolves target app action authorization and fails closed', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          authorization: 'bridge.authorize',
+          actions: {
+            publish: true
+          }
+        }
+      }
+    }
+  })
+  const originalIntrospectModels = sails.helpers.bridge.introspectModels
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  const targetAuthorize = async ({ actor, action }) => {
+    if (!['editor', 'admin'].includes(actor.targetRole)) return false
+    if (['update', 'delete', 'bulkDelete', 'publish'].includes(action)) {
+      return actor.targetRole === 'admin'
+    }
+    return true
+  }
+  targetAuthorize.with = targetAuthorize
+
+  try {
+    sails.helpers.bridge.introspectModels = async () => ({
+      schemaVersion: contract.schemaVersion,
+      discover: contract.discover,
+      configured: contract.configured,
+      models: contract.resources
+    })
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-app-web')
+      const run = new Function('sails', `return (async () => {${code}})();`)
+      const output = await run({
+        helpers: {
+          bridge: {
+            authorize: targetAuthorize
+          }
+        }
+      })
+      return successfulResult(output)
+    }
+
+    const editorResources =
+      await sails.helpers.bridge.authorizeResourceActions.with({
+        containerName: 'bridge-app-web',
+        resources: contract.resources,
+        actor: {
+          id: '7',
+          email: 'editor@example.com',
+          targetRole: 'editor'
+        }
+      })
+    expect(editorResources.course.actions.viewAny).toBe(true)
+    expect(editorResources.course.actions.view).toBe(true)
+    expect(editorResources.course.actions.create).toBe(true)
+    expect(editorResources.course.actions.update).toBe(false)
+    expect(editorResources.course.actions.delete).toBe(false)
+    expect(editorResources.course.actions.publish).toBe(false)
+
+    const adminResources =
+      await sails.helpers.bridge.authorizeResourceActions.with({
+        containerName: 'bridge-app-web',
+        resources: contract.resources,
+        actor: {
+          id: '8',
+          email: 'admin@example.com',
+          targetRole: 'admin'
+        },
+        recordId: 42
+      })
+    expect(adminResources.course.actions.update).toBe(true)
+    expect(adminResources.course.actions.delete).toBe(true)
+    expect(adminResources.course.actions.publish).toBe(true)
+
+    let deniedUpdateError
+    try {
+      await sails.helpers.bridge.loadResource.with({
+        containerName: 'bridge-app-web',
+        environmentId: 218,
+        modelIdentity: 'course',
+        action: 'update',
+        actor: {
+          id: '7',
+          email: 'editor@example.com',
+          targetRole: 'editor'
+        },
+        recordId: '42'
+      })
+    } catch (error) {
+      deniedUpdateError = error
+    }
+    expect(deniedUpdateError.code).toBe('BRIDGE_ACTION_NOT_ALLOWED')
+  } finally {
+    sails.helpers.bridge.introspectModels = originalIntrospectModels
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
 test('Bridge denies raw HTML in Markdown fields by default', async ({
   sails,
   expect
@@ -832,5 +1023,63 @@ function uuidModelMetadata() {
       },
       associations: []
     }
+  }
+}
+
+function sensitiveModelMetadata() {
+  return {
+    user: {
+      identity: 'user',
+      globalId: 'User',
+      tableName: 'users',
+      primaryKey: 'id',
+      attributes: {
+        id: {
+          type: 'number',
+          autoIncrement: true
+        },
+        fullName: {
+          type: 'string',
+          required: true
+        },
+        email: {
+          type: 'string',
+          required: true,
+          isEmail: true
+        },
+        githubAccessToken: {
+          type: 'string'
+        },
+        emailChangeCandidate: {
+          type: 'string'
+        },
+        planCode: {
+          type: 'string'
+        },
+        subscriptionCode: {
+          type: 'string'
+        },
+        password: {
+          type: 'string',
+          encrypt: true
+        },
+        internalNote: {
+          type: 'string'
+        },
+        postalCode: {
+          type: 'string'
+        }
+      },
+      associations: []
+    }
+  }
+}
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
   }
 }


### PR DESCRIPTION
## Summary

- hide encrypted, protected, token-like, password-like, and configured sensitive fields from generated Bridge surfaces
- support per-field list, show, create, edit, and filter visibility with server-enforced payload allowlisting
- resolve view, create, update, delete, bulk delete, and custom action decisions through an optional target Sails helper
- pass a minimal authenticated actor context while retaining Slipway team and project access as the outer gate
- redact returned records again before they become Inertia props
- preserve the existing minimal UI by feeding it effective action booleans instead of adding authorization chrome

## Impact

Bridge can now match the existing Nexus clearance split: editors may discover, read, and create while target app admins may also update and delete. Sensitive Waterline fields no longer appear by default, and forged hidden-field payloads are rejected before target container execution.

## Validation

- npm run lint
- npm run check:consistency
- 166 unit trials
- 47 functional trials
- 20 browser trials
- light and dark authorization screenshots captured

Closes #218