### PR TITLE
feat(bridge): add typed field engine and uploads

### DIFF
--- a/api/controllers/project/bridge-create-record.js
+++ b/api/controllers/project/bridge-create-record.js
@@ -81,10 +81,15 @@ module.exports = {
       allowedValues = await sails.helpers.bridge.allowResourceValues.with({
         values,
         resource: loaded.resource,
-        surface: 'create'
+        surface: 'create',
+        uploadContext: {
+          actorId: user.id,
+          projectId: project.id,
+          environmentId: environment.id
+        }
       })
     } catch (error) {
-      throw { badRequest: { error: error.message } }
+      throw { badRequest: toBadRequest(error) }
     }
 
     try {
@@ -103,7 +108,17 @@ module.exports = {
       }
       return `/projects/${slug}${envPath}/bridge/${loaded.resource.identity}`
     } catch (error) {
-      throw { badRequest: { error: error.message } }
+      throw { badRequest: toBadRequest(error) }
     }
+  }
+}
+
+function toBadRequest(error) {
+  if (!error?.fieldErrors) return { error: error.message }
+  return {
+    error: error.message,
+    problems: Object.entries(error.fieldErrors).map(([field, message]) => ({
+      [field]: message
+    }))
   }
 }

--- a/api/controllers/project/bridge-update-record.js
+++ b/api/controllers/project/bridge-update-record.js
@@ -86,10 +86,15 @@ module.exports = {
       allowedValues = await sails.helpers.bridge.allowResourceValues.with({
         values,
         resource: loaded.resource,
-        surface: 'edit'
+        surface: 'edit',
+        uploadContext: {
+          actorId: user.id,
+          projectId: project.id,
+          environmentId: environment.id
+        }
       })
     } catch (error) {
-      throw { badRequest: { error: error.message } }
+      throw { badRequest: toBadRequest(error) }
     }
 
     const criteria = {
@@ -120,5 +125,15 @@ module.exports = {
     return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${encodeURIComponent(
       String(recordId)
     )}`
+  }
+}
+
+function toBadRequest(error) {
+  if (!error?.fieldErrors) return { error: error.message }
+  return {
+    error: error.message,
+    problems: Object.entries(error.fieldErrors).map(([field, message]) => ({
+      [field]: message
+    }))
   }
 }

--- a/api/controllers/project/bridge-upload-field.js
+++ b/api/controllers/project/bridge-upload-field.js
@@ -1,0 +1,244 @@
+const crypto = require('node:crypto')
+const path = require('node:path')
+
+const IMAGE_EXTENSIONS = {
+  'image/avif': '.avif',
+  'image/gif': '.gif',
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/webp': '.webp'
+}
+
+module.exports = {
+  friendlyName: 'Upload Bridge field',
+
+  description:
+    'Stream a configured Bridge file field to app-scoped object storage.',
+
+  files: ['file'],
+
+  inputs: {
+    slug: {
+      type: 'string',
+      required: true
+    },
+    envSlug: {
+      type: 'string',
+      defaultsTo: 'production'
+    },
+    modelIdentity: {
+      type: 'string',
+      required: true
+    },
+    fieldName: {
+      type: 'string',
+      required: true
+    },
+    recordId: {
+      type: 'string'
+    },
+    file: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      description: 'The configured Bridge field was uploaded.'
+    },
+    badRequest: {
+      statusCode: 400
+    },
+    forbidden: {
+      statusCode: 403
+    },
+    notFound: {
+      statusCode: 404
+    }
+  },
+
+  fn: async function ({ slug, envSlug, modelIdentity, fieldName, recordId }) {
+    const user = await User.findOne({
+      id: this.req.session.userId
+    }).populate('team')
+    if (!user) {
+      throw { forbidden: { message: 'Sign in before uploading a file.' } }
+    }
+
+    const project = await Project.findOne({ slug, team: user.team.id })
+    if (!project) {
+      throw { notFound: { message: 'Project not found.' } }
+    }
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug: envSlug
+    })
+    if (!environment) {
+      throw { notFound: { message: 'Environment not found.' } }
+    }
+    const app =
+      (await App.findOne({ environment: environment.id, isDefault: true })) ||
+      (await App.findOne({ environment: environment.id }))
+    if (!app || app.status !== 'running') {
+      throw { badRequest: { message: 'The target app is not running.' } }
+    }
+
+    let loaded
+    try {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
+      loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: recordId ? 'update' : 'create',
+        actor,
+        ...(recordId ? { recordId } : {})
+      })
+    } catch (error) {
+      throw { forbidden: { message: error.message } }
+    }
+
+    const surface = recordId ? 'edit' : 'create'
+    const attribute = loaded.resource.attributes?.[fieldName]
+    const fieldType = attribute?.field?.type
+    if (
+      !loaded.resource[surface]?.includes(fieldName) ||
+      !['file', 'image', 'upload'].includes(fieldType) ||
+      attribute.field.upload?.storage !== 'bridge'
+    ) {
+      throw {
+        notFound: { message: 'This Bridge upload field is not available.' }
+      }
+    }
+
+    let storage
+    try {
+      storage = await sails.helpers.bridge.getUploadStorageConfig.with({
+        app,
+        environment
+      })
+    } catch (error) {
+      throw { badRequest: { message: error.message } }
+    }
+
+    const upload = attribute.field.upload
+    const directory = [
+      'bridge',
+      `teams/${safeSegment(user.team.id)}`,
+      `projects/${safeSegment(project.id)}`,
+      `environments/${safeSegment(environment.id)}`,
+      safeSegment(modelIdentity),
+      safeSegment(fieldName),
+      upload.directory
+    ]
+      .filter(Boolean)
+      .join('/')
+    const objectId = crypto.randomUUID()
+
+    const uploadedFiles = await new Promise((resolve, reject) => {
+      this.req.file('file').upload(
+        {
+          adapter: require('skipper-s3'),
+          key: storage.key,
+          secret: storage.secret,
+          bucket: storage.bucket,
+          endpoint: storage.endpoint,
+          region: storage.region || 'us-east-1',
+          dirname: directory,
+          maxBytes: upload.maxBytes,
+          saveAs: (incoming, proceed) => {
+            if (!acceptsMimeType(incoming.type, upload.accept)) {
+              proceed(
+                new Error(
+                  `Choose a file matching: ${upload.accept.join(', ')}.`
+                )
+              )
+              return
+            }
+            const extension =
+              IMAGE_EXTENSIONS[incoming.type] ||
+              safeExtension(incoming.filename || '')
+            proceed(null, `${objectId}${extension}`)
+          }
+        },
+        (error, files) => {
+          if (error) reject(error)
+          else resolve(files)
+        }
+      )
+    }).catch((error) => {
+      throw {
+        badRequest: {
+          message:
+            error.code === 'E_EXCEEDS_UPLOAD_LIMIT'
+              ? `Files for ${attribute.label} must be ${formatBytes(
+                  upload.maxBytes
+                )} or smaller.`
+              : error.message || 'The file could not be uploaded.'
+        }
+      }
+    })
+
+    if (!uploadedFiles?.length) {
+      throw { badRequest: { message: 'Choose a file to upload.' } }
+    }
+
+    const fileName = String(uploadedFiles[0].fd).split('/').pop()
+    const objectPath = `${directory}/${fileName}`
+    const url = `${storage.publicUrl.replace(/\/$/, '')}/${objectPath}`
+    const receipt = await sails.helpers.bridge.createUploadReceipt.with({
+      url,
+      context: {
+        actorId: user.id,
+        projectId: project.id,
+        environmentId: environment.id,
+        resource: loaded.resource.identity,
+        field: fieldName
+      }
+    })
+
+    return {
+      url,
+      receipt,
+      file: {
+        name: uploadedFiles[0].filename,
+        size: uploadedFiles[0].size,
+        type: uploadedFiles[0].type
+      }
+    }
+  }
+}
+
+function acceptsMimeType(type, accepted) {
+  if (!Array.isArray(accepted) || accepted.length === 0) return true
+  return accepted.some((candidate) => {
+    if (candidate.endsWith('/*')) {
+      return type.startsWith(candidate.slice(0, -1))
+    }
+    return type === candidate
+  })
+}
+
+function safeExtension(filename) {
+  const extension = path.extname(filename).toLowerCase()
+  return /^\.[a-z0-9]{1,10}$/.test(extension) ? extension : ''
+}
+
+function safeSegment(value) {
+  return String(value).replace(/[^A-Za-z0-9._-]/g, '-')
+}
+
+function formatBytes(bytes) {
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${Math.round(bytes / (1024 * 1024 * 1024))} GB`
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${Math.round(bytes / (1024 * 1024))} MB`
+  }
+  return `${Math.round(bytes / 1024)} KB`
+}

--- a/api/helpers/bridge/allow-resource-values.js
+++ b/api/helpers/bridge/allow-resource-values.js
@@ -17,6 +17,11 @@ module.exports = {
       type: 'string',
       required: true,
       isIn: ['create', 'edit']
+    },
+    uploadContext: {
+      type: 'ref',
+      description:
+        'Authorized actor and resource context used to verify Bridge upload receipts.'
     }
   },
 
@@ -26,7 +31,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ values, resource, surface }) {
+  fn: async function ({ values, resource, surface, uploadContext }) {
     if (
       !values ||
       typeof values !== 'object' ||
@@ -54,6 +59,7 @@ module.exports = {
     const allowedValues = {}
     const rejectedFields = []
     const unsafeMarkdownFields = []
+    const fieldErrors = {}
 
     for (const key of Object.keys(values)) {
       if (
@@ -68,8 +74,9 @@ module.exports = {
       const association = (resource.associations || []).find(
         (candidate) => candidate.type === 'model' && candidate.alias === key
       )
+      const type = attribute.field?.type || attribute.type || 'text'
       if (
-        attribute.field?.type === 'richtext' &&
+        type === 'richtext' &&
         attribute.field?.format?.toLowerCase() === 'markdown' &&
         containsRawHtml(values[key])
       ) {
@@ -77,17 +84,60 @@ module.exports = {
         continue
       }
 
-      allowedValues[key] = association
-        ? await sails.helpers.bridge.normalizeIdentifier.with({
-            value: values[key],
-            attribute: {
-              type: association.primaryKeyType || attribute.type,
-              maxLength: attribute.maxLength
-            },
-            allowNull: !attribute.required,
-            label: `Bridge field "${resource.identity}.${key}"`
-          })
-        : values[key]
+      try {
+        if (association || type === 'belongsTo') {
+          allowedValues[key] =
+            await sails.helpers.bridge.normalizeIdentifier.with({
+              value: values[key],
+              attribute: {
+                type: association?.primaryKeyType || attribute.type,
+                maxLength: attribute.maxLength
+              },
+              allowNull: !attribute.required,
+              label: `Bridge field "${resource.identity}.${key}"`
+            })
+          continue
+        }
+
+        if (['file', 'image', 'upload'].includes(type)) {
+          allowedValues[key] =
+            await sails.helpers.bridge.verifyUploadReceipt.with({
+              receipt: values[key]?.receipt,
+              url: values[key]?.url,
+              context: {
+                ...uploadContext,
+                resource: resource.identity,
+                field: key
+              }
+            })
+          continue
+        }
+
+        allowedValues[key] = normalizeFieldValue({
+          value: values[key],
+          attribute,
+          type,
+          field: attribute.field,
+          label: attribute.label || key
+        })
+      } catch (error) {
+        if (error.code === 'BRIDGE_INVALID_IDENTIFIER') throw error
+        fieldErrors[key] = error.message
+      }
+    }
+
+    if (surface === 'create') {
+      for (const key of allowedFields) {
+        const attribute = resource.attributes[key]
+        if (
+          attribute.required === true &&
+          values[key] === undefined &&
+          attribute.defaultsTo === undefined &&
+          attribute.field?.default === undefined
+        ) {
+          fieldErrors[key] = `${attribute.label || key} is required.`
+        }
+      }
     }
 
     if (rejectedFields.length > 0) {
@@ -112,8 +162,165 @@ module.exports = {
       throw error
     }
 
+    if (Object.keys(fieldErrors).length > 0) {
+      const error = new Error('Some Bridge fields are invalid.')
+      error.code = 'BRIDGE_FIELD_INVALID'
+      error.fields = Object.keys(fieldErrors)
+      error.fieldErrors = fieldErrors
+      throw error
+    }
+
     return allowedValues
   }
+}
+
+function normalizeFieldValue({ value, attribute, type, field, label }) {
+  if (
+    (value === '' || value === null || value === undefined) &&
+    !attribute.required
+  ) {
+    if (['text', 'textarea', 'richtext', 'email', 'url'].includes(type)) {
+      return value === null || value === undefined ? '' : value
+    }
+    return null
+  }
+
+  if (value === undefined || value === null || value === '') {
+    throw new Error(`${label} is required.`)
+  }
+
+  if (type === 'boolean') {
+    if (typeof value !== 'boolean') {
+      throw new Error(`${label} must be true or false.`)
+    }
+    return value
+  }
+
+  if (type === 'json') {
+    let parsed = value
+    if (typeof value === 'string') {
+      try {
+        parsed = JSON.parse(value)
+      } catch {
+        throw new Error(`${label} must contain valid JSON.`)
+      }
+    }
+    try {
+      JSON.stringify(parsed)
+    } catch {
+      throw new Error(`${label} must contain valid JSON.`)
+    }
+    return parsed
+  }
+
+  if (type === 'number' || type === 'currency') {
+    const number = typeof value === 'number' ? value : Number(value)
+    if (!Number.isFinite(number)) {
+      throw new Error(`${label} must be a number.`)
+    }
+    const min = attribute.min ?? attribute.validations?.min
+    const max = attribute.max ?? attribute.validations?.max
+    if (min !== undefined && min !== null && number < min) {
+      throw new Error(`${label} must be at least ${min}.`)
+    }
+    if (max !== undefined && max !== null && number > max) {
+      throw new Error(`${label} must be at most ${max}.`)
+    }
+    if (type === 'currency' && field?.currency?.submit === 'minor') {
+      const digits = field.currency.maximumFractionDigits ?? 2
+      return Math.round(number * 10 ** digits)
+    }
+    return number
+  }
+
+  if (type === 'select') {
+    const options = field?.options || []
+    if (
+      options.length > 0 &&
+      !options.some(
+        (option) => option.disabled !== true && Object.is(option.value, value)
+      )
+    ) {
+      throw new Error(`${label} must use one of the available options.`)
+    }
+    return value
+  }
+
+  if (type === 'email') {
+    const email = requireString(value, label)
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      throw new Error(`${label} must be a valid email address.`)
+    }
+    return email
+  }
+
+  if (type === 'url') {
+    const url = requireString(value, label)
+    let parsed
+    try {
+      parsed = new URL(url)
+    } catch {
+      throw new Error(`${label} must be a valid URL.`)
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw new Error(`${label} must use HTTP or HTTPS.`)
+    }
+    return parsed.toString()
+  }
+
+  if (type === 'date') {
+    const date = requireString(value, label)
+    if (!isValidDateOnly(date)) {
+      throw new Error(`${label} must be a valid date.`)
+    }
+    return attribute.type === 'number'
+      ? Date.parse(`${date}T00:00:00.000Z`)
+      : date
+  }
+
+  if (['datetime', 'timestamp'].includes(type)) {
+    const timestamp =
+      typeof value === 'number'
+        ? value
+        : Date.parse(requireString(value, label))
+    if (!Number.isFinite(timestamp)) {
+      throw new Error(`${label} must be a valid date and time.`)
+    }
+    return attribute.type === 'number'
+      ? timestamp
+      : new Date(timestamp).toISOString()
+  }
+
+  const string = requireString(value, label)
+  const minLength = attribute.minLength ?? attribute.validations?.minLength
+  const maxLength = attribute.maxLength ?? attribute.validations?.maxLength
+  if (minLength && string.length < minLength) {
+    throw new Error(`${label} must contain at least ${minLength} characters.`)
+  }
+  if (maxLength && string.length > maxLength) {
+    throw new Error(`${label} must contain at most ${maxLength} characters.`)
+  }
+  return string
+}
+
+function requireString(value, label) {
+  if (typeof value !== 'string') {
+    throw new Error(`${label} must be text.`)
+  }
+  return value
+}
+
+function isValidDateOnly(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return false
+  const [, year, month, day] = match.map(Number)
+  const date = new Date(0)
+  date.setUTCFullYear(year, month - 1, day)
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  )
 }
 
 function containsRawHtml(value) {

--- a/api/helpers/bridge/create-upload-receipt.js
+++ b/api/helpers/bridge/create-upload-receipt.js
@@ -1,0 +1,96 @@
+const crypto = require('node:crypto')
+
+module.exports = {
+  friendlyName: 'Create Bridge upload receipt',
+
+  description:
+    'Sign a short-lived receipt that binds an uploaded URL to an authorized Bridge field.',
+
+  inputs: {
+    url: {
+      type: 'string',
+      required: true,
+      maxLength: 2048
+    },
+    context: {
+      type: 'ref',
+      required: true
+    },
+    expiresInMs: {
+      type: 'number',
+      defaultsTo: 30 * 60 * 1000,
+      min: 60 * 1000,
+      max: 24 * 60 * 60 * 1000
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ url, context, expiresInMs }) {
+    assertSafeUrl(url)
+    assertContext(context)
+    const payload = {
+      version: 1,
+      url,
+      actorId: String(context.actorId),
+      projectId: String(context.projectId),
+      environmentId: String(context.environmentId),
+      resource: String(context.resource),
+      field: String(context.field),
+      issuedAt: Date.now(),
+      expiresAt: Date.now() + expiresInMs
+    }
+
+    const encoded = Buffer.from(JSON.stringify(payload)).toString('base64url')
+    const signature = sign(encoded)
+    return `${encoded}.${signature}`
+  }
+}
+
+function sign(value) {
+  const secret = sails.config.session?.secret
+  if (typeof secret !== 'string' || secret.length < 16) {
+    const error = new Error(
+      'Bridge uploads require a strong Slipway session secret.'
+    )
+    error.code = 'BRIDGE_UPLOAD_SECRET_UNAVAILABLE'
+    throw error
+  }
+  return crypto.createHmac('sha256', secret).update(value).digest('base64url')
+}
+
+function assertSafeUrl(value) {
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw new Error('Bridge upload URL is invalid.')
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw new Error('Bridge upload URL must use HTTP or HTTPS.')
+  }
+}
+
+function assertContext(context) {
+  for (const key of [
+    'actorId',
+    'projectId',
+    'environmentId',
+    'resource',
+    'field'
+  ]) {
+    if (
+      context[key] === undefined ||
+      context[key] === null ||
+      !/^[A-Za-z0-9._-]+$/.test(String(context[key]))
+    ) {
+      const error = new Error(`Bridge upload context "${key}" is invalid.`)
+      error.code = 'BRIDGE_UPLOAD_CONTEXT_INVALID'
+      throw error
+    }
+  }
+}

--- a/api/helpers/bridge/get-upload-storage-config.js
+++ b/api/helpers/bridge/get-upload-storage-config.js
@@ -1,0 +1,124 @@
+module.exports = {
+  friendlyName: 'Get Bridge upload storage config',
+
+  description:
+    'Resolve app, environment, and instance-scoped BRIDGE_ upload settings.',
+
+  inputs: {
+    app: {
+      type: 'ref',
+      required: true
+    },
+    environment: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ app, environment }) {
+    let globalEnvVars = {}
+    try {
+      const stored = await sails.helpers.setting.get('globalEnvVars', '{}')
+      const parsed = JSON.parse(stored)
+      if (isPlainObject(parsed)) globalEnvVars = parsed
+    } catch {
+      // A malformed optional global setting must not expose or replace scoped values.
+    }
+
+    const values = {
+      ...onlyBridgeValues(globalEnvVars),
+      ...onlyBridgeValues(environment.envVars),
+      ...onlyBridgeValues(app.envVars)
+    }
+    const provider = String(values.BRIDGE_STORAGE_PROVIDER || '').toLowerCase()
+    if (!['r2', 's3'].includes(provider)) {
+      throw storageError(
+        'Set BRIDGE_STORAGE_PROVIDER to "r2" or "s3" for this app, environment, or Slipway instance.'
+      )
+    }
+
+    const prefix = provider === 'r2' ? 'BRIDGE_R2_' : 'BRIDGE_S3_'
+    const config = {
+      provider,
+      key: values[`${prefix}ACCESS_KEY`],
+      secret: values[`${prefix}SECRET_KEY`],
+      bucket: values[`${prefix}BUCKET`],
+      endpoint: values[`${prefix}ENDPOINT`],
+      publicUrl: values[`${prefix}PUBLIC_URL`],
+      region: values[`${prefix}REGION`] || (provider === 'r2' ? 'auto' : null)
+    }
+
+    const missing = ['key', 'secret', 'bucket'].filter(
+      (name) => !readString(config[name])
+    )
+    if (provider === 'r2' && !readString(config.endpoint)) {
+      missing.push('endpoint')
+    }
+    if (!readString(config.publicUrl)) {
+      missing.push('public URL')
+    }
+    if (missing.length > 0) {
+      throw storageError(
+        `Bridge ${provider.toUpperCase()} storage is missing: ${missing.join(
+          ', '
+        )}.`
+      )
+    }
+
+    assertHttpUrl(config.publicUrl, 'Bridge storage public URL', {
+      requireBase: true
+    })
+    if (config.endpoint) {
+      assertHttpUrl(config.endpoint, 'Bridge storage endpoint')
+    }
+
+    return config
+  }
+}
+
+function onlyBridgeValues(value) {
+  if (!isPlainObject(value)) return {}
+  return Object.fromEntries(
+    Object.entries(value).filter(([key]) => key.startsWith('BRIDGE_'))
+  )
+}
+
+function storageError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_UPLOAD_STORAGE_NOT_CONFIGURED'
+  return error
+}
+
+function assertHttpUrl(value, label, { requireBase = false } = {}) {
+  let url
+  try {
+    url = new URL(value)
+  } catch {
+    throw storageError(`${label} is invalid.`)
+  }
+  if (!['http:', 'https:'].includes(url.protocol)) {
+    throw storageError(`${label} must use HTTP or HTTPS.`)
+  }
+  if (requireBase && (url.search || url.hash)) {
+    throw storageError(`${label} must not include a query string or fragment.`)
+  }
+}
+
+function readString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function isPlainObject(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(value))
+  )
+}

--- a/api/helpers/bridge/introspect-models.js
+++ b/api/helpers/bridge/introspect-models.js
@@ -132,6 +132,7 @@ function buildIntrospectionCode() {
             allowNull: attr.allowNull || false,
             isUUID: relatedPrimaryKeyAttribute.isUUID || false,
             maxLength: relatedPrimaryKeyAttribute.maxLength || null,
+            description: attr.description || null,
             validations: {
               isUUID: relatedPrimaryKeyAttribute.isUUID || false
             }
@@ -163,9 +164,14 @@ function buildIntrospectionCode() {
             false,
           allowNull: attr.allowNull || false,
           isEmail: attr.isEmail || false,
+          isURL: attr.isURL || false,
           isUUID: attr.isUUID || false,
           isIn: attr.isIn || null,
+          min: attr.min ?? null,
+          max: attr.max ?? null,
+          minLength: attr.minLength || null,
           maxLength: attr.maxLength || null,
+          description: attr.description || null,
           encrypt: !!attr.encrypt,
           protect: !!attr.protect,
           validations: {}
@@ -173,8 +179,11 @@ function buildIntrospectionCode() {
 
         // Collect validation rules
         if (attr.isEmail) models[identity].attributes[attrName].validations.isEmail = true;
+        if (attr.isURL) models[identity].attributes[attrName].validations.isURL = true;
         if (attr.isUUID) models[identity].attributes[attrName].validations.isUUID = true;
         if (attr.isIn) models[identity].attributes[attrName].validations.isIn = attr.isIn;
+        if (attr.min !== undefined) models[identity].attributes[attrName].validations.min = attr.min;
+        if (attr.max !== undefined) models[identity].attributes[attrName].validations.max = attr.max;
         if (attr.maxLength) models[identity].attributes[attrName].validations.maxLength = attr.maxLength;
         if (attr.minLength) models[identity].attributes[attrName].validations.minLength = attr.minLength;
         if (attr.regex) models[identity].attributes[attrName].validations.regex = String(attr.regex);

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -43,6 +43,27 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'bulkDelete'
   ]
   const FIELD_VISIBILITY_SURFACES = ['list', 'show', 'create', 'edit', 'filter']
+  const FIELD_TYPES = [
+    'text',
+    'textarea',
+    'richtext',
+    'email',
+    'url',
+    'number',
+    'currency',
+    'boolean',
+    'select',
+    'belongsTo',
+    'json',
+    'date',
+    'datetime',
+    'timestamp',
+    'password',
+    'secret',
+    'file',
+    'image',
+    'upload'
+  ]
   const RESOURCE_OPTION_KEYS = [
     'label',
     'singularLabel',
@@ -74,7 +95,8 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'visibility',
     'currency',
     'relation',
-    'upload'
+    'upload',
+    'component'
   ]
 
   if (!isPlainObject(models)) {
@@ -363,7 +385,14 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         FIELD_OPTION_KEYS,
         `Bridge field "${identity}.${name}"`
       )
-      for (const option of ['label', 'type', 'format', 'help', 'placeholder']) {
+      for (const option of [
+        'label',
+        'type',
+        'format',
+        'help',
+        'placeholder',
+        'component'
+      ]) {
         assertOptionalString(
           fieldOptions[name][option],
           `Bridge field "${identity}.${name}".${option}`
@@ -386,6 +415,27 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       ) {
         throw new Error(
           `Bridge field "${identity}.${name}".options must be an array.`
+        )
+      }
+      if (fieldOptions[name].type !== undefined) {
+        const normalizedType = normalizeFieldType(fieldOptions[name].type)
+        if (!FIELD_TYPES.includes(normalizedType)) {
+          throw new Error(
+            `Bridge field "${identity}.${name}".type must be one of: ${FIELD_TYPES.join(
+              ', '
+            )}.`
+          )
+        }
+      }
+      validateFieldOptions(identity, name, fieldOptions[name].options)
+      validateCurrency(identity, name, fieldOptions[name].currency)
+      validateUpload(identity, name, fieldOptions[name].upload)
+      if (
+        fieldOptions[name].component !== undefined &&
+        !isSafeComponentName(fieldOptions[name].component)
+      ) {
+        throw new Error(
+          `Bridge field "${identity}.${name}".component must be a safe registered component name.`
         )
       }
       for (const option of ['relation', 'upload']) {
@@ -421,6 +471,24 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
             `${identity}.${name}`
           )
         }
+      }
+
+      safeField.type = inferFieldType({
+        name,
+        attribute,
+        association,
+        configuredType: rawField.type
+      })
+      const optionSource =
+        rawField.options ?? attribute.isIn ?? attribute.validations?.isIn
+      if (optionSource !== undefined) {
+        safeField.options = normalizeFieldOptions(optionSource)
+      }
+      if (safeField.type === 'currency') {
+        safeField.currency = normalizeCurrency(rawField.currency)
+      }
+      if (['file', 'image', 'upload'].includes(safeField.type)) {
+        safeField.upload = normalizeUpload(safeField.type, rawField.upload)
       }
 
       attributes[name] = {
@@ -588,6 +656,299 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         `Bridge field "${identity}.${name}".visibility.${surface}`
       )
     }
+  }
+
+  function inferFieldType({ name, attribute, association, configuredType }) {
+    if (configuredType) return normalizeFieldType(configuredType)
+    if (association) return 'belongsTo'
+    if (attribute.encrypt || attribute.protect) return 'password'
+    if (attribute.isEmail || attribute.validations?.isEmail) return 'email'
+    if (attribute.isURL || attribute.validations?.isURL) return 'url'
+    if (
+      Array.isArray(attribute.isIn) ||
+      Array.isArray(attribute.validations?.isIn)
+    ) {
+      return 'select'
+    }
+    if (attribute.type === 'boolean') return 'boolean'
+    if (attribute.type === 'json' || attribute.type === 'ref') return 'json'
+    if (attribute.autoCreatedAt || attribute.autoUpdatedAt) return 'timestamp'
+    if (attribute.type === 'number') return 'number'
+    const dateFieldType = inferDateFieldType(attribute.columnType)
+    if (dateFieldType) return dateFieldType
+    if (attribute.type === 'string' && looksLikeLongText(name, attribute)) {
+      return 'textarea'
+    }
+    return 'text'
+  }
+
+  function normalizeFieldType(type) {
+    const normalized = String(type).trim()
+    if (normalized === 'toggle') return 'boolean'
+    if (normalized === 'string') return 'text'
+    return normalized
+  }
+
+  function inferDateFieldType(columnType) {
+    if (typeof columnType !== 'string') return null
+    if (/^\s*date\s*$/i.test(columnType)) return 'date'
+    if (/(date|time|timestamp)/i.test(columnType)) return 'datetime'
+    return null
+  }
+
+  function looksLikeLongText(name, attribute) {
+    if (
+      typeof attribute.columnType === 'string' &&
+      /(text|clob)/i.test(attribute.columnType)
+    ) {
+      return true
+    }
+    return /(content|body|description|bio|about|summary|notes|markdown|html)/i.test(
+      name
+    )
+  }
+
+  function validateFieldOptions(identity, name, options) {
+    if (options === undefined) return
+    for (const [index, option] of options.entries()) {
+      if (
+        ['string', 'number', 'boolean'].includes(typeof option) ||
+        option === null
+      ) {
+        continue
+      }
+      if (!isPlainObject(option)) {
+        throw new Error(
+          `Bridge field "${identity}.${name}".options[${index}] must be a primitive or an option object.`
+        )
+      }
+      rejectUnknownKeys(
+        option,
+        ['label', 'value', 'disabled'],
+        `Bridge field "${identity}.${name}".options[${index}]`
+      )
+      if (!Object.prototype.hasOwnProperty.call(option, 'value')) {
+        throw new Error(
+          `Bridge field "${identity}.${name}".options[${index}].value is required.`
+        )
+      }
+      if (
+        !['string', 'number', 'boolean'].includes(typeof option.value) &&
+        option.value !== null
+      ) {
+        throw new Error(
+          `Bridge field "${identity}.${name}".options[${index}].value must be a string, number, boolean, or null.`
+        )
+      }
+      assertOptionalString(
+        option.label,
+        `Bridge field "${identity}.${name}".options[${index}].label`
+      )
+      assertOptionalBoolean(
+        option.disabled,
+        `Bridge field "${identity}.${name}".options[${index}].disabled`
+      )
+    }
+  }
+
+  function normalizeFieldOptions(options) {
+    return options.map((option) => {
+      if (isPlainObject(option)) {
+        return {
+          label:
+            readString(option.label) ||
+            (option.value === null ? 'None' : String(option.value)),
+          value: option.value,
+          disabled: option.disabled === true
+        }
+      }
+      return {
+        label: option === null ? 'None' : String(option),
+        value: option,
+        disabled: false
+      }
+    })
+  }
+
+  function validateCurrency(identity, name, currency) {
+    if (currency === undefined) return
+    if (!isPlainObject(currency)) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".currency must be an object.`
+      )
+    }
+    rejectUnknownKeys(
+      currency,
+      [
+        'code',
+        'locale',
+        'storage',
+        'submit',
+        'minimumFractionDigits',
+        'maximumFractionDigits'
+      ],
+      `Bridge field "${identity}.${name}".currency`
+    )
+    assertOptionalString(
+      currency.code,
+      `Bridge field "${identity}.${name}".currency.code`
+    )
+    assertOptionalString(
+      currency.locale,
+      `Bridge field "${identity}.${name}".currency.locale`
+    )
+    for (const option of ['storage', 'submit']) {
+      if (
+        currency[option] !== undefined &&
+        !['major', 'minor'].includes(currency[option])
+      ) {
+        throw new Error(
+          `Bridge field "${identity}.${name}".currency.${option} must be "major" or "minor".`
+        )
+      }
+    }
+    for (const option of ['minimumFractionDigits', 'maximumFractionDigits']) {
+      const value = currency[option]
+      if (
+        value !== undefined &&
+        (!Number.isInteger(value) || value < 0 || value > 20)
+      ) {
+        throw new Error(
+          `Bridge field "${identity}.${name}".currency.${option} must be an integer from 0 to 20.`
+        )
+      }
+    }
+  }
+
+  function normalizeCurrency(currency = {}) {
+    const code = readString(currency.code) || 'USD'
+    if (!/^[A-Za-z]{3}$/.test(code)) {
+      throw new Error(
+        'Bridge currency codes must use a three-letter ISO 4217 code.'
+      )
+    }
+    const minimumFractionDigits = currency.minimumFractionDigits ?? 2
+    const maximumFractionDigits =
+      currency.maximumFractionDigits ?? minimumFractionDigits
+    if (maximumFractionDigits < minimumFractionDigits) {
+      throw new Error(
+        'Bridge currency maximumFractionDigits cannot be smaller than minimumFractionDigits.'
+      )
+    }
+    return {
+      code: code.toUpperCase(),
+      locale: readString(currency.locale) || 'en-US',
+      storage: currency.storage || 'major',
+      submit: currency.submit || 'major',
+      minimumFractionDigits,
+      maximumFractionDigits
+    }
+  }
+
+  function validateUpload(identity, name, upload) {
+    if (upload === undefined) return
+    if (!isPlainObject(upload)) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload must be an object.`
+      )
+    }
+    rejectUnknownKeys(
+      upload,
+      ['kind', 'storage', 'directory', 'store', 'accept', 'maxBytes'],
+      `Bridge field "${identity}.${name}".upload`
+    )
+    for (const option of ['kind', 'storage', 'directory', 'store']) {
+      assertOptionalString(
+        upload[option],
+        `Bridge field "${identity}.${name}".upload.${option}`
+      )
+    }
+    if (upload.kind !== undefined && !['image', 'file'].includes(upload.kind)) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.kind must be "image" or "file".`
+      )
+    }
+    if (upload.storage !== undefined && upload.storage !== 'bridge') {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.storage must be "bridge".`
+      )
+    }
+    if (upload.store !== undefined && upload.store !== 'url') {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.store must be "url".`
+      )
+    }
+    if (
+      upload.directory !== undefined &&
+      !/^[A-Za-z0-9](?:[A-Za-z0-9_-]|\/(?=[A-Za-z0-9]))*$/.test(
+        upload.directory
+      )
+    ) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.directory must be a safe relative object path.`
+      )
+    }
+    if (
+      upload.accept !== undefined &&
+      !(
+        typeof upload.accept === 'string' ||
+        (Array.isArray(upload.accept) &&
+          upload.accept.every(
+            (value) => typeof value === 'string' && value.trim()
+          ))
+      )
+    ) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.accept must be a MIME type string or array.`
+      )
+    }
+    if (
+      upload.maxBytes !== undefined &&
+      (!Number.isSafeInteger(upload.maxBytes) ||
+        upload.maxBytes < 1 ||
+        upload.maxBytes > 2 * 1024 * 1024 * 1024)
+    ) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.maxBytes must be between 1 byte and 2 GiB.`
+      )
+    }
+  }
+
+  function normalizeUpload(type, upload = {}) {
+    const kind = upload.kind || (type === 'image' ? 'image' : 'file')
+    const accept = Array.isArray(upload.accept)
+      ? upload.accept.map((value) => value.trim())
+      : typeof upload.accept === 'string'
+      ? upload.accept
+          .split(',')
+          .map((value) => value.trim())
+          .filter(Boolean)
+      : kind === 'image'
+      ? ['image/avif', 'image/gif', 'image/jpeg', 'image/png', 'image/webp']
+      : []
+
+    return {
+      kind,
+      storage: upload.storage || 'bridge',
+      directory: readString(upload.directory) || '',
+      store: upload.store || 'url',
+      accept,
+      maxBytes:
+        upload.maxBytes ||
+        (kind === 'image' ? 5 * 1024 * 1024 : 100 * 1024 * 1024)
+    }
+  }
+
+  function isSafeComponentName(value) {
+    return (
+      typeof value === 'string' &&
+      /^[A-Za-z][A-Za-z0-9]*(?:[./-][A-Za-z0-9]+)*$/.test(value) &&
+      !value
+        .split(/[./-]/)
+        .some((part) =>
+          ['__proto__', 'constructor', 'prototype'].includes(part)
+        )
+    )
   }
 
   function isAllowedOnSurface(attribute, surface) {

--- a/api/helpers/bridge/redact-resource-records.js
+++ b/api/helpers/bridge/redact-resource-records.js
@@ -2,7 +2,7 @@ module.exports = {
   friendlyName: 'Redact Bridge resource records',
 
   description:
-    'Strip record properties that are outside the normalized Bridge field surface.',
+    'Strip unavailable properties and resolve stored field values for a Bridge surface.',
 
   inputs: {
     records: {
@@ -43,7 +43,10 @@ module.exports = {
           !['__proto__', 'constructor', 'prototype'].includes(field) &&
           Object.prototype.hasOwnProperty.call(record, field)
         ) {
-          safeRecord[field] = record[field]
+          safeRecord[field] = resolveFieldValue(
+            record[field],
+            resource.attributes?.[field]
+          )
         }
       }
       return safeRecord
@@ -51,4 +54,18 @@ module.exports = {
 
     return Array.isArray(records) ? records.map(redact) : redact(records)
   }
+}
+
+function resolveFieldValue(value, attribute) {
+  if (value === null || value === undefined) return value
+  if (
+    attribute?.field?.type === 'currency' &&
+    attribute.field.currency?.storage === 'minor'
+  ) {
+    const number = Number(value)
+    if (!Number.isFinite(number)) return value
+    const digits = attribute.field.currency.maximumFractionDigits ?? 2
+    return number / 10 ** digits
+  }
+  return value
 }

--- a/api/helpers/bridge/verify-upload-receipt.js
+++ b/api/helpers/bridge/verify-upload-receipt.js
@@ -1,0 +1,106 @@
+const crypto = require('node:crypto')
+
+module.exports = {
+  friendlyName: 'Verify Bridge upload receipt',
+
+  description:
+    'Verify that an uploaded URL was issued for the current Bridge actor and field.',
+
+  inputs: {
+    receipt: {
+      type: 'string',
+      required: true,
+      maxLength: 4096
+    },
+    url: {
+      type: 'string',
+      required: true,
+      maxLength: 2048
+    },
+    context: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ receipt, url, context }) {
+    const [encoded, suppliedSignature, extra] = receipt.split('.')
+    if (!encoded || !suppliedSignature || extra !== undefined) {
+      throw invalidReceipt()
+    }
+
+    const expectedSignature = sign(encoded)
+    const expectedBuffer = Buffer.from(expectedSignature)
+    const suppliedBuffer = Buffer.from(suppliedSignature)
+    if (
+      expectedBuffer.length !== suppliedBuffer.length ||
+      !crypto.timingSafeEqual(expectedBuffer, suppliedBuffer)
+    ) {
+      throw invalidReceipt()
+    }
+
+    let payload
+    try {
+      payload = JSON.parse(Buffer.from(encoded, 'base64url').toString('utf8'))
+    } catch {
+      throw invalidReceipt()
+    }
+
+    const expected = {
+      actorId: String(context.actorId),
+      projectId: String(context.projectId),
+      environmentId: String(context.environmentId),
+      resource: String(context.resource),
+      field: String(context.field)
+    }
+    if (
+      payload.version !== 1 ||
+      payload.url !== url ||
+      !Number.isSafeInteger(payload.issuedAt) ||
+      !Number.isSafeInteger(payload.expiresAt) ||
+      payload.issuedAt > Date.now() ||
+      payload.expiresAt <= Date.now() ||
+      Object.entries(expected).some(([key, value]) => payload[key] !== value)
+    ) {
+      throw invalidReceipt()
+    }
+
+    let parsed
+    try {
+      parsed = new URL(payload.url)
+    } catch {
+      throw invalidReceipt()
+    }
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      throw invalidReceipt()
+    }
+
+    return payload.url
+  }
+}
+
+function sign(value) {
+  const secret = sails.config.session?.secret
+  if (typeof secret !== 'string' || secret.length < 16) {
+    const error = new Error(
+      'Bridge uploads require a strong Slipway session secret.'
+    )
+    error.code = 'BRIDGE_UPLOAD_SECRET_UNAVAILABLE'
+    throw error
+  }
+  return crypto.createHmac('sha256', secret).update(value).digest('base64url')
+}
+
+function invalidReceipt() {
+  const error = new Error(
+    'Upload this file through Bridge before saving the record.'
+  )
+  error.code = 'BRIDGE_UPLOAD_RECEIPT_INVALID'
+  return error
+}

--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -1,0 +1,617 @@
+<script setup>
+import { computed, ref } from 'vue'
+import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
+import {
+  bridgeFieldType,
+  bridgeSelectOptions,
+  formatBridgeBytes,
+  safeBridgeHttpUrl
+} from '@/lib/bridge/fields.mjs'
+import { containsRawHtml } from '@/lib/content/markdown.mjs'
+import { resolveBridgeFieldComponent } from '@/lib/bridge/field-components.mjs'
+
+const props = defineProps({
+  field: {
+    type: Object,
+    required: true
+  },
+  modelValue: {
+    default: null
+  },
+  error: {
+    type: String,
+    default: ''
+  },
+  isEdit: Boolean,
+  modelIdentity: {
+    type: String,
+    required: true
+  },
+  recordId: {
+    type: [String, Number],
+    default: null
+  },
+  associationOptions: {
+    type: Array,
+    default: () => []
+  },
+  uploadUrl: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'blur', 'clear-error'])
+
+const fileInput = ref(null)
+const uploading = ref(false)
+const uploadError = ref('')
+const richTextEditor = ref(null)
+const richTextMode = ref('visual')
+const richTextCompatibility = ref({ supported: true })
+
+const attribute = computed(() => props.field.attr)
+const type = computed(() => bridgeFieldType(attribute.value))
+const label = computed(() => attribute.value.label || props.field.name)
+const description = computed(
+  () => attribute.value.field?.help || attribute.value.description || ''
+)
+const placeholder = computed(
+  () => attribute.value.field?.placeholder || defaultPlaceholder(type.value)
+)
+const options = computed(() => bridgeSelectOptions(attribute.value))
+const fieldId = computed(() =>
+  `bridge-${props.modelIdentity}-${props.field.name}`.replace(
+    /[^A-Za-z0-9_-]/g,
+    '-'
+  )
+)
+const errorId = computed(() => `${fieldId.value}-error`)
+const helpId = computed(() => `${fieldId.value}-help`)
+const describedBy = computed(
+  () =>
+    [
+      description.value ? helpId.value : null,
+      visibleError.value ? errorId.value : null
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined
+)
+const richTextSecurityError = computed(() => {
+  if (
+    type.value !== 'richtext' ||
+    attribute.value.field?.format?.toLowerCase() !== 'markdown'
+  ) {
+    return ''
+  }
+  return containsRawHtml(String(props.modelValue || ''))
+    ? 'Raw HTML is not allowed in Bridge Markdown fields.'
+    : ''
+})
+const visibleError = computed(
+  () => uploadError.value || richTextSecurityError.value || props.error
+)
+const customComponent = computed(() =>
+  resolveBridgeFieldComponent(attribute.value.field?.component, 'form')
+)
+const isImageUpload = computed(
+  () =>
+    type.value === 'image' || attribute.value.field?.upload?.kind === 'image'
+)
+const uploadedValue = computed(() =>
+  props.modelValue && typeof props.modelValue === 'object'
+    ? props.modelValue
+    : null
+)
+const currentUploadUrl = computed(
+  () => uploadedValue.value?.url || props.modelValue || ''
+)
+const safeCurrentUploadUrl = computed(() =>
+  safeBridgeHttpUrl(currentUploadUrl.value)
+)
+const accept = computed(() =>
+  (attribute.value.field?.upload?.accept || []).join(',')
+)
+const maxBytes = computed(
+  () => attribute.value.field?.upload?.maxBytes || 5 * 1024 * 1024
+)
+const uploadHint = computed(() => {
+  const accepted = attribute.value.field?.upload?.accept || []
+  const labels = accepted.map((value) => {
+    if (value.endsWith('/*')) return value.slice(0, -2)
+    return value.split('/').pop()?.replace('jpeg', 'jpg') || value
+  })
+  const types =
+    labels.length === 0
+      ? 'Any file type'
+      : new Intl.ListFormat(undefined, {
+          style: 'short',
+          type: 'disjunction'
+        }).format(labels.map((value) => value.toUpperCase()))
+  return `${types} · ${formatBridgeBytes(maxBytes.value)} max`
+})
+const currencySymbol = computed(() => {
+  const currency = attribute.value.field?.currency || {}
+  try {
+    return (
+      new Intl.NumberFormat(currency.locale || 'en-US', {
+        style: 'currency',
+        currency: currency.code || 'USD',
+        currencyDisplay: 'narrowSymbol'
+      })
+        .formatToParts(0)
+        .find((part) => part.type === 'currency')?.value ||
+      currency.code ||
+      'USD'
+    )
+  } catch {
+    return currency.code || 'USD'
+  }
+})
+const inputClass =
+  'focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500'
+const textareaClass =
+  'focus:border-brand min-h-28 w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500'
+
+function update(value) {
+  emit('update:modelValue', value)
+  if (props.error) emit('clear-error')
+}
+
+function handleBlur() {
+  emit('blur')
+}
+
+function toggleRichTextMode() {
+  const next = richTextMode.value === 'source' ? 'visual' : 'source'
+  richTextEditor.value?.setMode(next)
+}
+
+async function uploadFile(event) {
+  const file = event.target.files?.[0]
+  event.target.value = ''
+  if (!file) return
+
+  uploadError.value = ''
+  if (file.size > maxBytes.value) {
+    uploadError.value = `Choose a file no larger than ${formatBridgeBytes(
+      maxBytes.value
+    )}.`
+    return
+  }
+  if (!props.uploadUrl) {
+    uploadError.value = 'This Bridge upload field is not configured.'
+    return
+  }
+
+  uploading.value = true
+  try {
+    const data = new FormData()
+    data.append('file', file)
+    if (props.isEdit && props.recordId !== null) {
+      data.append('recordId', String(props.recordId))
+    }
+    const response = await fetch(props.uploadUrl, {
+      method: 'POST',
+      body: data
+    })
+    const result = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(result.message || 'The file could not be uploaded.')
+    }
+    if (!result.url || !result.receipt) {
+      throw new Error('The upload did not return a verifiable file URL.')
+    }
+    update({
+      url: result.url,
+      receipt: result.receipt,
+      file: result.file || { name: file.name, size: file.size, type: file.type }
+    })
+  } catch (error) {
+    uploadError.value = error.message || 'The file could not be uploaded.'
+  } finally {
+    uploading.value = false
+  }
+}
+
+function defaultPlaceholder(fieldType) {
+  if (fieldType === 'email') return 'name@example.com'
+  if (fieldType === 'url') return 'https://example.com'
+  if (fieldType === 'number' || fieldType === 'currency') return '0'
+  if (fieldType === 'json') return '{}'
+  if (fieldType === 'textarea' || fieldType === 'richtext') {
+    return 'Write your content here…'
+  }
+  return ''
+}
+</script>
+
+<template>
+  <component
+    :is="customComponent"
+    v-if="customComponent"
+    :field="field"
+    :model-value="modelValue"
+    :error="visibleError"
+    :is-edit="isEdit"
+    @update:model-value="update"
+    @blur="handleBlur"
+  />
+
+  <div v-else class="space-y-2">
+    <div
+      v-if="type === 'boolean'"
+      class="min-h-11 flex items-center justify-between gap-4"
+    >
+      <label
+        :for="fieldId"
+        class="text-sm font-medium text-gray-700 dark:text-gray-300"
+      >
+        {{ label }}
+      </label>
+      <div class="flex items-center gap-3">
+        <button
+          :id="fieldId"
+          type="button"
+          role="switch"
+          :aria-checked="Boolean(modelValue)"
+          :aria-describedby="describedBy"
+          :disabled="field.readOnly"
+          :data-test="`${fieldId}-input`"
+          :class="[
+            'relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 motion-reduce:transition-none dark:focus-visible:ring-gray-600 dark:focus-visible:ring-offset-gray-900',
+            modelValue
+              ? 'bg-gray-900 dark:bg-white'
+              : 'bg-gray-300 dark:bg-gray-600',
+            field.readOnly ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
+          ]"
+          @click="update(!modelValue)"
+          @blur="handleBlur"
+        >
+          <span
+            :class="[
+              'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform motion-reduce:transition-none dark:bg-gray-900',
+              modelValue ? 'translate-x-4' : 'translate-x-0'
+            ]"
+            aria-hidden="true"
+          ></span>
+        </button>
+        <span class="w-6 text-sm text-gray-500 dark:text-gray-400">
+          {{ modelValue ? 'Yes' : 'No' }}
+        </span>
+      </div>
+    </div>
+
+    <template v-else>
+      <div class="flex items-center justify-between gap-3">
+        <label
+          :id="type === 'richtext' ? `${fieldId}-label` : undefined"
+          :for="type === 'richtext' ? undefined : fieldId"
+          class="block text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          {{ label }}
+          <span
+            v-if="!attribute.required"
+            class="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500"
+          >
+            Optional
+          </span>
+        </label>
+        <button
+          v-if="
+            type === 'richtext' &&
+            attribute.field?.format?.toLowerCase() === 'markdown'
+          "
+          type="button"
+          :data-test="`${fieldId}-mode-toggle`"
+          :aria-label="`Edit ${label} as ${
+            richTextMode === 'source' ? 'Visual' : 'Markdown'
+          }`"
+          :disabled="
+            richTextMode === 'source' &&
+            richTextCompatibility.supported === false
+          "
+          class="text-xs font-medium text-gray-400 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-500 dark:hover:text-white"
+          @click="toggleRichTextMode"
+        >
+          {{ richTextMode === 'source' ? 'Visual' : 'Markdown' }}
+        </button>
+      </div>
+
+      <input
+        v-if="['text', 'email', 'url', 'password', 'secret'].includes(type)"
+        :id="fieldId"
+        :value="modelValue"
+        :type="
+          ['password', 'secret'].includes(type)
+            ? 'password'
+            : type === 'url'
+            ? 'url'
+            : type
+        "
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :maxlength="attribute.maxLength || undefined"
+        :placeholder="
+          ['password', 'secret'].includes(type) && isEdit
+            ? 'Leave blank to keep current'
+            : placeholder
+        "
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="inputClass"
+        @input="update($event.target.value)"
+        @blur="handleBlur"
+      />
+
+      <div
+        v-else-if="type === 'currency'"
+        class="flex items-center border-b border-dashed border-gray-200 focus-within:border-gray-900 dark:border-gray-700 dark:focus-within:border-white"
+      >
+        <span
+          class="shrink-0 pl-1 text-sm text-gray-400 dark:text-gray-500"
+          aria-hidden="true"
+        >
+          {{ currencySymbol }}
+        </span>
+        <input
+          :id="fieldId"
+          :value="modelValue"
+          type="number"
+          inputmode="decimal"
+          step="any"
+          :disabled="field.readOnly"
+          :required="attribute.required"
+          :min="attribute.min ?? undefined"
+          :max="attribute.max ?? undefined"
+          :placeholder="placeholder"
+          :aria-invalid="visibleError ? 'true' : undefined"
+          :aria-describedby="describedBy"
+          :data-test="`${fieldId}-input`"
+          class="h-11 w-full bg-transparent px-2 text-sm tabular-nums text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:text-white dark:placeholder-gray-500"
+          @input="update($event.target.value)"
+          @blur="handleBlur"
+        />
+      </div>
+
+      <input
+        v-else-if="type === 'number'"
+        :id="fieldId"
+        :value="modelValue"
+        type="number"
+        inputmode="decimal"
+        step="any"
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :min="attribute.min ?? undefined"
+        :max="attribute.max ?? undefined"
+        :placeholder="placeholder"
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="`${inputClass} tabular-nums`"
+        @input="update($event.target.value)"
+        @blur="handleBlur"
+      />
+
+      <input
+        v-else-if="type === 'date'"
+        :id="fieldId"
+        :value="modelValue"
+        type="date"
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="inputClass"
+        @input="update($event.target.value)"
+        @blur="handleBlur"
+      />
+
+      <input
+        v-else-if="['datetime', 'timestamp'].includes(type)"
+        :id="fieldId"
+        :value="modelValue"
+        type="datetime-local"
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="inputClass"
+        @input="update($event.target.value)"
+        @blur="handleBlur"
+      />
+
+      <select
+        v-else-if="type === 'select'"
+        :id="fieldId"
+        :value="modelValue"
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="inputClass"
+        @change="update(options[$event.target.selectedIndex - 1]?.value ?? '')"
+        @blur="handleBlur"
+      >
+        <option value="">Select…</option>
+        <option
+          v-for="option in options"
+          :key="`${typeof option.value}:${String(option.value)}`"
+          :value="String(option.value)"
+          :disabled="option.disabled"
+          :selected="Object.is(option.value, modelValue)"
+        >
+          {{ option.label }}
+        </option>
+      </select>
+
+      <select
+        v-else-if="type === 'belongsTo'"
+        :id="fieldId"
+        :value="modelValue"
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="inputClass"
+        @change="
+          update(associationOptions[$event.target.selectedIndex - 1]?.id ?? '')
+        "
+        @blur="handleBlur"
+      >
+        <option value="">{{ attribute.required ? 'Select…' : 'None' }}</option>
+        <option
+          v-for="option in associationOptions"
+          :key="String(option.id)"
+          :value="String(option.id)"
+          :selected="String(option.id) === String(modelValue)"
+        >
+          {{ option.label }}
+        </option>
+      </select>
+
+      <MarkdownEditor
+        v-else-if="
+          type === 'richtext' &&
+          attribute.field?.format?.toLowerCase() === 'markdown'
+        "
+        ref="richTextEditor"
+        :model-value="modelValue"
+        variant="field"
+        :editor-id="fieldId"
+        :placeholder="placeholder"
+        :aria-label="label"
+        :aria-labelledby="`${fieldId}-label`"
+        :aria-describedby="describedBy"
+        :required="attribute.required"
+        deny-raw-html
+        @update:model-value="update"
+        @blur="handleBlur"
+        @mode-change="richTextMode = $event"
+        @compatibility-change="richTextCompatibility = $event"
+      />
+
+      <textarea
+        v-else-if="['textarea', 'richtext'].includes(type)"
+        :id="fieldId"
+        :value="modelValue"
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :maxlength="attribute.maxLength || undefined"
+        :placeholder="placeholder"
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="textareaClass"
+        style="field-sizing: content"
+        @input="update($event.target.value)"
+        @blur="handleBlur"
+      ></textarea>
+
+      <textarea
+        v-else-if="type === 'json'"
+        :id="fieldId"
+        :value="modelValue"
+        :disabled="field.readOnly"
+        :required="attribute.required"
+        :placeholder="placeholder"
+        :aria-invalid="visibleError ? 'true' : undefined"
+        :aria-describedby="describedBy"
+        :data-test="`${fieldId}-input`"
+        :class="`${textareaClass} font-mono`"
+        style="field-sizing: content"
+        @input="update($event.target.value)"
+        @blur="handleBlur"
+      ></textarea>
+
+      <div
+        v-else-if="['file', 'image', 'upload'].includes(type)"
+        class="space-y-3"
+      >
+        <input
+          :id="fieldId"
+          ref="fileInput"
+          type="file"
+          class="sr-only"
+          :accept="accept || undefined"
+          :disabled="field.readOnly || uploading"
+          :data-test="`${fieldId}-input`"
+          @change="uploadFile"
+        />
+        <div
+          v-if="safeCurrentUploadUrl"
+          class="flex min-w-0 items-center gap-3 rounded-lg bg-gray-50 p-3 dark:bg-gray-900"
+        >
+          <img
+            v-if="isImageUpload"
+            :src="safeCurrentUploadUrl"
+            :alt="`${label} preview`"
+            class="h-12 w-16 shrink-0 rounded-md object-cover"
+          />
+          <div class="min-w-0 flex-1">
+            <p
+              class="truncate text-sm font-medium text-gray-700 dark:text-gray-200"
+            >
+              {{ uploadedValue?.file?.name || 'Uploaded file' }}
+            </p>
+            <a
+              :href="safeCurrentUploadUrl"
+              target="_blank"
+              rel="noreferrer"
+              class="block truncate text-xs text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300"
+            >
+              {{ safeCurrentUploadUrl }}
+            </a>
+          </div>
+          <button
+            type="button"
+            :disabled="field.readOnly || uploading"
+            class="shrink-0 text-xs font-medium text-gray-500 hover:text-gray-900 disabled:opacity-50 dark:text-gray-400 dark:hover:text-white"
+            @click="fileInput?.click()"
+          >
+            Replace
+          </button>
+        </div>
+        <button
+          v-else
+          type="button"
+          :disabled="field.readOnly || uploading"
+          class="inline-flex h-10 items-center rounded-md bg-gray-100 px-3 text-sm font-medium text-gray-700 hover:bg-gray-200 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700"
+          @click="fileInput?.click()"
+        >
+          {{
+            uploading
+              ? 'Uploading…'
+              : isImageUpload
+              ? 'Choose image'
+              : 'Choose file'
+          }}
+        </button>
+        <p class="text-xs text-gray-400 dark:text-gray-500">
+          {{ uploadHint }}
+        </p>
+      </div>
+    </template>
+
+    <p
+      v-if="visibleError"
+      :id="errorId"
+      class="text-xs text-red-600 dark:text-red-400"
+    >
+      {{ visibleError }}
+    </p>
+    <p
+      v-if="description"
+      :id="helpId"
+      class="text-xs leading-5 text-gray-400 dark:text-gray-500"
+    >
+      {{ description }}
+    </p>
+  </div>
+</template>

--- a/assets/js/components/bridge/BridgeFieldValue.vue
+++ b/assets/js/components/bridge/BridgeFieldValue.vue
@@ -1,0 +1,158 @@
+<script setup>
+import { computed } from 'vue'
+import {
+  bridgeFieldType,
+  formatBridgeFieldValue
+} from '@/lib/bridge/fields.mjs'
+import { resolveBridgeFieldComponent } from '@/lib/bridge/field-components.mjs'
+
+const props = defineProps({
+  name: {
+    type: String,
+    required: true
+  },
+  attribute: {
+    type: Object,
+    required: true
+  },
+  value: {
+    default: null
+  },
+  context: {
+    type: String,
+    default: 'show',
+    validator: (value) => ['list', 'show'].includes(value)
+  }
+})
+
+const formatted = computed(() =>
+  formatBridgeFieldValue(props.value, props.attribute, props.context)
+)
+const customComponent = computed(() =>
+  resolveBridgeFieldComponent(props.attribute.field?.component, props.context)
+)
+const isCompact = computed(() => props.context === 'list')
+const fieldType = computed(() => bridgeFieldType(props.attribute))
+</script>
+
+<template>
+  <component
+    :is="customComponent"
+    v-if="customComponent"
+    :name="name"
+    :attribute="attribute"
+    :value="value"
+    :context="context"
+  />
+
+  <span
+    v-else-if="formatted.kind === 'null'"
+    class="text-gray-300 dark:text-gray-600"
+  >
+    null
+  </span>
+
+  <span
+    v-else-if="formatted.kind === 'boolean' && isCompact"
+    class="inline-flex items-center gap-2"
+  >
+    <span
+      :class="[
+        'h-2 w-2 rounded-full',
+        formatted.value ? 'bg-emerald-500' : 'bg-gray-300 dark:bg-gray-600'
+      ]"
+      aria-hidden="true"
+    ></span>
+    <span class="sr-only">{{ formatted.display }}</span>
+  </span>
+
+  <span
+    v-else-if="formatted.kind === 'boolean'"
+    :class="[
+      'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+      formatted.value
+        ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400'
+        : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+    ]"
+  >
+    {{ formatted.display }}
+  </span>
+
+  <a
+    v-else-if="formatted.kind === 'image' && formatted.url"
+    :href="formatted.url"
+    target="_blank"
+    rel="noreferrer"
+    :class="[
+      'inline-flex overflow-hidden bg-gray-100 dark:bg-gray-800',
+      isCompact ? 'h-8 w-12 rounded-md' : 'max-h-48 max-w-xs rounded-lg'
+    ]"
+  >
+    <img
+      :src="formatted.url"
+      :alt="`${attribute.label || name} preview`"
+      :class="
+        isCompact
+          ? 'h-full w-full object-cover'
+          : 'h-auto w-auto object-contain'
+      "
+      loading="lazy"
+    />
+  </a>
+
+  <a
+    v-else-if="['file', 'url'].includes(formatted.kind) && formatted.url"
+    :href="formatted.url"
+    target="_blank"
+    rel="noreferrer"
+    :title="formatted.kind === 'url' ? formatted.display : undefined"
+    class="inline-flex max-w-full items-center gap-1.5 text-gray-900 hover:underline dark:text-white"
+  >
+    <span :class="isCompact ? 'max-w-52 truncate' : 'break-all'">
+      {{ formatted.display }}
+    </span>
+    <svg
+      class="h-3.5 w-3.5 shrink-0 text-gray-400"
+      viewBox="0 0 20 20"
+      fill="none"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M7.5 5h-2A2.5 2.5 0 0 0 3 7.5v7A2.5 2.5 0 0 0 5.5 17h7a2.5 2.5 0 0 0 2.5-2.5v-2M11 3h6v6m0-6-8 8"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="1.5"
+      />
+    </svg>
+  </a>
+
+  <a
+    v-else-if="formatted.kind === 'email'"
+    :href="`mailto:${formatted.email}`"
+    class="break-all text-gray-900 hover:underline dark:text-white"
+  >
+    {{ formatted.display }}
+  </a>
+
+  <pre
+    v-else-if="formatted.kind === 'json' && !isCompact"
+    class="max-h-56 overflow-auto rounded-lg bg-gray-50 p-3 font-mono text-xs leading-5 text-gray-700 dark:bg-gray-950 dark:text-gray-300"
+    >{{ formatted.display }}</pre
+  >
+
+  <span
+    v-else
+    :class="[
+      fieldType === 'currency' ? 'tabular-nums' : '',
+      formatted.kind === 'longtext' && !isCompact
+        ? 'whitespace-pre-wrap break-words leading-6'
+        : isCompact
+        ? 'max-w-72 block truncate'
+        : 'break-all'
+    ]"
+    :title="isCompact ? String(value ?? '') : undefined"
+  >
+    {{ formatted.display }}
+  </span>
+</template>

--- a/assets/js/lib/bridge/field-components.mjs
+++ b/assets/js/lib/bridge/field-components.mjs
@@ -1,0 +1,20 @@
+const registry = new Map()
+
+export function registerBridgeFieldComponent(name, components) {
+  if (!/^[A-Za-z][A-Za-z0-9]*(?:[./-][A-Za-z0-9]+)*$/.test(name)) {
+    throw new Error('Bridge field component names must be safe identifiers.')
+  }
+  if (!components || typeof components !== 'object') {
+    throw new Error('Bridge field components must be an object.')
+  }
+  registry.set(name, { ...components })
+}
+
+export function resolveBridgeFieldComponent(name, context) {
+  if (!name) return null
+  return registry.get(name)?.[context] || null
+}
+
+export function clearBridgeFieldComponents() {
+  registry.clear()
+}

--- a/assets/js/lib/bridge/fields.mjs
+++ b/assets/js/lib/bridge/fields.mjs
@@ -1,0 +1,328 @@
+const TEXT_TYPES = new Set([
+  'text',
+  'textarea',
+  'richtext',
+  'email',
+  'url',
+  'password',
+  'secret'
+])
+
+export function bridgeFieldType(attribute = {}) {
+  return attribute.field?.type || attribute.type || 'text'
+}
+
+export function toBridgeFieldInputValue(attribute, value) {
+  const type = bridgeFieldType(attribute)
+  const defaultValue = attribute.field?.default ?? attribute.defaultsTo
+  const resolved = value === undefined ? defaultValue : value
+
+  if (type === 'boolean') return Boolean(resolved ?? false)
+  if (type === 'json') {
+    if (resolved === undefined || resolved === null) return ''
+    return typeof resolved === 'string'
+      ? resolved
+      : JSON.stringify(resolved, null, 2)
+  }
+  if (type === 'date') return toDateInputValue(resolved)
+  if (['datetime', 'timestamp'].includes(type)) {
+    return toDateTimeInputValue(resolved)
+  }
+  return resolved ?? ''
+}
+
+export function validateBridgeFieldValue({ attribute, value, isEdit = false }) {
+  const type = bridgeFieldType(attribute)
+  if (isEdit && ['password', 'secret'].includes(type) && value === '') return ''
+  if (['file', 'image', 'upload'].includes(type)) {
+    if (!attribute.required || value?.receipt || typeof value === 'string') {
+      return ''
+    }
+    return `${attribute.label || 'This file'} is required.`
+  }
+
+  if (attribute.required && isEmpty(value, type)) {
+    return `${attribute.label || 'This field'} is required.`
+  }
+  if (isEmpty(value, type)) return ''
+
+  if (type === 'json') {
+    try {
+      JSON.parse(value)
+    } catch {
+      return `${attribute.label || 'This field'} must contain valid JSON.`
+    }
+  }
+  if (
+    ['number', 'currency'].includes(type) &&
+    !Number.isFinite(Number(value))
+  ) {
+    return `${attribute.label || 'This field'} must be a number.`
+  }
+  if (['number', 'currency'].includes(type)) {
+    const number = Number(value)
+    const min = attribute.min ?? attribute.validations?.min
+    const max = attribute.max ?? attribute.validations?.max
+    if (min !== undefined && min !== null && number < min) {
+      return `${attribute.label || 'This field'} must be at least ${min}.`
+    }
+    if (max !== undefined && max !== null && number > max) {
+      return `${attribute.label || 'This field'} must be at most ${max}.`
+    }
+  }
+  if (type === 'select') {
+    const options = bridgeSelectOptions(attribute)
+    if (
+      options.length > 0 &&
+      !options.some(
+        (option) => option.disabled !== true && Object.is(option.value, value)
+      )
+    ) {
+      return `${
+        attribute.label || 'This field'
+      } must use one of the available options.`
+    }
+  }
+  if (type === 'email' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+    return `${attribute.label || 'This field'} must be a valid email address.`
+  }
+  if (type === 'url') {
+    try {
+      const url = new URL(value)
+      if (!['http:', 'https:'].includes(url.protocol)) throw new Error()
+    } catch {
+      return `${
+        attribute.label || 'This field'
+      } must be a valid HTTP or HTTPS URL.`
+    }
+  }
+  if (type === 'date' && !isValidDateOnly(value)) {
+    return `${attribute.label || 'This field'} must be a valid date.`
+  }
+  if (
+    ['datetime', 'timestamp'].includes(type) &&
+    Number.isNaN(new Date(value).getTime())
+  ) {
+    return `${attribute.label || 'This field'} must be a valid date and time.`
+  }
+  if (TEXT_TYPES.has(type)) {
+    const length = String(value).length
+    const minLength = attribute.minLength ?? attribute.validations?.minLength
+    const maxLength = attribute.maxLength ?? attribute.validations?.maxLength
+    if (minLength && length < minLength) {
+      return `${
+        attribute.label || 'This field'
+      } must contain at least ${minLength} characters.`
+    }
+    if (maxLength && length > maxLength) {
+      return `${
+        attribute.label || 'This field'
+      } must contain at most ${maxLength} characters.`
+    }
+  }
+  return ''
+}
+
+export function prepareBridgeFieldSubmission({
+  attribute,
+  value,
+  isEdit = false
+}) {
+  const type = bridgeFieldType(attribute)
+
+  if (isEdit && ['password', 'secret'].includes(type) && value === '') {
+    return { include: false }
+  }
+  if (['file', 'image', 'upload'].includes(type)) {
+    return value?.receipt
+      ? { include: true, value: { url: value.url, receipt: value.receipt } }
+      : { include: false }
+  }
+  if (type === 'json' && typeof value === 'string' && value.trim()) {
+    return { include: true, value: JSON.parse(value) }
+  }
+  if (['number', 'currency'].includes(type) && value !== '' && value !== null) {
+    return { include: true, value: Number(value) }
+  }
+  if (
+    ['datetime', 'timestamp'].includes(type) &&
+    typeof value === 'string' &&
+    value
+  ) {
+    return { include: true, value: new Date(value).toISOString() }
+  }
+  if (value === '' && !attribute.required && !TEXT_TYPES.has(type)) {
+    return { include: true, value: null }
+  }
+  return { include: true, value }
+}
+
+export function bridgeSelectOptions(attribute = {}) {
+  const configured = attribute.field?.options
+  if (Array.isArray(configured)) return configured
+  const inferred = attribute.isIn || attribute.validations?.isIn || []
+  return inferred.map((value) => ({
+    label: String(value),
+    value,
+    disabled: false
+  }))
+}
+
+export function formatBridgeFieldValue(
+  value,
+  attribute = {},
+  context = 'show'
+) {
+  const type = bridgeFieldType(attribute)
+  if (value === null || value === undefined) {
+    return { kind: 'null', display: 'null' }
+  }
+  if (type === 'boolean') {
+    return { kind: 'boolean', display: value ? 'Yes' : 'No', value: !!value }
+  }
+  if (type === 'currency') {
+    const currency = attribute.field?.currency || {}
+    const number = Number(value)
+    if (!Number.isFinite(number))
+      return { kind: 'text', display: String(value) }
+    try {
+      return {
+        kind: 'currency',
+        display: new Intl.NumberFormat(currency.locale || 'en-US', {
+          style: 'currency',
+          currency: currency.code || 'USD',
+          minimumFractionDigits: currency.minimumFractionDigits ?? 2,
+          maximumFractionDigits: currency.maximumFractionDigits ?? 2
+        }).format(number)
+      }
+    } catch {
+      return { kind: 'text', display: String(value) }
+    }
+  }
+  if (['date', 'datetime', 'timestamp'].includes(type)) {
+    const date = new Date(
+      type === 'date' && typeof value === 'string' ? `${value}T00:00:00` : value
+    )
+    if (!Number.isNaN(date.getTime())) {
+      return {
+        kind: 'date',
+        display:
+          type === 'date'
+            ? date.toLocaleDateString(undefined, { dateStyle: 'medium' })
+            : date.toLocaleString(undefined, {
+                dateStyle: context === 'list' ? 'medium' : 'long',
+                timeStyle: context === 'list' ? 'short' : 'medium'
+              })
+      }
+    }
+  }
+  if (type === 'json' || typeof value === 'object') {
+    return {
+      kind: 'json',
+      display: JSON.stringify(value, null, context === 'list' ? 0 : 2)
+    }
+  }
+  if (['image'].includes(type) || attribute.field?.upload?.kind === 'image') {
+    return {
+      kind: 'image',
+      display: String(value),
+      url: safeBridgeHttpUrl(value)
+    }
+  }
+  if (['file', 'upload'].includes(type)) {
+    return {
+      kind: 'file',
+      display: fileNameFromUrl(value),
+      url: safeBridgeHttpUrl(value)
+    }
+  }
+  if (type === 'url') {
+    return {
+      kind: 'url',
+      display: String(value),
+      url: safeBridgeHttpUrl(value)
+    }
+  }
+  if (type === 'email') {
+    return { kind: 'email', display: String(value), email: String(value) }
+  }
+
+  const string = String(value)
+  return {
+    kind: type === 'richtext' || type === 'textarea' ? 'longtext' : 'text',
+    display:
+      context === 'list' && string.length > 60
+        ? `${string.slice(0, 60)}…`
+        : string
+  }
+}
+
+export function formatBridgeBytes(bytes) {
+  if (!Number.isFinite(bytes) || bytes < 0) return ''
+  if (bytes >= 1024 * 1024 * 1024) {
+    return `${Math.round(bytes / (1024 * 1024 * 1024))} GB`
+  }
+  if (bytes >= 1024 * 1024) {
+    return `${Math.round(bytes / (1024 * 1024))} MB`
+  }
+  return `${Math.max(1, Math.round(bytes / 1024))} KB`
+}
+
+function isEmpty(value, type) {
+  if (type === 'boolean') return typeof value !== 'boolean'
+  return (
+    value === null ||
+    value === undefined ||
+    (typeof value === 'string' && value.trim() === '')
+  )
+}
+
+function toDateInputValue(value) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return String(value).slice(0, 10)
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0')
+  ].join('-')
+}
+
+function isValidDateOnly(value) {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+  if (!match) return false
+  const [, year, month, day] = match.map(Number)
+  const date = new Date(0)
+  date.setUTCFullYear(year, month - 1, day)
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  )
+}
+
+function toDateTimeInputValue(value) {
+  if (!value) return ''
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const local = new Date(date.getTime() - date.getTimezoneOffset() * 60_000)
+  return local.toISOString().slice(0, 16)
+}
+
+export function safeBridgeHttpUrl(value) {
+  try {
+    const url = new URL(String(value))
+    return ['http:', 'https:'].includes(url.protocol) ? url.toString() : null
+  } catch {
+    return null
+  }
+}
+
+function fileNameFromUrl(value) {
+  try {
+    const url = new URL(String(value))
+    return decodeURIComponent(url.pathname.split('/').pop()) || 'Download file'
+  } catch {
+    return 'Download file'
+  }
+}

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -5,7 +5,12 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
-import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
+import BridgeFieldInput from '@/components/bridge/BridgeFieldInput.vue'
+import {
+  prepareBridgeFieldSubmission,
+  toBridgeFieldInputValue,
+  validateBridgeFieldValue
+} from '@/lib/bridge/fields.mjs'
 import { containsRawHtml } from '@/lib/content/markdown.mjs'
 
 defineOptions({
@@ -46,9 +51,6 @@ function displayIdentifier(value) {
 const formValues = ref({})
 const formErrors = ref({})
 const form = useForm({ values: {} })
-const richTextEditors = ref({})
-const richTextModes = ref({})
-const richTextCompatibility = ref({})
 
 // Initialize form values from props
 onMounted(() => {
@@ -59,12 +61,7 @@ onMounted(() => {
   for (const name of surface || []) {
     const attr = props.modelMeta.attributes[name]
     if (!attr) continue
-    const defaultValue = attr.field?.default ?? attr.defaultsTo
-    if (attr.type === 'boolean') values[name] = defaultValue ?? false
-    else if (attr.type === 'json')
-      values[name] =
-        defaultValue !== undefined ? JSON.stringify(defaultValue, null, 2) : ''
-    else values[name] = defaultValue ?? ''
+    values[name] = toBridgeFieldInputValue(attr, undefined)
   }
 
   // Load record values in edit mode
@@ -72,13 +69,9 @@ onMounted(() => {
     for (const name of Object.keys(values)) {
       if (props.record[name] !== undefined) {
         const attr = props.modelMeta.attributes[name]
-        if (attr?.type === 'json' && typeof props.record[name] === 'object') {
-          values[name] = JSON.stringify(props.record[name], null, 2)
-        } else if (attr?.encrypt) {
-          values[name] = '' // Don't pre-fill encrypted fields
-        } else {
-          values[name] = props.record[name]
-        }
+        values[name] = attr?.encrypt
+          ? ''
+          : toBridgeFieldInputValue(attr, props.record[name])
       }
     }
   }
@@ -118,223 +111,65 @@ const editableFields = computed(() => {
 })
 
 function hasRequiredValue(field) {
-  if (field.readOnly || !field.attr.required) return true
-
-  const value = formValues.value[field.name]
-  if (isEdit.value && field.attr.encrypt && value === '') return true
-  if (inputType(field) === 'toggle') return typeof value === 'boolean'
-  if (inputType(field) === 'number') {
-    return (
-      value !== '' &&
-      value !== null &&
-      value !== undefined &&
-      Number.isFinite(Number(value))
-    )
-  }
-  if (inputType(field) === 'json') {
-    if (typeof value !== 'string' || value.trim() === '') return false
-    try {
-      JSON.parse(value)
-      return true
-    } catch {
-      return false
-    }
-  }
-  if (typeof value === 'string') return value.trim().length > 0
-  return value !== null && value !== undefined
+  if (field.readOnly) return true
+  return validateField(field) === ''
 }
 
 const isFormReady = computed(
   () =>
     editableFields.value.every(hasRequiredValue) &&
-    editableFields.value.every((field) => !richTextSecurityError(field)) &&
     Object.keys(formErrors.value).length === 0
 )
 
-// Rich text field names (detect by name pattern)
-const richTextPatterns = [
-  'content',
-  'body',
-  'description',
-  'bio',
-  'about',
-  'summary',
-  'text',
-  'html',
-  'markdown',
-  'notes'
-]
-
-function inputType(field) {
+function validateField(field) {
   const attr = field.attr
-  const name = field.name.toLowerCase()
-
-  if (attr.isBelongsTo) return 'belongsTo'
   if (
-    [
-      'text',
-      'email',
-      'password',
-      'number',
-      'select',
-      'toggle',
-      'json',
-      'richtext'
-    ].includes(attr.field?.type)
+    attr.field?.type === 'richtext' &&
+    attr.field?.format?.toLowerCase() === 'markdown' &&
+    containsRawHtml(String(formValues.value[field.name] || ''))
   ) {
-    return attr.field.type
+    return 'Raw HTML is not allowed in Bridge Markdown fields.'
   }
-  if (attr.encrypt) return 'password'
-  if (attr.isEmail) return 'email'
-  if (attr.isIn && attr.isIn.length > 0) return 'select'
-  if (attr.type === 'boolean') return 'toggle'
-  if (attr.type === 'json') return 'json'
-  if (attr.type === 'number') return 'number'
-
-  // Detect rich text / long text fields
-  if (attr.type === 'string') {
-    if (attr.columnType === 'text') return 'richtext'
-    if (richTextPatterns.some((p) => name.includes(p))) return 'richtext'
-  }
-
-  return 'text'
+  return validateBridgeFieldValue({
+    attribute: attr,
+    value: formValues.value[field.name],
+    isEdit: isEdit.value
+  })
 }
 
-function isMarkdownRichText(field) {
-  return (
-    inputType(field) === 'richtext' &&
-    field.attr.field?.format?.toLowerCase() === 'markdown'
-  )
+function validateAndRemember(field) {
+  const error = validateField(field)
+  if (error) formErrors.value[field.name] = error
+  else delete formErrors.value[field.name]
 }
 
-function richTextEditorId(field) {
-  return `bridge-${props.modelIdentity}-${field.name}`.replace(
-    /[^a-zA-Z0-9_-]/g,
-    '-'
-  )
+function updateField(field, value) {
+  formValues.value[field.name] = value
+  if (formErrors.value[field.name]) validateAndRemember(field)
+  if (form.errors[field.name]) form.clearErrors(field.name)
 }
 
-function richTextLabelId(field) {
-  return `${richTextEditorId(field)}-label`
-}
-
-function richTextHelpId(field) {
-  return fieldDescription(field) ? `${richTextEditorId(field)}-help` : undefined
-}
-
-function richTextErrorId(field) {
-  return `${richTextEditorId(field)}-error`
-}
-
-function richTextDescribedBy(field) {
-  return (
-    [
-      richTextHelpId(field),
-      richTextSecurityError(field) && richTextErrorId(field)
-    ]
-      .filter(Boolean)
-      .join(' ') || undefined
-  )
-}
-
-function richTextSecurityError(field) {
-  if (!isMarkdownRichText(field)) return ''
-  if (!containsRawHtml(formValues.value[field.name] || '')) return ''
-  return 'Raw HTML is not allowed in Bridge Markdown fields.'
-}
-
-function registerRichTextEditor(field, editor) {
-  if (editor) richTextEditors.value[field.name] = editor
-  else delete richTextEditors.value[field.name]
-}
-
-function updateRichTextMode(field, mode) {
-  richTextModes.value[field.name] = mode
-}
-
-function updateRichTextCompatibility(field, compatibility) {
-  richTextCompatibility.value[field.name] = compatibility
-}
-
-function toggleRichTextMode(field) {
-  const nextMode =
-    richTextModes.value[field.name] === 'source' ? 'visual' : 'source'
-  richTextEditors.value[field.name]?.setMode(nextMode)
-}
-
-function canUseRichTextVisual(field) {
-  return richTextCompatibility.value[field.name]?.supported !== false
-}
-
-// Get field description based on type/validations
-function fieldDescription(field) {
-  return field.attr.field?.help || ''
-}
-
-function fieldLabel(field) {
-  return field.attr.label || field.name
-}
-
-function fieldPlaceholder(field, fallback = '') {
-  return field.attr.field?.placeholder || fallback
-}
-
-function selectOptions(field) {
-  return field.attr.field?.options || field.attr.isIn || []
-}
-
-// JSON validation
-function validateJson(name) {
-  const val = formValues.value[name]
-  if (!val || val.trim() === '') {
-    delete formErrors.value[name]
-    return
-  }
-  try {
-    JSON.parse(val)
-    delete formErrors.value[name]
-  } catch {
-    formErrors.value[name] = 'Invalid JSON'
-  }
+function clearFieldError(field) {
+  delete formErrors.value[field.name]
+  form.clearErrors(field.name)
 }
 
 function handleSubmit() {
+  for (const field of editableFields.value) validateAndRemember(field)
   if (!isFormReady.value) {
     toast({ message: 'Complete the required fields first.', type: 'error' })
     return
   }
 
-  if (Object.keys(formErrors.value).length > 0) {
-    toast({ message: 'Please fix validation errors.', type: 'error' })
-    return
-  }
-
-  // Prepare values
   const values = {}
   for (const field of editableFields.value) {
     if (field.readOnly) continue
-    const name = field.name
-    const attr = field.attr
-    let val = formValues.value[name]
-
-    // Type coercion
-    if (attr.type === 'json' && typeof val === 'string' && val.trim()) {
-      try {
-        val = JSON.parse(val)
-      } catch {
-        /* send as string */
-      }
-    }
-    if (attr.type === 'number' && val !== '' && val !== null) {
-      val = Number(val)
-    }
-    if (attr.encrypt && val === '') continue
-
-    if (val === '' && !attr.required && attr.type !== 'string') {
-      val = null
-    }
-
-    values[name] = val
+    const prepared = prepareBridgeFieldSubmission({
+      attribute: field.attr,
+      value: formValues.value[field.name],
+      isEdit: isEdit.value
+    })
+    if (prepared.include) values[field.name] = prepared.value
   }
 
   form.values = values
@@ -357,6 +192,10 @@ function handleSubmit() {
       toast({ message: errors.error || 'Failed to save record', type: 'error' })
     }
   })
+}
+
+function uploadUrl(field) {
+  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${field.name}/upload`
 }
 
 function bridgeUrl() {
@@ -564,314 +403,21 @@ function recordUrl() {
 
         <form @submit.prevent="handleSubmit" class="space-y-7">
           <div class="space-y-7">
-            <div v-for="field in editableFields" :key="field.name">
-              <!-- Simple fields (text, email, password, number, select) -->
-              <div
-                v-if="
-                  [
-                    'text',
-                    'email',
-                    'password',
-                    'number',
-                    'select',
-                    'belongsTo'
-                  ].includes(inputType(field))
-                "
-                class="space-y-2"
-              >
-                <label
-                  :for="field.name"
-                  class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                >
-                  {{ fieldLabel(field) }}
-                  <span v-if="field.attr.required" class="text-red-500">*</span>
-                </label>
-                <div class="flex-1">
-                  <!-- Text -->
-                  <input
-                    v-if="inputType(field) === 'text'"
-                    :id="field.name"
-                    v-model="formValues[field.name]"
-                    type="text"
-                    :disabled="field.readOnly"
-                    :required="field.attr.required"
-                    :maxlength="field.attr.maxLength || undefined"
-                    :placeholder="
-                      fieldPlaceholder(
-                        field,
-                        field.attr.defaultsTo !== undefined
-                          ? String(field.attr.defaultsTo)
-                          : ''
-                      )
-                    "
-                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                  />
-                  <!-- Email -->
-                  <input
-                    v-else-if="inputType(field) === 'email'"
-                    :id="field.name"
-                    v-model="formValues[field.name]"
-                    type="email"
-                    :disabled="field.readOnly"
-                    :required="field.attr.required"
-                    :placeholder="fieldPlaceholder(field, 'email@example.com')"
-                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                  />
-                  <!-- Password -->
-                  <input
-                    v-else-if="inputType(field) === 'password'"
-                    :id="field.name"
-                    v-model="formValues[field.name]"
-                    type="password"
-                    :disabled="field.readOnly"
-                    :placeholder="
-                      fieldPlaceholder(
-                        field,
-                        isEdit ? 'Leave blank to keep current' : ''
-                      )
-                    "
-                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                  />
-                  <!-- Number -->
-                  <input
-                    v-else-if="inputType(field) === 'number'"
-                    :id="field.name"
-                    v-model.number="formValues[field.name]"
-                    type="number"
-                    :disabled="field.readOnly"
-                    :required="field.attr.required"
-                    :placeholder="fieldPlaceholder(field, '0')"
-                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                  />
-                  <!-- Select (isIn) -->
-                  <select
-                    v-else-if="inputType(field) === 'select'"
-                    :id="field.name"
-                    v-model="formValues[field.name]"
-                    :disabled="field.readOnly"
-                    :required="field.attr.required"
-                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white"
-                  >
-                    <option value="">Select...</option>
-                    <option
-                      v-for="opt in selectOptions(field)"
-                      :key="opt"
-                      :value="opt"
-                    >
-                      {{ opt }}
-                    </option>
-                  </select>
-                  <!-- BelongsTo -->
-                  <select
-                    v-else-if="inputType(field) === 'belongsTo'"
-                    :id="field.name"
-                    v-model="formValues[field.name]"
-                    :disabled="field.readOnly"
-                    :required="field.attr.required"
-                    class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white"
-                  >
-                    <option value="">None</option>
-                    <option
-                      v-for="opt in assocOptions[field.name] || []"
-                      :key="opt.id"
-                      :value="opt.id"
-                    >
-                      {{ opt.label }}
-                    </option>
-                  </select>
-                  <p
-                    v-if="fieldDescription(field)"
-                    class="mt-1.5 text-xs text-gray-400 dark:text-gray-500"
-                  >
-                    {{ fieldDescription(field) }}
-                  </p>
-                </div>
-              </div>
-
-              <!-- Toggle (boolean) -->
-              <div v-else-if="inputType(field) === 'toggle'" class="space-y-3">
-                <label
-                  :for="field.name"
-                  class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                >
-                  {{ fieldLabel(field) }}
-                </label>
-                <div class="flex items-center gap-3">
-                  <button
-                    :id="field.name"
-                    type="button"
-                    role="switch"
-                    :aria-checked="Boolean(formValues[field.name])"
-                    :disabled="field.readOnly"
-                    @click="formValues[field.name] = !formValues[field.name]"
-                    :class="[
-                      'relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-gray-300 focus:ring-offset-2 dark:focus:ring-gray-600 dark:focus:ring-offset-gray-900',
-                      formValues[field.name]
-                        ? 'bg-gray-900 dark:bg-white'
-                        : 'bg-gray-300 dark:bg-gray-600',
-                      field.readOnly ? 'cursor-not-allowed opacity-50' : ''
-                    ]"
-                  >
-                    <span
-                      :class="[
-                        'pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out dark:bg-gray-900',
-                        formValues[field.name]
-                          ? 'translate-x-4'
-                          : 'translate-x-0'
-                      ]"
-                    ></span>
-                  </button>
-                  <span class="text-sm text-gray-500 dark:text-gray-400">{{
-                    formValues[field.name] ? 'Yes' : 'No'
-                  }}</span>
-                </div>
-              </div>
-
-              <!-- Markdown-backed rich text -->
-              <div v-else-if="isMarkdownRichText(field)" class="space-y-2">
-                <div class="flex items-center justify-between gap-3">
-                  <span
-                    :id="richTextLabelId(field)"
-                    class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                  >
-                    {{ fieldLabel(field) }}
-                    <span v-if="field.attr.required" class="text-red-500"
-                      >*</span
-                    >
-                  </span>
-                  <button
-                    type="button"
-                    :data-test="`${richTextEditorId(field)}-mode-toggle`"
-                    :aria-label="`Edit ${fieldLabel(field)} as ${
-                      richTextModes[field.name] === 'source'
-                        ? 'Visual'
-                        : 'Markdown'
-                    }`"
-                    :disabled="
-                      richTextModes[field.name] === 'source' &&
-                      !canUseRichTextVisual(field)
-                    "
-                    class="text-xs font-medium text-gray-400 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-500 dark:hover:text-white"
-                    @click="toggleRichTextMode(field)"
-                  >
-                    {{
-                      richTextModes[field.name] === 'source'
-                        ? 'Visual'
-                        : 'Markdown'
-                    }}
-                  </button>
-                </div>
-                <MarkdownEditor
-                  :ref="(editor) => registerRichTextEditor(field, editor)"
-                  v-model="formValues[field.name]"
-                  variant="field"
-                  :editor-id="richTextEditorId(field)"
-                  :placeholder="
-                    fieldPlaceholder(field, 'Write your content here...')
-                  "
-                  :aria-label="fieldLabel(field)"
-                  :aria-labelledby="richTextLabelId(field)"
-                  :aria-describedby="richTextDescribedBy(field)"
-                  :required="field.attr.required"
-                  deny-raw-html
-                  @mode-change="updateRichTextMode(field, $event)"
-                  @compatibility-change="
-                    updateRichTextCompatibility(field, $event)
-                  "
-                />
-                <p
-                  v-if="richTextSecurityError(field)"
-                  :id="richTextErrorId(field)"
-                  class="text-xs text-red-600 dark:text-red-400"
-                  role="alert"
-                >
-                  {{ richTextSecurityError(field) }}
-                </p>
-                <p
-                  v-if="fieldDescription(field)"
-                  :id="richTextHelpId(field)"
-                  class="mt-1.5 text-xs text-gray-400 dark:text-gray-500"
-                >
-                  {{ fieldDescription(field) }}
-                </p>
-              </div>
-
-              <!-- Long text -->
-              <div
-                v-else-if="inputType(field) === 'richtext'"
-                class="space-y-2"
-              >
-                <label
-                  :for="field.name"
-                  class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
-                >
-                  {{ fieldLabel(field) }}
-                  <span v-if="field.attr.required" class="text-red-500">*</span>
-                </label>
-                <textarea
-                  :id="field.name"
-                  v-model="formValues[field.name]"
-                  :disabled="field.readOnly"
-                  :required="field.attr.required"
-                  :placeholder="
-                    fieldPlaceholder(field, 'Write your content here...')
-                  "
-                  class="focus:border-brand min-h-28 w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                  style="field-sizing: content"
-                ></textarea>
-                <p
-                  v-if="fieldDescription(field)"
-                  class="mt-1.5 text-xs text-gray-400 dark:text-gray-500"
-                >
-                  {{ fieldDescription(field) }}
-                </p>
-              </div>
-
-              <!-- JSON -->
-              <div v-else-if="inputType(field) === 'json'" class="space-y-2">
-                <label
-                  :for="field.name"
-                  class="mb-2 block text-sm font-medium text-gray-700 dark:text-gray-300"
-                >
-                  {{ fieldLabel(field) }}
-                  <span class="ml-1 text-xs font-normal text-gray-400"
-                    >JSON</span
-                  >
-                </label>
-                <textarea
-                  :id="field.name"
-                  v-model="formValues[field.name]"
-                  :disabled="field.readOnly"
-                  @blur="validateJson(field.name)"
-                  :placeholder="fieldPlaceholder(field, '{}')"
-                  class="focus:border-brand min-h-28 w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-2 font-mono text-sm leading-6 text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                  style="field-sizing: content"
-                ></textarea>
-                <p
-                  v-if="formErrors[field.name]"
-                  class="mt-1 text-xs text-red-600 dark:text-red-400"
-                >
-                  {{ formErrors[field.name] }}
-                </p>
-              </div>
-
-              <!-- Fallback -->
-              <div v-else class="space-y-2">
-                <label
-                  :for="field.name"
-                  class="block text-sm font-medium text-gray-700 dark:text-gray-300"
-                  >{{ fieldLabel(field) }}</label
-                >
-                <input
-                  :id="field.name"
-                  v-model="formValues[field.name]"
-                  type="text"
-                  :disabled="field.readOnly"
-                  :placeholder="fieldPlaceholder(field)"
-                  class="focus:border-brand h-11 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-                />
-              </div>
-            </div>
+            <BridgeFieldInput
+              v-for="field in editableFields"
+              :key="field.name"
+              :field="field"
+              :model-value="formValues[field.name]"
+              :error="formErrors[field.name] || form.errors[field.name] || ''"
+              :is-edit="isEdit"
+              :model-identity="modelIdentity"
+              :record-id="recordId"
+              :association-options="assocOptions[field.name] || []"
+              :upload-url="uploadUrl(field)"
+              @update:model-value="updateField(field, $event)"
+              @blur="validateAndRemember(field)"
+              @clear-error="clearFieldError(field)"
+            />
           </div>
 
           <!-- Actions -->

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
+import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 
 defineOptions({
   layout: AppLayout
@@ -204,45 +205,6 @@ function toggleSelect(id) {
   else s.add(id)
   selectedIds.value = s
   selectAll.value = s.size === props.records.length
-}
-
-// Cell rendering
-function formatCell(value, attrName) {
-  if (value === null || value === undefined) return null
-  const attr = props.modelMeta?.attributes[attrName]
-  if (!attr) return String(value)
-
-  if (attr.autoCreatedAt || attr.autoUpdatedAt) {
-    return formatDate(value)
-  }
-  if (attr.type === 'boolean') return value
-  if (attr.type === 'json' || typeof value === 'object')
-    return JSON.stringify(value)
-  if (typeof value === 'string' && value.length > 60)
-    return value.slice(0, 60) + '...'
-  return String(value)
-}
-
-function formatDate(value) {
-  if (!value) return ''
-  try {
-    const d = new Date(value)
-    return d.toLocaleString(undefined, {
-      dateStyle: 'medium',
-      timeStyle: 'short'
-    })
-  } catch {
-    return String(value)
-  }
-}
-
-function isBooleanAttr(attrName) {
-  return props.modelMeta?.attributes[attrName]?.type === 'boolean'
-}
-
-function isTimestamp(attrName) {
-  const attr = props.modelMeta?.attributes[attrName]
-  return attr?.autoCreatedAt || attr?.autoUpdatedAt
 }
 
 // Delete single record
@@ -671,32 +633,8 @@ function createUrl() {
                   :key="col"
                   class="whitespace-nowrap px-4 py-2"
                 >
-                  <span v-if="isBooleanAttr(col)" class="flex items-center">
-                    <span
-                      :class="[
-                        'inline-block h-2 w-2 rounded-full',
-                        record[col]
-                          ? 'bg-green-500'
-                          : 'bg-gray-300 dark:bg-gray-600'
-                      ]"
-                    ></span>
-                  </span>
-                  <span
-                    v-else-if="isTimestamp(col)"
-                    class="text-gray-500 dark:text-gray-400"
-                  >
-                    {{ formatDate(record[col]) }}
-                  </span>
-                  <span
-                    v-else-if="
-                      record[col] === null || record[col] === undefined
-                    "
-                    class="text-gray-300 dark:text-gray-600"
-                  >
-                    null
-                  </span>
                   <Link
-                    v-else-if="
+                    v-if="
                       col === modelMeta.primaryKey &&
                       modelMeta.actions?.view !== false
                     "
@@ -706,9 +644,14 @@ function createUrl() {
                   >
                     {{ displayIdentifier(record[col]) }}
                   </Link>
-                  <span v-else class="text-gray-700 dark:text-gray-300">
-                    {{ formatCell(record[col], col) }}
-                  </span>
+                  <BridgeFieldValue
+                    v-else
+                    :name="col"
+                    :attribute="modelMeta.attributes[col]"
+                    :value="record[col]"
+                    context="list"
+                    class="text-gray-700 dark:text-gray-300"
+                  />
                 </td>
                 <td v-if="hasRecordActions" class="px-4 py-2">
                   <div class="relative flex justify-end" @click.stop>

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
+import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 
 defineOptions({
   layout: AppLayout
@@ -72,37 +73,6 @@ const collectionAssociations = computed(() => {
 
 function fieldLabel(name) {
   return props.modelMeta?.attributes[name]?.label || name
-}
-
-function formatValue(value, attr) {
-  if (value === null || value === undefined)
-    return { display: 'null', isNull: true }
-  if (attr?.autoCreatedAt || attr?.autoUpdatedAt) {
-    try {
-      const d = new Date(value)
-      return {
-        display: d.toLocaleString(undefined, {
-          dateStyle: 'long',
-          timeStyle: 'medium'
-        }),
-        isNull: false
-      }
-    } catch {
-      /* fall through */
-    }
-  }
-  if (attr?.type === 'boolean')
-    return { display: value, isBoolean: true, isNull: false }
-  if (attr?.encrypt)
-    return { display: '(encrypted)', isEncrypted: true, isNull: false }
-  if (attr?.type === 'json' || typeof value === 'object') {
-    return {
-      display: JSON.stringify(value, null, 2),
-      isJson: true,
-      isNull: false
-    }
-  }
-  return { display: String(value), isNull: false }
 }
 
 function collectionRecords(alias) {
@@ -408,45 +378,12 @@ function relatedRecordUrl(model, id) {
                   <dd
                     class="min-w-0 flex-1 text-sm text-gray-900 dark:text-white"
                   >
-                    <template v-if="formatValue(record[name], attr).isNull">
-                      <span class="text-gray-300 dark:text-gray-600">null</span>
-                    </template>
-                    <template
-                      v-else-if="formatValue(record[name], attr).isBoolean"
-                    >
-                      <span
-                        :class="[
-                          'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
-                          record[name]
-                            ? 'bg-green-50 text-green-700 dark:bg-green-900/20 dark:text-green-400'
-                            : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-                        ]"
-                      >
-                        {{ record[name] }}
-                      </span>
-                    </template>
-                    <template
-                      v-else-if="formatValue(record[name], attr).isEncrypted"
-                    >
-                      <span
-                        class="inline-flex rounded-full bg-yellow-50 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:bg-yellow-900/20 dark:text-yellow-400"
-                      >
-                        encrypted
-                      </span>
-                    </template>
-                    <template
-                      v-else-if="formatValue(record[name], attr).isJson"
-                    >
-                      <pre
-                        class="max-h-40 overflow-auto rounded-lg bg-gray-50 p-2 font-mono text-xs dark:bg-gray-950"
-                        >{{ formatValue(record[name], attr).display }}</pre
-                      >
-                    </template>
-                    <template v-else>
-                      <span class="break-all">{{
-                        formatValue(record[name], attr).display
-                      }}</span>
-                    </template>
+                    <BridgeFieldValue
+                      :name="name"
+                      :attribute="attr"
+                      :value="record[name]"
+                      context="show"
+                    />
                   </dd>
                 </div>
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -363,6 +363,10 @@ module.exports.routes = {
     'project/bridge-create-record',
   'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/create':
     'project/bridge-create-record',
+  'POST /projects/:slug/bridge/:modelIdentity/:fieldName/upload':
+    'project/bridge-upload-field',
+  'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/:fieldName/upload':
+    'project/bridge-upload-field',
   'POST /projects/:slug/bridge/:modelIdentity/:recordId/update':
     'project/bridge-update-record',
   'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/:recordId/update':

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -15,12 +15,13 @@ module.exports.slipway = {
         group: 'Content',
         title: 'title',
         search: ['title'],
-        list: ['title', 'published', 'createdAt'],
+        list: ['title', 'price', 'published', 'createdAt'],
         show: [
           'id',
           'title',
           'description',
           'thumbnailUrl',
+          'price',
           'published',
           'creator'
         ],
@@ -28,10 +29,18 @@ module.exports.slipway = {
           'title',
           'description',
           'thumbnailUrl',
+          'price',
           'published',
           'creator'
         ],
-        edit: ['title', 'description', 'thumbnailUrl', 'published', 'creator'],
+        edit: [
+          'title',
+          'description',
+          'thumbnailUrl',
+          'price',
+          'published',
+          'creator'
+        ],
         filters: ['published'],
         sort: {
           field: 'createdAt',
@@ -44,6 +53,15 @@ module.exports.slipway = {
           helper: 'bridge.authorize'
         },
         fields: {
+          price: {
+            label: 'Price',
+            type: 'currency',
+            currency: {
+              code: 'USD',
+              storage: 'minor',
+              submit: 'major'
+            }
+          },
           description: {
             label: 'Course description',
             type: 'richtext',
@@ -136,6 +154,7 @@ Every field may define serializable UI metadata:
 | `currency`    | Currency display and hydration metadata                |
 | `relation`    | Relationship display metadata                          |
 | `upload`      | Upload constraints and canonical URL storage           |
+| `component`   | Registered Slipway field component extension point     |
 
 Sensitive names such as password, token, secret, API key, credential, recovery
 code, `emailChangeCandidate`, `planCode`, and `subscriptionCode` are omitted
@@ -249,8 +268,71 @@ executing the mutation in the target app. Normal Markdown and autolinks continue
 to work. Applications must still sanitize the HTML produced by their Markdown
 renderer because stored content remains untrusted at the rendering boundary.
 
-Uploads, currency hydration, and other specialized renderers build on the same
-field contract in their respective Bridge features.
+## Typed fields and hydration
+
+Bridge normalizes Waterline metadata and explicit field overrides into one
+field contract. The same contract drives form input, validation, mutation
+hydration, list display, and record display.
+
+Supported field types are:
+
+```text
+text, textarea, richtext, email, url, number, currency, boolean,
+select, belongsTo, json, date, datetime, timestamp, password,
+secret, file, image, upload
+```
+
+Email, URL, boolean, JSON, enums, relationships, timestamps, encrypted values,
+and long text are inferred from Waterline metadata. Use an explicit `type` when
+the stored Waterline type does not communicate the intended editor.
+
+JSON is validated in the browser and again by Slipway, then submitted to the
+target model as an object. Email and URL fields use their native browser input
+types and server validation; URL values are restricted to HTTP and HTTPS.
+Select values support primitives or labeled option objects:
+
+```js
+status: {
+  type: 'select',
+  options: [
+    { label: 'Draft', value: 'draft' },
+    { label: 'Published', value: 'published' }
+  ]
+}
+```
+
+### Currency and lifecycle callbacks
+
+Currency fields distinguish the value stored in the database from the value
+submitted to the target Waterline model:
+
+```js
+price: {
+  type: 'currency',
+  currency: {
+    code: 'USD',
+    locale: 'en-US',
+    storage: 'minor',
+    submit: 'major'
+  }
+}
+```
+
+With this configuration, a stored value of `3499` is displayed and edited as
+`$34.99`. Bridge submits `34.99`, so an existing `beforeCreate` or
+`beforeUpdate` lifecycle callback can continue converting dollars to cents.
+Set `submit: 'minor'` when the target model expects Bridge itself to submit
+`3499`. Set `storage: 'major'` when the database already stores `34.99`.
+
+`minimumFractionDigits` and `maximumFractionDigits` default to `2` and may be
+overridden for currencies with a different precision.
+
+### Custom components
+
+The optional `component` value names a component registered with Slipway's
+Bridge field registry. A registration may provide separate `form`, `list`, and
+`show` components. Application configuration contains only the safe,
+serializable name; it never ships executable target-app code into Slipway.
 
 ## Primary keys and belongs-to fields
 
@@ -297,9 +379,9 @@ Upload fields describe behavior only. Never put R2 or S3 credentials in
 to the Bridge UI.
 
 Bridge storage credentials use `BRIDGE_`-prefixed environment variables. The
-upload field engine will resolve the effective values from the current app
-first, then its environment, then instance-global defaults. This lets one app
-use its own R2 bucket while other apps inherit a shared provider configuration.
+upload field engine resolves the effective values from the current app first,
+then its environment, then instance-global defaults. This lets one app use its
+own R2 bucket while other apps inherit a shared provider configuration.
 
 The R2 provider contract is:
 
@@ -313,7 +395,33 @@ BRIDGE_R2_PUBLIC_URL=https://cdn.example.com
 BRIDGE_R2_REGION=auto
 ```
 
-The planned upload flow returns the canonical public URL and a short-lived,
-server-verifiable upload receipt. The model mutation stores the URL, while the
-receipt prevents a client from claiming an arbitrary object was uploaded by
-Bridge.
+The S3 provider uses the same names with `BRIDGE_S3_`:
+
+```text
+BRIDGE_STORAGE_PROVIDER=s3
+BRIDGE_S3_ACCESS_KEY=...
+BRIDGE_S3_SECRET_KEY=...
+BRIDGE_S3_BUCKET=...
+BRIDGE_S3_ENDPOINT=https://objects.example.com
+BRIDGE_S3_PUBLIC_URL=https://cdn.example.com
+BRIDGE_S3_REGION=us-east-1
+```
+
+Only `BRIDGE_` variables are considered. App values override environment
+values, and environment values override instance-global values.
+
+The upload endpoint:
+
+- authorizes the current actor against the target resource and create/edit
+  action before accepting bytes;
+- enforces the field's MIME allowlist and `maxBytes`;
+- streams directly to the configured object store instead of buffering the
+  entire file in Slipway memory;
+- scopes the object key to the team, project, environment, resource, and field;
+  and
+- returns the canonical public URL plus a short-lived, signed receipt.
+
+The subsequent create or update accepts the URL only when its receipt matches
+the current actor, project, environment, resource, and field. The target model
+stores only the URL. A browser therefore cannot forge a different remote URL
+or reuse a receipt across apps or fields.

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -34,10 +34,14 @@ test(
     const authorizationScreenshotRoot = path.resolve(
       '.tmp/screenshots/issue-218-bridge-authorization'
     )
+    const fieldEngineScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-219-bridge-field-engine'
+    )
 
     fs.mkdirSync(screenshotRoot, { recursive: true })
     fs.mkdirSync(identifierScreenshotRoot, { recursive: true })
     fs.mkdirSync(authorizationScreenshotRoot, { recursive: true })
+    fs.mkdirSync(fieldEngineScreenshotRoot, { recursive: true })
 
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: resourceMetadata(),
@@ -50,18 +54,21 @@ test(
       {
         id: courseRecordId,
         title: 'Build a production Sails app',
+        price: 3499,
         published: true,
         createdAt: Date.UTC(2026, 6, 21, 9, 30)
       },
       {
         id: '018f2a5c-7b34-7f8a-9c12-4a73b9d80210',
         title: 'Own the deployment path',
+        price: 2900,
         published: true,
         createdAt: Date.UTC(2026, 6, 18, 15, 10)
       },
       {
         id: '018f2a5c-7b34-7f8a-9c12-4a73b9d8020f',
         title: 'A legible cloud on one server',
+        price: 1900,
         published: false,
         createdAt: Date.UTC(2026, 6, 12, 11, 5)
       }
@@ -72,6 +79,12 @@ test(
       description:
         'A practical path from a Waterline model to a calm production release.',
       thumbnailUrl: 'https://cdn.example.com/courses/production-sails.webp',
+      price: 3499,
+      website: 'https://sailsjs.com',
+      metadata: {
+        level: 'production',
+        lessons: 12
+      },
       published: true,
       creator: creatorId
     }
@@ -134,7 +147,8 @@ test(
           ...submittedValues
         }
         persistedCourseRecord = {
-          ...createdValues
+          ...createdValues,
+          price: submittedValues.price * 100
         }
         return successfulResult({ record: persistedCourseRecord })
       }
@@ -142,7 +156,10 @@ test(
         updatedValues = readEmbeddedValue(code, 'values')
         persistedCourseRecord = {
           ...persistedCourseRecord,
-          ...updatedValues
+          ...updatedValues,
+          ...(updatedValues.price !== undefined
+            ? { price: updatedValues.price * 100 }
+            : {})
         }
         return successfulResult({ record: persistedCourseRecord })
       }
@@ -185,6 +202,28 @@ test(
           body: JSON.stringify({ updateAvailable: false })
         })
       })
+      await page.raw.route(
+        'https://cdn.example.com/courses/**',
+        async (route) => {
+          await route.fulfill({
+            status: 200,
+            contentType: 'image/svg+xml',
+            body: `
+              <svg xmlns="http://www.w3.org/2000/svg" width="640" height="400" viewBox="0 0 640 400">
+                <defs>
+                  <linearGradient id="sea" x1="0" x2="1" y1="0" y2="1">
+                    <stop stop-color="#0ea5e9"/>
+                    <stop offset="1" stop-color="#0f172a"/>
+                  </linearGradient>
+                </defs>
+                <rect width="640" height="400" fill="url(#sea)"/>
+                <path d="M0 290 C140 230 250 360 390 285 S550 245 640 300 V400 H0Z" fill="#fff" fill-opacity=".16"/>
+                <text x="48" y="90" fill="#fff" font-family="system-ui" font-size="24" font-weight="600">Build a production Sails app</text>
+              </svg>
+            `
+          })
+        }
+      )
       await login.withPassword('genesisUser', page, {
         password: current.auth.genesisUserPassword
       })
@@ -215,6 +254,7 @@ test(
       await page.goto(coursePath)
       await page.wait('text=Build a production Sails app')
       await expect(page).toSee('Course title')
+      await expect(page).toSee('$34.99')
       expect(await page.raw.locator('input[type="checkbox"]').count()).toBe(0)
       await page.screenshot(
         path.join(screenshotRoot, 'course-list-light.png'),
@@ -222,6 +262,16 @@ test(
           fullPage: true
         }
       )
+      await page.screenshot(
+        path.join(fieldEngineScreenshotRoot, 'typed-list-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(fieldEngineScreenshotRoot, 'typed-list-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
 
       const actionsButton = page.raw.getByRole('button', {
         name: 'Actions for Build a production Sails app'
@@ -251,6 +301,9 @@ test(
       await page.wait('text=Create Course')
       await expect(page).toSee('Course description')
       await expect(page).toSee('Thumbnail')
+      await expect(page).toSee('Price')
+      await expect(page).toSee('Website')
+      await expect(page).toSee('Metadata')
       await expect(page).toSee('Creator')
       expect(await page.raw.getByLabel('Id').count()).toBe(0)
       const createRecordButton = page.raw.getByRole('button', {
@@ -258,12 +311,32 @@ test(
       })
       expect(await createRecordButton.isDisabled()).toBe(true)
       await page.screenshot(
-        path.join(screenshotRoot, 'course-create-light.png'),
+        path.join(fieldEngineScreenshotRoot, 'typed-create-light.png'),
+        { fullPage: true }
+      )
+      await createRecordButton.scrollIntoViewIfNeeded()
+      await page.screenshot(
+        path.join(
+          fieldEngineScreenshotRoot,
+          'typed-create-required-fields-light.png'
+        ),
         { fullPage: true }
       )
       await page.raw.getByLabel('Course title').fill('Ship a durable course')
+      await page.raw.getByLabel('Price').fill('49')
       await page.raw.getByLabel('Creator').selectOption(creatorId)
       expect(await createRecordButton.isEnabled()).toBe(true)
+      await createRecordButton.scrollIntoViewIfNeeded()
+      await page.screenshot(
+        path.join(fieldEngineScreenshotRoot, 'typed-create-ready-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(fieldEngineScreenshotRoot, 'typed-create-ready-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
       await page.screenshot(
         path.join(
           identifierScreenshotRoot,
@@ -363,6 +436,7 @@ test(
       expect(createdValues.description).toBe(createdMarkdown)
       expect(createdValues.id).toBe(createdCourseRecordId)
       expect(createdValues.creator).toBe(creatorId)
+      expect(createdValues.price).toBe(49)
       await expect(page).toSee('Ship a durable course')
 
       await page.goto(`${coursePath}/${createdCourseRecordId}/edit`)
@@ -402,6 +476,7 @@ test(
         { timeout: 10000 }
       )
       expect(updatedValues.description).toBe(updatedMarkdown)
+      expect(updatedValues.price).toBe(49)
 
       await page.raw.setViewportSize({ width: 1440, height: 900 })
       await page.goto(`${coursePath}/${createdCourseRecordId}/edit`)
@@ -421,12 +496,23 @@ test(
       await page.wait('text=A practical path')
       await expect(page).toSee('Course description')
       await expect(page).toSee('Thumbnail')
+      await expect(page).toSee('$34.99')
+      await expect(page).toSee('https://sailsjs.com')
+      await expect(page).toSee('"lessons": 12')
+      await page.screenshot(
+        path.join(fieldEngineScreenshotRoot, 'typed-record-light.png'),
+        { fullPage: true }
+      )
       await page.raw.emulateMedia({ colorScheme: 'dark' })
       await page.screenshot(
         path.join(screenshotRoot, 'course-record-dark.png'),
         {
           fullPage: true
         }
+      )
+      await page.screenshot(
+        path.join(fieldEngineScreenshotRoot, 'typed-record-dark.png'),
+        { fullPage: true }
       )
 
       await page.raw.emulateMedia({ colorScheme: 'light' })
@@ -493,12 +579,15 @@ function resourceConfig() {
         group: 'Content',
         title: 'title',
         search: ['title'],
-        list: ['title', 'published', 'createdAt'],
+        list: ['title', 'price', 'published', 'createdAt'],
         show: [
           'id',
           'title',
           'description',
           'thumbnailUrl',
+          'price',
+          'website',
+          'metadata',
           'published',
           'creator'
         ],
@@ -506,10 +595,22 @@ function resourceConfig() {
           'title',
           'description',
           'thumbnailUrl',
+          'price',
+          'website',
+          'metadata',
           'published',
           'creator'
         ],
-        edit: ['title', 'description', 'thumbnailUrl', 'published', 'creator'],
+        edit: [
+          'title',
+          'description',
+          'thumbnailUrl',
+          'price',
+          'website',
+          'metadata',
+          'published',
+          'creator'
+        ],
         sort: {
           field: 'createdAt',
           direction: 'DESC'
@@ -543,6 +644,25 @@ function resourceConfig() {
               directory: 'courses/thumbnails',
               store: 'url'
             }
+          },
+          price: {
+            label: 'Price',
+            type: 'currency',
+            currency: {
+              code: 'USD',
+              storage: 'minor',
+              submit: 'major'
+            }
+          },
+          website: {
+            label: 'Website',
+            type: 'url',
+            placeholder: 'https://example.com/course'
+          },
+          metadata: {
+            label: 'Metadata',
+            type: 'json',
+            help: 'Structured course metadata stored as JSON.'
           },
           creator: {
             label: 'Creator'
@@ -590,6 +710,17 @@ function resourceMetadata() {
         },
         thumbnailUrl: {
           type: 'string'
+        },
+        price: {
+          type: 'number',
+          required: true
+        },
+        website: {
+          type: 'string',
+          isURL: true
+        },
+        metadata: {
+          type: 'json'
         },
         published: {
           type: 'boolean',

--- a/tests/unit/assets/bridge-fields.test.js
+++ b/tests/unit/assets/bridge-fields.test.js
@@ -1,0 +1,119 @@
+const { test } = require('sounding')
+
+test('Bridge field inputs and submissions use the normalized contract', async ({
+  expect
+}) => {
+  const {
+    bridgeFieldType,
+    prepareBridgeFieldSubmission,
+    toBridgeFieldInputValue,
+    validateBridgeFieldValue
+  } = await import('../../../assets/js/lib/bridge/fields.mjs')
+  const currency = {
+    type: 'number',
+    required: true,
+    label: 'Price',
+    field: {
+      type: 'currency',
+      currency: {
+        code: 'USD',
+        storage: 'minor',
+        submit: 'major',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+      }
+    }
+  }
+  const json = {
+    type: 'json',
+    required: true,
+    label: 'Metadata',
+    field: { type: 'json' }
+  }
+
+  expect(bridgeFieldType(currency)).toBe('currency')
+  expect(toBridgeFieldInputValue(json, { level: 'production' })).toBe(
+    '{\n  "level": "production"\n}'
+  )
+  expect(
+    validateBridgeFieldValue({
+      attribute: json,
+      value: '{broken'
+    })
+  ).toBe('Metadata must contain valid JSON.')
+  expect(
+    prepareBridgeFieldSubmission({
+      attribute: json,
+      value: '{"level":"production"}'
+    })
+  ).toEqual({
+    include: true,
+    value: { level: 'production' }
+  })
+  expect(
+    prepareBridgeFieldSubmission({
+      attribute: currency,
+      value: '34.99'
+    })
+  ).toEqual({ include: true, value: 34.99 })
+  expect(
+    validateBridgeFieldValue({
+      attribute: {
+        type: 'string',
+        label: 'Release date',
+        field: { type: 'date' }
+      },
+      value: '2026-02-31'
+    })
+  ).toBe('Release date must be a valid date.')
+})
+
+test('Bridge field formatting is safe and typed', async ({ expect }) => {
+  const { formatBridgeFieldValue, safeBridgeHttpUrl } = await import(
+    '../../../assets/js/lib/bridge/fields.mjs'
+  )
+
+  expect(
+    formatBridgeFieldValue(
+      34.99,
+      {
+        field: {
+          type: 'currency',
+          currency: {
+            code: 'USD',
+            locale: 'en-US',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+          }
+        }
+      },
+      'show'
+    ).display
+  ).toBe('$34.99')
+  expect(safeBridgeHttpUrl('javascript:alert(1)')).toBe(null)
+  expect(safeBridgeHttpUrl('https://example.com/file.png')).toBe(
+    'https://example.com/file.png'
+  )
+})
+
+test('Bridge custom field components are registered per surface', async ({
+  expect
+}) => {
+  const {
+    clearBridgeFieldComponents,
+    registerBridgeFieldComponent,
+    resolveBridgeFieldComponent
+  } = await import('../../../assets/js/lib/bridge/field-components.mjs')
+  const form = { name: 'RatingForm' }
+  const list = { name: 'RatingList' }
+
+  try {
+    registerBridgeFieldComponent('content/rating', { form, list })
+
+    expect(resolveBridgeFieldComponent('content/rating', 'form')).toBe(form)
+    expect(resolveBridgeFieldComponent('content/rating', 'list')).toBe(list)
+    expect(resolveBridgeFieldComponent('content/rating', 'show')).toBe(null)
+  } finally {
+    clearBridgeFieldComponents()
+  }
+})

--- a/tests/unit/helpers/bridge/field-engine.test.js
+++ b/tests/unit/helpers/bridge/field-engine.test.js
@@ -1,0 +1,356 @@
+const { test } = require('sounding')
+
+test('Bridge normalizes typed fields and resolves currency for display', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: fieldModelMetadata(),
+    config: fieldResourceConfig()
+  })
+  const course = contract.resources.course
+
+  expect(course.attributes.email.field.type).toBe('email')
+  expect(course.attributes.website.field.type).toBe('url')
+  expect(course.attributes.metadata.field.type).toBe('json')
+  expect(course.attributes.published.field.type).toBe('boolean')
+  expect(course.attributes.releaseDate.field.type).toBe('date')
+  expect(course.attributes.status.field.options).toEqual([
+    { label: 'Draft', value: 'draft', disabled: false },
+    { label: 'Published', value: 'published', disabled: false }
+  ])
+  expect(course.attributes.description.field).toEqual({
+    type: 'richtext',
+    format: 'markdown',
+    help: 'The public course description.'
+  })
+  expect(course.attributes.price.field.currency).toEqual({
+    code: 'USD',
+    locale: 'en-US',
+    storage: 'minor',
+    submit: 'major',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  })
+  expect(course.attributes.thumbnailUrl.field.upload).toEqual({
+    kind: 'image',
+    storage: 'bridge',
+    directory: 'courses/thumbnails',
+    store: 'url',
+    accept: [
+      'image/avif',
+      'image/gif',
+      'image/jpeg',
+      'image/png',
+      'image/webp'
+    ],
+    maxBytes: 5 * 1024 * 1024
+  })
+
+  const record = await sails.helpers.bridge.redactResourceRecords.with({
+    records: {
+      id: 1,
+      title: 'Build with Sails',
+      price: 3499
+    },
+    resource: course,
+    surface: 'edit'
+  })
+
+  expect(record.price).toBe(34.99)
+})
+
+test('Bridge hydrates typed values before target lifecycle callbacks', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: fieldModelMetadata(),
+    config: fieldResourceConfig()
+  })
+
+  const values = await sails.helpers.bridge.allowResourceValues.with({
+    resource: contract.resources.course,
+    surface: 'create',
+    values: {
+      title: 'A typed course',
+      description: 'Write with **Markdown**.',
+      email: 'editor@example.com',
+      website: 'https://sailsjs.com',
+      metadata: '{"level":"production"}',
+      published: true,
+      status: 'draft',
+      price: 34.99
+    }
+  })
+
+  expect(values.metadata).toEqual({ level: 'production' })
+  expect(values.website).toBe('https://sailsjs.com/')
+  expect(values.price).toBe(34.99)
+})
+
+test('Bridge can submit currency as minor units when the target expects them', async ({
+  sails,
+  expect
+}) => {
+  const config = fieldResourceConfig()
+  config.resources.course.fields.price.currency.submit = 'minor'
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: fieldModelMetadata(),
+    config
+  })
+
+  const values = await sails.helpers.bridge.allowResourceValues.with({
+    resource: contract.resources.course,
+    surface: 'create',
+    values: {
+      title: 'Minor units',
+      email: 'editor@example.com',
+      website: 'https://example.com',
+      metadata: {},
+      published: false,
+      status: 'draft',
+      price: 34.99
+    }
+  })
+
+  expect(values.price).toBe(3499)
+})
+
+test('Bridge returns field errors for invalid typed values', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: fieldModelMetadata(),
+    config: fieldResourceConfig()
+  })
+  let receivedError
+
+  try {
+    await sails.helpers.bridge.allowResourceValues.with({
+      resource: contract.resources.course,
+      surface: 'create',
+      values: {
+        title: '',
+        email: 'not-an-email',
+        website: 'javascript:alert(1)',
+        metadata: '{broken',
+        published: 'yes',
+        status: 'retired',
+        price: 'free',
+        releaseDate: '2026-02-31'
+      }
+    })
+  } catch (error) {
+    receivedError = error
+  }
+
+  expect(receivedError.code).toBe('BRIDGE_FIELD_INVALID')
+  expect(Object.keys(receivedError.fieldErrors).sort()).toEqual([
+    'email',
+    'metadata',
+    'price',
+    'published',
+    'releaseDate',
+    'status',
+    'title',
+    'website'
+  ])
+})
+
+test('Bridge upload receipts bind URLs to the actor and field', async ({
+  sails,
+  expect
+}) => {
+  const originalSecret = sails.config.session.secret
+  sails.config.session.secret =
+    'bridge-upload-test-secret-that-is-long-and-unique'
+  const context = {
+    actorId: 7,
+    projectId: 11,
+    environmentId: 13,
+    resource: 'course',
+    field: 'thumbnailUrl'
+  }
+  const url = 'https://cdn.example.com/bridge/course/thumbnail.webp'
+
+  try {
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: fieldModelMetadata(),
+      config: fieldResourceConfig()
+    })
+    const receipt = await sails.helpers.bridge.createUploadReceipt.with({
+      url,
+      context
+    })
+    const verified = await sails.helpers.bridge.verifyUploadReceipt.with({
+      receipt,
+      url,
+      context
+    })
+    expect(verified).toBe(url)
+    const values = await sails.helpers.bridge.allowResourceValues.with({
+      resource: contract.resources.course,
+      surface: 'edit',
+      values: {
+        thumbnailUrl: { url, receipt }
+      },
+      uploadContext: {
+        actorId: context.actorId,
+        projectId: context.projectId,
+        environmentId: context.environmentId
+      }
+    })
+    expect(values.thumbnailUrl).toBe(url)
+
+    let forgedError
+    try {
+      await sails.helpers.bridge.verifyUploadReceipt.with({
+        receipt,
+        url: 'https://evil.example/forged.webp',
+        context
+      })
+    } catch (error) {
+      forgedError = error
+    }
+    expect(forgedError.code).toBe('BRIDGE_UPLOAD_RECEIPT_INVALID')
+  } finally {
+    sails.config.session.secret = originalSecret
+  }
+})
+
+test('Bridge upload storage uses only scoped BRIDGE_ settings', async ({
+  sails,
+  expect
+}) => {
+  const originalSettingGet = sails.helpers.setting.get
+  sails.helpers.setting.get = async () =>
+    JSON.stringify({
+      BRIDGE_STORAGE_PROVIDER: 'r2',
+      BRIDGE_R2_ACCESS_KEY: 'global-key',
+      BRIDGE_R2_SECRET_KEY: 'global-secret',
+      BRIDGE_R2_BUCKET: 'global-bucket',
+      BRIDGE_R2_ENDPOINT: 'https://account.r2.cloudflarestorage.com',
+      BRIDGE_R2_PUBLIC_URL: 'https://cdn.example.com',
+      R2_SECRET_KEY: 'must-not-leak'
+    })
+
+  try {
+    const storage = await sails.helpers.bridge.getUploadStorageConfig.with({
+      environment: {
+        envVars: {
+          BRIDGE_R2_BUCKET: 'environment-bucket'
+        }
+      },
+      app: {
+        envVars: {
+          BRIDGE_R2_ACCESS_KEY: 'app-key'
+        }
+      }
+    })
+
+    expect(storage).toEqual({
+      provider: 'r2',
+      key: 'app-key',
+      secret: 'global-secret',
+      bucket: 'environment-bucket',
+      endpoint: 'https://account.r2.cloudflarestorage.com',
+      publicUrl: 'https://cdn.example.com',
+      region: 'auto'
+    })
+  } finally {
+    sails.helpers.setting.get = originalSettingGet
+  }
+})
+
+function fieldResourceConfig() {
+  return {
+    resources: {
+      course: {
+        create: [
+          'title',
+          'description',
+          'email',
+          'website',
+          'metadata',
+          'published',
+          'status',
+          'price',
+          'releaseDate',
+          'thumbnailUrl'
+        ],
+        edit: [
+          'title',
+          'description',
+          'email',
+          'website',
+          'metadata',
+          'published',
+          'status',
+          'price',
+          'releaseDate',
+          'thumbnailUrl'
+        ],
+        fields: {
+          description: {
+            type: 'richtext',
+            format: 'markdown',
+            help: 'The public course description.'
+          },
+          status: {
+            options: [
+              { label: 'Draft', value: 'draft' },
+              { label: 'Published', value: 'published' }
+            ]
+          },
+          price: {
+            type: 'currency',
+            currency: {
+              code: 'USD',
+              storage: 'minor',
+              submit: 'major'
+            }
+          },
+          thumbnailUrl: {
+            type: 'image',
+            upload: {
+              storage: 'bridge',
+              directory: 'courses/thumbnails'
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+function fieldModelMetadata() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'courses',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'number', autoIncrement: true },
+        title: { type: 'string', required: true },
+        description: { type: 'string', columnType: 'text' },
+        email: { type: 'string', required: true, isEmail: true },
+        website: { type: 'string', required: true, isURL: true },
+        metadata: { type: 'json', required: true },
+        published: { type: 'boolean', required: true },
+        status: {
+          type: 'string',
+          required: true,
+          isIn: ['draft', 'published']
+        },
+        price: { type: 'number', required: true },
+        releaseDate: { type: 'string', columnType: 'date' },
+        thumbnailUrl: { type: 'string' },
+        createdAt: { type: 'number', autoCreatedAt: true }
+      },
+      associations: []
+    }
+  }
+}

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -208,7 +208,15 @@ test('Bridge represents a fully configured content resource', async ({
     kind: 'image',
     storage: 'bridge',
     directory: 'courses/thumbnails',
-    store: 'url'
+    store: 'url',
+    accept: [
+      'image/avif',
+      'image/gif',
+      'image/jpeg',
+      'image/png',
+      'image/webp'
+    ],
+    maxBytes: 5 * 1024 * 1024
   })
 })
 


### PR DESCRIPTION
## Summary

- add a normalized Bridge field engine shared across create, edit, list, and record views
- support typed inputs and hydration for rich text, currency, JSON, dates, URLs, relationships, protected values, files, and images
- add app-, environment-, and instance-scoped R2/S3 upload configuration
- stream uploads to object storage and store only the canonical public URL in the target model
- protect upload mutations with short-lived actor-, app-, resource-, and field-bound receipts
- retain the existing minimal Slipway UI while adding reusable field components

## Impact

Bridge can now represent production Sails models without hand-building admin forms. A field such as `thumbnailUrl` can use `type: 'image'`; Bridge applies safe image defaults, uploads the asset, and submits only its public URL to the target Waterline model.

## Verification

- `npm run test:unit` — 175 passed
- `npm run test:functional` — 47 passed
- `npm run test:e2e` — 20 passed
- `npm run lint`
- `npm run check:consistency`

Closes #219