### PR TITLE
feat(bridge): manage Waterline relationships

### DIFF
--- a/api/controllers/project/bridge-create-record.js
+++ b/api/controllers/project/bridge-create-record.js
@@ -88,6 +88,13 @@ module.exports = {
           environmentId: environment.id
         }
       })
+      await sails.helpers.bridge.authorizeRelationshipValues.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        resource: loaded.resource,
+        actor,
+        values: allowedValues
+      })
     } catch (error) {
       throw { badRequest: toBadRequest(error) }
     }

--- a/api/controllers/project/bridge-relationship-options.js
+++ b/api/controllers/project/bridge-relationship-options.js
@@ -1,0 +1,161 @@
+module.exports = {
+  friendlyName: 'Bridge relationship options',
+
+  description:
+    'Return a bounded page of authorized relationship choices for Bridge.',
+
+  inputs: {
+    slug: {
+      type: 'string',
+      required: true
+    },
+    envSlug: {
+      type: 'string',
+      defaultsTo: 'production'
+    },
+    modelIdentity: {
+      type: 'string',
+      required: true
+    },
+    relationshipAlias: {
+      type: 'string',
+      required: true
+    },
+    surface: {
+      type: 'string',
+      defaultsTo: 'create',
+      isIn: ['create', 'edit', 'manage']
+    },
+    recordId: {
+      type: 'string'
+    },
+    q: {
+      type: 'string',
+      defaultsTo: ''
+    },
+    page: {
+      type: 'number',
+      defaultsTo: 1
+    }
+  },
+
+  exits: {
+    success: {
+      statusCode: 200
+    },
+    notFound: {
+      statusCode: 404
+    },
+    forbidden: {
+      statusCode: 403
+    },
+    badRequest: {
+      responseType: 'badRequest'
+    }
+  },
+
+  fn: async function ({
+    slug,
+    envSlug,
+    modelIdentity,
+    relationshipAlias,
+    surface,
+    recordId,
+    q,
+    page
+  }) {
+    const user = await User.findOne({ id: this.req.session.userId }).populate(
+      'team'
+    )
+    if (!user) throw 'forbidden'
+
+    const project = await Project.findOne({ slug, team: user.team.id })
+    if (!project) throw 'notFound'
+
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug: envSlug
+    })
+    if (!environment) throw 'notFound'
+
+    const app =
+      (await App.findOne({ environment: environment.id, isDefault: true })) ||
+      (await App.findOne({ environment: environment.id }))
+    if (!app || app.status !== 'running' || !app.containerName) {
+      throw { badRequest: { error: 'App is not running' } }
+    }
+    if (surface !== 'create' && !recordId) {
+      throw {
+        badRequest: {
+          error: 'A record identifier is required for this relationship.'
+        }
+      }
+    }
+
+    try {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
+      const loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: surface === 'create' ? 'create' : 'update',
+        actor,
+        ...(recordId ? { recordId } : {})
+      })
+      const relationship = loaded.resource.relationships?.[relationshipAlias]
+      if (
+        !relationship ||
+        (surface !== 'manage' &&
+          (relationship.type !== 'model' ||
+            !loaded.resource[surface].includes(relationshipAlias))) ||
+        (surface === 'manage' &&
+          (relationship.type !== 'collection' || relationship.show !== true))
+      ) {
+        throw relationshipError(
+          `Bridge relationship "${modelIdentity}.${relationshipAlias}" is unavailable.`
+        )
+      }
+      if (
+        surface === 'manage' &&
+        relationship.attach !== true &&
+        relationship.detach !== true
+      ) {
+        throw relationshipError(
+          `Bridge relationship "${modelIdentity}.${relationshipAlias}" cannot be managed.`
+        )
+      }
+
+      const related = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity: relationship.resource,
+        action: 'viewAny',
+        actor
+      })
+      return await sails.helpers.bridge.searchRelationshipOptions.with({
+        containerName: app.containerName,
+        resources: {
+          ...loaded.contract.models,
+          [related.resource.identity]: related.resource
+        },
+        resource: loaded.resource,
+        relationshipAlias,
+        search: q,
+        page,
+        ...(loaded.recordId !== undefined ? { recordId: loaded.recordId } : {})
+      })
+    } catch (error) {
+      throw { badRequest: { error: error.message } }
+    }
+  }
+}
+
+function relationshipError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_RELATIONSHIP_NOT_ALLOWED'
+  return error
+}

--- a/api/controllers/project/bridge-update-record.js
+++ b/api/controllers/project/bridge-update-record.js
@@ -93,6 +93,13 @@ module.exports = {
           environmentId: environment.id
         }
       })
+      await sails.helpers.bridge.authorizeRelationshipValues.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        resource: loaded.resource,
+        actor,
+        values: allowedValues
+      })
     } catch (error) {
       throw { badRequest: toBadRequest(error) }
     }

--- a/api/controllers/project/bridge-update-relationship.js
+++ b/api/controllers/project/bridge-update-relationship.js
@@ -1,0 +1,191 @@
+module.exports = {
+  friendlyName: 'Bridge update relationship',
+
+  description:
+    'Attach or detach one related record through an explicitly manageable Waterline collection.',
+
+  inputs: {
+    slug: {
+      type: 'string',
+      required: true
+    },
+    envSlug: {
+      type: 'string',
+      defaultsTo: 'production'
+    },
+    modelIdentity: {
+      type: 'string',
+      required: true
+    },
+    recordId: {
+      type: 'string',
+      required: true
+    },
+    relationshipAlias: {
+      type: 'string',
+      required: true
+    },
+    operation: {
+      type: 'string',
+      required: true,
+      isIn: ['attach', 'detach']
+    },
+    relatedId: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      responseType: 'redirect'
+    },
+    notFound: {
+      responseType: 'redirect'
+    },
+    badRequest: {
+      responseType: 'badRequest'
+    }
+  },
+
+  fn: async function ({
+    slug,
+    envSlug,
+    modelIdentity,
+    recordId,
+    relationshipAlias,
+    operation,
+    relatedId
+  }) {
+    const user = await User.findOne({ id: this.req.session.userId }).populate(
+      'team'
+    )
+    if (!user) throw { notFound: '/login' }
+
+    const project = await Project.findOne({ slug, team: user.team.id })
+    if (!project) throw { notFound: '/' }
+
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug: envSlug
+    })
+    if (!environment) throw { notFound: `/projects/${slug}` }
+
+    const app =
+      (await App.findOne({ environment: environment.id, isDefault: true })) ||
+      (await App.findOne({ environment: environment.id }))
+    if (!app || app.status !== 'running' || !app.containerName) {
+      throw { badRequest: { error: 'App is not running' } }
+    }
+
+    try {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
+      const loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: 'update',
+        actor,
+        recordId
+      })
+      const relationship = loaded.resource.relationships?.[relationshipAlias]
+      if (
+        !relationship ||
+        relationship.type !== 'collection' ||
+        relationship[operation] !== true
+      ) {
+        throw relationshipError(
+          `${loaded.resource.singularLabel} does not allow this relationship operation.`
+        )
+      }
+
+      const related = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity: relationship.resource,
+        action: 'viewAny',
+        actor
+      })
+      const normalizedRelatedId =
+        await sails.helpers.bridge.normalizeIdentifier.with({
+          value: relatedId,
+          resource: related.resource,
+          label: `${related.resource.singularLabel} identifier`
+        })
+
+      const definition = {
+        parentIdentity: loaded.resource.identity,
+        parentPrimaryKey: loaded.resource.primaryKey,
+        parentId: loaded.recordId,
+        alias: relationship.alias,
+        relatedIdentity: related.resource.identity,
+        relatedPrimaryKey: related.resource.primaryKey,
+        relatedId: normalizedRelatedId,
+        operation
+      }
+      const mutationCode = `
+        const definition = ${JSON.stringify(definition)};
+        const parentModel = sails.models[definition.parentIdentity];
+        const relatedModel = sails.models[definition.relatedIdentity];
+        if (!parentModel || !relatedModel) {
+          throw new Error('Configured Bridge relationship model is unavailable.');
+        }
+
+        const [parent, related] = await Promise.all([
+          parentModel
+            .findOne({
+              [definition.parentPrimaryKey]: definition.parentId
+            })
+            .select([definition.parentPrimaryKey]),
+          relatedModel
+            .findOne({
+              [definition.relatedPrimaryKey]: definition.relatedId
+            })
+            .select([definition.relatedPrimaryKey])
+        ]);
+        if (!parent) throw new Error('The parent record no longer exists.');
+        if (!related) throw new Error('The related record no longer exists.');
+
+        if (definition.operation === 'attach') {
+          await parentModel
+            .addToCollection(definition.parentId, definition.alias)
+            .members([definition.relatedId]);
+        } else {
+          await parentModel
+            .removeFromCollection(definition.parentId, definition.alias)
+            .members([definition.relatedId]);
+        }
+        return { success: true };
+      `
+      const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+        mutationCode
+      )
+      const result = await sails.helpers.bridge.executeInContainer(
+        app.containerName,
+        wrappedCode
+      )
+      if (!result.success) {
+        throw new Error(
+          result.error || `Failed to ${operation} the related record.`
+        )
+      }
+    } catch (error) {
+      throw { badRequest: { error: error.message } }
+    }
+
+    const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
+    return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${encodeURIComponent(
+      String(recordId)
+    )}`
+  }
+}
+
+function relationshipError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_RELATIONSHIP_NOT_ALLOWED'
+  return error
+}

--- a/api/controllers/project/view-bridge-create.js
+++ b/api/controllers/project/view-bridge-create.js
@@ -75,9 +75,38 @@ module.exports = {
           actor
         })
         modelMeta = loaded.resource
+        const authorizedResources = {
+          [modelMeta.identity]: modelMeta
+        }
+        for (const relationship of Object.values(
+          modelMeta.relationships || {}
+        )) {
+          if (
+            relationship.type !== 'model' ||
+            !modelMeta.create.includes(relationship.alias)
+          ) {
+            continue
+          }
+          try {
+            const related = await sails.helpers.bridge.loadResource.with({
+              containerName: app.containerName,
+              environmentId: environment.id,
+              modelIdentity: relationship.resource,
+              action: 'viewAny',
+              actor
+            })
+            authorizedResources[relationship.resource] = related.resource
+          } catch (relationshipAuthorizationError) {
+            delete authorizedResources[relationship.resource]
+            modelMeta.create = modelMeta.create.filter(
+              (field) => field !== relationship.alias
+            )
+            modelMeta.relationships[relationship.alias].show = false
+          }
+        }
         assocOptions = await sails.helpers.bridge.loadAssociationOptions.with({
           containerName: app.containerName,
-          resources: loaded.contract.models,
+          resources: authorizedResources,
           resource: modelMeta,
           surface: 'create'
         })

--- a/api/controllers/project/view-bridge-edit.js
+++ b/api/controllers/project/view-bridge-edit.js
@@ -130,12 +130,42 @@ module.exports = {
         }
 
         if (!error) {
+          const authorizedResources = {
+            [modelMeta.identity]: modelMeta
+          }
+          for (const relationship of Object.values(
+            modelMeta.relationships || {}
+          )) {
+            if (
+              relationship.type !== 'model' ||
+              !modelMeta.edit.includes(relationship.alias)
+            ) {
+              continue
+            }
+            try {
+              const related = await sails.helpers.bridge.loadResource.with({
+                containerName: app.containerName,
+                environmentId: environment.id,
+                modelIdentity: relationship.resource,
+                action: 'viewAny',
+                actor
+              })
+              authorizedResources[relationship.resource] = related.resource
+            } catch (relationshipAuthorizationError) {
+              delete authorizedResources[relationship.resource]
+              modelMeta.edit = modelMeta.edit.filter(
+                (field) => field !== relationship.alias
+              )
+              modelMeta.relationships[relationship.alias].show = false
+            }
+          }
           assocOptions = await sails.helpers.bridge.loadAssociationOptions.with(
             {
               containerName: app.containerName,
-              resources: loaded.contract.models,
+              resources: authorizedResources,
               resource: modelMeta,
-              surface: 'edit'
+              surface: 'edit',
+              values: record
             }
           )
         }

--- a/api/controllers/project/view-bridge-record.js
+++ b/api/controllers/project/view-bridge-record.js
@@ -62,6 +62,7 @@ module.exports = {
 
     let modelMeta = null
     let record = null
+    let relationships = {}
     let error = null
 
     if (appRunning) {
@@ -119,6 +120,36 @@ module.exports = {
         } else {
           error = result.error || 'Failed to fetch record'
         }
+
+        if (!error) {
+          const authorizedResources = {
+            [modelMeta.identity]: modelMeta
+          }
+          for (const relationship of Object.values(
+            modelMeta.relationships || {}
+          )) {
+            if (relationship.show !== true) continue
+            try {
+              const related = await sails.helpers.bridge.loadResource.with({
+                containerName: app.containerName,
+                environmentId: environment.id,
+                modelIdentity: relationship.resource,
+                action: 'viewAny',
+                actor
+              })
+              authorizedResources[relationship.resource] = related.resource
+            } catch (relationshipAuthorizationError) {
+              delete authorizedResources[relationship.resource]
+            }
+          }
+          relationships =
+            await sails.helpers.bridge.loadResourceRelationships.with({
+              containerName: app.containerName,
+              resources: authorizedResources,
+              resource: modelMeta,
+              recordId: loaded.recordId
+            })
+        }
       } catch (err) {
         error = err.message
       }
@@ -142,6 +173,7 @@ module.exports = {
         appRunning,
         modelMeta,
         record,
+        relationships,
         error
       }
     }

--- a/api/helpers/bridge/authorize-relationship-values.js
+++ b/api/helpers/bridge/authorize-relationship-values.js
@@ -1,0 +1,153 @@
+module.exports = {
+  friendlyName: 'Authorize Bridge relationship values',
+
+  description:
+    'Authorize and verify belongs-to values before a Bridge record mutation.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    environmentId: {
+      type: 'number',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    actor: {
+      type: 'ref',
+      required: true
+    },
+    values: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    containerName,
+    environmentId,
+    resource,
+    actor,
+    values
+  }) {
+    const definitions = []
+
+    for (const association of resource.associations || []) {
+      if (
+        association.type !== 'model' ||
+        !Object.prototype.hasOwnProperty.call(values, association.alias) ||
+        values[association.alias] === null ||
+        values[association.alias] === ''
+      ) {
+        continue
+      }
+
+      const relationship = resource.relationships?.[association.alias]
+      if (!relationship) {
+        throw relationshipError(
+          `Bridge relationship "${resource.identity}.${association.alias}" is unavailable.`
+        )
+      }
+
+      let related
+      try {
+        related = await sails.helpers.bridge.loadResource.with({
+          containerName,
+          environmentId,
+          modelIdentity: relationship.resource,
+          action: 'viewAny',
+          actor
+        })
+      } catch {
+        throw relationshipError(
+          `${relationship.label} is not available to the current actor.`
+        )
+      }
+
+      definitions.push({
+        alias: association.alias,
+        identity: related.resource.identity,
+        primaryKey: related.resource.primaryKey,
+        id: values[association.alias]
+      })
+    }
+
+    if (definitions.length === 0) return values
+
+    const verificationCode = `
+      const definitions = ${JSON.stringify(definitions)};
+      const missing = [];
+
+      for (const definition of definitions) {
+        const model = sails.models[definition.identity];
+        if (!model) {
+          throw new Error('Configured Bridge relationship model is unavailable.');
+        }
+        const record = await model
+          .findOne({ [definition.primaryKey]: definition.id })
+          .select([definition.primaryKey]);
+        if (!record) missing.push(definition.alias);
+      }
+
+      return { missing };
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+      verificationCode
+    )
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+    if (!result.success) {
+      const error = relationshipError(
+        result.error || 'Failed to verify Bridge relationship values.'
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_VERIFICATION_FAILED'
+      throw error
+    }
+
+    let data
+    try {
+      data = JSON.parse(result.output)
+    } catch (cause) {
+      const error = relationshipError(
+        'Failed to parse Bridge relationship verification.'
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_VERIFICATION_FAILED'
+      error.cause = cause
+      throw error
+    }
+
+    if (Array.isArray(data.missing) && data.missing.length > 0) {
+      const error = relationshipError(
+        'Some selected Bridge relationships no longer exist.'
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_NOT_FOUND'
+      error.fieldErrors = Object.fromEntries(
+        data.missing.map((alias) => [
+          alias,
+          `${resource.attributes?.[alias]?.label || alias} no longer exists.`
+        ])
+      )
+      throw error
+    }
+
+    return values
+  }
+}
+
+function relationshipError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_RELATIONSHIP_NOT_ALLOWED'
+  return error
+}

--- a/api/helpers/bridge/introspect-models.js
+++ b/api/helpers/bridge/introspect-models.js
@@ -144,7 +144,9 @@ function buildIntrospectionCode() {
             alias: attrName,
             type: 'collection',
             collection: attr.collection,
-            via: attr.via || null
+            via: attr.via || null,
+            dominant: attr.dominant === true,
+            on: attr.on || null
           });
           continue;
         }

--- a/api/helpers/bridge/load-association-options.js
+++ b/api/helpers/bridge/load-association-options.js
@@ -21,6 +21,10 @@ module.exports = {
       type: 'string',
       required: true,
       isIn: ['create', 'edit']
+    },
+    values: {
+      type: 'ref',
+      defaultsTo: {}
     }
   },
 
@@ -30,7 +34,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ containerName, resources, resource, surface }) {
+  fn: async function ({ containerName, resources, resource, surface, values }) {
     const surfaceFields = new Set(resource[surface] || [])
     const definitions = []
 
@@ -49,12 +53,16 @@ module.exports = {
         ? resources[association.model]
         : null
       if (!relatedResource || relatedResource.hidden) continue
+      const relationship = resource.relationships?.[association.alias]
+      if (!relationship) continue
 
       definitions.push({
         alias: association.alias,
         identity: relatedResource.identity,
         primaryKey: relatedResource.primaryKey,
-        title: relatedResource.title
+        title: relatedResource.title,
+        limit: relationship.limit,
+        selectedId: values?.[association.alias]
       })
     }
 
@@ -75,7 +83,28 @@ module.exports = {
           definition.primaryKey,
           definition.title
         ].filter(Boolean)));
-        const records = await model.find({ limit: 100 }).select(fields);
+        const records = await model
+          .find({
+            sort: definition.title + ' ASC',
+            limit: definition.limit
+          })
+          .select(fields);
+        if (
+          definition.selectedId !== undefined &&
+          definition.selectedId !== null &&
+          !records.some(
+            (record) =>
+              String(record[definition.primaryKey]) ===
+              String(definition.selectedId)
+          )
+        ) {
+          const selected = await model
+            .findOne({
+              [definition.primaryKey]: definition.selectedId
+            })
+            .select(fields);
+          if (selected) records.unshift(selected);
+        }
         options[definition.alias] = records.map((record) => ({
           id: record[definition.primaryKey],
           label: record[definition.title] == null

--- a/api/helpers/bridge/load-resource-relationships.js
+++ b/api/helpers/bridge/load-resource-relationships.js
@@ -1,0 +1,165 @@
+module.exports = {
+  friendlyName: 'Load Bridge resource relationships',
+
+  description:
+    'Load bounded, display-safe relationship data for a Bridge record.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resources: {
+      type: 'ref',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    recordId: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, resources, resource, recordId }) {
+    const definitions = []
+
+    for (const relationship of Object.values(resource.relationships || {})) {
+      if (relationship.show !== true) continue
+      const relatedResource = resources?.[relationship.resource]
+      if (
+        !relatedResource ||
+        relatedResource.hidden ||
+        relatedResource.actions?.viewAny !== true
+      ) {
+        continue
+      }
+
+      definitions.push({
+        alias: relationship.alias,
+        type: relationship.type,
+        label: relationship.label,
+        identity: relatedResource.identity,
+        primaryKey: relatedResource.primaryKey,
+        title: relatedResource.title,
+        fields: relationship.fields,
+        limit: relationship.limit,
+        canAttach:
+          relationship.type === 'collection' &&
+          relationship.attach === true &&
+          resource.actions?.update === true,
+        canDetach:
+          relationship.type === 'collection' &&
+          relationship.detach === true &&
+          resource.actions?.update === true
+      })
+    }
+
+    if (definitions.length === 0) return {}
+
+    const criteria = { [resource.primaryKey]: recordId }
+    const queryCode = `
+      const parentIdentity = ${JSON.stringify(resource.identity)};
+      const parentPrimaryKey = ${JSON.stringify(resource.primaryKey)};
+      const criteria = ${JSON.stringify(criteria)};
+      const definitions = ${JSON.stringify(definitions)};
+      const parentModel = sails.models[parentIdentity];
+      if (!parentModel) {
+        throw new Error('Configured Bridge parent model is unavailable.');
+      }
+
+      const modelAliases = definitions
+        .filter((definition) => definition.type === 'model')
+        .map((definition) => definition.alias);
+      const parent = await parentModel
+        .findOne(criteria)
+        .select(Array.from(new Set([parentPrimaryKey, ...modelAliases])));
+      if (!parent) return {};
+
+      function present(definition, record) {
+        if (!record) return null;
+        const values = {};
+        for (const field of definition.fields) {
+          values[field] = record[field];
+        }
+        return {
+          id: record[definition.primaryKey],
+          label: record[definition.title] == null
+            ? '#' + record[definition.primaryKey]
+            : String(record[definition.title]),
+          values
+        };
+      }
+
+      const relationships = {};
+      for (const definition of definitions) {
+        const relatedModel = sails.models[definition.identity];
+        if (!relatedModel) continue;
+
+        if (definition.type === 'model') {
+          const relatedId = parent[definition.alias];
+          const relatedRecord =
+            relatedId === undefined || relatedId === null
+              ? null
+              : await relatedModel
+                  .findOne({ [definition.primaryKey]: relatedId })
+                  .select(definition.fields);
+          relationships[definition.alias] = {
+            ...definition,
+            record: present(definition, relatedRecord)
+          };
+          continue;
+        }
+
+        const owner = await parentModel.findOne(criteria).populate(
+          definition.alias,
+          {
+            sort: definition.title + ' ASC',
+            limit: definition.limit + 1,
+            select: definition.fields
+          }
+        );
+        const relatedRecords = owner?.[definition.alias] || [];
+        relationships[definition.alias] = {
+          ...definition,
+          records: relatedRecords
+            .slice(0, definition.limit)
+            .map((record) => present(definition, record)),
+          hasMore: relatedRecords.length > definition.limit
+        };
+      }
+
+      return relationships;
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(queryCode)
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      const error = new Error(
+        result.error || 'Failed to load Bridge relationships.'
+      )
+      error.code = 'BRIDGE_RELATIONSHIPS_FAILED'
+      throw error
+    }
+
+    try {
+      return JSON.parse(result.output)
+    } catch (cause) {
+      const error = new Error('Failed to parse Bridge relationships.')
+      error.code = 'BRIDGE_RELATIONSHIPS_FAILED'
+      error.cause = cause
+      throw error
+    }
+  }
+}

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -79,7 +79,18 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'hidden',
     'actions',
     'authorization',
-    'fields'
+    'fields',
+    'relationships'
+  ]
+  const RELATIONSHIP_OPTION_KEYS = [
+    'label',
+    'show',
+    'searchable',
+    'search',
+    'fields',
+    'limit',
+    'attach',
+    'detach'
   ]
   const FIELD_OPTION_KEYS = [
     'label',
@@ -164,6 +175,16 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       model,
       rawResource === false ? { hidden: true } : rawResource || {},
       rawResource !== undefined
+    )
+  }
+
+  for (const [identity, resource] of Object.entries(resources)) {
+    const rawResource = configuredResources[identity]
+    resource.relationships = normalizeRelationships(
+      identity,
+      resource,
+      isPlainObject(rawResource) ? rawResource.relationships : undefined,
+      resources
     )
   }
 
@@ -430,6 +451,14 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       validateFieldOptions(identity, name, fieldOptions[name].options)
       validateCurrency(identity, name, fieldOptions[name].currency)
       validateUpload(identity, name, fieldOptions[name].upload)
+      validateRelationshipOptions(
+        identity,
+        name,
+        fieldOptions[name].relation,
+        associations.find(
+          (candidate) => candidate.type === 'model' && candidate.alias === name
+        )
+      )
       if (
         fieldOptions[name].component !== undefined &&
         !isSafeComponentName(fieldOptions[name].component)
@@ -532,6 +561,229 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         ...(primaryKeyType ? { primaryKeyType } : {})
       }
     })
+  }
+
+  function normalizeRelationships(
+    identity,
+    resource,
+    rawRelationships,
+    normalizedResources
+  ) {
+    if (rawRelationships !== undefined && !isPlainObject(rawRelationships)) {
+      throw new Error(
+        `Bridge resource "${identity}".relationships must be an object.`
+      )
+    }
+
+    const associationsByAlias = new Map(
+      resource.associations.map((association) => [
+        association.alias,
+        association
+      ])
+    )
+    for (const alias of Object.keys(rawRelationships || {})) {
+      if (!associationsByAlias.has(alias)) {
+        throw new Error(
+          `Bridge resource "${identity}".relationships references unknown association "${alias}".`
+        )
+      }
+    }
+
+    const relationships = {}
+    for (const association of resource.associations) {
+      const fieldRelation =
+        association.type === 'model'
+          ? resource.attributes[association.alias]?.field?.relation
+          : undefined
+      const configuredRelationship = rawRelationships?.[association.alias]
+      const raw =
+        configuredRelationship === undefined
+          ? fieldRelation
+          : configuredRelationship
+
+      if (raw !== undefined && raw !== false && !isPlainObject(raw)) {
+        throw new Error(
+          `Bridge relationship "${identity}.${association.alias}" must be an object or false.`
+        )
+      }
+      if (isPlainObject(raw)) {
+        validateRelationshipOptions(
+          identity,
+          association.alias,
+          raw,
+          association
+        )
+      }
+
+      const relatedIdentity =
+        association.type === 'model'
+          ? association.model
+          : association.collection
+      const relatedResource = normalizedResources[relatedIdentity]
+      const hidden = !relatedResource || relatedResource.hidden === true
+      const disabled = raw === false
+      const defaultFields = relatedResource
+        ? Array.from(
+            new Set([relatedResource.primaryKey, relatedResource.title])
+          ).filter((field) => relatedResource.show.includes(field))
+        : []
+      const searchFields = normalizeRelationshipFieldList({
+        identity,
+        alias: association.alias,
+        option: 'search',
+        value: raw?.search,
+        allowed: relatedResource?.search || []
+      })
+      const configuredFields = normalizeRelationshipFieldList({
+        identity,
+        alias: association.alias,
+        option: 'fields',
+        value: raw?.fields,
+        allowed: relatedResource?.show || [],
+        defaults: defaultFields
+      })
+      const fields = relatedResource
+        ? Array.from(
+            new Set([
+              relatedResource.primaryKey,
+              relatedResource.title,
+              ...configuredFields
+            ])
+          )
+        : configuredFields
+      const defaultLimit = association.type === 'model' ? 20 : 5
+      const limit = raw?.limit ?? defaultLimit
+      const showByDefault =
+        association.type === 'collection'
+          ? true
+          : resource.show.includes(association.alias)
+      const relationship = {
+        alias: association.alias,
+        type: association.type,
+        resource: relatedIdentity,
+        label:
+          readString(raw?.label) ||
+          (association.type === 'collection'
+            ? relatedResource?.label
+            : resource.attributes[association.alias]?.label ||
+              relatedResource?.singularLabel) ||
+          humanize(association.alias),
+        primaryKey:
+          relatedResource?.primaryKey || association.primaryKey || 'id',
+        title:
+          relatedResource?.title ||
+          relatedResource?.primaryKey ||
+          association.primaryKey ||
+          'id',
+        show: !hidden && !disabled && (raw?.show ?? showByDefault),
+        searchable:
+          !hidden && !disabled && (raw?.searchable ?? searchFields.length > 0),
+        search: searchFields,
+        fields,
+        limit,
+        attach:
+          association.type === 'collection' &&
+          !hidden &&
+          !disabled &&
+          raw?.attach === true,
+        detach:
+          association.type === 'collection' &&
+          !hidden &&
+          !disabled &&
+          raw?.detach === true,
+        ...(association.via ? { via: association.via } : {}),
+        ...(association.dominant !== undefined
+          ? { dominant: association.dominant === true }
+          : {})
+      }
+
+      relationships[association.alias] = relationship
+      if (
+        association.type === 'model' &&
+        resource.attributes[association.alias]
+      ) {
+        resource.attributes[association.alias].field.relation = relationship
+      }
+    }
+
+    return relationships
+  }
+
+  function validateRelationshipOptions(identity, alias, relation, association) {
+    if (relation === undefined) return
+    if (!association) {
+      throw new Error(
+        `Bridge field "${identity}.${alias}".relation requires a belongs-to association.`
+      )
+    }
+    if (!isPlainObject(relation)) {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}" must be an object.`
+      )
+    }
+    rejectUnknownKeys(
+      relation,
+      RELATIONSHIP_OPTION_KEYS,
+      `Bridge relationship "${identity}.${alias}"`
+    )
+    assertOptionalString(
+      relation.label,
+      `Bridge relationship "${identity}.${alias}".label`
+    )
+    for (const option of ['show', 'searchable', 'attach', 'detach']) {
+      assertOptionalBoolean(
+        relation[option],
+        `Bridge relationship "${identity}.${alias}".${option}`
+      )
+    }
+    for (const option of ['search', 'fields']) {
+      if (
+        relation[option] !== undefined &&
+        (!Array.isArray(relation[option]) ||
+          relation[option].some((value) => typeof value !== 'string'))
+      ) {
+        throw new Error(
+          `Bridge relationship "${identity}.${alias}".${option} must be an array of field names.`
+        )
+      }
+    }
+    if (
+      relation.limit !== undefined &&
+      (!Number.isInteger(relation.limit) ||
+        relation.limit < 1 ||
+        relation.limit > 50)
+    ) {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}".limit must be an integer from 1 to 50.`
+      )
+    }
+    if (
+      association?.type === 'model' &&
+      (relation.attach !== undefined || relation.detach !== undefined)
+    ) {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}" can enable attach or detach only for a collection association.`
+      )
+    }
+  }
+
+  function normalizeRelationshipFieldList({
+    identity,
+    alias,
+    option,
+    value,
+    allowed,
+    defaults = allowed
+  }) {
+    const selected = value === undefined ? defaults : value
+    for (const field of selected) {
+      if (!allowed.includes(field)) {
+        throw new Error(
+          `Bridge relationship "${identity}.${alias}".${option} references unavailable field "${field}".`
+        )
+      }
+    }
+    return Array.from(new Set(selected))
   }
 
   function hasGeneratedPrimaryKey(attribute) {
@@ -1080,8 +1332,8 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
 
   function inferTitleField(primaryKey, visibleFields) {
     return (
-      ['name', 'title', 'email', 'slug'].find((name) =>
-        visibleFields.includes(name)
+      ['name', 'title', 'fullName', 'displayName', 'email', 'slug'].find(
+        (name) => visibleFields.includes(name)
       ) || (visibleFields.includes(primaryKey) ? primaryKey : visibleFields[0])
     )
   }

--- a/api/helpers/bridge/search-relationship-options.js
+++ b/api/helpers/bridge/search-relationship-options.js
@@ -1,0 +1,188 @@
+module.exports = {
+  friendlyName: 'Search Bridge relationship options',
+
+  description:
+    'Load one bounded page of safe relationship choices from a target application.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resources: {
+      type: 'ref',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    relationshipAlias: {
+      type: 'string',
+      required: true
+    },
+    search: {
+      type: 'string',
+      defaultsTo: ''
+    },
+    page: {
+      type: 'number',
+      defaultsTo: 1
+    },
+    recordId: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    containerName,
+    resources,
+    resource,
+    relationshipAlias,
+    search,
+    page,
+    recordId
+  }) {
+    const relationship = resource.relationships?.[relationshipAlias]
+    if (!relationship) {
+      throw relationshipError(
+        `Bridge relationship "${resource.identity}.${relationshipAlias}" is unavailable.`
+      )
+    }
+
+    const relatedResource = resources?.[relationship.resource]
+    if (!relatedResource || relatedResource.hidden) {
+      throw relationshipError(
+        `Bridge relationship "${resource.identity}.${relationshipAlias}" has no visible resource.`
+      )
+    }
+
+    const normalizedPage = Number.isSafeInteger(page) && page > 0 ? page : 1
+    const normalizedSearch = String(search || '')
+      .trim()
+      .slice(0, 100)
+    const limit = Math.min(Math.max(relationship.limit || 20, 1), 50)
+    const definition = {
+      alias: relationship.alias,
+      type: relationship.type,
+      identity: relatedResource.identity,
+      primaryKey: relatedResource.primaryKey,
+      title: relatedResource.title,
+      search: relationship.search,
+      limit,
+      page: normalizedPage,
+      query: normalizedSearch,
+      parentIdentity: resource.identity,
+      parentPrimaryKey: resource.primaryKey,
+      recordId
+    }
+
+    const queryCode = `
+      const definition = ${JSON.stringify(definition)};
+      const model = sails.models[definition.identity];
+      if (!model) {
+        throw new Error('Configured Bridge relationship model is unavailable.');
+      }
+
+      const where = definition.query && definition.search.length > 0
+        ? {
+            or: definition.search.map((field) => ({
+              [field]: { contains: definition.query }
+            }))
+          }
+        : {};
+      const fields = Array.from(new Set([
+        definition.primaryKey,
+        definition.title
+      ].filter(Boolean)));
+      const records = await model
+        .find({
+          where,
+          sort: definition.title + ' ASC',
+          skip: (definition.page - 1) * definition.limit,
+          limit: definition.limit + 1
+        })
+        .select(fields);
+      const pageRecords = records.slice(0, definition.limit);
+      const attachedIds = new Set();
+
+      if (
+        definition.type === 'collection' &&
+        definition.recordId !== undefined &&
+        definition.recordId !== null &&
+        pageRecords.length > 0
+      ) {
+        const parentModel = sails.models[definition.parentIdentity];
+        if (!parentModel) {
+          throw new Error('Configured Bridge parent model is unavailable.');
+        }
+        const candidateIds = pageRecords.map(
+          (record) => record[definition.primaryKey]
+        );
+        const owner = await parentModel
+          .findOne({
+            [definition.parentPrimaryKey]: definition.recordId
+          })
+          .populate(definition.alias, {
+            where: {
+              [definition.primaryKey]: { in: candidateIds }
+            },
+            select: [definition.primaryKey],
+            limit: candidateIds.length
+          });
+        for (const related of owner?.[definition.alias] || []) {
+          attachedIds.add(String(related[definition.primaryKey]));
+        }
+      }
+
+      return {
+        options: pageRecords.map((record) => ({
+          id: record[definition.primaryKey],
+          label: record[definition.title] == null
+            ? '#' + record[definition.primaryKey]
+            : String(record[definition.title]),
+          attached: attachedIds.has(String(record[definition.primaryKey]))
+        })),
+        page: definition.page,
+        limit: definition.limit,
+        hasMore: records.length > definition.limit
+      };
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(queryCode)
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      const error = relationshipError(
+        result.error || 'Failed to search Bridge relationship options.'
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_SEARCH_FAILED'
+      throw error
+    }
+
+    try {
+      return JSON.parse(result.output)
+    } catch (cause) {
+      const error = relationshipError(
+        'Failed to parse Bridge relationship options.'
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_SEARCH_FAILED'
+      error.cause = cause
+      throw error
+    }
+  }
+}
+
+function relationshipError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_RELATIONSHIP_NOT_ALLOWED'
+  return error
+}

--- a/assets/js/components/bridge/BridgeCollectionManager.vue
+++ b/assets/js/components/bridge/BridgeCollectionManager.vue
@@ -1,0 +1,307 @@
+<script setup>
+import { router } from '@inertiajs/vue3'
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+
+const props = defineProps({
+  relationship: {
+    type: Object,
+    required: true
+  },
+  optionsUrl: {
+    type: String,
+    required: true
+  },
+  mutationBaseUrl: {
+    type: String,
+    required: true
+  }
+})
+
+const open = ref(false)
+const triggerButton = ref(null)
+const dialog = ref(null)
+const searchInput = ref(null)
+const query = ref('')
+const options = ref([])
+const loading = ref(false)
+const error = ref('')
+const processingId = ref('')
+const page = ref(1)
+const hasMore = ref(false)
+let debounceTimer
+let requestController
+
+const canManage = computed(
+  () => props.relationship.canAttach || props.relationship.canDetach
+)
+
+watch(query, () => {
+  if (!open.value) return
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => loadOptions(1), 180)
+})
+
+async function show() {
+  open.value = true
+  await nextTick()
+  searchInput.value?.focus()
+  await loadOptions(1)
+}
+
+function close() {
+  open.value = false
+  query.value = ''
+  error.value = ''
+  nextTick(() => triggerButton.value?.focus())
+}
+
+async function loadOptions(nextPage, { append = false } = {}) {
+  requestController?.abort()
+  const controller = new AbortController()
+  requestController = controller
+  loading.value = true
+  error.value = ''
+  try {
+    const url = new URL(props.optionsUrl, window.location.origin)
+    url.searchParams.set('q', query.value)
+    url.searchParams.set('page', String(nextPage))
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal
+    })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data.error || 'Related records could not be loaded.')
+    }
+    options.value = append
+      ? [...options.value, ...(data.options || [])]
+      : data.options || []
+    page.value = data.page || nextPage
+    hasMore.value = data.hasMore === true
+  } catch (loadError) {
+    if (loadError.name !== 'AbortError') {
+      error.value = loadError.message || 'Related records could not be loaded.'
+    }
+  } finally {
+    if (requestController === controller) loading.value = false
+  }
+}
+
+function handleDialogKeydown(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    close()
+    return
+  }
+  if (event.key !== 'Tab') return
+
+  const focusable = Array.from(
+    dialog.value?.querySelectorAll(
+      'button:not([disabled]), input:not([disabled]), [href], [tabindex]:not([tabindex="-1"])'
+    ) || []
+  )
+  if (focusable.length === 0) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+
+function mutate(option) {
+  const operation = option.attached ? 'detach' : 'attach'
+  if (
+    (operation === 'attach' && !props.relationship.canAttach) ||
+    (operation === 'detach' && !props.relationship.canDetach)
+  ) {
+    return
+  }
+
+  processingId.value = String(option.id)
+  error.value = ''
+  router.post(
+    `${props.mutationBaseUrl}/${operation}`,
+    { relatedId: option.id },
+    {
+      preserveScroll: true,
+      onSuccess: () => {
+        option.attached = !option.attached
+      },
+      onError: (errors) => {
+        error.value = errors.error || `The record could not be ${operation}ed.`
+      },
+      onFinish: () => {
+        processingId.value = ''
+      }
+    }
+  )
+}
+
+onBeforeUnmount(() => {
+  clearTimeout(debounceTimer)
+  requestController?.abort()
+})
+</script>
+
+<template>
+  <button
+    v-if="canManage"
+    ref="triggerButton"
+    type="button"
+    class="text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+    :aria-label="`Manage ${relationship.label.toLowerCase()}`"
+    @click="show"
+  >
+    Manage
+  </button>
+
+  <Teleport to="body">
+    <div
+      v-if="open"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-gray-950/30 px-4 py-8 backdrop-blur-[1px] dark:bg-black/60"
+      @mousedown.self="close"
+    >
+      <section
+        ref="dialog"
+        role="dialog"
+        aria-modal="true"
+        :aria-labelledby="`bridge-${relationship.alias}-manager-title`"
+        class="flex max-h-[min(680px,calc(100vh-4rem))] w-full max-w-lg flex-col overflow-hidden rounded-xl bg-white shadow-2xl dark:bg-gray-900"
+        @keydown="handleDialogKeydown"
+      >
+        <header
+          class="flex items-start justify-between gap-4 border-b border-gray-100 px-5 py-4 dark:border-gray-800"
+        >
+          <div>
+            <h2
+              :id="`bridge-${relationship.alias}-manager-title`"
+              class="text-base font-semibold text-gray-900 dark:text-white"
+            >
+              {{ relationship.label }}
+            </h2>
+            <p class="mt-0.5 text-sm text-gray-500 dark:text-gray-400">
+              Search records, then attach or remove them.
+            </p>
+          </div>
+          <button
+            type="button"
+            aria-label="Close relationship manager"
+            class="-mr-1 rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+            @click="close"
+          >
+            <svg
+              class="h-5 w-5"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                d="M5.22 5.22a.75.75 0 0 1 1.06 0L10 8.94l3.72-3.72a.75.75 0 1 1 1.06 1.06L11.06 10l3.72 3.72a.75.75 0 1 1-1.06 1.06L10 11.06l-3.72 3.72a.75.75 0 0 1-1.06-1.06L8.94 10 5.22 6.28a.75.75 0 0 1 0-1.06Z"
+              />
+            </svg>
+          </button>
+        </header>
+
+        <div class="border-b border-gray-100 p-4 dark:border-gray-800">
+          <label
+            :for="`bridge-${relationship.alias}-manager-search`"
+            class="sr-only"
+            >Search {{ relationship.label.toLowerCase() }}</label
+          >
+          <input
+            :id="`bridge-${relationship.alias}-manager-search`"
+            ref="searchInput"
+            v-model="query"
+            type="search"
+            autocomplete="off"
+            :placeholder="`Search ${relationship.label.toLowerCase()}…`"
+            class="h-10 w-full rounded-md bg-gray-50 px-3 text-sm text-gray-900 outline-none ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-700 dark:focus:ring-gray-500"
+          />
+        </div>
+
+        <div class="min-h-40 flex-1 overflow-y-auto py-1">
+          <div
+            v-for="option in options"
+            :key="String(option.id)"
+            class="flex items-center justify-between gap-4 px-5 py-3"
+          >
+            <div class="min-w-0">
+              <p
+                class="truncate text-sm font-medium text-gray-900 dark:text-white"
+              >
+                {{ option.label }}
+              </p>
+              <p
+                class="truncate font-mono text-xs text-gray-400 dark:text-gray-500"
+                :title="String(option.id)"
+              >
+                {{ option.id }}
+              </p>
+            </div>
+            <button
+              v-if="
+                (option.attached && relationship.canDetach) ||
+                (!option.attached && relationship.canAttach)
+              "
+              type="button"
+              :disabled="processingId === String(option.id)"
+              :class="[
+                'shrink-0 rounded-md px-3 py-1.5 text-xs font-medium disabled:cursor-not-allowed disabled:opacity-50',
+                option.attached
+                  ? 'text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30'
+                  : 'bg-gray-900 text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
+              ]"
+              @click="mutate(option)"
+            >
+              {{
+                processingId === String(option.id)
+                  ? 'Saving…'
+                  : option.attached
+                  ? 'Remove'
+                  : 'Attach'
+              }}
+            </button>
+            <span
+              v-else-if="option.attached"
+              class="text-xs font-medium text-gray-400 dark:text-gray-500"
+              >Attached</span
+            >
+          </div>
+
+          <p
+            v-if="!loading && !error && options.length === 0"
+            class="px-5 py-10 text-center text-sm text-gray-400 dark:text-gray-500"
+          >
+            No matching records
+          </p>
+          <p
+            v-if="loading"
+            class="px-5 py-6 text-center text-sm text-gray-400 dark:text-gray-500"
+            role="status"
+          >
+            Loading…
+          </p>
+          <p
+            v-if="error"
+            class="px-5 py-4 text-sm text-red-600 dark:text-red-400"
+            role="alert"
+          >
+            {{ error }}
+          </p>
+          <button
+            v-if="hasMore && !loading"
+            type="button"
+            class="w-full px-5 py-3 text-left text-xs font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+            @click="loadOptions(page + 1, { append: true })"
+          >
+            Load more
+          </button>
+        </div>
+      </section>
+    </div>
+  </Teleport>
+</template>

--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, ref } from 'vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
+import BridgeRelationshipSelect from '@/components/bridge/BridgeRelationshipSelect.vue'
 import {
   bridgeFieldType,
   bridgeSelectOptions,
@@ -34,6 +35,10 @@ const props = defineProps({
   associationOptions: {
     type: Array,
     default: () => []
+  },
+  associationSearchUrl: {
+    type: String,
+    default: ''
   },
   uploadUrl: {
     type: String,
@@ -450,31 +455,21 @@ function defaultPlaceholder(fieldType) {
         </option>
       </select>
 
-      <select
+      <BridgeRelationshipSelect
         v-else-if="type === 'belongsTo'"
         :id="fieldId"
-        :value="modelValue"
+        :label="label"
+        :model-value="modelValue"
+        :options="associationOptions"
+        :search-url="associationSearchUrl"
+        :searchable="attribute.field?.relation?.searchable !== false"
         :disabled="field.readOnly"
         :required="attribute.required"
-        :aria-invalid="visibleError ? 'true' : undefined"
-        :aria-describedby="describedBy"
-        :data-test="`${fieldId}-input`"
-        :class="inputClass"
-        @change="
-          update(associationOptions[$event.target.selectedIndex - 1]?.id ?? '')
-        "
+        :invalid="Boolean(visibleError)"
+        :described-by="describedBy"
+        @update:model-value="update"
         @blur="handleBlur"
-      >
-        <option value="">{{ attribute.required ? 'Select…' : 'None' }}</option>
-        <option
-          v-for="option in associationOptions"
-          :key="String(option.id)"
-          :value="String(option.id)"
-          :selected="String(option.id) === String(modelValue)"
-        >
-          {{ option.label }}
-        </option>
-      </select>
+      />
 
       <MarkdownEditor
         v-else-if="

--- a/assets/js/components/bridge/BridgeRelationshipSelect.vue
+++ b/assets/js/components/bridge/BridgeRelationshipSelect.vue
@@ -1,0 +1,299 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+
+const props = defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  label: {
+    type: String,
+    required: true
+  },
+  modelValue: {
+    default: null
+  },
+  options: {
+    type: Array,
+    default: () => []
+  },
+  searchUrl: {
+    type: String,
+    default: ''
+  },
+  searchable: {
+    type: Boolean,
+    default: true
+  },
+  required: Boolean,
+  disabled: Boolean,
+  invalid: Boolean,
+  describedBy: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'blur'])
+
+const root = ref(null)
+const searchInput = ref(null)
+const open = ref(false)
+const query = ref('')
+const results = ref([])
+const loading = ref(false)
+const loadError = ref('')
+const page = ref(1)
+const hasMore = ref(false)
+const openAbove = ref(false)
+let debounceTimer
+let requestController
+
+const allOptions = computed(() => {
+  const merged = new Map()
+  for (const option of [...props.options, ...results.value]) {
+    merged.set(String(option.id), option)
+  }
+  return Array.from(merged.values())
+})
+const selected = computed(() =>
+  allOptions.value.find(
+    (option) => String(option.id) === String(props.modelValue)
+  )
+)
+const listboxId = computed(() => `${props.id}-options`)
+
+watch(
+  () => props.options,
+  (options) => {
+    results.value = [...options]
+  },
+  { immediate: true }
+)
+
+watch(query, () => {
+  if (!open.value || !props.searchUrl) return
+  clearTimeout(debounceTimer)
+  debounceTimer = setTimeout(() => loadOptions(1), 180)
+})
+
+async function showOptions() {
+  if (props.disabled) return
+  const bounds = root.value?.getBoundingClientRect()
+  openAbove.value =
+    Boolean(bounds) &&
+    bounds.bottom + 300 > window.innerHeight &&
+    bounds.top > 300
+  open.value = true
+  loadError.value = ''
+  if (props.searchUrl) await loadOptions(1)
+  if (props.searchable) {
+    await nextTick()
+    searchInput.value?.focus()
+  }
+}
+
+function hideOptions({ blur = true } = {}) {
+  open.value = false
+  query.value = ''
+  if (blur) emit('blur')
+}
+
+async function loadOptions(nextPage, { append = false } = {}) {
+  if (!props.searchUrl) return
+  requestController?.abort()
+  const controller = new AbortController()
+  requestController = controller
+  loading.value = true
+  loadError.value = ''
+
+  try {
+    const url = new URL(props.searchUrl, window.location.origin)
+    url.searchParams.set('q', query.value)
+    url.searchParams.set('page', String(nextPage))
+    const response = await fetch(url, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal
+    })
+    const data = await response.json().catch(() => ({}))
+    if (!response.ok) {
+      throw new Error(data.error || 'Relationships could not be loaded.')
+    }
+    results.value = append
+      ? [...results.value, ...(data.options || [])]
+      : data.options || []
+    page.value = data.page || nextPage
+    hasMore.value = data.hasMore === true
+  } catch (error) {
+    if (error.name !== 'AbortError') {
+      loadError.value = error.message || 'Relationships could not be loaded.'
+    }
+  } finally {
+    if (requestController === controller) loading.value = false
+  }
+}
+
+function choose(option) {
+  emit('update:modelValue', option ? option.id : '')
+  hideOptions()
+}
+
+function handleDocumentPointerDown(event) {
+  if (open.value && root.value && !root.value.contains(event.target)) {
+    hideOptions()
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', handleDocumentPointerDown)
+})
+
+onBeforeUnmount(() => {
+  clearTimeout(debounceTimer)
+  requestController?.abort()
+  document.removeEventListener('pointerdown', handleDocumentPointerDown)
+})
+</script>
+
+<template>
+  <div ref="root" class="relative">
+    <button
+      :id="id"
+      type="button"
+      role="combobox"
+      :aria-label="label"
+      :aria-expanded="open"
+      :aria-controls="listboxId"
+      aria-autocomplete="list"
+      :aria-invalid="invalid ? 'true' : undefined"
+      :aria-describedby="describedBy || undefined"
+      :disabled="disabled"
+      :data-test="`${id}-input`"
+      class="focus:border-brand flex h-11 w-full items-center justify-between border-b border-dashed border-gray-200 bg-transparent px-1 text-left text-sm text-gray-900 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:border-gray-700 dark:text-white"
+      @click="open ? hideOptions() : showOptions()"
+      @keydown.down.prevent="showOptions"
+      @keydown.esc.prevent="hideOptions"
+    >
+      <span
+        :class="
+          selected ? 'truncate' : 'truncate text-gray-400 dark:text-gray-500'
+        "
+      >
+        {{ selected?.label || (required ? 'Select…' : 'None') }}
+      </span>
+      <svg
+        class="ml-3 h-4 w-4 shrink-0 text-gray-400 transition"
+        :class="{ 'rotate-180': open }"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          fill-rule="evenodd"
+          d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.168l3.71-3.938a.75.75 0 1 1 1.08 1.04l-4.25 4.51a.75.75 0 0 1-1.08 0l-4.25-4.51a.75.75 0 0 1 .02-1.06Z"
+          clip-rule="evenodd"
+        />
+      </svg>
+    </button>
+
+    <div
+      v-if="open"
+      :class="[
+        'absolute z-40 w-full overflow-hidden rounded-lg border border-gray-200 bg-white shadow-xl shadow-gray-900/10 dark:border-gray-700 dark:bg-gray-900 dark:shadow-black/30',
+        openAbove ? 'bottom-full mb-2' : 'mt-2'
+      ]"
+    >
+      <div
+        v-if="searchable && searchUrl"
+        class="border-b border-gray-100 p-2 dark:border-gray-800"
+      >
+        <label :for="`${id}-search`" class="sr-only"
+          >Search {{ label.toLowerCase() }}</label
+        >
+        <input
+          :id="`${id}-search`"
+          ref="searchInput"
+          v-model="query"
+          type="search"
+          autocomplete="off"
+          :placeholder="`Search ${label.toLowerCase()}…`"
+          class="h-9 w-full rounded-md bg-gray-50 px-3 text-sm text-gray-900 outline-none ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-700 dark:focus:ring-gray-500"
+          @keydown.esc.prevent="hideOptions"
+        />
+      </div>
+
+      <div
+        :id="listboxId"
+        role="listbox"
+        :aria-label="`${label} options`"
+        class="max-h-64 overflow-y-auto py-1"
+      >
+        <button
+          v-if="!required"
+          type="button"
+          role="option"
+          :aria-selected="
+            modelValue === '' || modelValue === null || modelValue === undefined
+          "
+          class="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-gray-500 hover:bg-gray-50 dark:text-gray-400 dark:hover:bg-gray-800"
+          @click="choose(null)"
+        >
+          None
+        </button>
+        <button
+          v-for="option in results"
+          :key="String(option.id)"
+          type="button"
+          role="option"
+          :aria-selected="String(option.id) === String(modelValue)"
+          class="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-gray-800"
+          @click="choose(option)"
+        >
+          <span class="truncate">{{ option.label }}</span>
+          <svg
+            v-if="String(option.id) === String(modelValue)"
+            class="text-brand h-4 w-4 shrink-0"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M16.704 5.29a1 1 0 0 1 .006 1.414l-7.2 7.26a1 1 0 0 1-1.42.002l-3.8-3.82a1 1 0 1 1 1.42-1.412l3.09 3.107 6.49-6.545a1 1 0 0 1 1.414-.006Z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        </button>
+
+        <p
+          v-if="!loading && !loadError && results.length === 0"
+          class="px-3 py-6 text-center text-sm text-gray-400 dark:text-gray-500"
+        >
+          No matching records
+        </p>
+        <p
+          v-if="loadError"
+          class="px-3 py-4 text-sm text-red-600 dark:text-red-400"
+          role="alert"
+        >
+          {{ loadError }}
+        </p>
+        <p
+          v-if="loading"
+          class="px-3 py-4 text-sm text-gray-400 dark:text-gray-500"
+          role="status"
+        >
+          Loading…
+        </p>
+        <button
+          v-if="hasMore && !loading"
+          type="button"
+          class="w-full px-3 py-2 text-left text-xs font-medium text-gray-500 hover:bg-gray-50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+          @click="loadOptions(page + 1, { append: true })"
+        >
+          Load more
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -198,6 +198,21 @@ function uploadUrl(field) {
   return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${field.name}/upload`
 }
 
+function relationshipSearchUrl(field) {
+  if (!field.attr.isBelongsTo) return ''
+  const params = new URLSearchParams({
+    surface: isEdit.value ? 'edit' : 'create'
+  })
+  if (isEdit.value && props.recordId !== null) {
+    params.set('recordId', String(props.recordId))
+  }
+  return `/api/v1/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/relationships/${encodePathSegment(
+    field.name
+  )}/options?${params.toString()}`
+}
+
 function bridgeUrl() {
   return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
 }
@@ -413,6 +428,7 @@ function recordUrl() {
               :model-identity="modelIdentity"
               :record-id="recordId"
               :association-options="assocOptions[field.name] || []"
+              :association-search-url="relationshipSearchUrl(field)"
               :upload-url="uploadUrl(field)"
               @update:model-value="updateField(field, $event)"
               @blur="validateAndRemember(field)"

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -6,6 +6,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
+import BridgeCollectionManager from '@/components/bridge/BridgeCollectionManager.vue'
 
 defineOptions({
   layout: AppLayout
@@ -19,6 +20,7 @@ const props = defineProps({
   appRunning: Boolean,
   modelMeta: Object,
   record: Object,
+  relationships: Object,
   error: String
 })
 
@@ -40,11 +42,6 @@ function displayIdentifier(value) {
   return `${identifier.slice(0, 10)}…${identifier.slice(-6)}`
 }
 
-function relatedIdentifier(record) {
-  if (!record) return ''
-  return record.id ?? record[Object.keys(record)[0]]
-}
-
 // Categorize attributes
 const regularAttrs = computed(() => {
   if (!props.modelMeta) return []
@@ -54,37 +51,19 @@ const regularAttrs = computed(() => {
 })
 
 const modelAssociations = computed(() => {
-  if (!props.modelMeta) return []
-  const visibleFields = new Set(props.modelMeta.show || [])
-  return (props.modelMeta.associations || []).filter(
-    (association) =>
-      association.type === 'model' && visibleFields.has(association.alias)
+  return Object.values(props.relationships || {}).filter(
+    (relationship) => relationship.type === 'model'
   )
 })
 
 const collectionAssociations = computed(() => {
-  if (!props.modelMeta) return []
-  const visibleFields = new Set(props.modelMeta.show || [])
-  return (props.modelMeta.associations || []).filter(
-    (association) =>
-      association.type === 'collection' && visibleFields.has(association.alias)
+  return Object.values(props.relationships || {}).filter(
+    (relationship) => relationship.type === 'collection'
   )
 })
 
 function fieldLabel(name) {
   return props.modelMeta?.attributes[name]?.label || name
-}
-
-function collectionRecords(alias) {
-  if (!props.record || !props.record[alias]) return []
-  const data = props.record[alias]
-  return Array.isArray(data) ? data.slice(0, 5) : []
-}
-
-function collectionCount(alias) {
-  if (!props.record || !props.record[alias]) return 0
-  const data = props.record[alias]
-  return Array.isArray(data) ? data.length : 0
 }
 
 function confirmDelete() {
@@ -123,6 +102,26 @@ function relatedRecordUrl(model, id) {
   return `/projects/${props.project.slug}/environments/${
     props.environment.slug
   }/bridge/${model}/${encodePathSegment(id)}`
+}
+
+function relationshipOptionsUrl(relationship) {
+  const params = new URLSearchParams({
+    surface: 'manage',
+    recordId: String(props.recordId)
+  })
+  return `/api/v1/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/relationships/${encodePathSegment(
+    relationship.alias
+  )}/options?${params.toString()}`
+}
+
+function relationshipMutationBaseUrl(relationship) {
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/${encodePathSegment(
+    props.recordId
+  )}/relationships/${encodePathSegment(relationship.alias)}`
 }
 </script>
 
@@ -396,28 +395,19 @@ function relatedRecordUrl(model, id) {
                   <dt
                     class="w-40 shrink-0 text-sm font-medium text-gray-500 dark:text-gray-400"
                   >
-                    {{ fieldLabel(assoc.alias) }}
-                    <span
-                      class="block text-xs font-normal text-gray-400 dark:text-gray-500"
-                      >→ {{ assoc.model }}</span
-                    >
+                    {{ assoc.label }}
                   </dt>
                   <dd class="min-w-0 flex-1 text-sm">
-                    <template
-                      v-if="
-                        record[assoc.alias] === null ||
-                        record[assoc.alias] === undefined
-                      "
-                    >
+                    <template v-if="!assoc.record">
                       <span class="text-gray-300 dark:text-gray-600">null</span>
                     </template>
                     <Link
                       v-else
-                      :href="relatedRecordUrl(assoc.model, record[assoc.alias])"
+                      :href="relatedRecordUrl(assoc.resource, assoc.record.id)"
+                      :title="String(assoc.record.id)"
                       class="font-medium text-gray-900 hover:underline dark:text-white"
                     >
-                      {{ assoc.model }}
-                      {{ displayIdentifier(record[assoc.alias]) }}
+                      {{ assoc.record.label }}
                     </Link>
                   </dd>
                 </div>
@@ -426,63 +416,66 @@ function relatedRecordUrl(model, id) {
           </div>
 
           <!-- Right: Collection associations -->
-          <div v-if="collectionAssociations.length > 0" class="space-y-4">
-            <div
+          <div
+            v-if="collectionAssociations.length > 0"
+            class="self-start overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
+          >
+            <div class="px-4 py-3">
+              <h2 class="text-sm font-semibold text-gray-900 dark:text-white">
+                Relationships
+              </h2>
+            </div>
+            <section
               v-for="assoc in collectionAssociations"
               :key="assoc.alias"
-              class="overflow-hidden rounded-xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-900"
+              class="border-t border-gray-100 dark:border-gray-800"
             >
               <div
-                class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800"
+                class="flex items-center justify-between gap-3 px-4 pb-2 pt-3"
               >
-                <h3 class="text-sm font-semibold text-gray-900 dark:text-white">
-                  {{ assoc.alias }}
+                <h3 class="text-sm font-medium text-gray-900 dark:text-white">
+                  {{ assoc.label }}
                   <span
                     class="ml-1 text-xs font-normal text-gray-400 dark:text-gray-500"
-                    >({{ collectionCount(assoc.alias) }})</span
+                    >{{ assoc.records.length
+                    }}{{ assoc.hasMore ? '+' : '' }}</span
                   >
                 </h3>
-                <Link
-                  v-if="collectionCount(assoc.alias) > 0"
-                  :href="`${bridgeUrl()}/${assoc.collection}`"
-                  class="text-xs text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-                >
-                  View all
-                </Link>
+                <BridgeCollectionManager
+                  :relationship="assoc"
+                  :options-url="relationshipOptionsUrl(assoc)"
+                  :mutation-base-url="relationshipMutationBaseUrl(assoc)"
+                />
               </div>
               <div
-                v-if="collectionRecords(assoc.alias).length === 0"
-                class="px-4 py-6 text-center text-xs text-gray-400 dark:text-gray-500"
+                v-if="assoc.records.length === 0"
+                class="px-4 pb-4 text-xs text-gray-400 dark:text-gray-500"
               >
                 No related records
               </div>
-              <ul v-else class="divide-y divide-gray-100 dark:divide-gray-800">
+              <ul v-else class="pb-2">
                 <li
-                  v-for="(related, i) in collectionRecords(assoc.alias)"
-                  :key="i"
-                  class="px-4 py-2"
+                  v-for="related in assoc.records"
+                  :key="String(related.id)"
+                  class="px-4 py-1.5"
                 >
                   <Link
-                    :href="
-                      relatedRecordUrl(
-                        assoc.collection,
-                        relatedIdentifier(related)
-                      )
-                    "
-                    :title="String(relatedIdentifier(related))"
-                    class="text-sm font-medium text-gray-900 hover:underline dark:text-white"
+                    :href="relatedRecordUrl(assoc.identity, related.id)"
+                    :title="String(related.id)"
+                    class="block min-w-0"
                   >
-                    {{ displayIdentifier(relatedIdentifier(related)) }}
+                    <span
+                      class="block truncate text-sm font-medium text-gray-900 hover:underline dark:text-white"
+                      >{{ related.label }}</span
+                    >
+                    <span
+                      class="block truncate font-mono text-[11px] text-gray-400 dark:text-gray-500"
+                      >{{ displayIdentifier(related.id) }}</span
+                    >
                   </Link>
-                  <span
-                    v-if="related.name || related.title || related.email"
-                    class="ml-2 text-xs text-gray-500 dark:text-gray-400"
-                  >
-                    {{ related.name || related.title || related.email }}
-                  </span>
                 </li>
               </ul>
-            </div>
+            </section>
           </div>
         </div>
       </div>

--- a/config/routes.js
+++ b/config/routes.js
@@ -379,6 +379,15 @@ module.exports.routes = {
     'project/bridge-bulk-delete',
   'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/bulk-delete':
     'project/bridge-bulk-delete',
+  // Bridge relationship search is JSON transport for async comboboxes.
+  'GET /api/v1/projects/:slug/bridge/:modelIdentity/relationships/:relationshipAlias/options':
+    'project/bridge-relationship-options',
+  'GET /api/v1/projects/:slug/environments/:envSlug/bridge/:modelIdentity/relationships/:relationshipAlias/options':
+    'project/bridge-relationship-options',
+  'POST /projects/:slug/bridge/:modelIdentity/:recordId/relationships/:relationshipAlias/:operation':
+    'project/bridge-update-relationship',
+  'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/:recordId/relationships/:relationshipAlias/:operation':
+    'project/bridge-update-relationship',
 
   /***************************************************************************
    *                                                                          *

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -52,6 +52,20 @@ module.exports.slipway = {
         authorization: {
           helper: 'bridge.authorize'
         },
+        relationships: {
+          chapters: {
+            fields: ['id', 'title'],
+            search: ['title'],
+            limit: 8
+          },
+          lessons: {
+            fields: ['id', 'title'],
+            search: ['title'],
+            limit: 12,
+            attach: true,
+            detach: true
+          }
+        },
         fields: {
           price: {
             label: 'Price',
@@ -76,6 +90,13 @@ module.exports.slipway = {
               storage: 'bridge',
               directory: 'courses/thumbnails',
               store: 'url'
+            }
+          },
+          creator: {
+            relation: {
+              label: 'Creator',
+              search: ['fullName', 'email'],
+              limit: 20
             }
           }
         }
@@ -371,6 +392,92 @@ and runs it inside the target application, then asks the target Waterline model
 to validate the generated value before creating the record. Helper defaults are
 currently supported only for primary keys and receive no client-controlled
 inputs.
+
+## Relationships
+
+Bridge treats Waterline `model` and `collection` associations as first-class
+resource metadata.
+
+Belongs-to fields derive their label, primary-key type, title field, and search
+fields from the related resource. Use the field's `relation` option only when
+the generated behavior needs an override:
+
+```js
+lesson: {
+  fields: {
+    chapter: {
+      relation: {
+        label: 'Chapter',
+        search: ['title', 'slug'],
+        limit: 20
+      }
+    },
+    creator: {
+      relation: {
+        search: ['fullName', 'email']
+      }
+    }
+  }
+}
+```
+
+The form receives only the first bounded page. Its combobox searches through a
+dedicated JSON transport and loads additional pages on demand, so a large user
+or course table is never serialized into an Inertia page.
+
+Create and update requests repeat the related resource's `viewAny`
+authorization and verify that every submitted belongs-to ID still exists.
+Hiding a selector therefore cannot be bypassed with a forged form payload.
+
+Collection associations appear as compact related-record lists on the detail
+page. Values are selected only from the related resource's safe `show` fields.
+The primary key and title field are always included; additional fields must be
+explicit:
+
+```js
+course: {
+  relationships: {
+    chapters: {
+      label: 'Chapters',
+      fields: ['id', 'title', 'position'],
+      search: ['title'],
+      limit: 8
+    }
+  }
+}
+```
+
+`limit` must be between 1 and 50. `search` and `fields` may reference only
+fields already allowed by the related resource contract. A hidden related
+resource, a denied `viewAny` decision, or an unavailable association fails
+closed.
+
+Collection mutation is disabled by default. Enable the exact operations a
+resource needs:
+
+```js
+course: {
+  relationships: {
+    lessons: {
+      attach: true,
+      detach: true
+    }
+  }
+}
+```
+
+Attach and detach use Waterline's `addToCollection()` and
+`removeFromCollection()` methods. Bridge never deletes the related record.
+Every mutation requires all three gates:
+
+1. the operation is explicitly enabled on the collection relationship;
+2. the current actor is allowed to `update` the parent resource; and
+3. the current actor is allowed to `viewAny` on the related resource.
+
+This keeps existing target-app authorization helpers authoritative. A
+one-to-many detach can still be rejected by Waterline when the related foreign
+key is required; Bridge returns that model error instead of forcing an invalid
+state.
 
 ## Upload configuration boundary
 

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -37,11 +37,15 @@ test(
     const fieldEngineScreenshotRoot = path.resolve(
       '.tmp/screenshots/issue-219-bridge-field-engine'
     )
+    const relationshipScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-220-bridge-relationships'
+    )
 
     fs.mkdirSync(screenshotRoot, { recursive: true })
     fs.mkdirSync(identifierScreenshotRoot, { recursive: true })
     fs.mkdirSync(authorizationScreenshotRoot, { recursive: true })
     fs.mkdirSync(fieldEngineScreenshotRoot, { recursive: true })
+    fs.mkdirSync(relationshipScreenshotRoot, { recursive: true })
 
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: resourceMetadata(),
@@ -50,6 +54,8 @@ test(
     const courseRecordId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80211'
     const createdCourseRecordId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80212'
     const creatorId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80213'
+    const chapterId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80214'
+    const lessonId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80215'
     const records = [
       {
         id: courseRecordId,
@@ -128,6 +134,116 @@ test(
       if (code.includes('const options = {};')) {
         return successfulResult({
           creator: [{ id: creatorId, label: 'Ada Lovelace' }]
+        })
+      }
+      if (code.includes('const missing = [];')) {
+        return successfulResult({ missing: [] })
+      }
+      if (code.includes('const where = definition.query')) {
+        const definition = readEmbeddedValue(code, 'definition')
+        if (definition.identity === 'user') {
+          return successfulResult({
+            options: [
+              {
+                id: creatorId,
+                label: 'Ada Lovelace',
+                attached: false
+              }
+            ],
+            page: definition.page,
+            limit: definition.limit,
+            hasMore: false
+          })
+        }
+        return successfulResult({
+          options: [
+            {
+              id: lessonId,
+              label: 'Deploy with confidence',
+              attached: true
+            },
+            {
+              id: '018f2a5c-7b34-7f8a-9c12-4a73b9d80216',
+              label: 'Operate the boring path',
+              attached: false
+            }
+          ],
+          page: definition.page,
+          limit: definition.limit,
+          hasMore: false
+        })
+      }
+      if (
+        code.includes('const parentIdentity =') &&
+        code.includes('function present')
+      ) {
+        return successfulResult({
+          creator: {
+            alias: 'creator',
+            type: 'model',
+            label: 'Creator',
+            identity: 'user',
+            primaryKey: 'id',
+            title: 'fullName',
+            fields: ['id', 'fullName'],
+            limit: 20,
+            canAttach: false,
+            canDetach: false,
+            record: {
+              id: creatorId,
+              label: 'Ada Lovelace',
+              values: {
+                id: creatorId,
+                fullName: 'Ada Lovelace'
+              }
+            }
+          },
+          chapters: {
+            alias: 'chapters',
+            type: 'collection',
+            label: 'Chapters',
+            identity: 'chapter',
+            primaryKey: 'id',
+            title: 'title',
+            fields: ['id', 'title'],
+            limit: 5,
+            canAttach: false,
+            canDetach: false,
+            records: [
+              {
+                id: chapterId,
+                label: 'The deployment path',
+                values: {
+                  id: chapterId,
+                  title: 'The deployment path'
+                }
+              }
+            ],
+            hasMore: false
+          },
+          lessons: {
+            alias: 'lessons',
+            type: 'collection',
+            label: 'Lessons',
+            identity: 'lesson',
+            primaryKey: 'id',
+            title: 'title',
+            fields: ['id', 'title'],
+            limit: 5,
+            canAttach: true,
+            canDetach: true,
+            records: [
+              {
+                id: lessonId,
+                label: 'Deploy with confidence',
+                values: {
+                  id: lessonId,
+                  title: 'Deploy with confidence'
+                }
+              }
+            ],
+            hasMore: false
+          }
         })
       }
       if (code.includes('const total = await model.count(where);')) {
@@ -239,7 +355,7 @@ test(
       await page.wait('text=Courses')
       await expect(page).toSee('Content')
       await expect(page).toSee('People')
-      await expect(page).toSee('2 resources')
+      await expect(page).toSee('4 resources')
       expect(await page.raw.getByText('Model Settings').count()).toBe(0)
       await page.screenshot(path.join(screenshotRoot, 'resources-light.png'), {
         fullPage: true
@@ -324,7 +440,35 @@ test(
       )
       await page.raw.getByLabel('Course title').fill('Ship a durable course')
       await page.raw.getByLabel('Price').fill('49')
-      await page.raw.getByLabel('Creator').selectOption(creatorId)
+      await page.raw.setViewportSize({ width: 1440, height: 1100 })
+      const creatorRelationshipSelect = page.raw.getByRole('combobox', {
+        name: 'Creator'
+      })
+      await creatorRelationshipSelect.evaluate((element) => {
+        element.scrollIntoView({ block: 'center' })
+      })
+      await creatorRelationshipSelect.click()
+      await page.wait('text=Ada Lovelace')
+      await page.screenshot(
+        path.join(
+          relationshipScreenshotRoot,
+          'searchable-creator-select-light.png'
+        ),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(
+          relationshipScreenshotRoot,
+          'searchable-creator-select-dark.png'
+        ),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .getByRole('option', { name: 'Ada Lovelace', exact: true })
+        .click()
+      await page.raw.setViewportSize({ width: 1440, height: 900 })
       expect(await createRecordButton.isEnabled()).toBe(true)
       await createRecordButton.scrollIntoViewIfNeeded()
       await page.screenshot(
@@ -499,8 +643,15 @@ test(
       await expect(page).toSee('$34.99')
       await expect(page).toSee('https://sailsjs.com')
       await expect(page).toSee('"lessons": 12')
+      await expect(page).toSee('Ada Lovelace')
+      await expect(page).toSee('The deployment path')
+      await expect(page).toSee('Deploy with confidence')
       await page.screenshot(
         path.join(fieldEngineScreenshotRoot, 'typed-record-light.png'),
+        { fullPage: true }
+      )
+      await page.screenshot(
+        path.join(relationshipScreenshotRoot, 'course-relations-light.png'),
         { fullPage: true }
       )
       await page.raw.emulateMedia({ colorScheme: 'dark' })
@@ -514,6 +665,30 @@ test(
         path.join(fieldEngineScreenshotRoot, 'typed-record-dark.png'),
         { fullPage: true }
       )
+      await page.screenshot(
+        path.join(relationshipScreenshotRoot, 'course-relations-dark.png'),
+        { fullPage: true }
+      )
+
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .getByRole('button', { name: 'Manage lessons', exact: true })
+        .click()
+      await page.wait('text=Operate the boring path')
+      await expect(page).toSee('Remove')
+      await expect(page).toSee('Attach')
+      await page.screenshot(
+        path.join(relationshipScreenshotRoot, 'manage-lessons-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(relationshipScreenshotRoot, 'manage-lessons-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw
+        .getByRole('button', { name: 'Close relationship manager' })
+        .click()
 
       await page.raw.emulateMedia({ colorScheme: 'light' })
       await page.goto(`${bridgePath}/user/${creatorId}`)
@@ -618,6 +793,20 @@ function resourceConfig() {
         actions: {
           bulkDelete: false
         },
+        relationships: {
+          chapters: {
+            fields: ['id', 'title'],
+            search: ['title'],
+            limit: 5
+          },
+          lessons: {
+            fields: ['id', 'title'],
+            search: ['title'],
+            limit: 5,
+            attach: true,
+            detach: true
+          }
+        },
         fields: {
           id: {
             default: {
@@ -682,6 +871,22 @@ function resourceConfig() {
         actions: {
           bulkDelete: false
         }
+      },
+      chapter: {
+        label: 'Chapters',
+        singularLabel: 'Chapter',
+        group: 'Content',
+        title: 'title',
+        search: ['title'],
+        list: ['title']
+      },
+      lesson: {
+        label: 'Lessons',
+        singularLabel: 'Lesson',
+        group: 'Content',
+        title: 'title',
+        search: ['title'],
+        list: ['title']
       }
     }
   }
@@ -744,6 +949,18 @@ function resourceMetadata() {
           alias: 'creator',
           type: 'model',
           model: 'user'
+        },
+        {
+          alias: 'chapters',
+          type: 'collection',
+          collection: 'chapter',
+          via: 'course'
+        },
+        {
+          alias: 'lessons',
+          type: 'collection',
+          collection: 'lesson',
+          via: 'course'
         }
       ]
     },
@@ -785,6 +1002,62 @@ function resourceMetadata() {
         }
       },
       associations: []
+    },
+    chapter: {
+      identity: 'chapter',
+      globalId: 'Chapter',
+      tableName: 'chapter',
+      primaryKey: 'id',
+      attributes: {
+        id: {
+          type: 'string',
+          required: true,
+          isUUID: true
+        },
+        title: {
+          type: 'string',
+          required: true
+        },
+        course: {
+          type: 'string',
+          model: 'course'
+        }
+      },
+      associations: [
+        {
+          alias: 'course',
+          type: 'model',
+          model: 'course'
+        }
+      ]
+    },
+    lesson: {
+      identity: 'lesson',
+      globalId: 'Lesson',
+      tableName: 'lesson',
+      primaryKey: 'id',
+      attributes: {
+        id: {
+          type: 'string',
+          required: true,
+          isUUID: true
+        },
+        title: {
+          type: 'string',
+          required: true
+        },
+        course: {
+          type: 'string',
+          model: 'course'
+        }
+      },
+      associations: [
+        {
+          alias: 'course',
+          type: 'model',
+          model: 'course'
+        }
+      ]
     }
   }
 }

--- a/tests/functional/pages/bridge-relationships.test.js
+++ b/tests/functional/pages/bridge-relationships.test.js
@@ -85,7 +85,7 @@ test(
 
       const browser = await withCsrfFromPage(
         request,
-        `/projects/${project.slug}/environments/${environment.slug}`,
+        '/projects/new',
         'genesisUser'
       )
       const optionsPath =
@@ -190,7 +190,7 @@ test(
 
       const browser = await withCsrfFromPage(
         request,
-        `/projects/${project.slug}/environments/${environment.slug}`,
+        '/projects/new',
         'genesisUser'
       )
       const mutationPath =

--- a/tests/functional/pages/bridge-relationships.test.js
+++ b/tests/functional/pages/bridge-relationships.test.js
@@ -1,0 +1,316 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'Bridge searches and attaches relationships through bounded authorized endpoints',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-relationship-management',
+          name: 'Bridge relationship management'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const courseId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80221'
+    const lessonId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80222'
+    let mutation
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: relationshipModels(),
+      config: relationshipConfig({ attach: true, detach: true })
+    })
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-relationship-management-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-relationship-management-web')
+        if (code.includes('const decisions = Object.create(null);')) {
+          const requests = readEmbeddedValue(code, 'requests')
+          const decisions = {}
+          for (const authorizationRequest of requests) {
+            decisions[authorizationRequest.key] =
+              decisions[authorizationRequest.key] || {}
+            decisions[authorizationRequest.key][
+              authorizationRequest.action
+            ] = true
+          }
+          return successfulResult(decisions)
+        }
+        if (code.includes('const where = definition.query')) {
+          const definition = readEmbeddedValue(code, 'definition')
+          expect(definition.page).toBe(2)
+          expect(definition.query).toBe('deploy')
+          expect(definition.limit).toBe(12)
+          expect(definition.recordId).toBe(courseId)
+          return successfulResult({
+            options: [
+              {
+                id: lessonId,
+                label: 'Deploy without drama',
+                attached: false
+              }
+            ],
+            page: 2,
+            limit: 12,
+            hasMore: false
+          })
+        }
+        if (code.includes('const [parent, related] = await Promise.all')) {
+          mutation = readEmbeddedValue(code, 'definition')
+          return successfulResult({ success: true })
+        }
+        return failedResult('Unexpected Bridge relationship query.')
+      }
+
+      const browser = await withCsrfFromPage(
+        request,
+        `/projects/${project.slug}/environments/${environment.slug}`,
+        'genesisUser'
+      )
+      const optionsPath =
+        `/api/v1/projects/${project.slug}/environments/${environment.slug}` +
+        `/bridge/course/relationships/lessons/options` +
+        `?surface=manage&recordId=${courseId}&q=deploy&page=2`
+      const optionsResponse = await browser.request.get(optionsPath)
+
+      expect(optionsResponse).toHaveStatus(200)
+      expect(optionsResponse).toHaveJsonPath(
+        'options.0.label',
+        'Deploy without drama'
+      )
+      expect(optionsResponse).toHaveJsonPath('options.0.attached', false)
+      expect(optionsResponse).toHaveJsonPath('hasMore', false)
+
+      const mutationResponse = await browser.request.post(
+        `/projects/${project.slug}/environments/${environment.slug}` +
+          `/bridge/course/${courseId}/relationships/lessons/attach`,
+        { relatedId: lessonId }
+      )
+      expect(mutationResponse).toHaveStatus(302)
+      expect(mutation).toEqual({
+        parentIdentity: 'course',
+        parentPrimaryKey: 'id',
+        parentId: courseId,
+        alias: 'lessons',
+        relatedIdentity: 'lesson',
+        relatedPrimaryKey: 'id',
+        relatedId: lessonId,
+        operation: 'attach'
+      })
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+test(
+  'Bridge collection mutations fail closed without explicit config or update authorization',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-relationship-denials',
+          name: 'Bridge relationship denials'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const courseId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80231'
+    const lessonId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80232'
+    let contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: relationshipModels(),
+      config: relationshipConfig({ attach: false, detach: false })
+    })
+    let allowUpdate = true
+    let mutationCount = 0
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-relationship-denials-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-relationship-denials-web')
+        if (code.includes('const decisions = Object.create(null);')) {
+          const requests = readEmbeddedValue(code, 'requests')
+          const decisions = {}
+          for (const authorizationRequest of requests) {
+            decisions[authorizationRequest.key] =
+              decisions[authorizationRequest.key] || {}
+            decisions[authorizationRequest.key][authorizationRequest.action] =
+              authorizationRequest.action !== 'update' || allowUpdate
+          }
+          return successfulResult(decisions)
+        }
+        if (code.includes('const [parent, related] = await Promise.all')) {
+          mutationCount += 1
+          return successfulResult({ success: true })
+        }
+        return failedResult('Unexpected Bridge relationship query.')
+      }
+
+      const browser = await withCsrfFromPage(
+        request,
+        `/projects/${project.slug}/environments/${environment.slug}`,
+        'genesisUser'
+      )
+      const mutationPath =
+        `/projects/${project.slug}/environments/${environment.slug}` +
+        `/bridge/course/${courseId}/relationships/lessons/attach`
+
+      const disabledResponse = await browser.request.post(mutationPath, {
+        relatedId: lessonId
+      })
+      expect(disabledResponse).toHaveStatus(400)
+      expect(disabledResponse).toHaveHeader('x-exit', 'badRequest')
+      expect(mutationCount).toBe(0)
+
+      contract = await sails.helpers.bridge.normalizeResourceContract.with({
+        models: relationshipModels(),
+        config: relationshipConfig({ attach: true, detach: true })
+      })
+      allowUpdate = false
+      const deniedResponse = await browser.request.post(mutationPath, {
+        relatedId: lessonId
+      })
+      expect(deniedResponse).toHaveStatus(400)
+      expect(deniedResponse).toHaveHeader('x-exit', 'badRequest')
+      expect(mutationCount).toBe(0)
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function relationshipConfig({ attach, detach }) {
+  return {
+    schemaVersion: 1,
+    resources: {
+      course: {
+        title: 'title',
+        authorization: 'bridge.authorize',
+        relationships: {
+          lessons: {
+            label: 'Lessons',
+            fields: ['id', 'title'],
+            search: ['title'],
+            limit: 12,
+            attach,
+            detach
+          }
+        }
+      },
+      lesson: {
+        title: 'title',
+        search: ['title'],
+        authorization: 'bridge.authorize'
+      }
+    }
+  }
+}
+
+function relationshipModels() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'course',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true, isUUID: true },
+        title: { type: 'string', required: true }
+      },
+      associations: [
+        {
+          alias: 'lessons',
+          type: 'collection',
+          collection: 'lesson',
+          via: 'course'
+        }
+      ]
+    },
+    lesson: {
+      identity: 'lesson',
+      globalId: 'Lesson',
+      tableName: 'lesson',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true, isUUID: true },
+        title: { type: 'string', required: true },
+        course: { type: 'string', model: 'course' }
+      },
+      associations: [
+        {
+          alias: 'course',
+          type: 'model',
+          model: 'course'
+        }
+      ]
+    }
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
+}
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function failedResult(error) {
+  return {
+    success: false,
+    output: '',
+    error,
+    exitCode: 1
+  }
+}

--- a/tests/unit/config/routes.test.js
+++ b/tests/unit/config/routes.test.js
@@ -27,6 +27,16 @@ test('browser actions and JSON transports have explicit route contracts', ({
       'POST /api/v1/projects/:slug/environments/:envSlug/content/:collection/:file/images'
     ]
   ).toBe('project/content-upload-image')
+  expect(
+    routes[
+      'GET /api/v1/projects/:slug/environments/:envSlug/bridge/:modelIdentity/relationships/:relationshipAlias/options'
+    ]
+  ).toBe('project/bridge-relationship-options')
+  expect(
+    routes[
+      'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/:recordId/relationships/:relationshipAlias/:operation'
+    ]
+  ).toBe('project/bridge-update-relationship')
   expect(routes['POST /switch-team']).toBe('team/switch-team')
   expect(routes['POST /settings/notifications/test']).toBe(
     'setting/test-notification'

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -263,6 +263,223 @@ test('Bridge preserves UUID primary keys and derives belongs-to identifier types
   expect(values.author).toBe(authorId)
 })
 
+test('Bridge normalizes bounded relationships and keeps collection mutations opt-in', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: relationshipModelMetadata(),
+    config: {
+      resources: {
+        lesson: {
+          show: ['id', 'title', 'chapter', 'course', 'creator'],
+          fields: {
+            chapter: {
+              relation: {
+                label: 'Chapter',
+                search: ['title'],
+                limit: 12
+              }
+            }
+          }
+        },
+        course: {
+          relationships: {
+            chapters: {
+              label: 'Course chapters',
+              fields: ['id', 'title'],
+              search: ['title'],
+              limit: 8,
+              attach: true,
+              detach: true
+            },
+            lessons: {
+              limit: 6
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const lesson = contract.resources.lesson
+  expect(lesson.relationships.chapter).toEqual({
+    alias: 'chapter',
+    type: 'model',
+    resource: 'chapter',
+    label: 'Chapter',
+    primaryKey: 'id',
+    title: 'title',
+    show: true,
+    searchable: true,
+    search: ['title'],
+    fields: ['id', 'title'],
+    limit: 12,
+    attach: false,
+    detach: false
+  })
+  expect(lesson.attributes.chapter.field.relation).toEqual(
+    lesson.relationships.chapter
+  )
+  expect(lesson.relationships.course.primaryKey).toBe('id')
+  expect(lesson.relationships.creator.title).toBe('fullName')
+
+  const course = contract.resources.course
+  expect(course.relationships.chapters).toEqual({
+    alias: 'chapters',
+    type: 'collection',
+    resource: 'chapter',
+    label: 'Course chapters',
+    primaryKey: 'id',
+    title: 'title',
+    show: true,
+    searchable: true,
+    search: ['title'],
+    fields: ['id', 'title'],
+    limit: 8,
+    attach: true,
+    detach: true,
+    via: 'course'
+  })
+  expect(course.relationships.lessons.attach).toBe(false)
+  expect(course.relationships.lessons.detach).toBe(false)
+  expect(course.relationships.lessons.limit).toBe(6)
+})
+
+test('Bridge rejects unsafe relationship configuration', async ({
+  sails,
+  expect
+}) => {
+  let mutationError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: relationshipModelMetadata(),
+      config: {
+        resources: {
+          lesson: {
+            fields: {
+              chapter: {
+                relation: {
+                  attach: true
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    mutationError = error
+  }
+  expect(mutationError.message).toContain(
+    'can enable attach or detach only for a collection association'
+  )
+
+  let fieldError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: relationshipModelMetadata(),
+      config: {
+        resources: {
+          course: {
+            relationships: {
+              chapters: {
+                fields: ['internalNotes']
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    fieldError = error
+  }
+  expect(fieldError.message).toContain(
+    'fields references unavailable field "internalNotes"'
+  )
+})
+
+test('Bridge authorizes and verifies submitted belongs-to values', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: relationshipModelMetadata(),
+    config: {}
+  })
+  const originalIntrospectModels = sails.helpers.bridge.introspectModels
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  const chapterId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80241'
+  let missing = []
+
+  try {
+    sails.helpers.bridge.introspectModels = async () => ({
+      schemaVersion: contract.schemaVersion,
+      discover: contract.discover,
+      configured: contract.configured,
+      models: contract.resources
+    })
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-app-web')
+      expect(code).toContain('const missing = [];')
+      const definitions = readEmbeddedValue(code, 'definitions')
+      expect(definitions).toEqual([
+        {
+          alias: 'chapter',
+          identity: 'chapter',
+          primaryKey: 'id',
+          id: chapterId
+        }
+      ])
+      return successfulResult({ missing })
+    }
+
+    const values = await sails.helpers.bridge.authorizeRelationshipValues.with({
+      containerName: 'bridge-app-web',
+      environmentId: 220,
+      resource: contract.resources.lesson,
+      actor: {
+        id: '7',
+        email: 'editor@example.com'
+      },
+      values: {
+        title: 'A safe lesson',
+        chapter: chapterId
+      }
+    })
+    expect(values.chapter).toBe(chapterId)
+
+    missing = ['chapter']
+    let missingError
+    try {
+      await sails.helpers.bridge.authorizeRelationshipValues.with({
+        containerName: 'bridge-app-web',
+        environmentId: 220,
+        resource: contract.resources.lesson,
+        actor: {
+          id: '7',
+          email: 'editor@example.com'
+        },
+        values: {
+          chapter: chapterId
+        }
+      })
+    } catch (error) {
+      missingError = error
+    }
+    expect(missingError.code).toBe('BRIDGE_RELATIONSHIP_NOT_FOUND')
+    expect(missingError.fieldErrors).toEqual({
+      chapter: 'Chapter no longer exists.'
+    })
+  } finally {
+    sails.helpers.bridge.introspectModels = originalIntrospectModels
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
 test('Bridge applies configured target helpers to generated primary keys', async ({
   sails,
   expect
@@ -1034,6 +1251,83 @@ function uuidModelMetadata() {
   }
 }
 
+function relationshipModelMetadata() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'course',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true, isUUID: true },
+        title: { type: 'string', required: true }
+      },
+      associations: [
+        {
+          alias: 'chapters',
+          type: 'collection',
+          collection: 'chapter',
+          via: 'course'
+        },
+        {
+          alias: 'lessons',
+          type: 'collection',
+          collection: 'lesson',
+          via: 'course'
+        }
+      ]
+    },
+    chapter: {
+      identity: 'chapter',
+      globalId: 'Chapter',
+      tableName: 'chapter',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true, isUUID: true },
+        title: { type: 'string', required: true },
+        internalNotes: { type: 'string', protect: true },
+        course: { type: 'string', model: 'course' }
+      },
+      associations: [
+        {
+          alias: 'course',
+          type: 'model',
+          model: 'course'
+        }
+      ]
+    },
+    lesson: {
+      identity: 'lesson',
+      globalId: 'Lesson',
+      tableName: 'lesson',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true, isUUID: true },
+        title: { type: 'string', required: true },
+        chapter: { type: 'string', model: 'chapter' },
+        course: { type: 'string', model: 'course' },
+        creator: { type: 'string', model: 'user' }
+      },
+      associations: [
+        { alias: 'chapter', type: 'model', model: 'chapter' },
+        { alias: 'course', type: 'model', model: 'course' },
+        { alias: 'creator', type: 'model', model: 'user' }
+      ]
+    },
+    user: {
+      identity: 'user',
+      globalId: 'User',
+      tableName: 'user',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true, isUUID: true },
+        fullName: { type: 'string', required: true }
+      },
+      associations: []
+    }
+  }
+}
+
 function sensitiveModelMetadata() {
   return {
     user: {
@@ -1090,4 +1384,10 @@ function successfulResult(output) {
     error: null,
     exitCode: 0
   }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
 }


### PR DESCRIPTION
## Summary

- add safe, bounded, searchable belongs-to relationship selectors
- add explicit collection attach and detach management without deleting related records
- enforce Bridge resource authorization and relationship configuration at every read and mutation boundary
- add minimal light and dark UI states plus unit, functional, and browser coverage
- document the complete Bridge relationship contract

## Impact

Bridge can now manage real Waterline relationships instead of exposing only simple preloaded belongs-to selects. Large related datasets remain bounded and searchable, collection mutations are explicit opt-ins, and forged relation IDs are rejected before writes.

## Validation

- `npm run test:unit` — 178 passed
- `npm run test:functional` — 49 passed
- `npm run test:e2e` — 20 passed
- `npm run lint`
- `npm run check:consistency`
- `git diff --check`

Closes #220