### PR TITLE
feat(bridge): add configurable custom actions

### DIFF
--- a/api/controllers/project/bridge-execute-action.js
+++ b/api/controllers/project/bridge-execute-action.js
@@ -1,0 +1,213 @@
+module.exports = {
+  friendlyName: 'Execute Bridge action',
+
+  description:
+    'Authorize and execute a configured Bridge resource, record, or bulk action.',
+
+  inputs: {
+    slug: {
+      type: 'string',
+      required: true
+    },
+    envSlug: {
+      type: 'string',
+      defaultsTo: 'production'
+    },
+    modelIdentity: {
+      type: 'string',
+      required: true
+    },
+    actionName: {
+      type: 'string',
+      required: true
+    },
+    values: {
+      type: 'ref',
+      defaultsTo: {}
+    },
+    recordId: {
+      type: 'ref'
+    },
+    recordIds: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      responseType: 'redirect'
+    },
+    notFound: {
+      responseType: 'redirect'
+    },
+    badRequest: {
+      responseType: 'badRequest'
+    }
+  },
+
+  fn: async function ({
+    slug,
+    envSlug,
+    modelIdentity,
+    actionName,
+    values,
+    recordId,
+    recordIds
+  }) {
+    const user = await User.findOne({ id: this.req.session.userId }).populate(
+      'team'
+    )
+    if (!user) {
+      throw { notFound: '/login' }
+    }
+
+    const project = await Project.findOne({ slug, team: user.team.id })
+    if (!project) {
+      throw { notFound: '/' }
+    }
+
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug: envSlug
+    })
+    if (!environment) {
+      throw { notFound: `/projects/${slug}` }
+    }
+
+    const app =
+      (await App.findOne({ environment: environment.id, isDefault: true })) ||
+      (await App.findOne({ environment: environment.id }))
+    if (!app || app.status !== 'running') {
+      throw { badRequest: { error: 'App is not running' } }
+    }
+
+    let actor
+    let loaded
+    let allowedValues
+    try {
+      actor = await sails.helpers.bridge.buildActor.with({
+        user,
+        project,
+        environment
+      })
+      loaded = await sails.helpers.bridge.loadResource.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        modelIdentity,
+        action: actionName,
+        actor,
+        ...(recordId !== undefined ? { recordId } : {}),
+        ...(recordIds !== undefined ? { recordIds } : {})
+      })
+      if (!loaded.actionDefinition) {
+        const error = new Error(
+          `${loaded.resource.singularLabel} does not define this custom action.`
+        )
+        error.code = 'BRIDGE_ACTION_NOT_FOUND'
+        throw error
+      }
+      allowedValues = await sails.helpers.bridge.allowActionValues.with({
+        values,
+        resource: loaded.resource,
+        action: loaded.actionDefinition
+      })
+    } catch (error) {
+      throw { badRequest: toBadRequest(error) }
+    }
+
+    const action = loaded.actionDefinition
+    const auditDetails = {
+      projectId: project.id,
+      projectSlug: project.slug,
+      environmentId: environment.id,
+      environmentSlug: environment.slug,
+      appId: app.id,
+      resource: loaded.resource.identity,
+      action: action.name,
+      scope: action.scope,
+      ...(loaded.recordId !== undefined
+        ? { recordId: String(loaded.recordId) }
+        : {}),
+      ...(loaded.recordIds !== undefined
+        ? {
+            recordCount: loaded.recordIds.length,
+            recordIds: loaded.recordIds.map(String)
+          }
+        : {})
+    }
+
+    let outcome
+    try {
+      outcome = await sails.helpers.bridge.executeCustomAction.with({
+        containerName: app.containerName,
+        resource: loaded.resource,
+        action,
+        actor,
+        values: allowedValues,
+        ...(loaded.recordId !== undefined ? { recordId: loaded.recordId } : {}),
+        ...(loaded.recordIds !== undefined
+          ? { recordIds: loaded.recordIds }
+          : {})
+      })
+    } catch (error) {
+      await sails.helpers.audit.log.with({
+        action: 'bridge.action.failed',
+        resourceType: 'bridgeAction',
+        resourceId: auditResourceId(loaded.resource, action, loaded),
+        details: {
+          ...auditDetails,
+          error: safeAuditError(error.message)
+        },
+        userId: user.id,
+        teamId: user.team.id,
+        ipAddress: this.req.ip
+      })
+      throw { badRequest: { error: error.message } }
+    }
+
+    await sails.helpers.audit.log.with({
+      action: 'bridge.action.succeeded',
+      resourceType: 'bridgeAction',
+      resourceId: auditResourceId(loaded.resource, action, loaded),
+      details: auditDetails,
+      userId: user.id,
+      teamId: user.team.id,
+      ipAddress: this.req.ip
+    })
+
+    sails.inertia.flash(
+      'success',
+      outcome.message || action.success || `${action.label} completed.`
+    )
+    return actionRedirect({ slug, envSlug, resource: loaded.resource, loaded })
+  }
+}
+
+function actionRedirect({ slug, envSlug, resource, loaded }) {
+  const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
+  const modelPath = `/projects/${slug}${envPath}/bridge/${resource.identity}`
+  if (loaded.actionDefinition.scope !== 'record') return modelPath
+  return `${modelPath}/${encodeURIComponent(String(loaded.recordId))}`
+}
+
+function auditResourceId(resource, action, loaded) {
+  if (loaded.recordId !== undefined) return String(loaded.recordId)
+  return `${resource.identity}:${action.name}`.slice(0, 200)
+}
+
+function safeAuditError(message) {
+  return String(message || 'Bridge action failed.')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 500)
+}
+
+function toBadRequest(error) {
+  if (!error?.fieldErrors) return { error: error.message }
+  return {
+    error: error.message,
+    problems: Object.entries(error.fieldErrors).map(([field, message]) => ({
+      [field]: message
+    }))
+  }
+}

--- a/api/helpers/bridge/allow-action-values.js
+++ b/api/helpers/bridge/allow-action-values.js
@@ -1,0 +1,82 @@
+module.exports = {
+  friendlyName: 'Allow Bridge action values',
+
+  description:
+    'Apply Bridge field validation to the typed values submitted for a custom action.',
+
+  inputs: {
+    values: {
+      type: 'ref',
+      defaultsTo: {}
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    action: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ values, resource, action }) {
+    if (
+      !action ||
+      typeof action !== 'object' ||
+      Array.isArray(action) ||
+      !action.name ||
+      !action.fields
+    ) {
+      const error = new Error('Bridge action definition is invalid.')
+      error.code = 'BRIDGE_ACTION_INVALID'
+      throw error
+    }
+    if (
+      !values ||
+      typeof values !== 'object' ||
+      Array.isArray(values) ||
+      ![Object.prototype, null].includes(Object.getPrototypeOf(values))
+    ) {
+      const error = new Error('Action values must be a plain object.')
+      error.code = 'INVALID_BRIDGE_VALUES'
+      throw error
+    }
+
+    const submittedValues = {
+      ...defaultValues(action.fields),
+      ...values
+    }
+
+    return sails.helpers.bridge.allowResourceValues.with({
+      values: submittedValues,
+      resource: {
+        identity: `${resource.identity}.${action.name}`,
+        primaryKey: '__bridgeActionPrimaryKey',
+        create: Object.keys(action.fields),
+        attributes: action.fields,
+        associations: []
+      },
+      surface: 'create'
+    })
+  }
+}
+
+function defaultValues(fields) {
+  const values = {}
+  for (const [name, attribute] of Object.entries(fields || {})) {
+    if (attribute?.field?.default !== undefined) {
+      values[name] = clone(attribute.field.default)
+    }
+  }
+  return values
+}
+
+function clone(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value))
+}

--- a/api/helpers/bridge/authorize-resource-actions.js
+++ b/api/helpers/bridge/authorize-resource-actions.js
@@ -18,6 +18,9 @@ module.exports = {
     },
     recordId: {
       type: 'ref'
+    },
+    recordIds: {
+      type: 'ref'
     }
   },
 
@@ -27,7 +30,13 @@ module.exports = {
     }
   },
 
-  fn: async function ({ containerName, resources, actor, recordId }) {
+  fn: async function ({
+    containerName,
+    resources,
+    actor,
+    recordId,
+    recordIds
+  }) {
     const effectiveResources = cloneResources(resources)
     const requests = []
 
@@ -59,6 +68,7 @@ module.exports = {
           key,
           action,
           helperIdentity,
+          scope: resource.actionDefinitions?.[action]?.scope || null,
           resource: {
             identity: resource.identity,
             primaryKey: resource.primaryKey,
@@ -82,6 +92,7 @@ module.exports = {
       const requests = ${JSON.stringify(requests)};
       const actor = ${JSON.stringify(actor)};
       const recordId = ${JSON.stringify(recordId)};
+      const recordIds = ${JSON.stringify(recordIds)};
       const decisions = Object.create(null);
 
       function resolveHelper(identity) {
@@ -106,8 +117,24 @@ module.exports = {
           action: request.action,
           resource: request.resource
         };
-        if (recordId !== undefined && recordId !== null) {
+        if (
+          recordId !== undefined &&
+          recordId !== null &&
+          (
+            request.scope === 'record' ||
+            ['view', 'update', 'delete'].includes(request.action)
+          )
+        ) {
           inputs.recordId = recordId;
+        }
+        if (
+          Array.isArray(recordIds) &&
+          (
+            request.scope === 'bulk' ||
+            request.action === 'bulkDelete'
+          )
+        ) {
+          inputs.recordIds = recordIds;
         }
 
         const result = await helper.with(inputs);
@@ -155,6 +182,7 @@ module.exports = {
       effectiveResources[request.key].actions[request.action] =
         decisions?.[request.key]?.[request.action] === true
     }
+    removeDeniedDefinitions(effectiveResources)
 
     return effectiveResources
   }
@@ -183,4 +211,14 @@ function isSafeHelperIdentity(value) {
     typeof value === 'string' &&
     value.split('.').every((part) => isSafeIdentifier(part))
   )
+}
+
+function removeDeniedDefinitions(resources) {
+  for (const resource of Object.values(resources)) {
+    for (const action of Object.keys(resource.actionDefinitions || {})) {
+      if (resource.actions?.[action] !== true) {
+        delete resource.actionDefinitions[action]
+      }
+    }
+  }
 }

--- a/api/helpers/bridge/execute-custom-action.js
+++ b/api/helpers/bridge/execute-custom-action.js
@@ -1,0 +1,155 @@
+module.exports = {
+  friendlyName: 'Execute Bridge custom action',
+
+  description:
+    'Run a configured Bridge action helper inside the target Sails application.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    action: {
+      type: 'ref',
+      required: true
+    },
+    actor: {
+      type: 'ref',
+      required: true
+    },
+    values: {
+      type: 'ref',
+      defaultsTo: {}
+    },
+    recordId: {
+      type: 'ref'
+    },
+    recordIds: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    containerName,
+    resource,
+    action,
+    actor,
+    values,
+    recordId,
+    recordIds
+  }) {
+    if (!isSafeHelperIdentity(action?.helper)) {
+      throw bridgeActionError(
+        'Configured Bridge action helper is invalid.',
+        'BRIDGE_ACTION_INVALID'
+      )
+    }
+
+    const actionCode = `
+      const helperIdentity = ${JSON.stringify(action.helper)};
+      const inputs = {
+        actor: ${JSON.stringify(actor)},
+        resource: ${JSON.stringify({
+          identity: resource.identity,
+          primaryKey: resource.primaryKey,
+          label: resource.label,
+          singularLabel: resource.singularLabel
+        })},
+        values: ${JSON.stringify(values)}
+      };
+      const recordId = ${JSON.stringify(recordId)};
+      const recordIds = ${JSON.stringify(recordIds)};
+
+      let helper = sails.helpers;
+      for (const segment of helperIdentity.split('.')) {
+        helper = helper && helper[segment];
+      }
+      if (!helper || typeof helper.with !== 'function') {
+        throw new Error(
+          'Configured Bridge action helper "' +
+            helperIdentity +
+            '" is unavailable.'
+        );
+      }
+
+      if (recordId !== undefined && recordId !== null) {
+        inputs.recordId = recordId;
+      }
+      if (Array.isArray(recordIds)) {
+        inputs.recordIds = recordIds;
+      }
+
+      const result = await helper.with(inputs);
+      if (result === undefined || result === null) return {};
+      if (typeof result === 'string') return { message: result };
+      if (typeof result !== 'object' || Array.isArray(result)) return {};
+      return {
+        message:
+          typeof result.message === 'string'
+            ? result.message
+            : undefined
+      };
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(actionCode)
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      throw bridgeActionError(
+        result.error || `${action.label || action.name} failed.`,
+        'BRIDGE_ACTION_EXECUTION_FAILED'
+      )
+    }
+
+    let output
+    try {
+      output = result.output ? JSON.parse(result.output) : {}
+    } catch {
+      throw bridgeActionError(
+        'The target app returned an invalid Bridge action result.',
+        'BRIDGE_ACTION_EXECUTION_FAILED'
+      )
+    }
+
+    return {
+      message: safeMessage(output?.message) || action.success
+    }
+  }
+}
+
+function safeMessage(value) {
+  if (typeof value !== 'string') return null
+  const message = value.replace(/\s+/g, ' ').trim()
+  return message ? message.slice(0, 500) : null
+}
+
+function bridgeActionError(message, code) {
+  const error = new Error(message)
+  error.code = code
+  return error
+}
+
+function isSafeHelperIdentity(value) {
+  return (
+    typeof value === 'string' &&
+    value
+      .split('.')
+      .every(
+        (part) =>
+          /^[A-Za-z][A-Za-z0-9]*$/.test(part) &&
+          !['__proto__', 'constructor', 'prototype'].includes(part)
+      )
+  )
+}

--- a/api/helpers/bridge/load-resource.js
+++ b/api/helpers/bridge/load-resource.js
@@ -25,6 +25,9 @@ module.exports = {
     },
     recordId: {
       type: 'ref'
+    },
+    recordIds: {
+      type: 'ref'
     }
   },
 
@@ -40,7 +43,8 @@ module.exports = {
     modelIdentity,
     action,
     actor,
-    recordId
+    recordId,
+    recordIds
   }) {
     const contract = await sails.helpers.bridge.introspectModels(
       containerName,
@@ -78,6 +82,16 @@ module.exports = {
       throw error
     }
 
+    const actionDefinition = action
+      ? resource.actionDefinitions?.[action]
+      : null
+    validateCustomActionContext({
+      resource,
+      action: actionDefinition,
+      recordId,
+      recordIds
+    })
+
     let normalizedRecordId
     if (recordId !== undefined && recordId !== null) {
       normalizedRecordId = await sails.helpers.bridge.normalizeIdentifier.with({
@@ -86,6 +100,24 @@ module.exports = {
         label: `${resource.singularLabel || modelIdentity} identifier`
       })
     }
+    let normalizedRecordIds
+    if (Array.isArray(recordIds)) {
+      normalizedRecordIds = []
+      for (const value of recordIds) {
+        const normalized = await sails.helpers.bridge.normalizeIdentifier.with({
+          value,
+          resource,
+          label: `${resource.singularLabel || modelIdentity} identifier`
+        })
+        if (
+          !normalizedRecordIds.some((candidate) =>
+            Object.is(candidate, normalized)
+          )
+        ) {
+          normalizedRecordIds.push(normalized)
+        }
+      }
+    }
 
     const effective = await sails.helpers.bridge.authorizeResourceActions.with({
       containerName,
@@ -93,6 +125,9 @@ module.exports = {
       actor,
       ...(normalizedRecordId !== undefined
         ? { recordId: normalizedRecordId }
+        : {}),
+      ...(normalizedRecordIds !== undefined
+        ? { recordIds: normalizedRecordIds }
         : {})
     })
     resource = effective.resource
@@ -119,9 +154,63 @@ module.exports = {
         }
       },
       resource,
+      ...(actionDefinition
+        ? { actionDefinition: resource.actionDefinitions[action] }
+        : {}),
       ...(normalizedRecordId !== undefined
         ? { recordId: normalizedRecordId }
+        : {}),
+      ...(normalizedRecordIds !== undefined
+        ? { recordIds: normalizedRecordIds }
         : {})
     }
   }
+}
+
+function validateCustomActionContext({
+  resource,
+  action,
+  recordId,
+  recordIds
+}) {
+  if (!action) return
+
+  if (action.scope === 'record') {
+    if (recordId === undefined || recordId === null || recordId === '') {
+      throw actionContextError(
+        `${resource.singularLabel} identifier is required for this action.`
+      )
+    }
+    if (recordIds !== undefined) {
+      throw actionContextError('This record action accepts one record only.')
+    }
+    return
+  }
+
+  if (action.scope === 'bulk') {
+    if (!Array.isArray(recordIds) || recordIds.length === 0) {
+      throw actionContextError('Select at least one record for this action.')
+    }
+    if (recordIds.length > 100) {
+      throw actionContextError(
+        'Select no more than 100 records for a custom action.'
+      )
+    }
+    if (recordId !== undefined) {
+      throw actionContextError('This bulk action requires a record selection.')
+    }
+    return
+  }
+
+  if (recordId !== undefined || recordIds !== undefined) {
+    throw actionContextError(
+      'This resource action does not accept record identifiers.'
+    )
+  }
+}
+
+function actionContextError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_ACTION_CONTEXT_INVALID'
+  return error
 }

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -42,6 +42,47 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'delete',
     'bulkDelete'
   ]
+  const CUSTOM_ACTION_SCOPES = ['resource', 'record', 'bulk']
+  const CUSTOM_ACTION_FIELD_TYPES = [
+    'text',
+    'textarea',
+    'richtext',
+    'email',
+    'url',
+    'number',
+    'currency',
+    'boolean',
+    'select',
+    'json',
+    'date',
+    'datetime',
+    'timestamp'
+  ]
+  const CUSTOM_ACTION_OPTION_KEYS = [
+    'scope',
+    'helper',
+    'label',
+    'description',
+    'confirm',
+    'success',
+    'destructive',
+    'fields'
+  ]
+  const CUSTOM_ACTION_FIELD_OPTION_KEYS = [
+    'type',
+    'label',
+    'help',
+    'placeholder',
+    'required',
+    'default',
+    'options',
+    'min',
+    'max',
+    'minLength',
+    'maxLength',
+    'format',
+    'currency'
+  ]
   const FIELD_VISIBILITY_SURFACES = ['list', 'show', 'create', 'edit', 'filter']
   const FIELD_TYPES = [
     'text',
@@ -289,6 +330,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     const singularLabel =
       readString(raw.singularLabel) || singularizeLabel(label)
 
+    const normalizedActions = normalizeActions(identity, raw.actions)
     const resource = {
       identity: model.identity || identity,
       globalId: model.globalId,
@@ -347,7 +389,8 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       ),
       hidden: raw.hidden === true,
       configured,
-      actions: normalizeActions(identity, raw.actions),
+      actions: normalizedActions.permissions,
+      actionDefinitions: normalizedActions.definitions,
       authorization: normalizeAuthorization(identity, raw.authorization),
       attributes,
       associations
@@ -850,19 +893,355 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       }
     }
 
-    const actions = {}
+    const permissions = {}
+    const definitions = {}
     for (const action of Array.from(
       new Set([...DEFAULT_RESOURCE_ACTIONS, ...Object.keys(rawActions || {})])
     )) {
       const value = rawActions?.[action]
-      if (value !== undefined && typeof value !== 'boolean') {
+      const isBuiltIn = DEFAULT_RESOURCE_ACTIONS.includes(action)
+      if (
+        value !== undefined &&
+        typeof value !== 'boolean' &&
+        !isPlainObject(value)
+      ) {
         throw new Error(
-          `Bridge action "${identity}.${action}" must be a boolean.`
+          `Bridge action "${identity}.${action}" must be a boolean or an action definition.`
         )
       }
-      actions[action] = value !== false
+      if (isBuiltIn && isPlainObject(value)) {
+        throw new Error(
+          `Built-in Bridge action "${identity}.${action}" must be a boolean.`
+        )
+      }
+
+      permissions[action] = value !== false
+      if (!isBuiltIn && isPlainObject(value)) {
+        definitions[action] = normalizeCustomAction(identity, action, value)
+      }
     }
-    return actions
+    return { permissions, definitions }
+  }
+
+  function normalizeCustomAction(identity, name, rawAction) {
+    const path = `Bridge action "${identity}.${name}"`
+    rejectUnknownKeys(rawAction, CUSTOM_ACTION_OPTION_KEYS, path)
+
+    if (!CUSTOM_ACTION_SCOPES.includes(rawAction.scope)) {
+      throw new Error(
+        `${path}.scope must be one of: ${CUSTOM_ACTION_SCOPES.join(', ')}.`
+      )
+    }
+    if (!isSafeHelperIdentity(rawAction.helper)) {
+      throw new Error(`${path}.helper must be a safe Sails helper identity.`)
+    }
+    for (const option of ['label', 'description', 'confirm', 'success']) {
+      assertOptionalString(rawAction[option], `${path}.${option}`)
+    }
+    assertOptionalBoolean(rawAction.destructive, `${path}.destructive`)
+
+    if (rawAction.fields !== undefined && !isPlainObject(rawAction.fields)) {
+      throw new Error(`${path}.fields must be an object.`)
+    }
+
+    const fields = {}
+    for (const [fieldName, rawField] of Object.entries(
+      rawAction.fields || {}
+    )) {
+      if (!isSafeIdentifier(fieldName)) {
+        throw new Error(
+          `${path}.fields must use safe JavaScript-style field names.`
+        )
+      }
+      fields[fieldName] = normalizeCustomActionField(
+        identity,
+        name,
+        fieldName,
+        rawField
+      )
+    }
+
+    const label = readString(rawAction.label) || humanize(name)
+    const destructive = rawAction.destructive === true
+    return {
+      name,
+      scope: rawAction.scope,
+      helper: rawAction.helper,
+      label,
+      description: readString(rawAction.description),
+      confirm:
+        readString(rawAction.confirm) ||
+        (destructive
+          ? `This will run ${label.toLowerCase()}. This action may not be reversible.`
+          : null),
+      success:
+        readString(rawAction.success) || `${label} completed successfully.`,
+      destructive,
+      fields
+    }
+  }
+
+  function normalizeCustomActionField(
+    resourceIdentity,
+    actionName,
+    fieldName,
+    rawField
+  ) {
+    const path = `Bridge action field "${resourceIdentity}.${actionName}.${fieldName}"`
+    if (!isPlainObject(rawField)) {
+      throw new Error(`${path} must be an object.`)
+    }
+    rejectUnknownKeys(rawField, CUSTOM_ACTION_FIELD_OPTION_KEYS, path)
+
+    const type = normalizeFieldType(rawField.type || 'text')
+    if (!CUSTOM_ACTION_FIELD_TYPES.includes(type)) {
+      throw new Error(
+        `${path}.type must be one of: ${CUSTOM_ACTION_FIELD_TYPES.join(', ')}.`
+      )
+    }
+    for (const option of ['label', 'help', 'placeholder', 'format']) {
+      assertOptionalString(rawField[option], `${path}.${option}`)
+    }
+    assertOptionalBoolean(rawField.required, `${path}.required`)
+
+    for (const option of ['min', 'max']) {
+      if (
+        rawField[option] !== undefined &&
+        (typeof rawField[option] !== 'number' ||
+          !Number.isFinite(rawField[option]))
+      ) {
+        throw new Error(`${path}.${option} must be a finite number.`)
+      }
+    }
+    for (const option of ['minLength', 'maxLength']) {
+      if (
+        rawField[option] !== undefined &&
+        (!Number.isSafeInteger(rawField[option]) || rawField[option] < 0)
+      ) {
+        throw new Error(`${path}.${option} must be a non-negative integer.`)
+      }
+    }
+    if (
+      rawField.min !== undefined &&
+      rawField.max !== undefined &&
+      rawField.max < rawField.min
+    ) {
+      throw new Error(`${path}.max cannot be smaller than min.`)
+    }
+    if (
+      rawField.minLength !== undefined &&
+      rawField.maxLength !== undefined &&
+      rawField.maxLength < rawField.minLength
+    ) {
+      throw new Error(`${path}.maxLength cannot be smaller than minLength.`)
+    }
+    if (
+      (rawField.min !== undefined || rawField.max !== undefined) &&
+      !['number', 'currency'].includes(type)
+    ) {
+      throw new Error(`${path}.min and max require a numeric field type.`)
+    }
+    if (
+      (rawField.minLength !== undefined || rawField.maxLength !== undefined) &&
+      !['text', 'textarea', 'richtext'].includes(type)
+    ) {
+      throw new Error(
+        `${path}.minLength and maxLength require a text field type.`
+      )
+    }
+
+    if (rawField.options !== undefined && !Array.isArray(rawField.options)) {
+      throw new Error(`${path}.options must be an array.`)
+    }
+    if (rawField.options !== undefined && type !== 'select') {
+      throw new Error(`${path}.options requires type "select".`)
+    }
+    validateFieldOptions(
+      `${resourceIdentity}.${actionName}`,
+      fieldName,
+      rawField.options
+    )
+    validateCurrency(
+      `${resourceIdentity}.${actionName}`,
+      fieldName,
+      rawField.currency
+    )
+    if (type === 'select' && !Array.isArray(rawField.options)) {
+      throw new Error(`${path}.options is required for select fields.`)
+    }
+    if (
+      rawField.format !== undefined &&
+      !(type === 'richtext' && rawField.format.toLowerCase() === 'markdown')
+    ) {
+      throw new Error(
+        `${path}.format currently supports only "markdown" on richtext fields.`
+      )
+    }
+    if (rawField.currency !== undefined && type !== 'currency') {
+      throw new Error(`${path}.currency requires type "currency".`)
+    }
+    if (rawField.default !== undefined) {
+      assertSerializable(rawField.default, `${path}.default`)
+    }
+
+    const field = {
+      type,
+      ...(readString(rawField.help) ? { help: rawField.help.trim() } : {}),
+      ...(readString(rawField.placeholder)
+        ? { placeholder: rawField.placeholder.trim() }
+        : {}),
+      ...(readString(rawField.format)
+        ? { format: rawField.format.trim().toLowerCase() }
+        : {}),
+      ...(rawField.default !== undefined
+        ? { default: cloneSerializable(rawField.default, `${path}.default`) }
+        : {}),
+      ...(rawField.options
+        ? { options: normalizeFieldOptions(rawField.options) }
+        : {}),
+      ...(type === 'currency'
+        ? { currency: normalizeCurrency(rawField.currency) }
+        : {})
+    }
+    validateCustomActionFieldDefault({
+      path,
+      type,
+      rawField,
+      field
+    })
+
+    return {
+      type:
+        type === 'number' || type === 'currency'
+          ? 'number'
+          : type === 'boolean'
+          ? 'boolean'
+          : type === 'json'
+          ? 'json'
+          : 'string',
+      label: readString(rawField.label) || humanize(fieldName),
+      required: rawField.required === true,
+      ...(rawField.min !== undefined ? { min: rawField.min } : {}),
+      ...(rawField.max !== undefined ? { max: rawField.max } : {}),
+      ...(rawField.minLength !== undefined
+        ? { minLength: rawField.minLength }
+        : {}),
+      ...(rawField.maxLength !== undefined
+        ? { maxLength: rawField.maxLength }
+        : {}),
+      field
+    }
+  }
+
+  function validateCustomActionFieldDefault({ path, type, rawField, field }) {
+    if (rawField.default === undefined) return
+    const value = rawField.default
+
+    if (type === 'boolean' && typeof value !== 'boolean') {
+      throw new Error(`${path}.default must be true or false.`)
+    }
+    if (
+      ['number', 'currency'].includes(type) &&
+      (typeof value !== 'number' || !Number.isFinite(value))
+    ) {
+      throw new Error(`${path}.default must be a finite number.`)
+    }
+    if (
+      ['number', 'currency'].includes(type) &&
+      rawField.min !== undefined &&
+      value < rawField.min
+    ) {
+      throw new Error(`${path}.default must be at least ${rawField.min}.`)
+    }
+    if (
+      ['number', 'currency'].includes(type) &&
+      rawField.max !== undefined &&
+      value > rawField.max
+    ) {
+      throw new Error(`${path}.default must be at most ${rawField.max}.`)
+    }
+    if (
+      [
+        'text',
+        'textarea',
+        'richtext',
+        'email',
+        'url',
+        'date',
+        'datetime',
+        'timestamp'
+      ].includes(type) &&
+      typeof value !== 'string'
+    ) {
+      throw new Error(`${path}.default must be a string.`)
+    }
+    if (
+      type === 'select' &&
+      !field.options.some(
+        (option) =>
+          option.disabled !== true && Object.is(option.value, rawField.default)
+      )
+    ) {
+      throw new Error(
+        `${path}.default must use one of the enabled select options.`
+      )
+    }
+    if (type === 'email' && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value)) {
+      throw new Error(`${path}.default must be a valid email address.`)
+    }
+    if (type === 'url') {
+      let url
+      try {
+        url = new URL(value)
+      } catch {
+        throw new Error(`${path}.default must be a valid URL.`)
+      }
+      if (!['http:', 'https:'].includes(url.protocol)) {
+        throw new Error(`${path}.default must use HTTP or HTTPS.`)
+      }
+    }
+    if (
+      ['datetime', 'timestamp'].includes(type) &&
+      Number.isNaN(new Date(value).getTime())
+    ) {
+      throw new Error(`${path}.default must be a valid date and time.`)
+    }
+    if (type === 'date' && !isValidDateOnly(value)) {
+      throw new Error(`${path}.default must be a valid date.`)
+    }
+    if (
+      ['text', 'textarea', 'richtext'].includes(type) &&
+      rawField.minLength !== undefined &&
+      value.length < rawField.minLength
+    ) {
+      throw new Error(
+        `${path}.default must contain at least ${rawField.minLength} characters.`
+      )
+    }
+    if (
+      ['text', 'textarea', 'richtext'].includes(type) &&
+      rawField.maxLength !== undefined &&
+      value.length > rawField.maxLength
+    ) {
+      throw new Error(
+        `${path}.default must contain at most ${rawField.maxLength} characters.`
+      )
+    }
+    if (
+      type === 'richtext' &&
+      field.format === 'markdown' &&
+      containsRawHtml(value)
+    ) {
+      throw new Error(`${path}.default cannot contain raw HTML.`)
+    }
+    if (type === 'json') {
+      try {
+        const parsed = typeof value === 'string' ? JSON.parse(value) : value
+        JSON.stringify(parsed)
+      } catch {
+        throw new Error(`${path}.default must contain valid JSON.`)
+      }
+    }
   }
 
   function normalizeAuthorization(identity, rawAuthorization) {
@@ -1414,6 +1793,29 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     if (value !== undefined && typeof value !== 'boolean') {
       throw new Error(`${path} must be a boolean.`)
     }
+  }
+
+  function isValidDateOnly(value) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value)
+    if (!match) return false
+    const [, year, month, day] = match.map(Number)
+    const date = new Date(0)
+    date.setUTCFullYear(year, month - 1, day)
+    return (
+      date.getUTCFullYear() === year &&
+      date.getUTCMonth() === month - 1 &&
+      date.getUTCDate() === day
+    )
+  }
+
+  function containsRawHtml(value) {
+    const withoutAutolinks = value.replace(
+      /<[a-z][a-z\d+.-]{1,31}:[^<>\s]*>|<[a-z\d.!#$%&'*+/=?^_`{|}~-]+@[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?(?:\.[a-z\d](?:[a-z\d-]{0,61}[a-z\d])?)+>/gi,
+      ''
+    )
+    return /<!--[\s\S]*?-->|<\/?[a-z][^<>]*>|<![A-Z][^>]*>|<\?[\s\S]*?\?>/i.test(
+      withoutAutolinks
+    )
   }
 
   function readString(value) {

--- a/assets/js/components/bridge/BridgeActionDialog.vue
+++ b/assets/js/components/bridge/BridgeActionDialog.vue
@@ -1,0 +1,322 @@
+<script setup>
+import { computed, nextTick, onUnmounted, ref, watch } from 'vue'
+import { useForm } from '@inertiajs/vue3'
+import BridgeFieldInput from '@/components/bridge/BridgeFieldInput.vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
+import {
+  prepareBridgeFieldSubmission,
+  toBridgeFieldInputValue,
+  validateBridgeFieldValue
+} from '@/lib/bridge/fields.mjs'
+import { containsRawHtml } from '@/lib/content/markdown.mjs'
+
+const props = defineProps({
+  show: Boolean,
+  action: {
+    type: Object,
+    default: null
+  },
+  submitUrl: {
+    type: String,
+    required: true
+  },
+  modelIdentity: {
+    type: String,
+    required: true
+  },
+  recordId: {
+    type: [String, Number],
+    default: null
+  },
+  recordIds: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const emit = defineEmits(['cancel', 'complete'])
+const dialog = ref(null)
+const formValues = ref({})
+const localErrors = ref({})
+const returnFocus = ref(null)
+const form = useForm({})
+let bodyOverflow = ''
+let scrollLocked = false
+
+const fields = computed(() =>
+  Object.entries(props.action?.fields || {}).map(([name, attr]) => ({
+    name,
+    attr,
+    readOnly: false
+  }))
+)
+const titleId = computed(
+  () => `bridge-action-${props.action?.name || 'dialog'}-title`
+)
+const selectionLabel = computed(() => {
+  if (props.action?.scope !== 'bulk') return ''
+  return `${props.recordIds.length.toLocaleString()} ${
+    props.recordIds.length === 1 ? 'record' : 'records'
+  } selected`
+})
+const isFormReady = computed(
+  () =>
+    fields.value.every(
+      (field) => validateField(field) === '' && !form.errors[field.name]
+    ) && Object.keys(localErrors.value).length === 0
+)
+
+watch(
+  () => [props.show, props.action],
+  async ([shown]) => {
+    if (!shown || !props.action) {
+      unlockPageScroll()
+      return
+    }
+    lockPageScroll()
+    returnFocus.value = document.activeElement
+    form.clearErrors()
+    localErrors.value = {}
+    formValues.value = Object.fromEntries(
+      fields.value.map((field) => [
+        field.name,
+        toBridgeFieldInputValue(field.attr, undefined)
+      ])
+    )
+    await nextTick()
+    const firstInput = dialog.value?.querySelector(
+      'input:not([type="hidden"]), textarea, select, button[role="switch"], [contenteditable="true"]'
+    )
+    const focusTarget = firstInput || dialog.value
+    focusTarget?.focus()
+  }
+)
+
+onUnmounted(unlockPageScroll)
+
+function lockPageScroll() {
+  if (scrollLocked) return
+  bodyOverflow = document.body.style.overflow
+  document.body.style.overflow = 'hidden'
+  scrollLocked = true
+}
+
+function unlockPageScroll() {
+  if (!scrollLocked) return
+  document.body.style.overflow = bodyOverflow
+  scrollLocked = false
+}
+
+function validateField(field) {
+  if (
+    field.attr.field?.type === 'richtext' &&
+    field.attr.field?.format?.toLowerCase() === 'markdown' &&
+    containsRawHtml(String(formValues.value[field.name] || ''))
+  ) {
+    return 'Raw HTML is not allowed in Bridge Markdown fields.'
+  }
+  return validateBridgeFieldValue({
+    attribute: field.attr,
+    value: formValues.value[field.name]
+  })
+}
+
+function validateAndRemember(field) {
+  const error = validateField(field)
+  if (error) localErrors.value[field.name] = error
+  else delete localErrors.value[field.name]
+}
+
+function updateField(field, value) {
+  formValues.value[field.name] = value
+  if (localErrors.value[field.name]) validateAndRemember(field)
+  if (form.errors[field.name]) form.clearErrors(field.name)
+}
+
+function clearFieldError(field) {
+  delete localErrors.value[field.name]
+  form.clearErrors(field.name)
+}
+
+function cancel() {
+  if (form.processing) return
+  emit('cancel')
+  nextTick(() => returnFocus.value?.focus?.())
+}
+
+function submit() {
+  for (const field of fields.value) validateAndRemember(field)
+  if (!isFormReady.value || form.processing) return
+
+  const values = {}
+  for (const field of fields.value) {
+    const prepared = prepareBridgeFieldSubmission({
+      attribute: field.attr,
+      value: formValues.value[field.name]
+    })
+    if (prepared.include) values[field.name] = prepared.value
+  }
+
+  form
+    .transform(() => ({
+      values,
+      ...(props.action.scope === 'record' ? { recordId: props.recordId } : {}),
+      ...(props.action.scope === 'bulk' ? { recordIds: props.recordIds } : {})
+    }))
+    .post(props.submitUrl, {
+      preserveScroll: true,
+      onSuccess: () => {
+        emit('complete')
+        nextTick(() => returnFocus.value?.focus?.())
+      }
+    })
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    cancel()
+    return
+  }
+  if (event.key !== 'Tab') return
+
+  const focusable = Array.from(
+    dialog.value?.querySelectorAll(
+      'button:not(:disabled), input:not(:disabled), textarea:not(:disabled), select:not(:disabled), [tabindex]:not([tabindex="-1"])'
+    ) || []
+  )
+  if (focusable.length === 0) return
+  const first = focusable[0]
+  const last = focusable[focusable.length - 1]
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-200 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-150 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="show && action"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <button
+          type="button"
+          class="fixed inset-0 cursor-default bg-black/50"
+          tabindex="-1"
+          aria-label="Close action dialog"
+          @click="cancel"
+        />
+        <Transition
+          enter-active-class="transition duration-200 ease-out"
+          enter-from-class="scale-95 opacity-0"
+          enter-to-class="scale-100 opacity-100"
+          leave-active-class="transition duration-150 ease-in"
+          leave-from-class="scale-100 opacity-100"
+          leave-to-class="scale-95 opacity-0"
+        >
+          <form
+            ref="dialog"
+            role="dialog"
+            aria-modal="true"
+            :aria-labelledby="titleId"
+            :data-test="`bridge-action-dialog-${action.name}`"
+            class="relative flex max-h-[min(44rem,calc(100vh-2rem))] w-full max-w-lg flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+            tabindex="-1"
+            @submit.prevent="submit"
+            @keydown="handleKeydown"
+          >
+            <div class="overflow-y-auto px-6 pb-2 pt-6">
+              <h2
+                :id="titleId"
+                class="text-lg font-semibold text-gray-900 dark:text-white"
+              >
+                {{ action.label }}
+              </h2>
+              <p
+                v-if="action.description"
+                class="mt-1.5 text-sm leading-6 text-gray-500 dark:text-gray-400"
+              >
+                {{ action.description }}
+              </p>
+              <p
+                v-if="selectionLabel"
+                class="mt-2 text-xs font-medium text-gray-400 dark:text-gray-500"
+              >
+                {{ selectionLabel }}
+              </p>
+              <p
+                v-if="action.confirm"
+                class="mt-4 text-sm leading-6 text-gray-600 dark:text-gray-300"
+              >
+                {{ action.confirm }}
+              </p>
+
+              <div v-if="fields.length > 0" class="mt-5 space-y-5 pb-3">
+                <BridgeFieldInput
+                  v-for="field in fields"
+                  :key="field.name"
+                  :field="field"
+                  :model-value="formValues[field.name]"
+                  :error="
+                    localErrors[field.name] || form.errors[field.name] || ''
+                  "
+                  :model-identity="`${modelIdentity}-${action.name}`"
+                  @update:model-value="updateField(field, $event)"
+                  @blur="validateAndRemember(field)"
+                  @clear-error="clearFieldError(field)"
+                />
+              </div>
+              <p
+                v-if="form.errors.error"
+                role="alert"
+                class="mt-4 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.error }}
+              </p>
+            </div>
+
+            <div class="flex justify-end gap-3 px-6 pb-6 pt-4">
+              <button
+                type="button"
+                :disabled="form.processing"
+                class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-900 disabled:opacity-50 dark:text-gray-400 dark:hover:text-white"
+                @click="cancel"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                :disabled="form.processing || !isFormReady"
+                :class="[
+                  'rounded-md px-3 py-1.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-40',
+                  action.destructive
+                    ? 'bg-red-600 hover:bg-red-700'
+                    : 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
+                ]"
+              >
+                <span v-if="form.processing" class="flex items-center gap-2">
+                  <SlippyLoader size="h-4 w-4" />
+                  Running…
+                </span>
+                <span v-else>{{ action.label }}</span>
+              </button>
+            </div>
+          </form>
+        </Transition>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/assets/js/components/bridge/BridgeActionMenu.vue
+++ b/assets/js/components/bridge/BridgeActionMenu.vue
@@ -1,0 +1,142 @@
+<script setup>
+import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+
+const props = defineProps({
+  items: {
+    type: Array,
+    default: () => []
+  },
+  label: {
+    type: String,
+    default: 'Actions'
+  },
+  disabled: Boolean,
+  testId: {
+    type: String,
+    default: 'bridge-action-menu'
+  }
+})
+
+const emit = defineEmits(['select'])
+const root = ref(null)
+const trigger = ref(null)
+const menu = ref(null)
+const open = ref(false)
+
+async function toggle() {
+  if (props.disabled) return
+  open.value = !open.value
+  if (open.value) {
+    await nextTick()
+    menu.value?.querySelector('[role="menuitem"]')?.focus()
+  }
+}
+
+function close({ restoreFocus = false } = {}) {
+  if (!open.value) return
+  open.value = false
+  if (restoreFocus) nextTick(() => trigger.value?.focus())
+}
+
+function select(item) {
+  trigger.value?.focus()
+  close()
+  emit('select', item)
+}
+
+function handleKeydown(event) {
+  const items = Array.from(
+    menu.value?.querySelectorAll('[role="menuitem"]:not(:disabled)') || []
+  )
+  const currentIndex = items.indexOf(document.activeElement)
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    close({ restoreFocus: true })
+    return
+  }
+
+  let nextIndex
+  if (event.key === 'ArrowDown') {
+    nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+  } else if (event.key === 'ArrowUp') {
+    nextIndex =
+      currentIndex < 0
+        ? items.length - 1
+        : (currentIndex - 1 + items.length) % items.length
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = items.length - 1
+  } else {
+    return
+  }
+
+  event.preventDefault()
+  items[nextIndex]?.focus()
+}
+
+function handlePointerDown(event) {
+  if (!root.value?.contains(event.target)) close()
+}
+
+onMounted(() => document.addEventListener('pointerdown', handlePointerDown))
+onUnmounted(() =>
+  document.removeEventListener('pointerdown', handlePointerDown)
+)
+</script>
+
+<template>
+  <div v-if="items.length > 0" ref="root" class="relative">
+    <button
+      ref="trigger"
+      type="button"
+      :disabled="disabled"
+      :data-test="`${testId}-trigger`"
+      class="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
+      :aria-label="label"
+      aria-haspopup="menu"
+      :aria-expanded="open"
+      @click.stop="toggle"
+    >
+      <svg
+        class="h-4 w-4"
+        fill="currentColor"
+        viewBox="0 0 20 20"
+        aria-hidden="true"
+      >
+        <path
+          d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"
+        />
+      </svg>
+    </button>
+
+    <div
+      v-if="open"
+      ref="menu"
+      role="menu"
+      :data-test="testId"
+      class="min-w-44 absolute right-0 top-full z-30 mt-1 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+      @click.stop
+      @keydown="handleKeydown"
+    >
+      <button
+        v-for="item in items"
+        :key="item.key"
+        type="button"
+        role="menuitem"
+        :disabled="item.disabled"
+        :data-test="`${testId}-${item.key}`"
+        :class="[
+          'flex w-full px-3 py-2 text-left text-sm focus:outline-none disabled:cursor-not-allowed disabled:opacity-40',
+          item.destructive
+            ? 'text-red-600 hover:bg-red-50 focus:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20 dark:focus:bg-red-900/20'
+            : 'text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800'
+        ]"
+        @click="select(item)"
+      >
+        {{ item.label }}
+      </button>
+    </div>
+  </div>
+</template>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -6,6 +6,8 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
+import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
+import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 
 defineOptions({
   layout: AppLayout
@@ -41,6 +43,7 @@ const selectAll = ref(false)
 const deleteModal = ref({ show: false, recordId: null })
 const bulkDeleteModal = ref({ show: false })
 const openActionMenu = ref(null)
+const actionDialog = ref({ show: false, action: null, recordIds: [] })
 
 const hasRecordActions = computed(() => {
   const actions = props.modelMeta?.actions || {}
@@ -50,6 +53,39 @@ const hasRecordActions = computed(() => {
     actions.delete !== false
   )
 })
+const customActions = computed(() =>
+  Object.values(props.modelMeta?.actionDefinitions || {}).filter(
+    (action) => props.modelMeta?.actions?.[action.name] === true
+  )
+)
+const resourceActions = computed(() =>
+  customActions.value.filter((action) => action.scope === 'resource')
+)
+const bulkActions = computed(() =>
+  customActions.value.filter((action) => action.scope === 'bulk')
+)
+const hasBulkActions = computed(
+  () =>
+    Boolean(props.modelMeta) &&
+    (props.modelMeta.actions?.bulkDelete !== false ||
+      bulkActions.value.length > 0)
+)
+const resourceMenuItems = computed(() =>
+  resourceActions.value.map(actionMenuItem)
+)
+const bulkMenuItems = computed(() => [
+  ...bulkActions.value.map(actionMenuItem),
+  ...(props.modelMeta?.actions?.bulkDelete !== false
+    ? [
+        {
+          key: 'bulkDelete',
+          label: 'Delete selected',
+          destructive: true,
+          builtIn: true
+        }
+      ]
+    : [])
+])
 
 function encodePathSegment(value) {
   return encodeURIComponent(String(value))
@@ -116,6 +152,7 @@ function handleActionMenuKeydown(event) {
 // Forms for delete actions
 const deleteForm = useForm({})
 const bulkDeleteForm = useForm({ ids: [] })
+const quickActionForm = useForm({})
 
 function openDeleteModal(record) {
   closeActionMenu()
@@ -257,6 +294,82 @@ function confirmBulkDelete() {
       }
     }
   )
+}
+
+function actionMenuItem(action) {
+  return {
+    key: action.name,
+    label: action.label,
+    destructive: action.destructive === true,
+    action
+  }
+}
+
+function customActionUrl(action) {
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/actions/${encodePathSegment(action.name)}`
+}
+
+function actionNeedsDialog(action) {
+  return (
+    action.destructive === true ||
+    Boolean(action.confirm) ||
+    Object.keys(action.fields || {}).length > 0
+  )
+}
+
+function runCustomAction(action, { recordIds = [] } = {}) {
+  if (actionNeedsDialog(action)) {
+    actionDialog.value = {
+      show: true,
+      action,
+      recordIds
+    }
+    return
+  }
+
+  quickActionForm
+    .transform(() => ({
+      values: {},
+      ...(action.scope === 'bulk' ? { recordIds } : {})
+    }))
+    .post(customActionUrl(action), {
+      preserveScroll: true,
+      onSuccess: () => {
+        if (action.scope === 'bulk') clearSelection()
+      },
+      onError: (errors) => {
+        toast({
+          message: errors.error || `${action.label} failed.`,
+          type: 'error'
+        })
+      }
+    })
+}
+
+function handleResourceAction(item) {
+  runCustomAction(item.action)
+}
+
+function handleBulkAction(item) {
+  if (item.builtIn) {
+    bulkDeleteModal.value = { show: true }
+    return
+  }
+  runCustomAction(item.action, {
+    recordIds: Array.from(selectedIds.value)
+  })
+}
+
+function clearSelection() {
+  selectedIds.value = new Set()
+  selectAll.value = false
+}
+
+function completeCustomAction() {
+  if (actionDialog.value.action?.scope === 'bulk') clearSelection()
+  actionDialog.value = { show: false, action: null, recordIds: [] }
 }
 
 // Pagination
@@ -450,33 +563,19 @@ function createUrl() {
             leave-to-class="opacity-0"
           >
             <div
-              v-if="
-                selectedIds.size > 0 && modelMeta?.actions?.bulkDelete !== false
-              "
+              v-if="selectedIds.size > 0 && hasBulkActions"
               class="flex items-center space-x-2"
             >
               <span class="text-xs text-gray-500 dark:text-gray-400"
                 >{{ selectedIds.size }} selected</span
               >
-              <button
-                @click="bulkDeleteModal.show = true"
-                class="inline-flex items-center rounded-md bg-red-50 px-2 py-1 text-xs font-medium text-red-700 hover:bg-red-100 dark:bg-red-900/20 dark:text-red-400 dark:hover:bg-red-900/30"
-              >
-                <svg
-                  class="mr-1 h-3.5 w-3.5"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                  />
-                </svg>
-                Delete
-              </button>
+              <BridgeActionMenu
+                :items="bulkMenuItems"
+                :disabled="quickActionForm.processing"
+                label="Actions for selected records"
+                test-id="bridge-bulk-action-menu"
+                @select="handleBulkAction"
+              />
             </div>
           </Transition>
         </div>
@@ -486,6 +585,13 @@ function createUrl() {
             class="text-xs text-gray-500 dark:text-gray-400"
             >{{ total.toLocaleString() }} records</span
           >
+          <BridgeActionMenu
+            :items="resourceMenuItems"
+            :disabled="quickActionForm.processing"
+            :label="`Actions for ${modelMeta?.label || modelIdentity}`"
+            test-id="bridge-resource-action-menu"
+            @select="handleResourceAction"
+          />
           <Link
             v-if="modelMeta?.actions?.create !== false"
             :href="createUrl()"
@@ -538,10 +644,7 @@ function createUrl() {
               class="border-b border-gray-200 bg-gray-50/50 dark:border-gray-800 dark:bg-gray-900/50"
             >
               <tr>
-                <th
-                  v-if="modelMeta?.actions?.bulkDelete !== false"
-                  class="w-10 px-4 py-2"
-                >
+                <th v-if="hasBulkActions" class="w-10 px-4 py-2">
                   <input
                     type="checkbox"
                     :checked="selectAll"
@@ -599,7 +702,7 @@ function createUrl() {
                 <td
                   :colspan="
                     visibleColumns.length +
-                    (modelMeta?.actions?.bulkDelete !== false ? 1 : 0) +
+                    (hasBulkActions ? 1 : 0) +
                     (hasRecordActions ? 1 : 0)
                   "
                   class="px-4 py-12 text-center text-sm text-gray-500 dark:text-gray-400"
@@ -617,10 +720,7 @@ function createUrl() {
                 :key="record[modelMeta.primaryKey]"
                 class="group hover:bg-gray-50 dark:hover:bg-gray-900/30"
               >
-                <td
-                  v-if="modelMeta?.actions?.bulkDelete !== false"
-                  class="px-4 py-2"
-                >
+                <td v-if="hasBulkActions" class="px-4 py-2">
                   <input
                     type="checkbox"
                     :checked="selectedIds.has(record[modelMeta.primaryKey])"
@@ -773,5 +873,17 @@ function createUrl() {
     :loading="bulkDeleteForm.processing"
     @confirm="confirmBulkDelete"
     @cancel="bulkDeleteModal = { show: false }"
+  />
+
+  <BridgeActionDialog
+    :show="actionDialog.show"
+    :action="actionDialog.action"
+    :submit-url="
+      actionDialog.action ? customActionUrl(actionDialog.action) : ''
+    "
+    :model-identity="modelIdentity"
+    :record-ids="actionDialog.recordIds"
+    @cancel="actionDialog = { show: false, action: null, recordIds: [] }"
+    @complete="completeCustomAction"
   />
 </template>

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Link, Head, useForm } from '@inertiajs/vue3'
+import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
@@ -7,6 +7,8 @@ import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 import BridgeCollectionManager from '@/components/bridge/BridgeCollectionManager.vue'
+import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
+import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 
 defineOptions({
   layout: AppLayout
@@ -31,6 +33,37 @@ const { toasts, toast, dismiss } = createToast()
 
 const deleteModal = ref({ show: false })
 const deleteForm = useForm({})
+const quickActionForm = useForm({})
+const actionDialog = ref({ show: false, action: null })
+
+const customRecordActions = computed(() =>
+  Object.values(props.modelMeta?.actionDefinitions || {}).filter(
+    (action) =>
+      action.scope === 'record' &&
+      props.modelMeta?.actions?.[action.name] === true
+  )
+)
+const recordMenuItems = computed(() => [
+  ...(props.modelMeta?.actions?.update !== false
+    ? [{ key: 'edit', label: 'Edit record', builtIn: true }]
+    : []),
+  ...customRecordActions.value.map((action) => ({
+    key: action.name,
+    label: action.label,
+    destructive: action.destructive === true,
+    action
+  })),
+  ...(props.modelMeta?.actions?.delete !== false
+    ? [
+        {
+          key: 'delete',
+          label: 'Delete record',
+          destructive: true,
+          builtIn: true
+        }
+      ]
+    : [])
+])
 
 function encodePathSegment(value) {
   return encodeURIComponent(String(value))
@@ -85,6 +118,54 @@ function confirmDelete() {
       }
     }
   )
+}
+
+function customActionUrl(action) {
+  return `/projects/${props.project.slug}/environments/${
+    props.environment.slug
+  }/bridge/${props.modelIdentity}/actions/${encodePathSegment(action.name)}`
+}
+
+function actionNeedsDialog(action) {
+  return (
+    action.destructive === true ||
+    Boolean(action.confirm) ||
+    Object.keys(action.fields || {}).length > 0
+  )
+}
+
+function runCustomAction(action) {
+  if (actionNeedsDialog(action)) {
+    actionDialog.value = { show: true, action }
+    return
+  }
+
+  quickActionForm
+    .transform(() => ({
+      values: {},
+      recordId: props.recordId
+    }))
+    .post(customActionUrl(action), {
+      preserveScroll: true,
+      onError: (errors) => {
+        toast({
+          message: errors.error || `${action.label} failed.`,
+          type: 'error'
+        })
+      }
+    })
+}
+
+function handleRecordAction(item) {
+  if (item.key === 'edit') {
+    router.visit(editUrl())
+    return
+  }
+  if (item.key === 'delete') {
+    deleteModal.value = { show: true }
+    return
+  }
+  runCustomAction(item.action)
 }
 
 function bridgeUrl() {
@@ -270,48 +351,16 @@ function relationshipMutationBaseUrl(relationship) {
           >
         </nav>
       </div>
-      <div v-if="record" class="flex items-center space-x-2">
-        <Link
-          v-if="modelMeta?.actions?.update !== false"
-          :href="editUrl()"
-          class="inline-flex items-center rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-        >
-          <svg
-            class="mr-1.5 h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"
-            />
-          </svg>
-          Edit
-        </Link>
-        <button
-          v-if="modelMeta?.actions?.delete !== false"
-          @click="deleteModal.show = true"
-          class="inline-flex items-center rounded-md border border-red-200 px-3 py-1.5 text-sm font-medium text-red-700 hover:bg-red-50 dark:border-red-800 dark:text-red-400 dark:hover:bg-red-900/20"
-        >
-          <svg
-            class="mr-1.5 h-4 w-4"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-            />
-          </svg>
-          Delete
-        </button>
-      </div>
+      <BridgeActionMenu
+        v-if="record"
+        :items="recordMenuItems"
+        :disabled="quickActionForm.processing"
+        :label="`Actions for ${
+          record[modelMeta?.title] || modelMeta?.singularLabel || modelIdentity
+        }`"
+        test-id="bridge-record-action-menu"
+        @select="handleRecordAction"
+      />
     </div>
 
     <!-- Content -->
@@ -491,5 +540,17 @@ function relationshipMutationBaseUrl(relationship) {
     :loading="deleteForm.processing"
     @confirm="confirmDelete"
     @cancel="deleteModal = { show: false }"
+  />
+
+  <BridgeActionDialog
+    :show="actionDialog.show"
+    :action="actionDialog.action"
+    :submit-url="
+      actionDialog.action ? customActionUrl(actionDialog.action) : ''
+    "
+    :model-identity="modelIdentity"
+    :record-id="recordId"
+    @cancel="actionDialog = { show: false, action: null }"
+    @complete="actionDialog = { show: false, action: null }"
   />
 </template>

--- a/config/routes.js
+++ b/config/routes.js
@@ -379,6 +379,10 @@ module.exports.routes = {
     'project/bridge-bulk-delete',
   'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/bulk-delete':
     'project/bridge-bulk-delete',
+  'POST /projects/:slug/bridge/:modelIdentity/actions/:actionName':
+    'project/bridge-execute-action',
+  'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/actions/:actionName':
+    'project/bridge-execute-action',
   // Bridge relationship search is JSON transport for async comboboxes.
   'GET /api/v1/projects/:slug/bridge/:modelIdentity/relationships/:relationshipAlias/options':
     'project/bridge-relationship-options',

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -265,9 +265,156 @@ context (`id`, `email`, `fullName`, team role, and current project/environment
 identifiers). The target app remains responsible for mapping that identity to
 its own user and roles.
 
-Custom action names may be declared in `actions`. They pass through the same
-authorization helper even when their executor is supplied by a later Bridge
-feature.
+Custom actions use the same authorization helper. A denied action is removed
+from the effective contract sent to the UI and the execution endpoint repeats
+authorization immediately before calling the target helper.
+
+For a record action, the authorization helper receives `recordId`. A bulk
+action receives `recordIds` during execution. Resource actions receive neither.
+This keeps a helper from accidentally treating a resource-level permission as
+a record-level decision.
+
+## Custom actions
+
+Bridge actions connect a small, declarative UI contract to a Sails helper in
+the target application. The configuration is data only: JavaScript functions
+cannot cross the Bridge boundary.
+
+```js
+course: {
+  authorization: 'bridge.authorize',
+  actions: {
+    bulkDelete: false,
+
+    syncCatalog: {
+      scope: 'resource',
+      helper: 'bridge.syncCatalog',
+      label: 'Sync catalog',
+      success: 'Catalog synchronized.'
+    },
+
+    publish: {
+      scope: 'record',
+      helper: 'bridge.publishCourse',
+      label: 'Publish course',
+      description: 'Make this course available to students.',
+      confirm: 'Publish this course now?',
+      success: 'Course published.',
+      fields: {
+        notifyStudents: {
+          type: 'boolean',
+          label: 'Notify students',
+          default: true
+        },
+        releaseNote: {
+          type: 'textarea',
+          label: 'Release note',
+          help: 'Included in the student notification.',
+          required: true,
+          minLength: 3,
+          maxLength: 280
+        }
+      }
+    },
+
+    regenerateLicenses: {
+      scope: 'bulk',
+      helper: 'bridge.regenerateLicenses',
+      label: 'Regenerate licenses',
+      destructive: true,
+      confirm: 'Existing license links will stop working.',
+      fields: {
+        reason: {
+          type: 'select',
+          required: true,
+          default: 'security',
+          options: [
+            { label: 'Security rotation', value: 'security' },
+            { label: 'Content update', value: 'content' }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+The three scopes determine where the action appears and which identifiers the
+helper receives:
+
+| Scope      | UI location                             | Helper context |
+| ---------- | --------------------------------------- | -------------- |
+| `resource` | Resource list toolbar                   | No record IDs  |
+| `record`   | Record detail action menu               | `recordId`     |
+| `bulk`     | Selected-record action menu on the list | `recordIds`    |
+
+Bulk actions accept at most 100 selected IDs per execution. Slipway normalizes
+and deduplicates every identifier against the resource primary-key contract
+before authorization or helper execution.
+
+Actions without fields, confirmation, or destructive behavior execute
+directly from the menu. An action with fields or confirmation opens one focused
+dialog. `destructive: true` supplies a safe confirmation message when none is
+configured and uses the existing destructive button treatment.
+
+Action fields reuse Bridge input, browser validation, and server validation.
+They support:
+
+```text
+text, textarea, richtext, email, url, number, currency, boolean,
+select, json, date, datetime, timestamp
+```
+
+Fields may define `label`, `help`, `placeholder`, `required`, `default`,
+`options`, `min`, `max`, `minLength`, `maxLength`, `format`, and `currency`.
+Defaults and option values are validated when the resource contract is
+normalized. Rich text supports the explicit Markdown format and repeats the
+raw-HTML denial on the server. Relationship and upload fields are not action
+inputs; use record forms for those workflows.
+
+The configured helper runs inside the target Sails application:
+
+```js
+// api/helpers/bridge/publish-course.js
+module.exports = {
+  friendlyName: 'Publish course',
+
+  inputs: {
+    actor: { type: 'ref', required: true },
+    resource: { type: 'ref', required: true },
+    values: { type: 'ref', required: true },
+    recordId: { type: 'ref', required: true }
+  },
+
+  fn: async function ({ actor, values, recordId }) {
+    await Course.updateOne({ id: recordId }).set({ published: true })
+
+    if (values.notifyStudents) {
+      await sails.helpers.course.notifyStudents.with({
+        courseId: recordId,
+        note: values.releaseNote,
+        triggeredBy: actor.email
+      })
+    }
+
+    return { message: 'Course published and students notified.' }
+  }
+}
+```
+
+Resource helpers omit `recordId`. Bulk helpers declare
+`recordIds: { type: 'ref', required: true }`. A helper may return a string or
+`{ message }`; Slipway normalizes the message to plain text and limits it to
+500 characters. Other return data stays inside the target application.
+
+Custom actions execute synchronously with Bridge's existing target-container
+timeout. Use Quest or another background job from the helper for long-running
+work, and return a message that the job was queued.
+
+Every completed or failed helper execution creates a Slipway audit event with
+the actor, project, environment, resource, action, scope, and affected record
+identifiers. Submitted field values and helper return data are deliberately not
+written to the audit log.
 
 Set `type: 'richtext'` and `format: 'markdown'` to use Bridge's TipTap editor:
 

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -40,12 +40,16 @@ test(
     const relationshipScreenshotRoot = path.resolve(
       '.tmp/screenshots/issue-220-bridge-relationships'
     )
+    const actionScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-221-bridge-actions'
+    )
 
     fs.mkdirSync(screenshotRoot, { recursive: true })
     fs.mkdirSync(identifierScreenshotRoot, { recursive: true })
     fs.mkdirSync(authorizationScreenshotRoot, { recursive: true })
     fs.mkdirSync(fieldEngineScreenshotRoot, { recursive: true })
     fs.mkdirSync(relationshipScreenshotRoot, { recursive: true })
+    fs.mkdirSync(actionScreenshotRoot, { recursive: true })
 
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: resourceMetadata(),
@@ -279,6 +283,17 @@ test(
         }
         return successfulResult({ record: persistedCourseRecord })
       }
+      if (code.includes('const helperIdentity =')) {
+        const helperIdentity = readEmbeddedValue(code, 'helperIdentity')
+        return successfulResult({
+          message:
+            helperIdentity === 'bridge.syncCatalog'
+              ? 'Catalog synchronized.'
+              : helperIdentity === 'bridge.publishCourse'
+              ? 'Course published.'
+              : 'Licenses regenerated.'
+        })
+      }
       if (code.includes('const record = await model.findOne(criteria)')) {
         if (code.includes('const identity = "user";')) {
           return successfulResult({
@@ -371,7 +386,7 @@ test(
       await page.wait('text=Build a production Sails app')
       await expect(page).toSee('Course title')
       await expect(page).toSee('$34.99')
-      expect(await page.raw.locator('input[type="checkbox"]').count()).toBe(0)
+      expect(await page.raw.locator('input[type="checkbox"]').count()).toBe(4)
       await page.screenshot(
         path.join(screenshotRoot, 'course-list-light.png'),
         {
@@ -388,6 +403,72 @@ test(
         { fullPage: true }
       )
       await page.raw.emulateMedia({ colorScheme: 'light' })
+
+      const resourceActionsButton = page.raw.getByRole('button', {
+        name: 'Actions for Courses'
+      })
+      await resourceActionsButton.click()
+      await expect(page).toSee('Sync catalog')
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'resource-actions-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'resource-actions-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .getByRole('menuitem', { name: 'Sync catalog', exact: true })
+        .click()
+      await page.wait('text=Catalog synchronized.')
+      await page.raw
+        .getByText('Catalog synchronized.', { exact: true })
+        .locator('..')
+        .getByRole('button')
+        .click()
+
+      const rowCheckboxes = page.raw.locator('tbody input[type="checkbox"]')
+      await rowCheckboxes.nth(0).click()
+      await rowCheckboxes.nth(1).click()
+      await page.raw
+        .getByRole('button', { name: 'Actions for selected records' })
+        .click()
+      await expect(page).toSee('Regenerate licenses')
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'bulk-actions-menu-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'bulk-actions-menu-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .getByRole('menuitem', {
+          name: 'Regenerate licenses',
+          exact: true
+        })
+        .click()
+      await page.raw
+        .locator('[data-test="bridge-action-dialog-regenerateLicenses"]')
+        .waitFor({ state: 'visible' })
+      await page.wait(250)
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'bulk-action-dialog-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'bulk-action-dialog-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw.getByRole('button', { name: 'Cancel' }).click()
+      await rowCheckboxes.nth(0).click()
+      await rowCheckboxes.nth(1).click()
 
       const actionsButton = page.raw.getByRole('button', {
         name: 'Actions for Build a production Sails app'
@@ -646,6 +727,50 @@ test(
       await expect(page).toSee('Ada Lovelace')
       await expect(page).toSee('The deployment path')
       await expect(page).toSee('Deploy with confidence')
+
+      const recordActionsButton = page.raw.getByRole('button', {
+        name: 'Actions for Build a production Sails app'
+      })
+      await recordActionsButton.click()
+      await expect(page).toSee('Publish course')
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'record-actions-menu-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'record-actions-menu-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .getByRole('menuitem', { name: 'Publish course', exact: true })
+        .click()
+      await page.raw
+        .locator('[data-test="bridge-action-dialog-publish"]')
+        .waitFor({ state: 'visible' })
+      await page.wait(250)
+      await expect(page).toSee('Publish this course now?')
+      const publishButton = page.raw.getByRole('button', {
+        name: 'Publish course',
+        exact: true
+      })
+      expect(await publishButton.isDisabled()).toBe(true)
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'record-action-dialog-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.getByLabel('Release note').fill('Ready for students.')
+      expect(await publishButton.isEnabled()).toBe(true)
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(actionScreenshotRoot, 'record-action-dialog-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await publishButton.click()
+      await page.wait('text=Course published.')
+
       await page.screenshot(
         path.join(fieldEngineScreenshotRoot, 'typed-record-light.png'),
         { fullPage: true }
@@ -791,7 +916,58 @@ function resourceConfig() {
           direction: 'DESC'
         },
         actions: {
-          bulkDelete: false
+          bulkDelete: false,
+          syncCatalog: {
+            scope: 'resource',
+            helper: 'bridge.syncCatalog',
+            label: 'Sync catalog',
+            success: 'Catalog synchronized.'
+          },
+          publish: {
+            scope: 'record',
+            helper: 'bridge.publishCourse',
+            label: 'Publish course',
+            description: 'Make this course available to students.',
+            confirm: 'Publish this course now?',
+            success: 'Course published.',
+            fields: {
+              notifyStudents: {
+                type: 'boolean',
+                label: 'Notify students',
+                default: true
+              },
+              releaseNote: {
+                type: 'textarea',
+                label: 'Release note',
+                help: 'Included in the student notification.',
+                required: true,
+                minLength: 3,
+                maxLength: 280
+              }
+            }
+          },
+          regenerateLicenses: {
+            scope: 'bulk',
+            helper: 'bridge.regenerateLicenses',
+            label: 'Regenerate licenses',
+            description: 'Issue fresh license files for the selected courses.',
+            confirm:
+              'Existing license download links for these courses will stop working.',
+            success: 'Licenses regenerated.',
+            destructive: true,
+            fields: {
+              reason: {
+                type: 'select',
+                label: 'Reason',
+                required: true,
+                default: 'security',
+                options: [
+                  { label: 'Security rotation', value: 'security' },
+                  { label: 'Content update', value: 'content' }
+                ]
+              }
+            }
+          }
         },
         relationships: {
           chapters: {

--- a/tests/functional/pages/bridge-custom-actions.test.js
+++ b/tests/functional/pages/bridge-custom-actions.test.js
@@ -1,0 +1,358 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'Bridge executes an authorized record action and records a sanitized audit event',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-custom-action',
+          name: 'Bridge custom action'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const user = current.users.genesisUser
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const courseId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80241'
+    let helperInputs
+    let actionExecutionCount = 0
+    let allowPublish = true
+    let publishError = null
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: courseModels(),
+      config: actionConfig()
+    })
+    const targetPublish = async (inputs) => {
+      actionExecutionCount += 1
+      helperInputs = inputs
+      if (publishError) throw new Error(publishError)
+      return {
+        message: 'Course published for 12 students.',
+        internalReceipt: 'must not enter Slipway audit details'
+      }
+    }
+    targetPublish.with = targetPublish
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-custom-action-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-custom-action-web')
+
+        if (code.includes('const decisions = Object.create(null);')) {
+          const requests = readEmbeddedValue(code, 'requests')
+          const scopedRecordId = readEmbeddedValue(code, 'recordId')
+          expect(scopedRecordId).toBe(courseId)
+          const decisions = {}
+          for (const authorizationRequest of requests) {
+            decisions[authorizationRequest.key] =
+              decisions[authorizationRequest.key] || {}
+            decisions[authorizationRequest.key][authorizationRequest.action] =
+              authorizationRequest.action !== 'publish' || allowPublish
+          }
+          return successfulResult(decisions)
+        }
+
+        if (code.includes('const helperIdentity =')) {
+          try {
+            const run = new Function(
+              'sails',
+              `return (async () => {${code}})();`
+            )
+            const output = await run({
+              helpers: {
+                bridge: {
+                  publishCourse: targetPublish
+                }
+              }
+            })
+            return successfulResult(output)
+          } catch (error) {
+            return failedResult(error.message)
+          }
+        }
+
+        return failedResult('Unexpected Bridge action query.')
+      }
+
+      const browser = await withCsrfFromPage(
+        request,
+        '/projects/new',
+        'genesisUser'
+      )
+      const actionPath =
+        `/projects/${project.slug}/environments/${environment.slug}` +
+        '/bridge/course/actions/publish'
+      const response = await browser.request.post(actionPath, {
+        recordId: courseId,
+        values: {
+          notifyStudents: true,
+          note: 'Ready for production.'
+        }
+      })
+
+      expect(response).toHaveStatus(302)
+      expect(actionExecutionCount).toBe(1)
+      expect(helperInputs.recordId).toBe(courseId)
+      expect(helperInputs.values).toEqual({
+        notifyStudents: true,
+        note: 'Ready for production.'
+      })
+      expect(helperInputs.actor.email).toBe(user.email)
+      expect(helperInputs.resource.identity).toBe('course')
+
+      const auditLog = await sails.models.auditlog.findOne({
+        action: 'bridge.action.succeeded',
+        user: user.id,
+        resourceId: courseId
+      })
+      expect(Boolean(auditLog)).toBe(true)
+      expect(auditLog.resourceType).toBe('bridgeAction')
+      expect(auditLog.resourceId).toBe(courseId)
+      expect(auditLog.details.action).toBe('publish')
+      expect(auditLog.details.scope).toBe('record')
+      expect(auditLog.details.recordId).toBe(courseId)
+      expect(auditLog.details.values).toBe(undefined)
+      expect(auditLog.details.internalReceipt).toBe(undefined)
+
+      allowPublish = false
+      const denied = await browser.request.post(actionPath, {
+        recordId: courseId,
+        values: {
+          notifyStudents: false,
+          note: 'A denied attempt.'
+        }
+      })
+      expect(denied).toHaveStatus(400)
+      expect(denied).toHaveHeader('x-exit', 'badRequest')
+      expect(actionExecutionCount).toBe(1)
+
+      allowPublish = true
+      publishError = 'Publishing provider unavailable.\nTry again shortly.'
+      const failed = await browser.request.post(actionPath, {
+        recordId: courseId,
+        values: {
+          notifyStudents: false,
+          note: 'This submitted value must not enter the audit log.'
+        }
+      })
+      expect(failed).toHaveStatus(400)
+      expect(failed).toHaveHeader('x-exit', 'badRequest')
+      expect(actionExecutionCount).toBe(2)
+
+      const failureAudit = await sails.models.auditlog.findOne({
+        action: 'bridge.action.failed',
+        user: user.id,
+        resourceId: courseId
+      })
+      expect(Boolean(failureAudit)).toBe(true)
+      expect(failureAudit.details.error).toBe(
+        'Publishing provider unavailable. Try again shortly.'
+      )
+      expect(failureAudit.details.values).toBe(undefined)
+      expect(failureAudit.details.note).toBe(undefined)
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+test(
+  'Bridge rejects invalid and oversized custom action payloads before helper execution',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-custom-action-denials',
+          name: 'Bridge custom action denials'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    let actionExecutionCount = 0
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: courseModels(),
+      config: actionConfig()
+    })
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-custom-action-denials-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-custom-action-denials-web')
+        if (code.includes('const decisions = Object.create(null);')) {
+          const requests = readEmbeddedValue(code, 'requests')
+          const decisions = {}
+          for (const authorizationRequest of requests) {
+            decisions[authorizationRequest.key] =
+              decisions[authorizationRequest.key] || {}
+            decisions[authorizationRequest.key][
+              authorizationRequest.action
+            ] = true
+          }
+          return successfulResult(decisions)
+        }
+        actionExecutionCount += 1
+        return successfulResult({})
+      }
+
+      const browser = await withCsrfFromPage(
+        request,
+        '/projects/new',
+        'genesisUser'
+      )
+      const basePath =
+        `/projects/${project.slug}/environments/${environment.slug}` +
+        '/bridge/course/actions'
+
+      const invalidFields = await browser.request.post(`${basePath}/publish`, {
+        recordId: '018f2a5c-7b34-7f8a-9c12-4a73b9d80242',
+        values: {
+          note: 'x',
+          injected: 'not allowed'
+        }
+      })
+      expect(invalidFields).toHaveStatus(400)
+
+      const oversizedBulk = await browser.request.post(
+        `${basePath}/regenerateLicenses`,
+        {
+          recordIds: Array.from({ length: 101 }, (_, index) => index + 1),
+          values: {}
+        }
+      )
+      expect(oversizedBulk).toHaveStatus(400)
+
+      const validBulk = await browser.request.post(
+        `${basePath}/regenerateLicenses`,
+        {
+          recordIds: [
+            '018f2a5c-7b34-7f8a-9c12-4a73b9d80243',
+            '018f2a5c-7b34-7f8a-9c12-4a73b9d80244'
+          ],
+          values: {}
+        }
+      )
+      expect(validBulk).toHaveStatus(302)
+      expect(actionExecutionCount).toBe(1)
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function actionConfig() {
+  return {
+    resources: {
+      course: {
+        authorization: 'bridge.authorize',
+        actions: {
+          publish: {
+            scope: 'record',
+            helper: 'bridge.publishCourse',
+            label: 'Publish course',
+            success: 'Course published.',
+            fields: {
+              notifyStudents: {
+                type: 'boolean',
+                default: true
+              },
+              note: {
+                type: 'textarea',
+                required: true,
+                minLength: 3
+              }
+            }
+          },
+          regenerateLicenses: {
+            scope: 'bulk',
+            helper: 'bridge.regenerateLicenses'
+          }
+        }
+      }
+    }
+  }
+}
+
+function courseModels() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'courses',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true, isUUID: true },
+        title: { type: 'string', required: true }
+      },
+      associations: []
+    }
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
+}
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function failedResult(error) {
+  return {
+    success: false,
+    output: '',
+    error,
+    exitCode: 1
+  }
+}

--- a/tests/unit/helpers/bridge/custom-actions.test.js
+++ b/tests/unit/helpers/bridge/custom-actions.test.js
@@ -1,0 +1,337 @@
+const { test } = require('sounding')
+
+test('Bridge normalizes resource, record, and bulk custom actions', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: courseMetadata(),
+    config: actionConfig()
+  })
+  const course = contract.resources.course
+
+  expect(course.actions.publish).toBe(true)
+  expect(course.actions.regenerateLicenses).toBe(true)
+  expect(course.actionDefinitions.publish).toEqual({
+    name: 'publish',
+    scope: 'record',
+    helper: 'bridge.publishCourse',
+    label: 'Publish course',
+    description: 'Make this course visible to students.',
+    confirm: 'Publish this course now?',
+    success: 'Course published.',
+    destructive: false,
+    fields: {
+      notifyStudents: {
+        type: 'boolean',
+        label: 'Notify Students',
+        required: false,
+        field: {
+          type: 'boolean',
+          default: true
+        }
+      },
+      note: {
+        type: 'string',
+        label: 'Release note',
+        required: true,
+        minLength: 3,
+        maxLength: 280,
+        field: {
+          type: 'textarea',
+          help: 'Shown in the release email.'
+        }
+      }
+    }
+  })
+  expect(course.actionDefinitions.regenerateLicenses.scope).toBe('bulk')
+  expect(course.actionDefinitions.regenerateLicenses.destructive).toBe(true)
+  expect(course.actionDefinitions.regenerateLicenses.confirm).toContain(
+    'may not be reversible'
+  )
+})
+
+test('Bridge fails closed for malformed custom action definitions', async ({
+  sails,
+  expect
+}) => {
+  const invalidConfigs = [
+    {
+      publish: {
+        scope: 'row',
+        helper: 'bridge.publishCourse'
+      }
+    },
+    {
+      publish: {
+        scope: 'record',
+        helper: 'bridge.__proto__.publish'
+      }
+    },
+    {
+      update: {
+        scope: 'record',
+        helper: 'bridge.updateCourse'
+      }
+    },
+    {
+      publish: {
+        scope: 'record',
+        helper: 'bridge.publishCourse',
+        fields: {
+          audience: {
+            type: 'select'
+          }
+        }
+      }
+    },
+    {
+      publish: {
+        scope: 'record',
+        helper: 'bridge.publishCourse',
+        fields: {
+          audience: {
+            type: 'select',
+            default: 'everyone',
+            options: ['customers']
+          }
+        }
+      }
+    }
+  ]
+
+  for (const actions of invalidConfigs) {
+    let receivedError
+    try {
+      await sails.helpers.bridge.normalizeResourceContract.with({
+        models: courseMetadata(),
+        config: {
+          resources: {
+            course: { actions }
+          }
+        }
+      })
+    } catch (error) {
+      receivedError = error
+    }
+    expect(Boolean(receivedError)).toBe(true)
+  }
+})
+
+test('Bridge validates action fields and applies configured defaults', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: courseMetadata(),
+    config: actionConfig()
+  })
+  const course = contract.resources.course
+  const action = course.actionDefinitions.publish
+
+  const values = await sails.helpers.bridge.allowActionValues.with({
+    resource: course,
+    action,
+    values: {
+      note: 'Ready for production.'
+    }
+  })
+  expect(values).toEqual({
+    notifyStudents: true,
+    note: 'Ready for production.'
+  })
+
+  let invalidError
+  try {
+    await sails.helpers.bridge.allowActionValues.with({
+      resource: course,
+      action,
+      values: {
+        note: 'x',
+        injected: 'must not reach the target helper'
+      }
+    })
+  } catch (error) {
+    invalidError = error
+  }
+  expect(invalidError.code).toBe('BRIDGE_FIELD_NOT_ALLOWED')
+  expect(invalidError.fields).toEqual(['injected'])
+})
+
+test('Bridge removes denied custom actions from the effective UI contract', async ({
+  sails,
+  expect
+}) => {
+  const config = actionConfig()
+  config.resources.course.authorization = 'bridge.authorize'
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: courseMetadata(),
+    config
+  })
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-app-web')
+      const requests = readEmbeddedValue(code, 'requests')
+      const decisions = {}
+      for (const request of requests) {
+        decisions[request.key] = decisions[request.key] || {}
+        decisions[request.key][request.action] = request.action !== 'publish'
+      }
+      return successfulResult(decisions)
+    }
+
+    const effective = await sails.helpers.bridge.authorizeResourceActions.with({
+      containerName: 'bridge-app-web',
+      resources: contract.resources,
+      actor: {
+        id: '7',
+        email: 'editor@example.com'
+      },
+      recordId: 42
+    })
+    expect(effective.course.actions.publish).toBe(false)
+    expect(effective.course.actionDefinitions.publish).toBe(undefined)
+    expect(effective.course.actionDefinitions.regenerateLicenses.scope).toBe(
+      'bulk'
+    )
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+test('Bridge custom actions expose only bounded helper feedback', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: courseMetadata(),
+    config: actionConfig()
+  })
+  const course = contract.resources.course
+  const action = course.actionDefinitions.publish
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  const targetPublish = async (inputs) => {
+    expect(inputs.recordId).toBe(42)
+    expect(inputs.values).toEqual({
+      notifyStudents: true,
+      note: 'Ready.'
+    })
+    expect(inputs.resource.identity).toBe('course')
+    return {
+      message: `  Published ${inputs.recordId}.  `,
+      secret: 'must not leave the target app'
+    }
+  }
+  targetPublish.with = targetPublish
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-app-web')
+      const run = new Function('sails', `return (async () => {${code}})();`)
+      const output = await run({
+        helpers: {
+          bridge: {
+            publishCourse: targetPublish
+          }
+        }
+      })
+      return successfulResult(output)
+    }
+
+    const result = await sails.helpers.bridge.executeCustomAction.with({
+      containerName: 'bridge-app-web',
+      resource: course,
+      action,
+      actor: {
+        id: '7',
+        email: 'editor@example.com'
+      },
+      values: {
+        notifyStudents: true,
+        note: 'Ready.'
+      },
+      recordId: 42
+    })
+    expect(result).toEqual({ message: 'Published 42.' })
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+function actionConfig() {
+  return {
+    resources: {
+      course: {
+        actions: {
+          publish: {
+            scope: 'record',
+            helper: 'bridge.publishCourse',
+            label: 'Publish course',
+            description: 'Make this course visible to students.',
+            confirm: 'Publish this course now?',
+            success: 'Course published.',
+            fields: {
+              notifyStudents: {
+                type: 'boolean',
+                default: true
+              },
+              note: {
+                type: 'textarea',
+                label: 'Release note',
+                help: 'Shown in the release email.',
+                required: true,
+                minLength: 3,
+                maxLength: 280
+              }
+            }
+          },
+          regenerateLicenses: {
+            scope: 'bulk',
+            helper: 'bridge.regenerateLicenses',
+            destructive: true
+          }
+        }
+      }
+    }
+  }
+}
+
+function courseMetadata() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'courses',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'number', autoIncrement: true },
+        title: { type: 'string', required: true },
+        published: { type: 'boolean', defaultsTo: false }
+      },
+      associations: []
+    }
+  }
+}
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
+}


### PR DESCRIPTION
## Summary

- add declarative resource, record, and bulk Bridge actions backed by target-app Sails helpers
- reuse the Bridge field engine for typed action inputs and enforce authorization again at execution time
- add minimal light/dark action menus and dialogs, sanitized audit events, documentation, and Sounding coverage

## Validation

- npm test
- npm run lint
- npm run check:consistency

Closes #221