### PR TITLE
feat(bridge): add configurable dashboards

### DIFF
--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -31,6 +31,10 @@ module.exports = {
     search: {
       type: 'string',
       defaultsTo: ''
+    },
+    dashboard: {
+      type: 'string',
+      defaultsTo: ''
     }
   },
 
@@ -50,7 +54,8 @@ module.exports = {
     page,
     perPage,
     sort,
-    search
+    search,
+    dashboard
   }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
@@ -90,6 +95,9 @@ module.exports = {
     let normalizedPerPage = perPage
     let normalizedSort = sort
     let normalizedSearch = search
+    let dashboards = []
+    let dashboardResources = {}
+    let activeDashboard = null
 
     if (appRunning) {
       try {
@@ -106,6 +114,50 @@ module.exports = {
           actor
         })
         modelMeta = loaded.resource
+        const dashboardDefinitions = Object.values(
+          loaded.contract.dashboards || {}
+        ).filter(
+          (definition) =>
+            definition.scope === 'resource' &&
+            definition.resource === modelIdentity
+        )
+        dashboards = dashboardDefinitions.map((definition) => ({
+          id: definition.id,
+          label: definition.label,
+          scope: definition.scope
+        }))
+        const selectedDashboard =
+          dashboardDefinitions.find(
+            (definition) => definition.id === dashboard
+          ) ||
+          dashboardDefinitions.find((definition) => definition.default) ||
+          dashboardDefinitions[0]
+
+        if (selectedDashboard) {
+          const authorizedResources =
+            await sails.helpers.bridge.authorizeResourceActions.with({
+              containerName: app.containerName,
+              resources: loaded.contract.models,
+              actor
+            })
+          const authorizedDashboardResources = Object.fromEntries(
+            Object.entries(authorizedResources).filter(
+              ([, resource]) => !resource.hidden
+            )
+          )
+          dashboardResources = Object.fromEntries(
+            Object.entries(authorizedResources).filter(
+              ([, resource]) =>
+                !resource.hidden && resource.actions?.viewAny !== false
+            )
+          )
+          activeDashboard = await sails.helpers.bridge.resolveDashboard.with({
+            containerName: app.containerName,
+            dashboard: selectedDashboard,
+            resources: authorizedDashboardResources,
+            actor
+          })
+        }
         const normalizedQuery =
           await sails.helpers.bridge.normalizeResourceQuery.with({
             resource: modelMeta,
@@ -183,7 +235,10 @@ module.exports = {
         perPage: normalizedPerPage,
         sort: normalizedSort,
         search: normalizedSearch,
-        error
+        error,
+        dashboards,
+        dashboardResources,
+        activeDashboard
       }
     }
   }

--- a/api/controllers/project/view-bridge.js
+++ b/api/controllers/project/view-bridge.js
@@ -11,6 +11,10 @@ module.exports = {
     envSlug: {
       type: 'string',
       defaultsTo: 'production'
+    },
+    dashboard: {
+      type: 'string',
+      defaultsTo: ''
     }
   },
 
@@ -23,7 +27,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug }) {
+  fn: async function ({ slug, envSlug, dashboard }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -55,6 +59,8 @@ module.exports = {
     // Load models server-side if app is running
     let models = {}
     let modelsError = null
+    let dashboards = []
+    let activeDashboard = null
 
     if (appRunning) {
       try {
@@ -77,12 +83,41 @@ module.exports = {
               resources: introspection.models || {},
               actor
             })
+          const dashboardResources = Object.fromEntries(
+            Object.entries(authorizedModels).filter(
+              ([, resource]) => !resource.hidden
+            )
+          )
           models = Object.fromEntries(
             Object.entries(authorizedModels).filter(
               ([, resource]) =>
                 !resource.hidden && resource.actions?.viewAny !== false
             )
           )
+
+          const dashboardDefinitions = Object.values(
+            introspection.dashboards || {}
+          ).filter((definition) => definition.scope !== 'resource')
+          dashboards = dashboardDefinitions.map((definition) => ({
+            id: definition.id,
+            label: definition.label,
+            scope: definition.scope
+          }))
+          const selectedDashboard =
+            dashboardDefinitions.find(
+              (definition) => definition.id === dashboard
+            ) ||
+            dashboardDefinitions.find((definition) => definition.default) ||
+            dashboardDefinitions[0]
+
+          if (selectedDashboard) {
+            activeDashboard = await sails.helpers.bridge.resolveDashboard.with({
+              containerName: app.containerName,
+              dashboard: selectedDashboard,
+              resources: dashboardResources,
+              actor
+            })
+          }
 
           // Get record counts for all models
           const definitions = Object.entries(models).map(([key, resource]) => ({
@@ -143,7 +178,9 @@ module.exports = {
         },
         appRunning,
         models,
-        modelsError
+        modelsError,
+        dashboards,
+        activeDashboard
       }
     }
   }

--- a/api/helpers/bridge/introspect-models.js
+++ b/api/helpers/bridge/introspect-models.js
@@ -74,7 +74,8 @@ module.exports = {
         schemaVersion: contract.schemaVersion,
         discover: contract.discover,
         configured: contract.configured,
-        models: contract.resources || {}
+        models: contract.resources || {},
+        dashboards: contract.dashboards || {}
       }
 
       // Store in cache

--- a/api/helpers/bridge/normalize-dashboard-contract.js
+++ b/api/helpers/bridge/normalize-dashboard-contract.js
@@ -1,0 +1,556 @@
+'use strict'
+
+const DASHBOARD_SCOPES = ['global', 'project', 'environment', 'resource']
+const CARD_TYPES = [
+  'metric',
+  'recent',
+  'action',
+  'trend',
+  'partition',
+  'custom'
+]
+const AGGREGATES = ['count', 'sum', 'average', 'min', 'max']
+const VALUE_FORMATS = ['number', 'compact', 'currency', 'percent']
+const DASHBOARD_KEYS = [
+  'label',
+  'description',
+  'default',
+  'scope',
+  'resource',
+  'cards'
+]
+const COMMON_CARD_KEYS = ['type', 'label', 'description', 'resource']
+const CARD_KEYS = {
+  metric: [
+    ...COMMON_CARD_KEYS,
+    'aggregate',
+    'field',
+    'where',
+    'format',
+    'currency',
+    'prefix',
+    'suffix'
+  ],
+  recent: [...COMMON_CARD_KEYS, 'fields', 'limit', 'sort'],
+  action: [...COMMON_CARD_KEYS, 'action'],
+  trend: [...COMMON_CARD_KEYS, 'helper'],
+  partition: [...COMMON_CARD_KEYS, 'helper'],
+  custom: [...COMMON_CARD_KEYS, 'helper']
+}
+
+module.exports = {
+  friendlyName: 'Normalize Bridge dashboard contract',
+
+  description:
+    'Validate target-app Bridge dashboards against the normalized resource contract.',
+
+  inputs: {
+    dashboard: {
+      type: 'ref'
+    },
+    dashboards: {
+      type: 'ref'
+    },
+    resources: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ dashboard, dashboards, resources }) {
+    if (!isPlainObject(resources)) {
+      throw new Error('Bridge dashboards require normalized resources.')
+    }
+    if (dashboard !== undefined && dashboards !== undefined) {
+      throw new Error(
+        'Configure either sails.config.slipway.bridge.dashboard or dashboards, not both.'
+      )
+    }
+
+    let definitions = dashboards
+    if (dashboard !== undefined) {
+      definitions = { overview: dashboard }
+    }
+    if (definitions === undefined) return {}
+    if (!isPlainObject(definitions)) {
+      throw new Error(
+        'sails.config.slipway.bridge.dashboards must be an object.'
+      )
+    }
+    if (Object.keys(definitions).length > 12) {
+      throw new Error('Bridge cannot contain more than 12 dashboards.')
+    }
+
+    const normalized = {}
+    const defaultByScope = new Map()
+
+    for (const [id, rawDashboard] of Object.entries(definitions)) {
+      assertSafeIdentifier(id, `Bridge dashboard "${id}"`)
+      if (!isPlainObject(rawDashboard)) {
+        throw new Error(`Bridge dashboard "${id}" must be an object.`)
+      }
+      rejectUnknownKeys(
+        rawDashboard,
+        DASHBOARD_KEYS,
+        `Bridge dashboard "${id}"`
+      )
+      assertOptionalString(
+        rawDashboard.label,
+        `Bridge dashboard "${id}".label`,
+        80
+      )
+      assertOptionalString(
+        rawDashboard.description,
+        `Bridge dashboard "${id}".description`,
+        240
+      )
+      assertOptionalBoolean(
+        rawDashboard.default,
+        `Bridge dashboard "${id}".default`
+      )
+
+      const scope = rawDashboard.scope || 'environment'
+      if (!DASHBOARD_SCOPES.includes(scope)) {
+        throw new Error(
+          `Bridge dashboard "${id}".scope must be one of: ${DASHBOARD_SCOPES.join(
+            ', '
+          )}.`
+        )
+      }
+
+      let resource = rawDashboard.resource
+      if (scope === 'resource' && !resource) {
+        throw new Error(
+          `Bridge dashboard "${id}".resource is required for resource-scoped dashboards.`
+        )
+      }
+      if (resource !== undefined) {
+        resource = normalizeResourceReference(
+          resource,
+          resources,
+          `Bridge dashboard "${id}".resource`
+        )
+      }
+      if (scope !== 'resource' && resource !== undefined) {
+        throw new Error(
+          `Bridge dashboard "${id}".resource is supported only when scope is "resource".`
+        )
+      }
+
+      if (!isPlainObject(rawDashboard.cards)) {
+        throw new Error(`Bridge dashboard "${id}".cards must be an object.`)
+      }
+
+      const cards = []
+      for (const [cardId, rawCard] of Object.entries(rawDashboard.cards)) {
+        cards.push(
+          normalizeCard({
+            dashboardId: id,
+            cardId,
+            rawCard,
+            dashboardResource: resource,
+            resources
+          })
+        )
+      }
+      if (cards.length === 0) {
+        throw new Error(`Bridge dashboard "${id}".cards cannot be empty.`)
+      }
+      if (cards.length > 24) {
+        throw new Error(
+          `Bridge dashboard "${id}" cannot contain more than 24 cards.`
+        )
+      }
+
+      const defaultKey = `${scope}:${resource || ''}`
+      if (rawDashboard.default === true) {
+        if (defaultByScope.has(defaultKey)) {
+          throw new Error(
+            `Bridge dashboards "${defaultByScope.get(
+              defaultKey
+            )}" and "${id}" cannot both be default for the same scope.`
+          )
+        }
+        defaultByScope.set(defaultKey, id)
+      }
+
+      normalized[id] = {
+        id,
+        label: readString(rawDashboard.label) || humanize(id),
+        description: readString(rawDashboard.description),
+        default: rawDashboard.default === true,
+        scope,
+        resource: resource || null,
+        cards
+      }
+    }
+
+    for (const dashboard of Object.values(normalized)) {
+      const defaultKey = `${dashboard.scope}:${dashboard.resource || ''}`
+      if (!defaultByScope.has(defaultKey)) {
+        dashboard.default = true
+        defaultByScope.set(defaultKey, dashboard.id)
+      }
+    }
+
+    return normalized
+  }
+}
+
+function normalizeCard({
+  dashboardId,
+  cardId,
+  rawCard,
+  dashboardResource,
+  resources
+}) {
+  const path = `Bridge dashboard card "${dashboardId}.${cardId}"`
+  assertSafeIdentifier(cardId, path)
+  if (!isPlainObject(rawCard)) {
+    throw new Error(`${path} must be an object.`)
+  }
+
+  const type = rawCard.type
+  if (!CARD_TYPES.includes(type)) {
+    throw new Error(`${path}.type must be one of: ${CARD_TYPES.join(', ')}.`)
+  }
+  rejectUnknownKeys(rawCard, CARD_KEYS[type], path)
+  assertOptionalString(rawCard.label, `${path}.label`, 80)
+  assertOptionalString(rawCard.description, `${path}.description`, 240)
+
+  let resourceReference = rawCard.resource ?? dashboardResource
+  if (['metric', 'recent', 'action'].includes(type) && !resourceReference) {
+    throw new Error(`${path}.resource is required for ${type} cards.`)
+  }
+  const resource = resourceReference
+    ? normalizeResourceReference(
+        resourceReference,
+        resources,
+        `${path}.resource`
+      )
+    : null
+  const resourceContract = resource ? resources[resource] : null
+  const common = {
+    id: cardId,
+    type,
+    label:
+      readString(rawCard.label) ||
+      defaultCardLabel({ cardId, type, resource: resourceContract }),
+    description: readString(rawCard.description),
+    resource
+  }
+
+  if (type === 'metric') {
+    return normalizeMetricCard(path, rawCard, resourceContract, common)
+  }
+  if (type === 'recent') {
+    return normalizeRecentCard(path, rawCard, resourceContract, common)
+  }
+  if (type === 'action') {
+    return normalizeActionCard(path, rawCard, resourceContract, common)
+  }
+
+  if (!isSafeHelperIdentity(rawCard.helper)) {
+    throw new Error(`${path}.helper must be a safe Sails helper identity.`)
+  }
+  return {
+    ...common,
+    helper: rawCard.helper
+  }
+}
+
+function normalizeMetricCard(path, raw, resource, common) {
+  const aggregate = raw.aggregate || 'count'
+  if (!AGGREGATES.includes(aggregate)) {
+    throw new Error(
+      `${path}.aggregate must be one of: ${AGGREGATES.join(', ')}.`
+    )
+  }
+
+  let field = null
+  if (aggregate !== 'count') {
+    if (typeof raw.field !== 'string' || !raw.field.trim()) {
+      throw new Error(`${path}.field is required for ${aggregate} metrics.`)
+    }
+    field = normalizeReadableField(raw.field, resource, `${path}.field`)
+    if (resource.attributes[field]?.type !== 'number') {
+      throw new Error(`${path}.field must reference a numeric field.`)
+    }
+  } else if (raw.field !== undefined) {
+    throw new Error(`${path}.field is not used by count metrics.`)
+  }
+
+  if (raw.where !== undefined) {
+    assertSafeSerializableObject(raw.where, `${path}.where`)
+    validateWhereFields(raw.where, resource, `${path}.where`)
+  }
+  const format = raw.format || 'number'
+  if (!VALUE_FORMATS.includes(format)) {
+    throw new Error(
+      `${path}.format must be one of: ${VALUE_FORMATS.join(', ')}.`
+    )
+  }
+  if (format === 'currency') {
+    if (
+      typeof raw.currency !== 'string' ||
+      !/^[A-Za-z]{3}$/.test(raw.currency)
+    ) {
+      throw new Error(
+        `${path}.currency must be a three-letter currency code when format is "currency".`
+      )
+    }
+  } else if (raw.currency !== undefined) {
+    throw new Error(`${path}.currency requires format "currency".`)
+  }
+  for (const option of ['prefix', 'suffix']) {
+    assertOptionalString(raw[option], `${path}.${option}`, 20)
+  }
+
+  return {
+    ...common,
+    aggregate,
+    field,
+    where: raw.where ? cloneSerializable(raw.where) : {},
+    format,
+    currency: raw.currency ? raw.currency.toUpperCase() : null,
+    prefix: readString(raw.prefix),
+    suffix: readString(raw.suffix)
+  }
+}
+
+function normalizeRecentCard(path, raw, resource, common) {
+  if (
+    raw.fields !== undefined &&
+    (!Array.isArray(raw.fields) ||
+      raw.fields.some((field) => typeof field !== 'string'))
+  ) {
+    throw new Error(`${path}.fields must be an array of field names.`)
+  }
+
+  const requestedFields =
+    raw.fields ||
+    Array.from(
+      new Set([resource.primaryKey, resource.title, ...resource.list])
+    ).slice(0, 4)
+  const fields = Array.from(
+    new Set([
+      resource.primaryKey,
+      ...requestedFields.map((field) =>
+        normalizeReadableField(field, resource, `${path}.fields`)
+      )
+    ])
+  )
+  const limit = raw.limit ?? 5
+  if (!Number.isInteger(limit) || limit < 1 || limit > 10) {
+    throw new Error(`${path}.limit must be an integer from 1 to 10.`)
+  }
+
+  const sort = normalizeCardSort(path, raw.sort, resource)
+  return {
+    ...common,
+    fields,
+    limit,
+    sort
+  }
+}
+
+function normalizeActionCard(path, raw, resource, common) {
+  const action = raw.action || 'create'
+  if (action !== 'create') {
+    throw new Error(`${path}.action currently supports only "create".`)
+  }
+  return {
+    ...common,
+    action
+  }
+}
+
+function normalizeCardSort(path, rawSort, resource) {
+  if (rawSort === undefined) return resource.sort
+  if (!isPlainObject(rawSort)) {
+    throw new Error(`${path}.sort must be an object.`)
+  }
+  rejectUnknownKeys(rawSort, ['field', 'direction'], `${path}.sort`)
+  const field = normalizeReadableField(
+    rawSort.field,
+    resource,
+    `${path}.sort.field`
+  )
+  const direction = String(rawSort.direction || 'DESC').toUpperCase()
+  if (!['ASC', 'DESC'].includes(direction)) {
+    throw new Error(`${path}.sort.direction must be "ASC" or "DESC".`)
+  }
+  return { field, direction }
+}
+
+function normalizeResourceReference(value, resources, path) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`${path} must be a resource identity.`)
+  }
+  const identity = value.trim()
+  const resource = resources[identity]
+  if (!resource) {
+    throw new Error(`${path} references unknown resource "${identity}".`)
+  }
+  if (resource.hidden === true) {
+    throw new Error(`${path} cannot reference hidden resource "${identity}".`)
+  }
+  return identity
+}
+
+function normalizeReadableField(value, resource, path) {
+  if (
+    typeof value !== 'string' ||
+    !Array.from(new Set([...resource.list, ...resource.show])).includes(value)
+  ) {
+    throw new Error(`${path} references unavailable field "${value}".`)
+  }
+  return value
+}
+
+function defaultCardLabel({ cardId, type, resource }) {
+  if (type === 'metric') return humanize(cardId)
+  if (type === 'recent') return `Recent ${resource?.label || humanize(cardId)}`
+  if (type === 'action')
+    return `New ${resource?.singularLabel || humanize(cardId)}`
+  return humanize(cardId)
+}
+
+function validateWhereFields(where, resource, path) {
+  const allowedFields = new Set([
+    ...(resource.list || []),
+    ...(resource.filters || [])
+  ])
+
+  visit(where)
+
+  function visit(node) {
+    if (!isPlainObject(node)) return
+    for (const [key, value] of Object.entries(node)) {
+      if (['and', 'or'].includes(key)) {
+        const branches = Array.isArray(value) ? value : [value]
+        for (const branch of branches) visit(branch)
+        continue
+      }
+      if (!allowedFields.has(key)) {
+        throw new Error(`${path} references unavailable field "${key}".`)
+      }
+    }
+  }
+}
+
+function assertSafeSerializableObject(value, path) {
+  if (!isPlainObject(value)) {
+    throw new Error(`${path} must be an object.`)
+  }
+  walkSerializable(value, path, 0)
+}
+
+function walkSerializable(value, path, depth) {
+  if (depth > 8) {
+    throw new Error(`${path} cannot be nested more than 8 levels.`)
+  }
+  if (value === null) return
+  if (Array.isArray(value)) {
+    if (value.length > 100) {
+      throw new Error(`${path} cannot contain arrays longer than 100 items.`)
+    }
+    for (const item of value) walkSerializable(item, path, depth + 1)
+    return
+  }
+  if (isPlainObject(value)) {
+    if (Object.keys(value).length > 50) {
+      throw new Error(`${path} cannot contain objects with more than 50 keys.`)
+    }
+    for (const [key, item] of Object.entries(value)) {
+      if (['__proto__', 'constructor', 'prototype'].includes(key)) {
+        throw new Error(`${path} contains an unsafe key.`)
+      }
+      walkSerializable(item, path, depth + 1)
+    }
+    return
+  }
+  if (
+    !['string', 'number', 'boolean'].includes(typeof value) ||
+    (typeof value === 'number' && !Number.isFinite(value))
+  ) {
+    throw new Error(`${path} must contain only serializable values.`)
+  }
+}
+
+function cloneSerializable(value) {
+  return JSON.parse(JSON.stringify(value))
+}
+
+function rejectUnknownKeys(value, allowed, path) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      throw new Error(`${path} has unsupported option "${key}".`)
+    }
+  }
+}
+
+function assertSafeIdentifier(value, path) {
+  if (
+    typeof value !== 'string' ||
+    !/^[A-Za-z][A-Za-z0-9]*$/.test(value) ||
+    ['__proto__', 'constructor', 'prototype'].includes(value)
+  ) {
+    throw new Error(`${path} must use a safe JavaScript-style identifier.`)
+  }
+}
+
+function isSafeHelperIdentity(value) {
+  return (
+    typeof value === 'string' &&
+    value
+      .split('.')
+      .every(
+        (part) =>
+          /^[A-Za-z][A-Za-z0-9]*$/.test(part) &&
+          !['__proto__', 'constructor', 'prototype'].includes(part)
+      )
+  )
+}
+
+function assertOptionalString(value, path, maxLength = 240) {
+  if (value !== undefined && typeof value !== 'string') {
+    throw new Error(`${path} must be a string.`)
+  }
+  if (typeof value === 'string' && value.trim().length > maxLength) {
+    throw new Error(`${path} cannot be longer than ${maxLength} characters.`)
+  }
+}
+
+function assertOptionalBoolean(value, path) {
+  if (value !== undefined && typeof value !== 'boolean') {
+    throw new Error(`${path} must be a boolean.`)
+  }
+}
+
+function readString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+function humanize(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^./, (character) => character.toUpperCase())
+}
+
+function isPlainObject(value) {
+  if (!value || Object.prototype.toString.call(value) !== '[object Object]') {
+    return false
+  }
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -24,7 +24,14 @@ module.exports = {
   },
 
   fn: async function ({ models, config }) {
-    return normalizeBridgeResourceContract({ models, config })
+    const contract = normalizeBridgeResourceContract({ models, config })
+    contract.dashboards =
+      await sails.helpers.bridge.normalizeDashboardContract.with({
+        dashboard: config.dashboard,
+        dashboards: config.dashboards,
+        resources: contract.resources
+      })
+    return contract
   }
 }
 

--- a/api/helpers/bridge/resolve-dashboard.js
+++ b/api/helpers/bridge/resolve-dashboard.js
@@ -1,0 +1,368 @@
+'use strict'
+
+module.exports = {
+  friendlyName: 'Resolve Bridge dashboard',
+
+  description:
+    'Load an authorized Bridge dashboard from the target Sails application.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    dashboard: {
+      type: 'ref',
+      required: true
+    },
+    resources: {
+      type: 'ref',
+      required: true
+    },
+    actor: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, dashboard, resources, actor }) {
+    const visibleCards = dashboard.cards.filter((card) =>
+      isCardAuthorized(card, resources)
+    )
+    if (visibleCards.length === 0) {
+      return {
+        ...dashboard,
+        cards: []
+      }
+    }
+
+    const definitions = visibleCards.map((card) => ({
+      ...card,
+      resourceDefinition: card.resource
+        ? summarizeResource(resources[card.resource])
+        : null
+    }))
+    const dashboardCode = buildDashboardCode({
+      dashboard: {
+        id: dashboard.id,
+        label: dashboard.label,
+        scope: dashboard.scope,
+        resource: dashboard.resource
+      },
+      definitions,
+      actor
+    })
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+      dashboardCode
+    )
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      sails.log.warn(
+        `Bridge dashboard "${dashboard.id}" failed:`,
+        result.error || 'Target app execution failed.'
+      )
+      return {
+        ...dashboard,
+        cards: visibleCards.map((card) => ({
+          ...card,
+          error: 'Dashboard data is temporarily unavailable.'
+        })),
+        error: 'Dashboard data is temporarily unavailable.'
+      }
+    }
+
+    let resolved
+    try {
+      resolved = JSON.parse(result.output)
+    } catch {
+      return {
+        ...dashboard,
+        cards: visibleCards.map((card) => ({
+          ...card,
+          error: 'Dashboard data is temporarily unavailable.'
+        })),
+        error: 'The target app returned an invalid dashboard result.'
+      }
+    }
+
+    const resultsById = new Map(
+      (Array.isArray(resolved) ? resolved : []).map((card) => [card.id, card])
+    )
+    const cards = []
+    for (const card of visibleCards) {
+      const cardResult = resultsById.get(card.id) || {}
+      if (typeof cardResult.error === 'string') {
+        sails.log.warn(
+          `Bridge dashboard card "${dashboard.id}.${card.id}" failed:`,
+          cardResult.error
+        )
+      }
+      const resolvedCard = {
+        ...card,
+        ...pickResult(card, cardResult)
+      }
+
+      if (card.type === 'recent' && Array.isArray(cardResult.records)) {
+        resolvedCard.records =
+          await sails.helpers.bridge.redactResourceRecords.with({
+            records: cardResult.records,
+            resource: {
+              ...resources[card.resource],
+              list: card.fields
+            },
+            surface: 'list'
+          })
+      }
+      cards.push(resolvedCard)
+    }
+
+    return {
+      ...dashboard,
+      cards
+    }
+  }
+}
+
+function isCardAuthorized(card, resources) {
+  if (!card.resource) return true
+  const resource = resources[card.resource]
+  if (!resource || resource.hidden === true) return false
+  if (card.type === 'action') {
+    return resource.actions?.[card.action] === true
+  }
+  return resource.actions?.viewAny === true
+}
+
+function summarizeResource(resource) {
+  return {
+    identity: resource.identity,
+    primaryKey: resource.primaryKey,
+    title: resource.title,
+    label: resource.label,
+    singularLabel: resource.singularLabel,
+    attributes: Object.fromEntries(
+      Object.entries(resource.attributes || {}).map(([name, attribute]) => [
+        name,
+        {
+          type: attribute.type,
+          columnType: attribute.columnType,
+          autoCreatedAt: attribute.autoCreatedAt === true,
+          autoUpdatedAt: attribute.autoUpdatedAt === true
+        }
+      ])
+    )
+  }
+}
+
+function buildDashboardCode({ dashboard, definitions, actor }) {
+  return `
+    const dashboard = ${JSON.stringify(dashboard)};
+    const definitions = ${JSON.stringify(definitions)};
+    const actor = ${JSON.stringify(actor)};
+    const results = [];
+
+    function safeText(value, limit) {
+      if (typeof value !== 'string') return null;
+      const text = value.replace(/\\s+/g, ' ').trim();
+      return text ? text.slice(0, limit) : null;
+    }
+
+    function resolveHelper(identity) {
+      let helper = sails.helpers;
+      for (const segment of identity.split('.')) {
+        helper = helper && helper[segment];
+      }
+      if (!helper || typeof helper.with !== 'function') {
+        throw new Error(
+          'Configured Bridge dashboard helper "' + identity + '" is unavailable.'
+        );
+      }
+      return helper;
+    }
+
+    function finiteNumber(value) {
+      const number = Number(value);
+      return Number.isFinite(number) ? number : null;
+    }
+
+    function normalizeHelperResult(definition, output) {
+      if (definition.type === 'trend') {
+        const source = Array.isArray(output) ? output : output?.points;
+        return {
+          points: (Array.isArray(source) ? source : [])
+            .slice(0, 31)
+            .map((point) => ({
+              label: safeText(point?.label, 80),
+              value: finiteNumber(point?.value)
+            }))
+            .filter((point) => point.label && point.value !== null)
+        };
+      }
+      if (definition.type === 'partition') {
+        const source = Array.isArray(output) ? output : output?.segments;
+        return {
+          segments: (Array.isArray(source) ? source : [])
+            .slice(0, 12)
+            .map((segment) => ({
+              label: safeText(segment?.label, 80),
+              value: finiteNumber(segment?.value)
+            }))
+            .filter((segment) => segment.label && segment.value !== null)
+        };
+      }
+
+      const source =
+        output && typeof output === 'object' && !Array.isArray(output)
+          ? output
+          : { value: output };
+      const value =
+        ['string', 'number', 'boolean'].includes(typeof source.value) &&
+        (
+          typeof source.value !== 'number' ||
+          Number.isFinite(source.value)
+          )
+          ? (
+              typeof source.value === 'string'
+                ? safeText(source.value, 160)
+                : source.value
+            )
+          : null;
+      return {
+        value,
+        detail: safeText(source.detail, 240)
+      };
+    }
+
+    for (const definition of definitions) {
+      try {
+        if (definition.type === 'action') {
+          results.push({ id: definition.id });
+          continue;
+        }
+
+        if (
+          ['custom', 'trend', 'partition'].includes(definition.type)
+        ) {
+          const helper = resolveHelper(definition.helper);
+          const output = await helper.with({
+            actor,
+            dashboard,
+            card: {
+              id: definition.id,
+              type: definition.type,
+              label: definition.label,
+              resource: definition.resourceDefinition
+            }
+          });
+          results.push({
+            id: definition.id,
+            ...normalizeHelperResult(definition, output)
+          });
+          continue;
+        }
+
+        const model = sails.models[definition.resourceDefinition.identity];
+        if (!model) {
+          throw new Error('Configured Bridge dashboard resource is unavailable.');
+        }
+
+        if (definition.type === 'recent') {
+          const records = await model.find({
+            where: {},
+            select: definition.fields,
+            sort:
+              definition.sort.field + ' ' + definition.sort.direction,
+            limit: definition.limit
+          });
+          results.push({ id: definition.id, records });
+          continue;
+        }
+
+        let value;
+        if (definition.aggregate === 'count') {
+          value = await model.count(definition.where);
+        } else if (definition.aggregate === 'sum') {
+          value = await model.sum(definition.field).where(definition.where);
+        } else if (definition.aggregate === 'average') {
+          value = await model.avg(definition.field).where(definition.where);
+        } else {
+          const direction = definition.aggregate === 'max' ? 'DESC' : 'ASC';
+          const records = await model.find({
+            where: definition.where,
+            select: [
+              definition.resourceDefinition.primaryKey,
+              definition.field
+            ],
+            sort: definition.field + ' ' + direction,
+            limit: 1
+          });
+          value = records[0]?.[definition.field] ?? null;
+        }
+        results.push({ id: definition.id, value: finiteNumber(value) });
+      } catch (error) {
+        results.push({
+          id: definition.id,
+          error:
+            safeText(error?.message, 180) ||
+            'Dashboard card is temporarily unavailable.'
+        });
+      }
+    }
+
+    return results;
+  `
+}
+
+function pickResult(card, result) {
+  const picked = {}
+  if (typeof result.error === 'string') {
+    picked.error = 'Dashboard data is temporarily unavailable.'
+  }
+  if (card.type === 'metric') {
+    picked.value =
+      typeof result.value === 'number' && Number.isFinite(result.value)
+        ? result.value
+        : null
+  } else if (card.type === 'custom') {
+    if (
+      ['string', 'number', 'boolean'].includes(typeof result.value) &&
+      (typeof result.value !== 'number' || Number.isFinite(result.value))
+    ) {
+      picked.value =
+        typeof result.value === 'string'
+          ? result.value.trim().slice(0, 160)
+          : result.value
+    } else {
+      picked.value = null
+    }
+    picked.detail =
+      typeof result.detail === 'string' ? result.detail.slice(0, 240) : null
+  } else if (card.type === 'trend') {
+    picked.points = normalizeSeries(result.points, 31)
+  } else if (card.type === 'partition') {
+    picked.segments = normalizeSeries(result.segments, 12)
+  }
+  return picked
+}
+
+function normalizeSeries(value, limit) {
+  if (!Array.isArray(value)) return []
+  return value
+    .slice(0, limit)
+    .map((item) => ({
+      label:
+        typeof item?.label === 'string' ? item.label.trim().slice(0, 80) : '',
+      value: Number(item?.value)
+    }))
+    .filter((item) => item.label && Number.isFinite(item.value))
+}

--- a/assets/js/components/bridge/BridgeActionMenu.vue
+++ b/assets/js/components/bridge/BridgeActionMenu.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { Link } from '@inertiajs/vue3'
 
 const props = defineProps({
   items: {
@@ -9,6 +10,11 @@ const props = defineProps({
   label: {
     type: String,
     default: 'Actions'
+  },
+  orientation: {
+    type: String,
+    default: 'horizontal',
+    validator: (value) => ['horizontal', 'vertical'].includes(value)
   },
   disabled: Boolean,
   testId: {
@@ -23,13 +29,22 @@ const trigger = ref(null)
 const menu = ref(null)
 const open = ref(false)
 
-async function toggle() {
+async function toggle(event) {
   if (props.disabled) return
   open.value = !open.value
-  if (open.value) {
+  if (open.value && event?.detail === 0) {
     await nextTick()
     menu.value?.querySelector('[role="menuitem"]')?.focus()
   }
+}
+
+async function openFromTrigger(position) {
+  if (props.disabled) return
+  open.value = true
+  await nextTick()
+  const items = menu.value?.querySelectorAll('[role="menuitem"]')
+  const item = position === 'last' ? items?.[items.length - 1] : items?.[0]
+  item?.focus()
 }
 
 function close({ restoreFocus = false } = {}) {
@@ -42,6 +57,15 @@ function select(item) {
   trigger.value?.focus()
   close()
   emit('select', item)
+}
+
+function itemClasses(item) {
+  return [
+    'flex w-full px-3 py-2 text-left text-sm focus:outline-none disabled:cursor-not-allowed disabled:opacity-40',
+    item.destructive
+      ? 'text-red-600 hover:bg-red-50 focus:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20 dark:focus:bg-red-900/20'
+      : 'text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800'
+  ]
 }
 
 function handleKeydown(event) {
@@ -98,6 +122,9 @@ onUnmounted(() =>
       aria-haspopup="menu"
       :aria-expanded="open"
       @click.stop="toggle"
+      @keydown.down.prevent="openFromTrigger('first')"
+      @keydown.up.prevent="openFromTrigger('last')"
+      @keydown.escape.prevent="close({ restoreFocus: true })"
     >
       <svg
         class="h-4 w-4"
@@ -106,6 +133,11 @@ onUnmounted(() =>
         aria-hidden="true"
       >
         <path
+          v-if="orientation === 'vertical'"
+          d="M10 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4Zm0 6a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z"
+        />
+        <path
+          v-else
           d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"
         />
       </svg>
@@ -120,23 +152,29 @@ onUnmounted(() =>
       @click.stop
       @keydown="handleKeydown"
     >
-      <button
-        v-for="item in items"
-        :key="item.key"
-        type="button"
-        role="menuitem"
-        :disabled="item.disabled"
-        :data-test="`${testId}-${item.key}`"
-        :class="[
-          'flex w-full px-3 py-2 text-left text-sm focus:outline-none disabled:cursor-not-allowed disabled:opacity-40',
-          item.destructive
-            ? 'text-red-600 hover:bg-red-50 focus:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20 dark:focus:bg-red-900/20'
-            : 'text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800'
-        ]"
-        @click="select(item)"
-      >
-        {{ item.label }}
-      </button>
+      <template v-for="item in items" :key="item.key">
+        <Link
+          v-if="item.href && !item.disabled"
+          :href="item.href"
+          role="menuitem"
+          :data-test="`${testId}-${item.key}`"
+          :class="itemClasses(item)"
+          @click="select(item)"
+        >
+          {{ item.label }}
+        </Link>
+        <button
+          v-else
+          type="button"
+          role="menuitem"
+          :disabled="item.disabled"
+          :data-test="`${testId}-${item.key}`"
+          :class="itemClasses(item)"
+          @click="select(item)"
+        >
+          {{ item.label }}
+        </button>
+      </template>
     </div>
   </div>
 </template>

--- a/assets/js/components/bridge/BridgeDashboard.vue
+++ b/assets/js/components/bridge/BridgeDashboard.vue
@@ -1,0 +1,338 @@
+<script setup>
+import { computed } from 'vue'
+import { Link } from '@inertiajs/vue3'
+import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
+import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
+
+const props = defineProps({
+  dashboard: {
+    type: Object,
+    required: true
+  },
+  resources: {
+    type: Object,
+    required: true
+  },
+  project: {
+    type: Object,
+    required: true
+  },
+  environment: {
+    type: Object,
+    required: true
+  }
+})
+
+const actionCards = computed(() =>
+  props.dashboard.cards.filter((card) => card.type === 'action')
+)
+const quickActions = computed(() =>
+  actionCards.value.map((card) => ({
+    key: card.id,
+    label: card.label,
+    href: actionUrl(card)
+  }))
+)
+const valueCards = computed(() =>
+  props.dashboard.cards.filter((card) =>
+    ['metric', 'custom'].includes(card.type)
+  )
+)
+const detailCards = computed(() =>
+  props.dashboard.cards.filter((card) =>
+    ['recent', 'trend', 'partition'].includes(card.type)
+  )
+)
+
+function resourceUrl(identity) {
+  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${identity}`
+}
+
+function actionUrl(card) {
+  return `${resourceUrl(card.resource)}/new`
+}
+
+function recordUrl(card, record) {
+  const resource = props.resources[card.resource]
+  const id = record?.[resource?.primaryKey]
+  return `${resourceUrl(card.resource)}/${encodeURIComponent(String(id))}`
+}
+
+function cardResource(card) {
+  return props.resources[card.resource]
+}
+
+function recentTitle(card, record) {
+  const resource = cardResource(card)
+  const title = record?.[resource?.title]
+  return title ?? record?.[resource?.primaryKey] ?? 'Record'
+}
+
+function recentDetailFields(card) {
+  const resource = cardResource(card)
+  return card.fields
+    .filter(
+      (field) =>
+        field !== resource?.primaryKey &&
+        field !== resource?.title &&
+        resource?.attributes?.[field]
+    )
+    .slice(0, 2)
+}
+
+function formatValue(card) {
+  if (card.error || card.value === null || card.value === undefined) return '—'
+  if (card.type === 'custom') return String(card.value)
+
+  const value = Number(card.value)
+  if (!Number.isFinite(value)) return '—'
+  let formatted
+  if (card.format === 'currency') {
+    formatted = new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: card.currency,
+      maximumFractionDigits: 2
+    }).format(value)
+  } else if (card.format === 'compact') {
+    formatted = new Intl.NumberFormat(undefined, {
+      notation: 'compact',
+      maximumFractionDigits: 1
+    }).format(value)
+  } else if (card.format === 'percent') {
+    formatted = new Intl.NumberFormat(undefined, {
+      style: 'percent',
+      maximumFractionDigits: 1
+    }).format(value)
+  } else {
+    formatted = new Intl.NumberFormat(undefined, {
+      maximumFractionDigits: 2
+    }).format(value)
+  }
+  return `${card.prefix || ''}${formatted}${card.suffix || ''}`
+}
+
+function trendPath(points) {
+  if (!Array.isArray(points) || points.length === 0) return ''
+  if (points.length === 1) return 'M 0 32 L 240 32'
+  const values = points.map((point) => Number(point.value))
+  const min = Math.min(...values)
+  const max = Math.max(...values)
+  const range = max - min || 1
+  return points
+    .map((point, index) => {
+      const x = (index / (points.length - 1)) * 240
+      const y = 58 - ((Number(point.value) - min) / range) * 52
+      return `${index === 0 ? 'M' : 'L'} ${x.toFixed(2)} ${y.toFixed(2)}`
+    })
+    .join(' ')
+}
+
+function partitionWidth(card, value) {
+  const max = Math.max(
+    1,
+    ...(card.segments || []).map((segment) => Number(segment.value) || 0)
+  )
+  return `${Math.max(2, (Number(value) / max) * 100)}%`
+}
+</script>
+
+<template>
+  <section aria-labelledby="bridge-dashboard-title">
+    <div class="flex items-start justify-between gap-4">
+      <div class="min-w-0">
+        <h1
+          id="bridge-dashboard-title"
+          class="text-xl font-semibold tracking-tight text-gray-950 dark:text-white"
+        >
+          {{ dashboard.label }}
+        </h1>
+        <p
+          v-if="dashboard.description"
+          class="mt-1 max-w-2xl text-sm leading-6 text-gray-500 dark:text-gray-400"
+        >
+          {{ dashboard.description }}
+        </p>
+      </div>
+
+      <BridgeActionMenu
+        :items="quickActions"
+        label="Quick actions"
+        orientation="vertical"
+        test-id="bridge-dashboard-quick-actions"
+        class="shrink-0"
+      />
+    </div>
+
+    <dl
+      v-if="valueCards.length"
+      class="mt-8 grid gap-x-10 gap-y-7 sm:grid-cols-2 lg:grid-cols-4"
+    >
+      <div v-for="card in valueCards" :key="card.id" class="min-w-0">
+        <dt class="truncate text-sm text-gray-500 dark:text-gray-400">
+          {{ card.label }}
+        </dt>
+        <dd
+          class="mt-1 truncate text-3xl font-semibold tabular-nums tracking-tight text-gray-950 dark:text-white"
+          :title="card.error || undefined"
+        >
+          {{ formatValue(card) }}
+        </dd>
+        <p
+          v-if="card.error"
+          class="mt-1 truncate text-xs text-red-600 dark:text-red-400"
+        >
+          Unavailable
+        </p>
+        <p
+          v-else-if="card.detail || card.description"
+          class="mt-1 truncate text-xs text-gray-400 dark:text-gray-500"
+        >
+          {{ card.detail || card.description }}
+        </p>
+      </div>
+    </dl>
+
+    <div
+      v-if="detailCards.length"
+      class="mt-10 grid gap-x-12 gap-y-10 lg:grid-cols-2"
+    >
+      <section
+        v-for="card in detailCards"
+        :key="card.id"
+        :aria-labelledby="`bridge-card-${card.id}`"
+        class="min-w-0"
+      >
+        <div class="flex items-baseline justify-between gap-4">
+          <div class="min-w-0">
+            <h2
+              :id="`bridge-card-${card.id}`"
+              class="truncate text-sm font-medium text-gray-950 dark:text-white"
+            >
+              {{ card.label }}
+            </h2>
+            <p
+              v-if="card.description"
+              class="mt-1 truncate text-xs text-gray-400 dark:text-gray-500"
+            >
+              {{ card.description }}
+            </p>
+          </div>
+          <Link
+            v-if="card.type === 'recent'"
+            :href="resourceUrl(card.resource)"
+            class="shrink-0 text-xs font-medium text-gray-500 hover:text-gray-950 dark:text-gray-400 dark:hover:text-white"
+          >
+            View all
+          </Link>
+        </div>
+
+        <p
+          v-if="card.error"
+          class="mt-5 text-sm text-red-600 dark:text-red-400"
+        >
+          This card is temporarily unavailable.
+        </p>
+
+        <ol
+          v-else-if="card.type === 'recent' && card.records?.length"
+          class="mt-3 divide-y divide-gray-100 dark:divide-gray-900"
+        >
+          <li v-for="record in card.records" :key="recordUrl(card, record)">
+            <Link
+              :href="recordUrl(card, record)"
+              class="min-h-12 group flex items-center justify-between gap-5 py-3"
+            >
+              <span
+                class="min-w-0 truncate text-sm font-medium text-gray-800 group-hover:text-gray-950 dark:text-gray-200 dark:group-hover:text-white"
+              >
+                {{ recentTitle(card, record) }}
+              </span>
+              <span
+                v-if="recentDetailFields(card).length"
+                class="flex min-w-0 shrink items-center gap-3 overflow-hidden text-xs text-gray-400 dark:text-gray-500"
+              >
+                <span
+                  v-for="field in recentDetailFields(card)"
+                  :key="field"
+                  class="min-w-0 truncate"
+                >
+                  <BridgeFieldValue
+                    :name="field"
+                    :attribute="cardResource(card).attributes[field]"
+                    :value="record[field]"
+                    context="list"
+                  />
+                </span>
+              </span>
+            </Link>
+          </li>
+        </ol>
+
+        <p
+          v-else-if="card.type === 'recent'"
+          class="mt-5 text-sm text-gray-400 dark:text-gray-500"
+        >
+          No records yet.
+        </p>
+
+        <div v-else-if="card.type === 'trend'" class="mt-5">
+          <svg
+            v-if="card.points?.length"
+            class="h-20 w-full overflow-visible text-gray-950 dark:text-white"
+            viewBox="0 0 240 64"
+            preserveAspectRatio="none"
+            role="img"
+            :aria-label="`${card.label} trend`"
+          >
+            <path
+              :d="trendPath(card.points)"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="2"
+              vector-effect="non-scaling-stroke"
+            />
+          </svg>
+          <p v-else class="text-sm text-gray-400 dark:text-gray-500">
+            No trend data yet.
+          </p>
+          <div
+            v-if="card.points?.length"
+            class="mt-2 flex justify-between text-xs text-gray-400 dark:text-gray-500"
+          >
+            <span>{{ card.points[0].label }}</span>
+            <span>{{ card.points[card.points.length - 1].label }}</span>
+          </div>
+        </div>
+
+        <div v-else-if="card.type === 'partition'" class="mt-5 space-y-3">
+          <div v-for="segment in card.segments || []" :key="segment.label">
+            <div
+              class="mb-1.5 flex items-baseline justify-between gap-4 text-xs"
+            >
+              <span class="truncate text-gray-500 dark:text-gray-400">
+                {{ segment.label }}
+              </span>
+              <span
+                class="shrink-0 tabular-nums text-gray-800 dark:text-gray-200"
+              >
+                {{ segment.value.toLocaleString() }}
+              </span>
+            </div>
+            <div class="h-1 rounded-full bg-gray-100 dark:bg-gray-900">
+              <div
+                class="h-1 rounded-full bg-gray-800 dark:bg-gray-200"
+                :style="{ width: partitionWidth(card, segment.value) }"
+              ></div>
+            </div>
+          </div>
+          <p
+            v-if="!card.segments?.length"
+            class="text-sm text-gray-400 dark:text-gray-500"
+          >
+            No partition data yet.
+          </p>
+        </div>
+      </section>
+    </div>
+  </section>
+</template>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -8,6 +8,7 @@ import { createToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
+import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 
 defineOptions({
   layout: AppLayout
@@ -26,7 +27,10 @@ const props = defineProps({
   perPage: Number,
   sort: String,
   search: String,
-  error: String
+  error: String,
+  dashboards: Array,
+  dashboardResources: Object,
+  activeDashboard: Object
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -177,7 +181,10 @@ function navigateWithParams(updates) {
   const params = {
     page: updates.page ?? page.value,
     sort: updates.sort ?? sortValue.value,
-    search: updates.search ?? searchInput.value
+    search: updates.search ?? searchInput.value,
+    dashboard:
+      updates.dashboard ??
+      (props.dashboards?.length > 1 ? props.activeDashboard?.id : '')
   }
 
   // Clean up defaults
@@ -187,6 +194,7 @@ function navigateWithParams(updates) {
     : ''
   if (params.sort === defaultSort) delete params.sort
   if (!params.search) delete params.search
+  if (!params.dashboard) delete params.dashboard
 
   const query = new URLSearchParams(params).toString()
   const basePath = `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}`
@@ -376,6 +384,10 @@ function completeCustomAction() {
 function goToPage(newPage) {
   page.value = newPage
   navigateWithParams({ page: newPage })
+}
+
+function switchDashboard(event) {
+  navigateWithParams({ dashboard: event.target.value, page: 1 })
 }
 
 // URL builders
@@ -580,6 +592,21 @@ function createUrl() {
           </Transition>
         </div>
         <div class="flex items-center space-x-4">
+          <select
+            v-if="dashboards?.length > 1"
+            :value="activeDashboard?.id"
+            @change="switchDashboard"
+            aria-label="Bridge dashboard"
+            class="rounded-md border-0 bg-transparent py-1 pl-2 pr-7 text-sm text-gray-600 focus:ring-1 focus:ring-gray-300 dark:bg-gray-950 dark:text-gray-300 dark:focus:ring-gray-700"
+          >
+            <option
+              v-for="dashboard in dashboards"
+              :key="dashboard.id"
+              :value="dashboard.id"
+            >
+              {{ dashboard.label }}
+            </option>
+          </select>
           <span
             v-if="total > 0"
             class="text-xs text-gray-500 dark:text-gray-400"
@@ -608,6 +635,15 @@ function createUrl() {
     <!-- Content -->
     <div class="flex-1 overflow-auto px-4 py-4 sm:px-8">
       <div class="mx-auto max-w-6xl">
+        <BridgeDashboard
+          v-if="activeDashboard"
+          :dashboard="activeDashboard"
+          :resources="dashboardResources"
+          :project="project"
+          :environment="environment"
+          class="mb-10"
+        />
+
         <!-- Error -->
         <div v-if="error" class="flex h-full items-center justify-center">
           <div class="text-center">

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -2,6 +2,7 @@
 import { Link, Head, router } from '@inertiajs/vue3'
 import { inject, computed, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 
 defineOptions({
   layout: AppLayout
@@ -12,7 +13,9 @@ const props = defineProps({
   environment: Object,
   appRunning: Boolean,
   models: Object,
-  modelsError: String
+  modelsError: String,
+  dashboards: Array,
+  activeDashboard: Object
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -60,7 +63,20 @@ function bridgeModelUrl(identity) {
 }
 
 function refresh() {
-  router.reload({ only: ['models', 'modelsError'] })
+  router.reload({ only: ['models', 'modelsError', 'activeDashboard'] })
+}
+
+function switchDashboard(event) {
+  const id = event.target.value
+  router.get(
+    `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`,
+    id ? { dashboard: id } : {},
+    {
+      preserveState: true,
+      preserveScroll: true,
+      replace: true
+    }
+  )
 }
 </script>
 
@@ -193,27 +209,44 @@ function refresh() {
           <span class="font-medium text-gray-900 dark:text-white">bridge</span>
         </nav>
       </div>
-      <!-- Refresh button -->
-      <button
-        v-if="appRunning && modelList.length > 0"
-        @click="refresh"
-        class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-        title="Refresh models"
-      >
-        <svg
-          class="h-4 w-4"
-          fill="none"
-          stroke="currentColor"
-          viewBox="0 0 24 24"
+      <div class="flex items-center gap-2">
+        <select
+          v-if="dashboards?.length > 1"
+          :value="activeDashboard?.id"
+          @change="switchDashboard"
+          aria-label="Bridge dashboard"
+          class="rounded-md border-0 bg-transparent py-1 pl-2 pr-7 text-sm text-gray-600 focus:ring-1 focus:ring-gray-300 dark:bg-gray-950 dark:text-gray-300 dark:focus:ring-gray-700"
         >
-          <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-          />
-        </svg>
-      </button>
+          <option
+            v-for="dashboard in dashboards"
+            :key="dashboard.id"
+            :value="dashboard.id"
+          >
+            {{ dashboard.label }}
+          </option>
+        </select>
+        <button
+          v-if="appRunning && (modelList.length > 0 || activeDashboard)"
+          @click="refresh"
+          class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
+          title="Refresh Bridge"
+          aria-label="Refresh Bridge"
+        >
+          <svg
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+        </button>
+      </div>
     </div>
 
     <!-- Content -->
@@ -306,7 +339,7 @@ function refresh() {
 
       <!-- No models -->
       <div
-        v-else-if="modelList.length === 0"
+        v-else-if="modelList.length === 0 && !activeDashboard"
         class="flex h-full items-center justify-center"
       >
         <div class="text-center">
@@ -336,10 +369,24 @@ function refresh() {
         </div>
       </div>
 
-      <!-- Models dashboard -->
+      <!-- Bridge dashboard and resources -->
       <div v-else class="mx-auto max-w-6xl px-4 py-6 sm:px-8">
+        <BridgeDashboard
+          v-if="activeDashboard"
+          :dashboard="activeDashboard"
+          :resources="models"
+          :project="project"
+          :environment="environment"
+        />
+
         <!-- Toolbar -->
-        <div class="mb-4 flex items-center justify-between">
+        <div
+          v-if="modelList.length > 0"
+          :class="[
+            'mb-4 flex items-center justify-between',
+            activeDashboard ? 'mt-12' : ''
+          ]"
+        >
           <input
             v-model="searchQuery"
             type="text"
@@ -355,7 +402,10 @@ function refresh() {
         </div>
 
         <!-- Resources table -->
-        <div class="rounded-lg border border-gray-200 dark:border-gray-800">
+        <div
+          v-if="modelList.length > 0"
+          class="rounded-lg border border-gray-200 dark:border-gray-800"
+        >
           <!-- Table Header -->
           <div
             class="grid grid-cols-12 gap-4 rounded-t-lg border-b border-gray-200 bg-gray-50/50 px-6 py-2 text-xs font-medium text-gray-500 dark:border-gray-800 dark:bg-gray-900/50"

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -133,6 +133,153 @@ module.exports.slipway = {
 
 A resource can also be removed from Bridge with `false` or `hidden: true`.
 
+## Dashboards
+
+Bridge can turn the resource directory into an application-specific dashboard
+without adding a second analytics service. Dashboard cards are configured in
+the target application's `config/slipway.js`, resolved through Waterline or
+target-app helpers, and returned as ordinary server-rendered Inertia props.
+
+Use `dashboard` for one dashboard:
+
+```js
+module.exports.slipway = {
+  bridge: {
+    dashboard: {
+      label: 'Content overview',
+      description: 'The content and audience signals that need attention.',
+      cards: {
+        users: {
+          type: 'metric',
+          label: 'Total users',
+          resource: 'user',
+          aggregate: 'count'
+        },
+        courses: {
+          type: 'metric',
+          resource: 'course',
+          aggregate: 'count',
+          where: { published: true }
+        },
+        recentLessons: {
+          type: 'recent',
+          resource: 'lesson',
+          fields: ['title', 'createdAt'],
+          limit: 5
+        },
+        recentSignups: {
+          type: 'recent',
+          resource: 'user',
+          fields: ['fullName', 'email', 'createdAt'],
+          limit: 5
+        },
+        newCourse: {
+          type: 'action',
+          resource: 'course'
+        },
+        newChapter: {
+          type: 'action',
+          resource: 'chapter'
+        },
+        newLesson: {
+          type: 'action',
+          resource: 'lesson'
+        }
+      }
+    }
+  }
+}
+```
+
+Use `dashboards` when an application needs more than one:
+
+```js
+bridge: {
+  dashboards: {
+    overview: {
+      default: true,
+      scope: 'environment',
+      cards: {
+        users: {
+          type: 'metric',
+          resource: 'user'
+        }
+      }
+    },
+    courseHealth: {
+      scope: 'resource',
+      resource: 'course',
+      cards: {
+        published: {
+          type: 'metric',
+          resource: 'course',
+          aggregate: 'count',
+          where: { published: true }
+        }
+      }
+    }
+  }
+}
+```
+
+Dashboard scope may be `global`, `project`, `environment`, or `resource`.
+Global, project, and environment dashboards appear on the Bridge landing page.
+A resource-scoped dashboard appears above that resource's record table and
+requires its `resource` identity. A contract may contain up to 12 dashboards
+and 24 cards per dashboard.
+
+### Card types
+
+| Type        | Source                  | Result                                |
+| ----------- | ----------------------- | ------------------------------------- |
+| `metric`    | Waterline               | Count, sum, average, minimum, maximum |
+| `recent`    | Waterline               | Up to 10 recent records               |
+| `action`    | Bridge resource action  | A link to create a record             |
+| `trend`     | Target-app Sails helper | Up to 31 labelled points              |
+| `partition` | Target-app Sails helper | Up to 12 labelled segments            |
+| `custom`    | Target-app Sails helper | A value and optional detail           |
+
+`metric.aggregate` accepts `count`, `sum`, `average`, `min`, or `max`.
+Non-count metrics require a numeric `field`. `format` accepts `number`,
+`compact`, `currency`, or `percent`; currency cards also require a three-letter
+`currency` code. `where` may use only fields already available on the
+resource's list or filter surface.
+
+Trend, partition, and custom helpers receive the current `actor`, a small
+`dashboard` description, and the configured `card`:
+
+```js
+// api/helpers/bridge/dashboard/signups.js
+module.exports = {
+  friendlyName: 'Bridge signup trend',
+
+  inputs: {
+    actor: { type: 'ref', required: true },
+    dashboard: { type: 'ref', required: true },
+    card: { type: 'ref', required: true }
+  },
+
+  fn: async function () {
+    return {
+      points: [
+        { label: 'Mon', value: 18 },
+        { label: 'Tue', value: 26 },
+        { label: 'Wed', value: 21 }
+      ]
+    }
+  }
+}
+```
+
+Custom cards return `{ value, detail }`. Partition helpers return
+`{ segments: [{ label, value }] }`. Helper results are length-limited and
+re-normalized before becoming Inertia props.
+
+Dashboard cards use the same authorization boundary as their resources.
+Metrics and recent records require `viewAny`; create actions require `create`;
+hidden and denied resources remove their cards entirely. Recent records are
+selected from configured fields and redacted again before rendering.
+
 ## Server enforcement
 
 The contract is an authorization boundary, not presentation-only metadata.

--- a/tests/e2e/pages/projects/bridge-dashboard.test.js
+++ b/tests/e2e/pages/projects/bridge-dashboard.test.js
@@ -1,0 +1,384 @@
+const fs = require('fs')
+const path = require('path')
+
+const { test } = require('sounding')
+
+test(
+  'Bridge renders an authorized target-app dashboard in the minimal Slipway UI',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-dashboard-ui',
+          name: 'Bridge Dashboard UI'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const screenshotRoot = path.resolve('.tmp/screenshots/issue-222-dashboard')
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: dashboardConfig()
+    })
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'running',
+      containerName: 'bridge-dashboard-ui-web'
+    })
+    sails.helpers.bridge.introspectModels = async () => ({
+      schemaVersion: contract.schemaVersion,
+      discover: contract.discover,
+      configured: contract.configured,
+      models: contract.resources,
+      dashboards: contract.dashboards
+    })
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-dashboard-ui-web')
+
+      if (code.includes('const decisions = Object.create(null);')) {
+        const requests = readEmbeddedValue(code, 'requests')
+        const decisions = {}
+        for (const request of requests) {
+          decisions[request.key] = decisions[request.key] || {}
+          decisions[request.key][request.action] = true
+        }
+        return successfulResult(decisions)
+      }
+      if (code.includes('const dashboard =')) {
+        return successfulResult([
+          { id: 'users', value: 1248 },
+          { id: 'courses', value: 42 },
+          { id: 'lessons', value: 286 },
+          {
+            id: 'recentLessons',
+            records: [
+              {
+                id: 91,
+                title: 'Make production failures boring',
+                createdAt: Date.UTC(2026, 6, 27, 10, 15)
+              },
+              {
+                id: 90,
+                title: 'A legible release boundary',
+                createdAt: Date.UTC(2026, 6, 26, 15, 40)
+              },
+              {
+                id: 89,
+                title: 'The server is raw land',
+                createdAt: Date.UTC(2026, 6, 25, 8, 5)
+              }
+            ]
+          },
+          {
+            id: 'recentSignups',
+            records: [
+              {
+                id: 301,
+                fullName: 'Ada Lovelace',
+                email: 'ada@example.com',
+                createdAt: Date.UTC(2026, 6, 27, 11, 30)
+              },
+              {
+                id: 300,
+                fullName: 'Grace Hopper',
+                email: 'grace@example.com',
+                createdAt: Date.UTC(2026, 6, 26, 18, 20)
+              }
+            ]
+          },
+          { id: 'newCourse' },
+          { id: 'newChapter' },
+          { id: 'newLesson' },
+          {
+            id: 'signupTrend',
+            points: [
+              { label: 'Mon', value: 18 },
+              { label: 'Tue', value: 26 },
+              { label: 'Wed', value: 21 },
+              { label: 'Thu', value: 34 },
+              { label: 'Fri', value: 41 },
+              { label: 'Sat', value: 37 },
+              { label: 'Sun', value: 52 }
+            ]
+          },
+          {
+            id: 'lessonStatus',
+            segments: [
+              { label: 'Published', value: 214 },
+              { label: 'Draft', value: 58 },
+              { label: 'Review', value: 14 }
+            ]
+          }
+        ])
+      }
+      if (code.includes('const counts = {};')) {
+        return successfulResult({
+          user: 1248,
+          course: 42,
+          chapter: 74,
+          lesson: 286
+        })
+      }
+      return {
+        success: false,
+        output: '',
+        error: 'Unexpected Bridge dashboard execution.',
+        exitCode: 1
+      }
+    }
+
+    try {
+      await page.raw.route('**/api/v1/system/check-update', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ updateAvailable: false })
+        })
+      })
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await page.raw.waitForURL((url) => !url.pathname.startsWith('/login'), {
+        timeout: 10000
+      })
+
+      const bridgePath = `/projects/${project.slug}/environments/${environment.slug}/bridge`
+      await page.goto(bridgePath)
+      await page.wait('text=Content overview')
+
+      await expect(page).toSee('Total users')
+      await expect(page).toSee('1,248')
+      await expect(page).toSee('42')
+      await expect(page).toSee('286')
+      await expect(page).toSee('Make production failures boring')
+      await expect(page).toSee('Ada Lovelace')
+      expect(
+        await page.raw.getByRole('button', { name: 'Quick actions' }).count()
+      ).toBe(1)
+      expect(
+        await page.raw.getByRole('menuitem', { name: 'New Course' }).count()
+      ).toBe(0)
+
+      await page.raw.getByRole('button', { name: 'Quick actions' }).click()
+      await page.raw.getByRole('menu').waitFor()
+      expect(
+        await page.raw
+          .getByRole('menuitem', { name: 'New Course' })
+          .getAttribute('href')
+      ).toBe(`${bridgePath}/course/new`)
+      expect(
+        await page.raw
+          .getByRole('menuitem', { name: 'New Chapter' })
+          .getAttribute('href')
+      ).toBe(`${bridgePath}/chapter/new`)
+      expect(
+        await page.raw
+          .getByRole('menuitem', { name: 'New Lesson' })
+          .getAttribute('href')
+      ).toBe(`${bridgePath}/lesson/new`)
+      await page.screenshot(
+        path.join(screenshotRoot, 'quick-actions-light.png'),
+        {
+          fullPage: true
+        }
+      )
+      await page.raw.keyboard.press('Escape')
+      expect(await page.raw.getByRole('menu').count()).toBe(0)
+      await page.raw.mouse.click(800, 400)
+
+      await page.screenshot(path.join(screenshotRoot, 'dashboard-light.png'), {
+        fullPage: true
+      })
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.raw.waitForTimeout(400)
+      await page.screenshot(path.join(screenshotRoot, 'dashboard-dark.png'), {
+        fullPage: true
+      })
+      await page.raw.getByRole('button', { name: 'Quick actions' }).click()
+      await page.raw.getByRole('menu').waitFor()
+      await page.screenshot(
+        path.join(screenshotRoot, 'quick-actions-dark.png'),
+        {
+          fullPage: true
+        }
+      )
+      await page.raw.keyboard.press('Escape')
+      await page.raw.mouse.click(800, 400)
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw.waitForTimeout(400)
+      await page.resize(390, 844)
+      await page.screenshot(path.join(screenshotRoot, 'dashboard-mobile.png'), {
+        fullPage: true
+      })
+      await page.raw.getByRole('button', { name: 'Quick actions' }).click()
+      await page.raw.getByRole('menu').waitFor()
+      await page.screenshot(
+        path.join(screenshotRoot, 'quick-actions-mobile.png'),
+        {
+          fullPage: true
+        }
+      )
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
+}
+
+function dashboardConfig() {
+  return {
+    discover: false,
+    resources: {
+      user: {
+        label: 'Users',
+        title: 'fullName',
+        list: ['fullName', 'email', 'createdAt']
+      },
+      course: {
+        label: 'Courses',
+        title: 'title',
+        list: ['title', 'published', 'createdAt']
+      },
+      chapter: {
+        label: 'Chapters',
+        title: 'title',
+        list: ['title', 'createdAt']
+      },
+      lesson: {
+        label: 'Lessons',
+        title: 'title',
+        list: ['title', 'published', 'createdAt']
+      }
+    },
+    dashboard: {
+      label: 'Content overview',
+      description: 'The content and audience signals that need attention.',
+      cards: {
+        users: {
+          type: 'metric',
+          label: 'Total users',
+          resource: 'user'
+        },
+        courses: {
+          type: 'metric',
+          label: 'Courses',
+          resource: 'course'
+        },
+        lessons: {
+          type: 'metric',
+          label: 'Lessons',
+          resource: 'lesson'
+        },
+        recentLessons: {
+          type: 'recent',
+          label: 'Recent lessons',
+          resource: 'lesson',
+          fields: ['title', 'createdAt'],
+          limit: 3
+        },
+        recentSignups: {
+          type: 'recent',
+          label: 'Recent signups',
+          resource: 'user',
+          fields: ['fullName', 'email', 'createdAt'],
+          limit: 3
+        },
+        newCourse: {
+          type: 'action',
+          label: 'New Course',
+          resource: 'course'
+        },
+        newChapter: {
+          type: 'action',
+          label: 'New Chapter',
+          resource: 'chapter'
+        },
+        newLesson: {
+          type: 'action',
+          label: 'New Lesson',
+          resource: 'lesson'
+        },
+        signupTrend: {
+          type: 'trend',
+          label: 'Signups this week',
+          resource: 'user',
+          helper: 'bridge.dashboard.signups'
+        },
+        lessonStatus: {
+          type: 'partition',
+          label: 'Lesson status',
+          resource: 'lesson',
+          helper: 'bridge.dashboard.lessonStatus'
+        }
+      }
+    }
+  }
+}
+
+function modelMetadata() {
+  return {
+    user: model('user', 'User', {
+      id: { type: 'number', autoIncrement: true },
+      fullName: { type: 'string', required: true },
+      email: { type: 'string', required: true, isEmail: true },
+      createdAt: { type: 'number', autoCreatedAt: true }
+    }),
+    course: model('course', 'Course', {
+      id: { type: 'number', autoIncrement: true },
+      title: { type: 'string', required: true },
+      published: { type: 'boolean', defaultsTo: false },
+      createdAt: { type: 'number', autoCreatedAt: true }
+    }),
+    chapter: model('chapter', 'Chapter', {
+      id: { type: 'number', autoIncrement: true },
+      title: { type: 'string', required: true },
+      createdAt: { type: 'number', autoCreatedAt: true }
+    }),
+    lesson: model('lesson', 'Lesson', {
+      id: { type: 'number', autoIncrement: true },
+      title: { type: 'string', required: true },
+      published: { type: 'boolean', defaultsTo: false },
+      createdAt: { type: 'number', autoCreatedAt: true }
+    })
+  }
+}
+
+function model(identity, globalId, attributes) {
+  return {
+    identity,
+    globalId,
+    tableName: identity,
+    primaryKey: 'id',
+    attributes,
+    associations: []
+  }
+}

--- a/tests/functional/pages/bridge-dashboard.test.js
+++ b/tests/functional/pages/bridge-dashboard.test.js
@@ -1,0 +1,182 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'Bridge filters dashboard data and quick actions through target-app authorization',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-dashboard-authorization',
+          name: 'Bridge dashboard authorization'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          user: {
+            authorization: 'bridge.authorize'
+          },
+          course: {
+            authorization: 'bridge.authorize'
+          }
+        },
+        dashboard: {
+          cards: {
+            users: {
+              type: 'metric',
+              resource: 'user'
+            },
+            courses: {
+              type: 'recent',
+              resource: 'course',
+              fields: ['title', 'createdAt']
+            },
+            newCourse: {
+              type: 'action',
+              resource: 'course'
+            }
+          }
+        }
+      }
+    })
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-dashboard-authorization-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources,
+        dashboards: contract.dashboards
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-dashboard-authorization-web')
+        if (code.includes('const decisions = Object.create(null);')) {
+          const requests = readEmbeddedValue(code, 'requests')
+          const decisions = {}
+          for (const authorizationRequest of requests) {
+            decisions[authorizationRequest.key] =
+              decisions[authorizationRequest.key] || {}
+            decisions[authorizationRequest.key][authorizationRequest.action] =
+              authorizationRequest.key === 'course' &&
+              authorizationRequest.action === 'viewAny'
+          }
+          return successfulResult(decisions)
+        }
+        if (code.includes('const dashboard =')) {
+          const definitions = readEmbeddedValue(code, 'definitions')
+          expect(definitions.map((definition) => definition.id)).toEqual([
+            'courses'
+          ])
+          return successfulResult([
+            {
+              id: 'courses',
+              records: [
+                {
+                  id: 11,
+                  title: 'A safe dashboard',
+                  createdAt: Date.UTC(2026, 6, 27, 8, 15)
+                }
+              ]
+            }
+          ])
+        }
+        if (code.includes('const counts = {};')) {
+          return successfulResult({ course: 1 })
+        }
+        return failedResult('Unexpected Bridge dashboard query.')
+      }
+
+      const browser = await withCsrfFromPage(
+        request,
+        '/projects/new',
+        'genesisUser'
+      )
+      const response = await browser.request.get(
+        `/projects/${project.slug}/environments/${environment.slug}/bridge`
+      )
+
+      expect(response).toHaveStatus(200)
+      expect(response).toHaveInertiaProp(
+        'activeDashboard.cards.0.id',
+        'courses'
+      )
+      expect(response).toHaveInertiaProp(
+        'activeDashboard.cards.0.records.0.title',
+        'A safe dashboard'
+      )
+      expect(response.data.props.models.user).toBe(undefined)
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function failedResult(error) {
+  return {
+    success: false,
+    output: '',
+    error,
+    exitCode: 1
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
+}
+
+function modelMetadata() {
+  return {
+    user: model('user', 'User', {
+      id: { type: 'number', autoIncrement: true },
+      fullName: { type: 'string', required: true },
+      createdAt: { type: 'number', autoCreatedAt: true }
+    }),
+    course: model('course', 'Course', {
+      id: { type: 'number', autoIncrement: true },
+      title: { type: 'string', required: true },
+      createdAt: { type: 'number', autoCreatedAt: true }
+    })
+  }
+}
+
+function model(identity, globalId, attributes) {
+  return {
+    identity,
+    globalId,
+    tableName: identity,
+    primaryKey: 'id',
+    attributes,
+    associations: []
+  }
+}

--- a/tests/unit/helpers/bridge/dashboard.test.js
+++ b/tests/unit/helpers/bridge/dashboard.test.js
@@ -1,0 +1,463 @@
+const { test } = require('sounding')
+
+test('Bridge normalizes dashboard metrics, recent records, quick actions, and helper cards', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      dashboards: {
+        overview: {
+          label: 'Content overview',
+          default: true,
+          scope: 'environment',
+          cards: {
+            users: {
+              type: 'metric',
+              label: 'Total users',
+              resource: 'user',
+              aggregate: 'count'
+            },
+            courses: {
+              type: 'metric',
+              resource: 'course',
+              aggregate: 'count',
+              where: { published: true }
+            },
+            lessons: {
+              type: 'recent',
+              resource: 'lesson',
+              fields: ['title', 'createdAt'],
+              limit: 4
+            },
+            newCourse: {
+              type: 'action',
+              resource: 'course'
+            },
+            signups: {
+              type: 'trend',
+              resource: 'user',
+              helper: 'bridge.dashboard.signups'
+            }
+          }
+        }
+      }
+    }
+  })
+
+  const dashboard = contract.dashboards.overview
+  expect(dashboard.label).toBe('Content overview')
+  expect(dashboard.default).toBe(true)
+  expect(dashboard.scope).toBe('environment')
+  expect(dashboard.cards.map((card) => card.type)).toEqual([
+    'metric',
+    'metric',
+    'recent',
+    'action',
+    'trend'
+  ])
+  expect(dashboard.cards[1].where).toEqual({ published: true })
+  expect(dashboard.cards[2].fields).toEqual(['id', 'title', 'createdAt'])
+  expect(dashboard.cards[3].label).toBe('New Course')
+})
+
+test('Bridge dashboard configuration fails closed for hidden resources and unsafe criteria', async ({
+  sails,
+  expect
+}) => {
+  let hiddenResourceError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          user: false
+        },
+        dashboard: {
+          cards: {
+            users: {
+              type: 'metric',
+              resource: 'user'
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    hiddenResourceError = error
+  }
+  expect(hiddenResourceError.message).toContain(
+    'cannot reference hidden resource "user"'
+  )
+
+  let unsafeCriteriaError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        dashboard: {
+          cards: {
+            users: {
+              type: 'metric',
+              resource: 'user',
+              where: {
+                createdAt: {
+                  '>': Number.POSITIVE_INFINITY
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    unsafeCriteriaError = error
+  }
+  expect(unsafeCriteriaError.message).toContain(
+    'must contain only serializable values'
+  )
+})
+
+test('Bridge resolves count metrics and bounded recent records through Waterline', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      dashboard: {
+        label: 'Overview',
+        cards: {
+          users: {
+            type: 'metric',
+            label: 'Total users',
+            resource: 'user'
+          },
+          lessons: {
+            type: 'recent',
+            label: 'Recent lessons',
+            resource: 'lesson',
+            fields: ['title', 'createdAt'],
+            limit: 2
+          }
+        }
+      }
+    }
+  })
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-dashboard-web')
+      expect(code).toContain('value = await model.count(definition.where)')
+      expect(code).toContain('limit: definition.limit')
+
+      const run = new Function('sails', `return (async () => {${code}})();`)
+      const output = await run({
+        models: {
+          user: {
+            count: async () => 128
+          },
+          lesson: {
+            find: async (criteria) => {
+              expect(criteria.limit).toBe(2)
+              expect(criteria.sort).toBe('createdAt DESC')
+              return [
+                {
+                  id: 7,
+                  title: 'Deploy without surprises',
+                  createdAt: Date.UTC(2026, 6, 26, 9, 15),
+                  internalToken: 'must-not-leak'
+                },
+                {
+                  id: 6,
+                  title: 'Build a boring release',
+                  createdAt: Date.UTC(2026, 6, 25, 16, 30),
+                  internalToken: 'must-not-leak'
+                }
+              ]
+            }
+          }
+        },
+        helpers: {}
+      })
+      return successfulResult(output)
+    }
+
+    const dashboard = await sails.helpers.bridge.resolveDashboard.with({
+      containerName: 'bridge-dashboard-web',
+      dashboard: contract.dashboards.overview,
+      resources: contract.resources,
+      actor: {
+        id: '1',
+        email: 'admin@example.com',
+        role: 'admin'
+      }
+    })
+
+    expect(dashboard.cards[0].value).toBe(128)
+    expect(dashboard.cards[1].records).toEqual([
+      {
+        id: 7,
+        title: 'Deploy without surprises',
+        createdAt: Date.UTC(2026, 6, 26, 9, 15)
+      },
+      {
+        id: 6,
+        title: 'Build a boring release',
+        createdAt: Date.UTC(2026, 6, 25, 16, 30)
+      }
+    ])
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+test('Bridge removes dashboard cards when resource authorization denies their data or action', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      dashboard: {
+        cards: {
+          users: {
+            type: 'metric',
+            resource: 'user'
+          },
+          lessons: {
+            type: 'recent',
+            resource: 'lesson'
+          },
+          newCourse: {
+            type: 'action',
+            resource: 'course'
+          }
+        }
+      }
+    }
+  })
+  const resources = JSON.parse(JSON.stringify(contract.resources))
+  resources.user.actions.viewAny = false
+  resources.course.actions.create = false
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+
+  try {
+    sails.helpers.bridge.executeInContainer = async () =>
+      successfulResult([
+        {
+          id: 'lessons',
+          records: []
+        }
+      ])
+
+    const dashboard = await sails.helpers.bridge.resolveDashboard.with({
+      containerName: 'bridge-dashboard-web',
+      dashboard: contract.dashboards.overview,
+      resources,
+      actor: {
+        id: '1',
+        email: 'editor@example.com',
+        role: 'editor'
+      }
+    })
+
+    expect(dashboard.cards.map((card) => card.id)).toEqual(['lessons'])
+  } finally {
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+test('Bridge resolves aggregate and helper-backed dashboard cards with bounded output', async ({
+  sails,
+  expect
+}) => {
+  const models = modelMetadata()
+  models.course.attributes.price = { type: 'number', required: true }
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models,
+    config: {
+      resources: {
+        course: {
+          list: ['title', 'createdAt'],
+          show: ['id', 'title', 'price', 'createdAt']
+        }
+      },
+      dashboard: {
+        cards: {
+          revenue: {
+            type: 'metric',
+            resource: 'course',
+            aggregate: 'sum',
+            field: 'price',
+            format: 'currency',
+            currency: 'usd'
+          },
+          averagePrice: {
+            type: 'metric',
+            resource: 'course',
+            aggregate: 'average',
+            field: 'price'
+          },
+          highestPrice: {
+            type: 'metric',
+            resource: 'course',
+            aggregate: 'max',
+            field: 'price'
+          },
+          lowestPrice: {
+            type: 'metric',
+            resource: 'course',
+            aggregate: 'min',
+            field: 'price'
+          },
+          growth: {
+            type: 'trend',
+            resource: 'course',
+            helper: 'bridge.dashboard.growth'
+          },
+          status: {
+            type: 'partition',
+            resource: 'course',
+            helper: 'bridge.dashboard.status'
+          },
+          note: {
+            type: 'custom',
+            helper: 'bridge.dashboard.note'
+          }
+        }
+      }
+    }
+  })
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (_containerName, code) => {
+      const run = new Function('sails', `return (async () => {${code}})();`)
+      const helper = (result) => ({ with: async () => result })
+      const output = await run({
+        models: {
+          course: {
+            sum: () => ({ where: async () => 9400 }),
+            avg: () => ({ where: async () => 2350 }),
+            find: async ({ sort }) =>
+              sort === 'price DESC'
+                ? [{ id: 1, price: 4900 }]
+                : [{ id: 2, price: 900 }]
+          }
+        },
+        helpers: {
+          bridge: {
+            dashboard: {
+              growth: helper({
+                points: Array.from({ length: 40 }, (_, index) => ({
+                  label: `Day ${index + 1}`,
+                  value: index
+                }))
+              }),
+              status: helper({
+                segments: [
+                  { label: 'Published', value: 3 },
+                  { label: 'Draft', value: 1 }
+                ]
+              }),
+              note: helper({
+                value: 'Healthy',
+                detail: 'All content checks passed.'
+              })
+            }
+          }
+        }
+      })
+      return successfulResult(output)
+    }
+
+    const dashboard = await sails.helpers.bridge.resolveDashboard.with({
+      containerName: 'bridge-dashboard-web',
+      dashboard: contract.dashboards.overview,
+      resources: contract.resources,
+      actor: { id: '1', email: 'admin@example.com', role: 'admin' }
+    })
+    const results = Object.fromEntries(
+      dashboard.cards.map((card) => [card.id, card])
+    )
+
+    expect(results.revenue.value).toBe(9400)
+    expect(results.revenue.currency).toBe('USD')
+    expect(results.averagePrice.value).toBe(2350)
+    expect(results.highestPrice.value).toBe(4900)
+    expect(results.lowestPrice.value).toBe(900)
+    expect(results.growth.points.length).toBe(31)
+    expect(results.status.segments).toEqual([
+      { label: 'Published', value: 3 },
+      { label: 'Draft', value: 1 }
+    ])
+    expect(results.note.value).toBe('Healthy')
+    expect(results.note.detail).toBe('All content checks passed.')
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+function successfulResult(value) {
+  return {
+    success: true,
+    output: JSON.stringify(value),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function modelMetadata() {
+  return {
+    user: model({
+      identity: 'user',
+      globalId: 'User',
+      attributes: {
+        id: { type: 'number', autoIncrement: true },
+        fullName: { type: 'string', required: true },
+        email: { type: 'string', required: true, isEmail: true },
+        createdAt: { type: 'number', autoCreatedAt: true }
+      }
+    }),
+    course: model({
+      identity: 'course',
+      globalId: 'Course',
+      attributes: {
+        id: { type: 'number', autoIncrement: true },
+        title: { type: 'string', required: true },
+        published: { type: 'boolean', defaultsTo: false },
+        createdAt: { type: 'number', autoCreatedAt: true }
+      }
+    }),
+    lesson: model({
+      identity: 'lesson',
+      globalId: 'Lesson',
+      attributes: {
+        id: { type: 'number', autoIncrement: true },
+        title: { type: 'string', required: true },
+        createdAt: { type: 'number', autoCreatedAt: true },
+        internalToken: { type: 'string', protect: true }
+      }
+    })
+  }
+}
+
+function model({ identity, globalId, attributes }) {
+  return {
+    identity,
+    globalId,
+    tableName: identity,
+    primaryKey: 'id',
+    attributes,
+    associations: []
+  }
+}


### PR DESCRIPTION
## Summary

- add a normalized Bridge dashboard contract for metrics, recent records, trends, partitions, custom values, and create actions
- resolve dashboard data inside the target Sails app with per-resource authorization, bounded queries, and isolated card failures
- render configurable dashboards at both the Bridge root and resource scopes
- consolidate create actions into the existing accessible quick-actions menu, using a minimal vertical-ellipsis trigger
- document the dashboard contract and its operational limits inside the Slipway repository

## Product impact

Bridge can now act as a focused, app-native operational dashboard instead of only a resource browser. Teams can expose the signals and shortcuts relevant to each application while retaining the same authorization boundary as the underlying resources. Expensive or broken cards fail independently, so one widget cannot take down the whole dashboard.

## Validation

- `npm run test:unit` — 188 passed
- `npm run test:functional` — 52 passed
- `npm run test:e2e` — 21 passed
- focused Bridge dashboard browser trial — passed
- `npm run lint` — passed
- light, dark, and 390px mobile states reviewed from generated browser screenshots

Closes #222