### PR TITLE
feat(bridge): add secure app-local access

### DIFF
--- a/api/controllers/api/v1/bridge/exchange.js
+++ b/api/controllers/api/v1/bridge/exchange.js
@@ -1,0 +1,181 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Exchange host Bridge identity',
+
+  description:
+    'Exchange an authenticated host-app user for a short-lived Bridge launch URL.',
+
+  inputs: {
+    appId: {
+      type: 'string',
+      required: true
+    },
+    hostUser: {
+      type: 'json',
+      required: true
+    },
+    inviteToken: {
+      type: 'string'
+    }
+  },
+
+  exits: {
+    success: {
+      statusCode: 201
+    },
+    badRequest: {
+      statusCode: 400
+    },
+    unauthorized: {
+      statusCode: 401
+    },
+    forbidden: {
+      statusCode: 403
+    }
+  },
+
+  fn: async function ({ appId, hostUser, inviteToken }) {
+    const presentedSecret = bearerToken(this.req)
+    const app = await App.findOne({ id: appId }).decrypt()
+
+    if (
+      !app ||
+      !app.bridgeEnabled ||
+      !app.bridgeSecret ||
+      !safeEqual(presentedSecret, app.bridgeSecret)
+    ) {
+      throw 'unauthorized'
+    }
+
+    const email = normalizeEmail(hostUser?.email)
+    const hostUserId = normalizeIdentifier(hostUser?.id)
+    const fullName = normalizeName(hostUser?.fullName)
+
+    if (!email || !hostUserId || hostUser?.emailVerified !== true) {
+      throw {
+        badRequest: {
+          error:
+            'Bridge requires an authenticated host-app user with a verified email address.'
+        }
+      }
+    }
+
+    const access = await BridgeAccess.findOne({
+      app: app.id,
+      email
+    })
+
+    if (!access || access.status === 'revoked') {
+      throw 'forbidden'
+    }
+
+    if (
+      access.status === 'active' &&
+      String(access.hostUserId) !== hostUserId
+    ) {
+      sails.log.warn(
+        `Bridge identity mismatch for ${email} on app ${app.id}; denying exchange.`
+      )
+      throw 'forbidden'
+    }
+
+    let currentAccess = access
+    let activated = false
+    if (access.status === 'pending') {
+      currentAccess = inviteToken
+        ? await sails.helpers.bridge.activateInvitation.with({
+            accessId: access.id,
+            inviteToken,
+            hostUserId,
+            hostUserName: fullName
+          })
+        : null
+
+      // Duplicate requests from the identity that just activated the
+      // invitation are harmless. A competing identity must never win.
+      if (!currentAccess) {
+        const racedAccess = await BridgeAccess.findOne({ id: access.id })
+        if (
+          !racedAccess ||
+          racedAccess.status !== 'active' ||
+          String(racedAccess.hostUserId) !== hostUserId
+        ) {
+          throw 'forbidden'
+        }
+        currentAccess = racedAccess
+      } else {
+        activated = true
+      }
+    } else {
+      currentAccess = await BridgeAccess.updateOne({
+        id: access.id,
+        status: 'active',
+        hostUserId
+      }).set({
+        hostUserName: fullName,
+        lastUsedAt: Date.now()
+      })
+      if (!currentAccess) throw 'forbidden'
+    }
+
+    const code = await sails.helpers.bridge.issueLaunchCode.with({
+      accessId: currentAccess.id,
+      appId: app.id
+    })
+    const instanceUrl = await sails.helpers.getInstanceUrl()
+
+    await sails.helpers.audit.log.with({
+      action: activated ? 'bridge.access.activated' : 'bridge.access.exchanged',
+      resourceType: 'app',
+      resourceId: String(app.id),
+      teamId: String(access.team),
+      ipAddress: this.req.ip,
+      details: {
+        email,
+        role: currentAccess.role,
+        hostUserId
+      }
+    })
+
+    return {
+      launchUrl: `${instanceUrl.replace(
+        /\/$/,
+        ''
+      )}/bridge/launch?code=${encodeURIComponent(code)}`
+    }
+  }
+}
+
+function bearerToken(req) {
+  const value = req.get('authorization') || ''
+  return value.startsWith('Bearer ') ? value.slice(7) : ''
+}
+
+function safeEqual(left, right) {
+  if (!left || !right) return false
+  const leftBuffer = Buffer.from(left)
+  const rightBuffer = Buffer.from(right)
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    crypto.timingSafeEqual(leftBuffer, rightBuffer)
+  )
+}
+
+function normalizeEmail(value) {
+  const email = String(value || '')
+    .trim()
+    .toLowerCase()
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : null
+}
+
+function normalizeIdentifier(value) {
+  if (value === undefined || value === null) return null
+  const identifier = String(value).trim()
+  return identifier && identifier.length <= 255 ? identifier : null
+}
+
+function normalizeName(value) {
+  const name = String(value || '').trim()
+  return name ? name.slice(0, 200) : null
+}

--- a/api/controllers/bridge/launch.js
+++ b/api/controllers/bridge/launch.js
@@ -1,0 +1,92 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Launch Bridge',
+
+  description:
+    'Consume a host-issued launch code and establish a dedicated Bridge session.',
+
+  inputs: {
+    code: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      responseType: 'redirect'
+    },
+    forbidden: {
+      responseType: 'redirect'
+    }
+  },
+
+  fn: async function ({ code }) {
+    const tokenHash = crypto.createHash('sha256').update(code).digest('hex')
+    const launchCode = await sails.helpers.bridge.consumeLaunchCode(tokenHash)
+    if (!launchCode) {
+      throw { forbidden: '/login?error=bridge_link_expired' }
+    }
+
+    const access = await BridgeAccess.findOne({
+      id: launchCode.access,
+      app: launchCode.app,
+      status: 'active'
+    })
+    const app = access
+      ? await App.findOne({
+          id: launchCode.app,
+          bridgeEnabled: true
+        }).decrypt()
+      : null
+    const environment = app
+      ? await Environment.findOne({ id: app.environment })
+      : null
+    const project = environment
+      ? await Project.findOne({ id: environment.project })
+      : null
+
+    if (!access || !app || !environment || !project) {
+      throw { forbidden: '/login?error=bridge_access_denied' }
+    }
+
+    const existingUserId = this.req.session.userId
+    await regenerateSession(this.req)
+    if (existingUserId) {
+      this.req.session.userId = existingUserId
+    }
+    this.req.session.bridgeAccessId = access.id
+    this.req.session.bridgeAppId = app.id
+    this.req.session.bridgeAuthenticatedAt = Date.now()
+    this.req.session.bridgeCredentialHash = hashCredential(app.bridgeSecret)
+
+    return `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
+  }
+}
+
+function regenerateSession(req) {
+  if (typeof req.session.regenerate !== 'function') {
+    // Sounding's virtual request transport exposes the session as a plain
+    // object. Clear it in place so the trial still exercises the same
+    // privilege-boundary behavior as a regenerated production session.
+    for (const key of Object.keys(req.session)) {
+      delete req.session[key]
+    }
+    return Promise.resolve()
+  }
+
+  return new Promise((resolve, reject) => {
+    req.session.regenerate((error) => {
+      if (error) return reject(error)
+      return resolve()
+    })
+  })
+}
+
+function hashCredential(value) {
+  return crypto
+    .createHash('sha256')
+    .update(String(value || ''))
+    .digest('hex')
+}

--- a/api/controllers/project/bridge-bulk-delete.js
+++ b/api/controllers/project/bridge-bulk-delete.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -30,38 +33,31 @@ module.exports = {
     notFound: {
       responseType: 'redirect'
     },
+    forbidden: {
+      statusCode: 403
+    },
     badRequest: {
       responseType: 'badRequest'
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity, ids }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-    if (!user) {
-      throw { notFound: '/login' }
-    }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running') {
+  fn: async function ({ slug, envSlug, appSlug, modelIdentity, ids }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'administrator',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
+      if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
+    const { project, environment, app, actor } = resolved
 
     if (!Array.isArray(ids) || ids.length === 0) {
       throw { badRequest: { error: 'No records selected' } }
@@ -83,11 +79,6 @@ module.exports = {
 
     let resource
     try {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       const loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -141,7 +132,9 @@ module.exports = {
     }
 
     // Redirect back to model list
-    const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/bridge/${modelIdentity}`
+    const bridgeBasePath = appSlug
+      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
+      : `/projects/${slug}/environments/${envSlug}/bridge`
+    return `${bridgeBasePath}/${modelIdentity}`
   }
 }

--- a/api/controllers/project/bridge-create-record.js
+++ b/api/controllers/project/bridge-create-record.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -30,47 +33,35 @@ module.exports = {
     notFound: {
       responseType: 'redirect'
     },
+    forbidden: {
+      statusCode: 403
+    },
     badRequest: {
       responseType: 'badRequest'
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity, values }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-    if (!user) {
-      throw { notFound: '/login' }
-    }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running') {
+  fn: async function ({ slug, envSlug, appSlug, modelIdentity, values }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
+      if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
+    const { project, environment, app, actor, actorId } = resolved
 
     let loaded
     let allowedValues
     try {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -83,7 +74,7 @@ module.exports = {
         resource: loaded.resource,
         surface: 'create',
         uploadContext: {
-          actorId: user.id,
+          actorId,
           projectId: project.id,
           environmentId: environment.id
         }
@@ -107,13 +98,15 @@ module.exports = {
       })
       const recordId = record?.[loaded.resource.primaryKey]
 
-      const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
+      const bridgeBasePath = appSlug
+        ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
+        : `/projects/${slug}/environments/${envSlug}/bridge`
       if (recordId !== undefined && recordId !== null) {
-        return `/projects/${slug}${envPath}/bridge/${
+        return `${bridgeBasePath}/${
           loaded.resource.identity
         }/${encodeURIComponent(String(recordId))}`
       }
-      return `/projects/${slug}${envPath}/bridge/${loaded.resource.identity}`
+      return `${bridgeBasePath}/${loaded.resource.identity}`
     } catch (error) {
       throw { badRequest: toBadRequest(error) }
     }

--- a/api/controllers/project/bridge-delete-record.js
+++ b/api/controllers/project/bridge-delete-record.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -29,47 +32,35 @@ module.exports = {
     notFound: {
       responseType: 'redirect'
     },
+    forbidden: {
+      statusCode: 403
+    },
     badRequest: {
       responseType: 'badRequest'
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity, recordId }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-    if (!user) {
-      throw { notFound: '/login' }
-    }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running') {
+  fn: async function ({ slug, envSlug, appSlug, modelIdentity, recordId }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'administrator',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
+      if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
+    const { project, environment, app, actor } = resolved
 
     let resource
     let normalizedRecordId
     try {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       const loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -107,7 +98,9 @@ module.exports = {
     }
 
     // Redirect back to model list
-    const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/bridge/${modelIdentity}`
+    const bridgeBasePath = appSlug
+      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
+      : `/projects/${slug}/environments/${envSlug}/bridge`
+    return `${bridgeBasePath}/${modelIdentity}`
   }
 }

--- a/api/controllers/project/bridge-execute-action.js
+++ b/api/controllers/project/bridge-execute-action.js
@@ -13,6 +13,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -40,6 +43,9 @@ module.exports = {
     notFound: {
       responseType: 'redirect'
     },
+    forbidden: {
+      statusCode: 403
+    },
     badRequest: {
       responseType: 'badRequest'
     }
@@ -48,48 +54,33 @@ module.exports = {
   fn: async function ({
     slug,
     envSlug,
+    appSlug,
     modelIdentity,
     actionName,
     values,
     recordId,
     recordIds
   }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-    if (!user) {
-      throw { notFound: '/login' }
-    }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running') {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
+      if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
+    const { project, environment, app, actor, auditUserId } = resolved
 
-    let actor
     let loaded
     let allowedValues
     try {
-      actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -158,8 +149,8 @@ module.exports = {
           ...auditDetails,
           error: safeAuditError(error.message)
         },
-        userId: user.id,
-        teamId: user.team.id,
+        ...(auditUserId ? { userId: auditUserId } : {}),
+        teamId: auditTeamId(project),
         ipAddress: this.req.ip
       })
       throw { badRequest: { error: error.message } }
@@ -170,8 +161,8 @@ module.exports = {
       resourceType: 'bridgeAction',
       resourceId: auditResourceId(loaded.resource, action, loaded),
       details: auditDetails,
-      userId: user.id,
-      teamId: user.team.id,
+      ...(auditUserId ? { userId: auditUserId } : {}),
+      teamId: auditTeamId(project),
       ipAddress: this.req.ip
     })
 
@@ -179,13 +170,21 @@ module.exports = {
       'success',
       outcome.message || action.success || `${action.label} completed.`
     )
-    return actionRedirect({ slug, envSlug, resource: loaded.resource, loaded })
+    return actionRedirect({
+      slug,
+      envSlug,
+      appSlug: appSlug ? app.slug : null,
+      resource: loaded.resource,
+      loaded
+    })
   }
 }
 
-function actionRedirect({ slug, envSlug, resource, loaded }) {
-  const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-  const modelPath = `/projects/${slug}${envPath}/bridge/${resource.identity}`
+function actionRedirect({ slug, envSlug, appSlug, resource, loaded }) {
+  const bridgeBasePath = appSlug
+    ? `/projects/${slug}/environments/${envSlug}/apps/${appSlug}/bridge`
+    : `/projects/${slug}/environments/${envSlug}/bridge`
+  const modelPath = `${bridgeBasePath}/${resource.identity}`
   if (loaded.actionDefinition.scope !== 'record') return modelPath
   return `${modelPath}/${encodeURIComponent(String(loaded.recordId))}`
 }
@@ -200,6 +199,14 @@ function safeAuditError(message) {
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 500)
+}
+
+function auditTeamId(project) {
+  return String(
+    project.team && typeof project.team === 'object'
+      ? project.team.id
+      : project.team
+  )
 }
 
 function toBadRequest(error) {

--- a/api/controllers/project/bridge-relationship-options.js
+++ b/api/controllers/project/bridge-relationship-options.js
@@ -13,6 +13,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -57,6 +60,7 @@ module.exports = {
   fn: async function ({
     slug,
     envSlug,
+    appSlug,
     modelIdentity,
     relationshipAlias,
     surface,
@@ -64,26 +68,22 @@ module.exports = {
     q,
     page
   }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-    if (!user) throw 'forbidden'
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) throw 'notFound'
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) throw 'notFound'
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running' || !app.containerName) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
+      if (error.code === 'notFound') throw 'notFound'
       throw { badRequest: { error: 'App is not running' } }
     }
+    const { environment, app, actor } = resolved
     if (surface !== 'create' && !recordId) {
       throw {
         badRequest: {
@@ -93,11 +93,6 @@ module.exports = {
     }
 
     try {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       const loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,

--- a/api/controllers/project/bridge-update-record.js
+++ b/api/controllers/project/bridge-update-record.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -34,47 +37,42 @@ module.exports = {
     notFound: {
       responseType: 'redirect'
     },
+    forbidden: {
+      statusCode: 403
+    },
     badRequest: {
       responseType: 'badRequest'
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity, recordId, values }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-    if (!user) {
-      throw { notFound: '/login' }
-    }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running') {
+  fn: async function ({
+    slug,
+    envSlug,
+    appSlug,
+    modelIdentity,
+    recordId,
+    values
+  }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
+      if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
+    const { project, environment, app, actor, actorId } = resolved
 
     let loaded
     let allowedValues
     try {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -88,7 +86,7 @@ module.exports = {
         resource: loaded.resource,
         surface: 'edit',
         uploadContext: {
-          actorId: user.id,
+          actorId,
           projectId: project.id,
           environmentId: environment.id
         }
@@ -128,8 +126,10 @@ module.exports = {
     }
 
     // Redirect back to record view
-    const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${encodeURIComponent(
+    const bridgeBasePath = appSlug
+      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
+      : `/projects/${slug}/environments/${envSlug}/bridge`
+    return `${bridgeBasePath}/${modelIdentity}/${encodeURIComponent(
       String(recordId)
     )}`
   }

--- a/api/controllers/project/bridge-update-relationship.js
+++ b/api/controllers/project/bridge-update-relationship.js
@@ -13,6 +13,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -43,6 +46,9 @@ module.exports = {
     notFound: {
       responseType: 'redirect'
     },
+    forbidden: {
+      statusCode: 403
+    },
     badRequest: {
       responseType: 'badRequest'
     }
@@ -51,39 +57,31 @@ module.exports = {
   fn: async function ({
     slug,
     envSlug,
+    appSlug,
     modelIdentity,
     recordId,
     relationshipAlias,
     operation,
     relatedId
   }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-    if (!user) throw { notFound: '/login' }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) throw { notFound: '/' }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) throw { notFound: `/projects/${slug}` }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running' || !app.containerName) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
+      if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
+    const { environment, app, actor } = resolved
 
     try {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       const loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -177,8 +175,10 @@ module.exports = {
       throw { badRequest: { error: error.message } }
     }
 
-    const envPath = envSlug !== 'production' ? `/environments/${envSlug}` : ''
-    return `/projects/${slug}${envPath}/bridge/${modelIdentity}/${encodeURIComponent(
+    const bridgeBasePath = appSlug
+      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
+      : `/projects/${slug}/environments/${envSlug}/bridge`
+    return `${bridgeBasePath}/${modelIdentity}/${encodeURIComponent(
       String(recordId)
     )}`
   }

--- a/api/controllers/project/bridge-upload-field.js
+++ b/api/controllers/project/bridge-upload-field.js
@@ -26,6 +26,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -58,39 +61,37 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity, fieldName, recordId }) {
-    const user = await User.findOne({
-      id: this.req.session.userId
-    }).populate('team')
-    if (!user) {
-      throw { forbidden: { message: 'Sign in before uploading a file.' } }
-    }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-    if (!project) {
-      throw { notFound: { message: 'Project not found.' } }
-    }
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-    if (!environment) {
-      throw { notFound: { message: 'Environment not found.' } }
-    }
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    if (!app || app.status !== 'running') {
+  fn: async function ({
+    slug,
+    envSlug,
+    appSlug,
+    modelIdentity,
+    fieldName,
+    recordId
+  }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor',
+        requireRunning: true
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') {
+        throw {
+          forbidden: { message: 'Your Bridge role cannot upload files.' }
+        }
+      }
+      if (error.code === 'notFound') throw 'notFound'
       throw { badRequest: { message: 'The target app is not running.' } }
     }
+    const { project, environment, app, actor, actorId } = resolved
 
     let loaded
     try {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user,
-        project,
-        environment
-      })
       loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -129,7 +130,7 @@ module.exports = {
     const upload = attribute.field.upload
     const directory = [
       'bridge',
-      `teams/${safeSegment(user.team.id)}`,
+      `teams/${safeSegment(project.team)}`,
       `projects/${safeSegment(project.id)}`,
       `environments/${safeSegment(environment.id)}`,
       safeSegment(modelIdentity),
@@ -194,7 +195,7 @@ module.exports = {
     const receipt = await sails.helpers.bridge.createUploadReceipt.with({
       url,
       context: {
-        actorId: user.id,
+        actorId,
         projectId: project.id,
         environmentId: environment.id,
         resource: loaded.resource.identity,

--- a/api/controllers/project/invite-bridge-user.js
+++ b/api/controllers/project/invite-bridge-user.js
@@ -1,0 +1,162 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Invite Bridge user',
+
+  description: 'Invite a verified host-app email to an app-scoped Bridge role.',
+
+  inputs: {
+    slug: { type: 'string', required: true },
+    envSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    email: {
+      type: 'string',
+      required: true,
+      isEmail: true,
+      maxLength: 200
+    },
+    role: {
+      type: 'string',
+      isIn: ['viewer', 'editor', 'administrator'],
+      required: true
+    }
+  },
+
+  exits: {
+    success: { responseType: 'redirect' },
+    badRequest: { responseType: 'badRequest' },
+    notFound: { responseType: 'redirect' },
+    forbidden: { responseType: 'redirect' }
+  },
+
+  fn: async function ({ slug, envSlug, appSlug, email, role }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveManager.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        appSlug
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw { forbidden: '/' }
+      throw { notFound: '/' }
+    }
+
+    const normalizedEmail = email.trim().toLowerCase()
+    const { user, project, environment, app } = resolved
+    const appUrl = await sails.helpers.bridge.getAppUrl.with({
+      app,
+      environment,
+      project
+    })
+    if (!appUrl) {
+      throw {
+        badRequest: {
+          problems: [
+            {
+              email:
+                'Deploy this app with a reachable URL before inviting Bridge users.'
+            }
+          ]
+        }
+      }
+    }
+
+    const inviteToken = `bli_${crypto.randomBytes(32).toString('base64url')}`
+    const inviteTokenHash = crypto
+      .createHash('sha256')
+      .update(inviteToken)
+      .digest('hex')
+    const inviteExpiresAt = Date.now() + 7 * 24 * 60 * 60 * 1000
+    const existing = await BridgeAccess.findOne({
+      app: app.id,
+      email: normalizedEmail
+    })
+
+    let access
+    if (existing) {
+      access = await BridgeAccess.updateOne({ id: existing.id }).set({
+        role,
+        status: 'pending',
+        hostUserId: null,
+        hostUserName: null,
+        activatedAt: null,
+        revokedAt: null,
+        revokedBy: null,
+        inviteTokenHash,
+        inviteExpiresAt,
+        invitedBy: user.id
+      })
+    } else {
+      access = await BridgeAccess.create({
+        email: normalizedEmail,
+        role,
+        status: 'pending',
+        inviteTokenHash,
+        inviteExpiresAt,
+        app: app.id,
+        environment: environment.id,
+        project: project.id,
+        team: user.team,
+        invitedBy: user.id
+      }).fetch()
+    }
+
+    const inviteUrl = `${appUrl}/bridge?invite=${encodeURIComponent(
+      inviteToken
+    )}`
+    try {
+      await sails.helpers.mail.sendConfigured.with({
+        to: normalizedEmail,
+        subject: `You have been invited to ${app.name} Bridge`,
+        template: 'bridge-invite',
+        templateData: {
+          appName: app.name,
+          projectName: project.name,
+          inviterName: user.fullName,
+          role,
+          inviteUrl,
+          expiresIn: '7 days'
+        }
+      })
+    } catch (error) {
+      sails.log.warn(
+        `Bridge invitation email failed for ${normalizedEmail}: ${
+          error.message || error
+        }`
+      )
+      throw {
+        badRequest: {
+          problems: [
+            {
+              email:
+                'The invitation was saved, but Slipway could not send the email. Check the mail settings and resend it.'
+            }
+          ]
+        }
+      }
+    }
+
+    await sails.helpers.audit.log.with({
+      action: existing ? 'bridge.access.reinvited' : 'bridge.access.invited',
+      resourceType: 'bridgeAccess',
+      resourceId: String(access.id),
+      userId: String(user.id),
+      teamId: String(user.team),
+      ipAddress: this.req.ip,
+      details: {
+        appId: app.id,
+        email: normalizedEmail,
+        role
+      }
+    })
+
+    sails.inertia.flash('success', `Invitation sent to ${normalizedEmail}.`)
+    return accessPath(project.slug, environment.slug, app.slug)
+  }
+}
+
+function accessPath(projectSlug, environmentSlug, appSlug) {
+  return `/projects/${projectSlug}/environments/${environmentSlug}/apps/${appSlug}/bridge/access`
+}

--- a/api/controllers/project/revoke-bridge-access.js
+++ b/api/controllers/project/revoke-bridge-access.js
@@ -1,0 +1,63 @@
+module.exports = {
+  friendlyName: 'Revoke Bridge access',
+
+  inputs: {
+    slug: { type: 'string', required: true },
+    envSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    accessId: { type: 'string', required: true }
+  },
+
+  exits: {
+    success: { responseType: 'redirect' },
+    notFound: { responseType: 'redirect' },
+    forbidden: { responseType: 'redirect' }
+  },
+
+  fn: async function ({ slug, envSlug, appSlug, accessId }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveManager.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        appSlug
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw { forbidden: '/' }
+      throw { notFound: '/' }
+    }
+
+    const access = await BridgeAccess.findOne({
+      id: accessId,
+      app: resolved.app.id
+    })
+    if (!access) throw { notFound: accessPath(slug, envSlug, appSlug) }
+
+    await BridgeAccess.updateOne({ id: access.id }).set({
+      status: 'revoked',
+      revokedAt: Date.now(),
+      revokedBy: resolved.user.id,
+      inviteTokenHash: null,
+      inviteExpiresAt: null
+    })
+    await BridgeLaunchCode.destroy({ access: access.id })
+
+    await sails.helpers.audit.log.with({
+      action: 'bridge.access.revoked',
+      resourceType: 'bridgeAccess',
+      resourceId: String(access.id),
+      userId: String(resolved.user.id),
+      teamId: String(resolved.user.team),
+      ipAddress: this.req.ip,
+      details: { email: access.email, role: access.role }
+    })
+
+    sails.inertia.flash('success', `Revoked ${access.email}'s Bridge access.`)
+    return accessPath(slug, envSlug, appSlug)
+  }
+}
+
+function accessPath(projectSlug, environmentSlug, appSlug) {
+  return `/projects/${projectSlug}/environments/${environmentSlug}/apps/${appSlug}/bridge/access`
+}

--- a/api/controllers/project/update-bridge-access.js
+++ b/api/controllers/project/update-bridge-access.js
@@ -1,0 +1,60 @@
+module.exports = {
+  friendlyName: 'Update Bridge access',
+
+  inputs: {
+    slug: { type: 'string', required: true },
+    envSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    accessId: { type: 'string', required: true },
+    role: {
+      type: 'string',
+      isIn: ['viewer', 'editor', 'administrator'],
+      required: true
+    }
+  },
+
+  exits: {
+    success: { responseType: 'redirect' },
+    notFound: { responseType: 'redirect' },
+    forbidden: { responseType: 'redirect' }
+  },
+
+  fn: async function ({ slug, envSlug, appSlug, accessId, role }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveManager.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        appSlug
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw { forbidden: '/' }
+      throw { notFound: '/' }
+    }
+
+    const access = await BridgeAccess.findOne({
+      id: accessId,
+      app: resolved.app.id
+    })
+    if (!access) throw { notFound: accessPath(slug, envSlug, appSlug) }
+
+    await BridgeAccess.updateOne({ id: access.id }).set({ role })
+    await sails.helpers.audit.log.with({
+      action: 'bridge.access.role_changed',
+      resourceType: 'bridgeAccess',
+      resourceId: String(access.id),
+      userId: String(resolved.user.id),
+      teamId: String(resolved.user.team),
+      ipAddress: this.req.ip,
+      details: { email: access.email, from: access.role, to: role }
+    })
+
+    sails.inertia.flash('success', `Updated ${access.email}'s Bridge role.`)
+    return accessPath(slug, envSlug, appSlug)
+  }
+}
+
+function accessPath(projectSlug, environmentSlug, appSlug) {
+  return `/projects/${projectSlug}/environments/${environmentSlug}/apps/${appSlug}/bridge/access`
+}

--- a/api/controllers/project/update-bridge-settings.js
+++ b/api/controllers/project/update-bridge-settings.js
@@ -1,0 +1,66 @@
+module.exports = {
+  friendlyName: 'Update Bridge settings',
+
+  description: 'Enable or disable the app-local Bridge entry point.',
+
+  inputs: {
+    slug: { type: 'string', required: true },
+    envSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    enabled: { type: 'boolean', required: true }
+  },
+
+  exits: {
+    success: { responseType: 'redirect' },
+    notFound: { responseType: 'redirect' },
+    forbidden: { responseType: 'redirect' }
+  },
+
+  fn: async function ({ slug, envSlug, appSlug, enabled }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveManager.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        appSlug
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw { forbidden: '/' }
+      throw { notFound: '/' }
+    }
+
+    const { user, project, app } = resolved
+    if (enabled) {
+      // Rotate on every disabled -> enabled transition. This makes credentials
+      // in an old container unusable until the app is deliberately redeployed.
+      await sails.helpers.bridge.ensureAppSecret.with({
+        appId: String(app.id),
+        rotate: !app.bridgeEnabled
+      })
+    }
+    await App.updateOne({ id: app.id }).set({ bridgeEnabled: enabled })
+
+    await sails.helpers.audit.log.with({
+      action: enabled ? 'bridge.enabled' : 'bridge.disabled',
+      resourceType: 'app',
+      resourceId: String(app.id),
+      userId: String(user.id),
+      teamId: String(user.team),
+      ipAddress: this.req.ip,
+      details: { project: project.slug, app: app.slug }
+    })
+
+    sails.inertia.flash(
+      'success',
+      enabled
+        ? 'Bridge enabled. Redeploy this app to activate its /bridge entry point.'
+        : 'Bridge access disabled.'
+    )
+    return accessPath(project.slug, resolved.environment.slug, app.slug)
+  }
+}
+
+function accessPath(projectSlug, environmentSlug, appSlug) {
+  return `/projects/${projectSlug}/environments/${environmentSlug}/apps/${appSlug}/bridge/access`
+}

--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -196,6 +196,11 @@ module.exports = {
       environment,
       app
     })
+    const bridgeUrl = await sails.helpers.bridge.getAppUrl.with({
+      app,
+      environment,
+      project
+    })
 
     return {
       page: 'projects/app',
@@ -214,7 +219,8 @@ module.exports = {
           containerHealth,
           directAccess,
           primaryUrl,
-          accessUrls
+          accessUrls,
+          bridgeUrl: bridgeUrl ? `${bridgeUrl}/bridge` : null
         },
         appEnvVars: decryptedApp.envVars || {},
         inheritedVars,
@@ -222,7 +228,8 @@ module.exports = {
         services,
         backupConfigured,
         checklist,
-        sourceReadiness
+        sourceReadiness,
+        canManageBridge: ['owner', 'admin'].includes(user.teamRole)
       }
     }
   }

--- a/api/controllers/project/view-bridge-access.js
+++ b/api/controllers/project/view-bridge-access.js
@@ -1,0 +1,91 @@
+module.exports = {
+  friendlyName: 'View Bridge access',
+
+  description: 'Manage app-scoped Bridge invitations and access.',
+
+  inputs: {
+    slug: { type: 'string', required: true },
+    envSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true }
+  },
+
+  exits: {
+    success: { responseType: 'inertia' },
+    notFound: { responseType: 'redirect' },
+    forbidden: { responseType: 'redirect' }
+  },
+
+  fn: async function ({ slug, envSlug, appSlug }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveManager.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        appSlug
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw { forbidden: '/' }
+      throw { notFound: '/' }
+    }
+
+    const { project, environment, app } = resolved
+    const access = await BridgeAccess.find({ app: app.id })
+      .sort(['status ASC', 'createdAt DESC'])
+      .populate('invitedBy')
+    const appUrl = await sails.helpers.bridge.getAppUrl.with({
+      app,
+      environment,
+      project
+    })
+
+    return {
+      page: 'projects/bridge-access',
+      props: {
+        project: pick(project, ['id', 'name', 'slug']),
+        environment: pick(environment, [
+          'id',
+          'name',
+          'slug',
+          'features',
+          'isProduction'
+        ]),
+        app: {
+          ...pick(app, [
+            'id',
+            'name',
+            'slug',
+            'status',
+            'routePath',
+            'bridgeEnabled'
+          ]),
+          appUrl,
+          bridgeUrl: appUrl ? `${appUrl}/bridge` : null
+        },
+        access: access.map((grant) => ({
+          id: grant.id,
+          email: grant.email,
+          role: grant.role,
+          status: grant.status,
+          hostUserId: grant.hostUserId,
+          hostUserName: grant.hostUserName,
+          activatedAt: grant.activatedAt,
+          lastUsedAt: grant.lastUsedAt,
+          inviteExpiresAt: grant.inviteExpiresAt,
+          createdAt: grant.createdAt,
+          invitedBy: grant.invitedBy
+            ? {
+                id: grant.invitedBy.id,
+                fullName: grant.invitedBy.fullName
+              }
+            : null
+        })),
+        hookDetected: Boolean(environment.features?.['sails-hook-slipway'])
+      }
+    }
+  }
+}
+
+function pick(value, keys) {
+  return Object.fromEntries(keys.map((key) => [key, value[key]]))
+}

--- a/api/controllers/project/view-bridge-create.js
+++ b/api/controllers/project/view-bridge-create.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -24,36 +27,27 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    forbidden: {
+      statusCode: 403
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-
-    if (!user) {
+  fn: async function ({ slug, envSlug, appSlug, modelIdentity }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor'
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
+    const { project, environment, app, actor } = resolved
     const appRunning = app && app.status === 'running'
 
     let modelMeta = null
@@ -62,11 +56,6 @@ module.exports = {
 
     if (appRunning) {
       try {
-        const actor = await sails.helpers.bridge.buildActor.with({
-          user,
-          project,
-          environment
-        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
@@ -128,6 +117,8 @@ module.exports = {
           name: environment.name,
           slug: environment.slug
         },
+        app: { id: app.id, name: app.name, slug: app.slug },
+        appScoped: Boolean(appSlug),
         mode: 'create',
         modelIdentity,
         recordId: null,

--- a/api/controllers/project/view-bridge-edit.js
+++ b/api/controllers/project/view-bridge-edit.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -28,36 +31,27 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    forbidden: {
+      statusCode: 403
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity, recordId }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-
-    if (!user) {
+  fn: async function ({ slug, envSlug, appSlug, modelIdentity, recordId }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'editor'
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
+    const { project, environment, app, actor } = resolved
     const appRunning = app && app.status === 'running'
 
     let modelMeta = null
@@ -67,11 +61,6 @@ module.exports = {
 
     if (appRunning) {
       try {
-        const actor = await sails.helpers.bridge.buildActor.with({
-          user,
-          project,
-          environment
-        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
@@ -187,6 +176,8 @@ module.exports = {
           name: environment.name,
           slug: environment.slug
         },
+        app: { id: app.id, name: app.name, slug: app.slug },
+        appScoped: Boolean(appSlug),
         mode: 'edit',
         modelIdentity,
         recordId,

--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -44,12 +47,16 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    forbidden: {
+      statusCode: 403
     }
   },
 
   fn: async function ({
     slug,
     envSlug,
+    appSlug,
     modelIdentity,
     page,
     perPage,
@@ -57,32 +64,20 @@ module.exports = {
     search,
     dashboard
   }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-
-    if (!user) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'viewer'
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
+    const { project, environment, app, actor } = resolved
     const appRunning = app && app.status === 'running'
 
     // Load model metadata and records server-side
@@ -101,11 +96,6 @@ module.exports = {
 
     if (appRunning) {
       try {
-        const actor = await sails.helpers.bridge.buildActor.with({
-          user,
-          project,
-          environment
-        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
@@ -225,6 +215,8 @@ module.exports = {
           name: environment.name,
           slug: environment.slug
         },
+        app: { id: app.id, name: app.name, slug: app.slug },
+        appScoped: Boolean(appSlug),
         modelIdentity,
         appRunning,
         modelMeta,

--- a/api/controllers/project/view-bridge-record.js
+++ b/api/controllers/project/view-bridge-record.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     modelIdentity: {
       type: 'string',
       required: true
@@ -28,36 +31,27 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    forbidden: {
+      statusCode: 403
     }
   },
 
-  fn: async function ({ slug, envSlug, modelIdentity, recordId }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-
-    if (!user) {
+  fn: async function ({ slug, envSlug, appSlug, modelIdentity, recordId }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'viewer'
+      })
+    } catch (error) {
+      if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
+    const { project, environment, app, actor } = resolved
     const appRunning = app && app.status === 'running'
 
     let modelMeta = null
@@ -67,11 +61,6 @@ module.exports = {
 
     if (appRunning) {
       try {
-        const actor = await sails.helpers.bridge.buildActor.with({
-          user,
-          project,
-          environment
-        })
         const loaded = await sails.helpers.bridge.loadResource.with({
           containerName: app.containerName,
           environmentId: environment.id,
@@ -168,6 +157,8 @@ module.exports = {
           name: environment.name,
           slug: environment.slug
         },
+        app: { id: app.id, name: app.name, slug: app.slug },
+        appScoped: Boolean(appSlug),
         modelIdentity,
         recordId,
         appRunning,

--- a/api/controllers/project/view-bridge.js
+++ b/api/controllers/project/view-bridge.js
@@ -12,6 +12,9 @@ module.exports = {
       type: 'string',
       defaultsTo: 'production'
     },
+    appSlug: {
+      type: 'string'
+    },
     dashboard: {
       type: 'string',
       defaultsTo: ''
@@ -24,36 +27,38 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    forbidden: {
+      statusCode: 403
     }
   },
 
-  fn: async function ({ slug, envSlug, dashboard }) {
-    const user = await User.findOne({ id: this.req.session.userId }).populate(
-      'team'
-    )
-
-    if (!user) {
-      throw { notFound: '/login' }
+  fn: async function ({ slug, envSlug, appSlug, dashboard }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bridge.resolveRequest.with({
+        req: this.req,
+        projectSlug: slug,
+        environmentSlug: envSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requiredRole: 'viewer'
+      })
+    } catch (error) {
+      if (error.code === 'forbidden' && !this.req.session.userId) {
+        throw 'forbidden'
+      }
+      if (error.code === 'forbidden' && appSlug) {
+        throw {
+          notFound: `/projects/${slug}/environments/${envSlug}/apps/${appSlug}/bridge/access`
+        }
+      }
+      throw {
+        notFound: this.req.session.userId
+          ? `/projects/${slug}/environments/${envSlug}`
+          : '/login'
+      }
     }
-
-    const project = await Project.findOne({ slug, team: user.team.id })
-
-    if (!project) {
-      throw { notFound: '/' }
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: envSlug
-    })
-
-    if (!environment) {
-      throw { notFound: `/projects/${slug}` }
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
+    const { project, environment, app, actor } = resolved
     const appRunning = app && app.status === 'running'
 
     // Load models server-side if app is running
@@ -64,11 +69,6 @@ module.exports = {
 
     if (appRunning) {
       try {
-        const actor = await sails.helpers.bridge.buildActor.with({
-          user,
-          project,
-          environment
-        })
         const introspection = await sails.helpers.bridge.introspectModels(
           app.containerName,
           environment.id
@@ -176,6 +176,12 @@ module.exports = {
           name: environment.name,
           slug: environment.slug
         },
+        app: {
+          id: app.id,
+          name: app.name,
+          slug: app.slug
+        },
+        appScoped: Boolean(appSlug),
         appRunning,
         models,
         modelsError,

--- a/api/helpers/bridge/activate-invitation.js
+++ b/api/helpers/bridge/activate-invitation.js
@@ -1,0 +1,64 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Activate Bridge invitation',
+
+  description:
+    'Atomically bind one unexpired Bridge invitation to a verified host-app identity.',
+
+  inputs: {
+    accessId: {
+      type: 'string',
+      required: true
+    },
+    inviteToken: {
+      type: 'string',
+      required: true
+    },
+    hostUserId: {
+      type: 'string',
+      required: true
+    },
+    hostUserName: {
+      type: 'string',
+      allowNull: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ accessId, inviteToken, hostUserId, hostUserName }) {
+    const tokenHash = crypto
+      .createHash('sha256')
+      .update(inviteToken)
+      .digest('hex')
+    const now = Date.now()
+    const database = sails.getDatastore().manager
+    const result = database
+      .prepare(
+        `
+          UPDATE bridge_access
+          SET status = 'active',
+              host_user_id = ?,
+              host_user_name = ?,
+              activated_at = ?,
+              last_used_at = ?,
+              invite_token_hash = NULL,
+              invite_expires_at = NULL,
+              updated_at = ?
+          WHERE id = ?
+            AND status = 'pending'
+            AND invite_token_hash = ?
+            AND invite_expires_at > ?
+        `
+      )
+      .run(hostUserId, hostUserName, now, now, now, accessId, tokenHash, now)
+
+    if (result.changes !== 1) return null
+    return BridgeAccess.findOne({ id: accessId })
+  }
+}

--- a/api/helpers/bridge/build-access-actor.js
+++ b/api/helpers/bridge/build-access-actor.js
@@ -1,0 +1,35 @@
+module.exports = {
+  friendlyName: 'Build Bridge access actor',
+
+  description:
+    'Build the serializable actor passed to host-app authorization for an invited Bridge user.',
+
+  inputs: {
+    access: { type: 'ref', required: true },
+    project: { type: 'ref', required: true },
+    environment: { type: 'ref', required: true },
+    app: { type: 'ref', required: true }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: async function ({ access, project, environment, app }) {
+    return {
+      id: String(access.hostUserId),
+      email: access.email,
+      fullName: access.hostUserName,
+      role: access.role,
+      bridgeRole: access.role,
+      source: 'host-app',
+      appId: String(app.id),
+      appSlug: app.slug,
+      teamId: String(access.team),
+      projectId: String(project.id),
+      projectSlug: project.slug,
+      environmentId: String(environment.id),
+      environmentSlug: environment.slug
+    }
+  }
+}

--- a/api/helpers/bridge/consume-launch-code.js
+++ b/api/helpers/bridge/consume-launch-code.js
@@ -1,0 +1,38 @@
+module.exports = {
+  friendlyName: 'Consume Bridge launch code',
+
+  description:
+    'Atomically consume one unexpired Bridge launch code and return its record.',
+
+  inputs: {
+    tokenHash: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ tokenHash }) {
+    const now = Date.now()
+    const database = sails.getDatastore().manager
+    const result = database
+      .prepare(
+        `
+          UPDATE bridge_launch_codes
+          SET used_at = ?, updated_at = ?
+          WHERE token_hash = ?
+            AND used_at IS NULL
+            AND expires_at > ?
+        `
+      )
+      .run(now, now, tokenHash, now)
+
+    if (result.changes !== 1) return null
+    return BridgeLaunchCode.findOne({ tokenHash })
+  }
+}

--- a/api/helpers/bridge/ensure-app-secret.js
+++ b/api/helpers/bridge/ensure-app-secret.js
@@ -1,0 +1,38 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Ensure Bridge app secret',
+
+  description:
+    'Return the dedicated Bridge exchange credential for an app, creating it when necessary.',
+
+  inputs: {
+    appId: {
+      type: 'string',
+      required: true
+    },
+    rotate: {
+      type: 'boolean',
+      defaultsTo: false
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    },
+    notFound: {}
+  },
+
+  fn: async function ({ appId, rotate }) {
+    let app = await App.findOne({ id: appId }).decrypt()
+    if (!app) throw 'notFound'
+    if (app.bridgeSecret && !rotate) return app.bridgeSecret
+
+    const bridgeSecret = `slb_${crypto.randomBytes(32).toString('base64url')}`
+    await App.updateOne({ id: app.id }).set({ bridgeSecret })
+
+    app = await App.findOne({ id: app.id }).decrypt()
+    return app.bridgeSecret
+  }
+}

--- a/api/helpers/bridge/ensure-schema.js
+++ b/api/helpers/bridge/ensure-schema.js
@@ -1,0 +1,81 @@
+module.exports = {
+  friendlyName: 'Ensure Bridge schema',
+
+  description:
+    'Create app-scoped Bridge access tables and credentials on existing production databases.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore()
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS bridge_access (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        email TEXT NOT NULL,
+        role TEXT NOT NULL DEFAULT 'viewer',
+        status TEXT NOT NULL DEFAULT 'pending',
+        host_user_id TEXT,
+        host_user_name TEXT,
+        activated_at INTEGER,
+        last_used_at INTEGER,
+        revoked_at INTEGER,
+        invite_token_hash TEXT,
+        invite_expires_at INTEGER,
+        app INTEGER NOT NULL,
+        environment INTEGER NOT NULL,
+        project INTEGER NOT NULL,
+        team INTEGER NOT NULL,
+        invited_by INTEGER NOT NULL,
+        revoked_by INTEGER,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE UNIQUE INDEX IF NOT EXISTS bridge_access_app_email
+      ON bridge_access (app, email)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS bridge_access_app_status
+      ON bridge_access (app, status, created_at)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS bridge_launch_codes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        token_hash TEXT NOT NULL UNIQUE,
+        expires_at INTEGER NOT NULL,
+        used_at INTEGER,
+        access_id INTEGER NOT NULL,
+        app INTEGER NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS bridge_launch_codes_expiry
+      ON bridge_launch_codes (expires_at, used_at)
+    `)
+
+    const result = await datastore.sendNativeQuery('PRAGMA table_info(apps)')
+    const existing = new Set(
+      (result.rows || result || []).map((row) => row.name)
+    )
+    const columns = [
+      ['bridge_enabled', 'BOOLEAN NOT NULL DEFAULT 0'],
+      ['bridge_secret', 'TEXT']
+    ]
+
+    for (const [name, type] of columns) {
+      if (!existing.has(name)) {
+        await datastore.sendNativeQuery(
+          `ALTER TABLE apps ADD COLUMN ${name} ${type}`
+        )
+      }
+    }
+  }
+}

--- a/api/helpers/bridge/get-app-url.js
+++ b/api/helpers/bridge/get-app-url.js
@@ -1,0 +1,46 @@
+module.exports = {
+  friendlyName: 'Get Bridge app URL',
+
+  description:
+    'Resolve the public app URL, including a non-root application route prefix.',
+
+  inputs: {
+    app: {
+      type: 'ref',
+      required: true
+    },
+    environment: {
+      type: 'ref',
+      required: true
+    },
+    project: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ app, environment, project }) {
+    if (app.routePath === null) return ''
+
+    const serverIp = await sails.helpers.getServerIp()
+    const directUrl =
+      app.hostPort && serverIp ? `http://${serverIp}:${app.hostPort}` : null
+    const { primaryUrl } = await Environment.resolveAppUrls(
+      { ...environment, project },
+      { directUrl }
+    )
+    if (!primaryUrl) return ''
+
+    const routePath =
+      app.routePath && app.routePath !== '/'
+        ? `/${String(app.routePath).replace(/^\/+|\/+$/g, '')}`
+        : ''
+    return `${primaryUrl.replace(/\/$/, '')}${routePath}`
+  }
+}

--- a/api/helpers/bridge/issue-launch-code.js
+++ b/api/helpers/bridge/issue-launch-code.js
@@ -1,0 +1,44 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Issue Bridge launch code',
+
+  description:
+    'Create a short-lived, single-use code for a verified host-app identity.',
+
+  inputs: {
+    accessId: {
+      type: 'string',
+      required: true
+    },
+    appId: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ accessId, appId }) {
+    const token = `blc_${crypto.randomBytes(32).toString('base64url')}`
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex')
+    const now = Date.now()
+
+    await BridgeLaunchCode.destroy({
+      expiresAt: { '<': now }
+    })
+
+    await BridgeLaunchCode.create({
+      tokenHash,
+      expiresAt: now + 2 * 60 * 1000,
+      access: accessId,
+      app: appId
+    })
+
+    return token
+  }
+}

--- a/api/helpers/bridge/resolve-manager.js
+++ b/api/helpers/bridge/resolve-manager.js
@@ -1,0 +1,60 @@
+module.exports = {
+  friendlyName: 'Resolve Bridge manager',
+
+  description:
+    'Resolve an app and require a Slipway owner or administrator from its team.',
+
+  inputs: {
+    req: {
+      type: 'ref',
+      required: true
+    },
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    appSlug: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    },
+    forbidden: {},
+    notFound: {}
+  },
+
+  fn: async function ({ req, projectSlug, environmentSlug, appSlug }) {
+    const user = await User.findOne({ id: req.session.userId })
+    if (!user || !['owner', 'admin'].includes(user.teamRole)) {
+      throw 'forbidden'
+    }
+
+    const project = await Project.findOne({
+      slug: projectSlug,
+      team: user.team
+    })
+    if (!project) throw 'notFound'
+
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug: environmentSlug
+    })
+    if (!environment) throw 'notFound'
+
+    const app = await App.findOne({
+      environment: environment.id,
+      slug: appSlug
+    })
+    if (!app) throw 'notFound'
+
+    return { user, project, environment, app }
+  }
+}

--- a/api/helpers/bridge/resolve-request.js
+++ b/api/helpers/bridge/resolve-request.js
@@ -1,0 +1,222 @@
+const crypto = require('crypto')
+
+const ROLE_RANK = {
+  viewer: 1,
+  editor: 2,
+  administrator: 3
+}
+
+module.exports = {
+  friendlyName: 'Resolve Bridge request',
+
+  description:
+    'Resolve either a Slipway operator or an invited host-app Bridge session.',
+
+  inputs: {
+    req: { type: 'ref', required: true },
+    projectSlug: { type: 'string', required: true },
+    environmentSlug: { type: 'string', defaultsTo: 'production' },
+    appSlug: { type: 'string' },
+    requiredRole: {
+      type: 'string',
+      isIn: ['viewer', 'editor', 'administrator'],
+      defaultsTo: 'viewer'
+    },
+    requireRunning: {
+      type: 'boolean',
+      defaultsTo: false
+    }
+  },
+
+  exits: {
+    success: { outputType: 'ref' },
+    forbidden: {},
+    notFound: {},
+    appNotRunning: {}
+  },
+
+  fn: async function ({
+    req,
+    projectSlug,
+    environmentSlug,
+    appSlug,
+    requiredRole,
+    requireRunning
+  }) {
+    const bridgeAccessId = req.session.bridgeAccessId
+    if (bridgeAccessId) {
+      return resolveHostSession({
+        req,
+        bridgeAccessId,
+        projectSlug,
+        environmentSlug,
+        appSlug,
+        requiredRole,
+        requireRunning
+      })
+    }
+
+    const resolved = await sails.helpers.resolveApp
+      .with({
+        req,
+        projectSlug,
+        environmentSlug,
+        ...(appSlug ? { appSlug } : {}),
+        requireRunning
+      })
+      .intercept('forbidden', 'forbidden')
+      .intercept('notFound', 'notFound')
+      .intercept('appNotRunning', 'appNotRunning')
+
+    // Existing dashboard Bridge remains available to the team until app-local
+    // Bridge is enabled. Once enabled, every person must first prove a matching
+    // host-app account through /bridge.
+    if (!resolved.app.bridgeEnabled) {
+      const actor = await sails.helpers.bridge.buildActor.with({
+        user: resolved.user,
+        project: resolved.project,
+        environment: resolved.environment
+      })
+      return {
+        ...resolved,
+        actor,
+        actorId: String(resolved.user.id),
+        auditUserId: String(resolved.user.id),
+        access: null
+      }
+    }
+
+    const access = await BridgeAccess.findOne({
+      app: resolved.app.id,
+      email: resolved.user.email.toLowerCase(),
+      status: 'active'
+    })
+    if (!access || !roleAllows(access.role, requiredRole)) {
+      throw 'forbidden'
+    }
+
+    const actor = await sails.helpers.bridge.buildAccessActor.with({
+      access,
+      project: resolved.project,
+      environment: resolved.environment,
+      app: resolved.app
+    })
+    return {
+      ...resolved,
+      actor,
+      actorId: actor.id,
+      auditUserId: String(resolved.user.id),
+      access
+    }
+  }
+}
+
+async function resolveHostSession({
+  req,
+  bridgeAccessId,
+  projectSlug,
+  environmentSlug,
+  appSlug,
+  requiredRole,
+  requireRunning
+}) {
+  if (
+    !req.session.bridgeAuthenticatedAt ||
+    Date.now() - req.session.bridgeAuthenticatedAt > 8 * 60 * 60 * 1000
+  ) {
+    clearBridgeSession(req)
+    throw 'forbidden'
+  }
+
+  const access = await BridgeAccess.findOne({
+    id: bridgeAccessId,
+    status: 'active'
+  })
+  const app = access
+    ? await App.findOne({
+        id: access.app,
+        bridgeEnabled: true
+      }).decrypt()
+    : null
+  const environment = app
+    ? await Environment.findOne({
+        id: app.environment,
+        slug: environmentSlug
+      })
+    : null
+  const project = environment
+    ? await Project.findOne({
+        id: environment.project,
+        slug: projectSlug
+      })
+    : null
+
+  if (
+    !access ||
+    !app ||
+    !environment ||
+    !project ||
+    (appSlug && app.slug !== appSlug) ||
+    String(req.session.bridgeAppId) !== String(app.id) ||
+    !safeEqual(
+      req.session.bridgeCredentialHash,
+      hashCredential(app.bridgeSecret)
+    )
+  ) {
+    clearBridgeSession(req)
+    throw 'forbidden'
+  }
+  if (!roleAllows(access.role, requiredRole)) {
+    throw 'forbidden'
+  }
+
+  if (requireRunning && (app.status !== 'running' || !app.containerName)) {
+    throw 'appNotRunning'
+  }
+
+  const actor = await sails.helpers.bridge.buildAccessActor.with({
+    access,
+    project,
+    environment,
+    app
+  })
+  return {
+    user: null,
+    project,
+    environment,
+    app,
+    apps: [app],
+    actor,
+    actorId: actor.id,
+    auditUserId: null,
+    access
+  }
+}
+
+function roleAllows(actual, required) {
+  return ROLE_RANK[actual] >= ROLE_RANK[required]
+}
+
+function clearBridgeSession(req) {
+  delete req.session.bridgeAccessId
+  delete req.session.bridgeAppId
+  delete req.session.bridgeAuthenticatedAt
+  delete req.session.bridgeCredentialHash
+}
+
+function hashCredential(value) {
+  return crypto
+    .createHash('sha256')
+    .update(String(value || ''))
+    .digest('hex')
+}
+
+function safeEqual(left, right) {
+  if (!left || !right) return false
+  const leftBuffer = Buffer.from(left)
+  const rightBuffer = Buffer.from(right)
+  return (
+    leftBuffer.length === rightBuffer.length &&
+    crypto.timingSafeEqual(leftBuffer, rightBuffer)
+  )
+}

--- a/api/helpers/cleanup/remove-records.js
+++ b/api/helpers/cleanup/remove-records.js
@@ -33,6 +33,16 @@ module.exports = {
       }
 
       if (target.scopeType === 'app') {
+        removed.default.bridgeLaunchCodes = await destroyCriteriaCount(
+          BridgeLaunchCode,
+          { app: { in: records.appIds } },
+          db
+        )
+        removed.default.bridgeAccess = await destroyCriteriaCount(
+          BridgeAccess,
+          { app: { in: records.appIds } },
+          db
+        )
         removed.default.repositories = await destroyCount(
           GitRepository,
           records.repositoryIds,
@@ -63,6 +73,16 @@ module.exports = {
       }
 
       await updateCount(App, records.appIds, { currentDeployment: null }, db)
+      removed.default.bridgeLaunchCodes = await destroyCriteriaCount(
+        BridgeLaunchCode,
+        { app: { in: records.appIds } },
+        db
+      )
+      removed.default.bridgeAccess = await destroyCriteriaCount(
+        BridgeAccess,
+        { app: { in: records.appIds } },
+        db
+      )
       removed.default.deploymentLeases = await destroyCount(
         DeploymentLease,
         records.deploymentLeaseIds,
@@ -202,6 +222,18 @@ async function destroyCount(model, ids, db) {
     .destroy({ id: { in: ids } })
     .fetch()
     .usingConnection(db)
+  return destroyed.length
+}
+
+async function destroyCriteriaCount(model, criteria, db) {
+  if (
+    Object.values(criteria).some(
+      (value) => value && Array.isArray(value.in) && value.in.length === 0
+    )
+  ) {
+    return 0
+  }
+  const destroyed = await model.destroy(criteria).fetch().usingConnection(db)
   return destroyed.length
 }
 

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -221,6 +221,20 @@ module.exports = {
         envVars.SLIPWAY_TELEMETRY_TOKEN = envRecord.telemetryToken
       }
 
+      // 7c. App-local Bridge is an explicit, app-scoped capability. Its
+      // credential is separate from telemetry and never reaches the browser.
+      if (targetApp?.bridgeEnabled) {
+        const bridgeHost =
+          sails.config.environment === 'production'
+            ? 'slipway'
+            : 'host.docker.internal'
+        envVars.SLIPWAY_BRIDGE_ENABLED = 'true'
+        envVars.SLIPWAY_BRIDGE_EXCHANGE_URL = `http://${bridgeHost}:1337/api/v1/bridge/exchange`
+        envVars.SLIPWAY_BRIDGE_APP_ID = String(targetApp.id)
+        envVars.SLIPWAY_BRIDGE_SECRET =
+          await sails.helpers.bridge.ensureAppSecret(String(targetApp.id))
+      }
+
       // 8. Get resource limits from existing app
       const existingApp =
         targetApp ||

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -151,6 +151,18 @@ module.exports = {
         ...(existingApp?.envVars || {})
       }
 
+      if (existingApp?.bridgeEnabled) {
+        const bridgeHost =
+          sails.config.environment === 'production'
+            ? 'slipway'
+            : 'host.docker.internal'
+        envVars.SLIPWAY_BRIDGE_ENABLED = 'true'
+        envVars.SLIPWAY_BRIDGE_EXCHANGE_URL = `http://${bridgeHost}:1337/api/v1/bridge/exchange`
+        envVars.SLIPWAY_BRIDGE_APP_ID = String(existingApp.id)
+        envVars.SLIPWAY_BRIDGE_SECRET =
+          await sails.helpers.bridge.ensureAppSecret(String(existingApp.id))
+      }
+
       const containerResult = await sails.helpers.docker.runContainer.with({
         imageName: targetDeployment.imageName,
         containerName: candidateContainerName,

--- a/api/helpers/sails/detect-features.js
+++ b/api/helpers/sails/detect-features.js
@@ -79,6 +79,15 @@ module.exports = {
       sails.log.info(`[sails/detect-features] Detected sails-hook-uploads`)
     }
 
+    // Detect the Sails-native Slipway runtime. Bridge can only expose the
+    // app-local /bridge entry point when this hook is installed.
+    if (deps['sails-hook-slipway']) {
+      features['sails-hook-slipway'] = {
+        version: deps['sails-hook-slipway']
+      }
+      sails.log.info('[sails/detect-features] Detected sails-hook-slipway')
+    }
+
     // Detect sails-stash (caching)
     if (deps['sails-stash']) {
       features['sails-stash'] = {

--- a/api/models/App.js
+++ b/api/models/App.js
@@ -129,6 +129,23 @@ module.exports = {
       columnName: 'resource_limits'
     },
 
+    bridgeEnabled: {
+      type: 'boolean',
+      defaultsTo: false,
+      description: 'Whether the app-local Bridge entry point is enabled',
+      columnName: 'bridge_enabled'
+    },
+
+    bridgeSecret: {
+      type: 'string',
+      allowNull: true,
+      encrypt: true,
+      protect: true,
+      description:
+        'App-specific credential used for the host-to-Slipway Bridge exchange',
+      columnName: 'bridge_secret'
+    },
+
     // Associations
     environment: {
       model: 'environment',

--- a/api/models/BridgeAccess.js
+++ b/api/models/BridgeAccess.js
@@ -1,0 +1,116 @@
+/**
+ * BridgeAccess.js
+ *
+ * App-scoped invitations and grants for host-app users. Bridge users are not
+ * Slipway team members and never inherit infrastructure permissions.
+ */
+
+module.exports = {
+  tableName: 'bridge_access',
+
+  attributes: {
+    email: {
+      type: 'string',
+      required: true,
+      isEmail: true,
+      maxLength: 200
+    },
+
+    role: {
+      type: 'string',
+      isIn: ['viewer', 'editor', 'administrator'],
+      defaultsTo: 'viewer'
+    },
+
+    status: {
+      type: 'string',
+      isIn: ['pending', 'active', 'revoked'],
+      defaultsTo: 'pending'
+    },
+
+    hostUserId: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'host_user_id'
+    },
+
+    hostUserName: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'host_user_name'
+    },
+
+    activatedAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'activated_at'
+    },
+
+    lastUsedAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'last_used_at'
+    },
+
+    revokedAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'revoked_at'
+    },
+
+    inviteTokenHash: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'invite_token_hash'
+    },
+
+    inviteExpiresAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'invite_expires_at'
+    },
+
+    app: {
+      model: 'app',
+      required: true
+    },
+
+    environment: {
+      model: 'environment',
+      required: true
+    },
+
+    project: {
+      model: 'project',
+      required: true
+    },
+
+    team: {
+      model: 'team',
+      required: true
+    },
+
+    invitedBy: {
+      model: 'user',
+      required: true,
+      columnName: 'invited_by'
+    },
+
+    revokedBy: {
+      model: 'user',
+      columnName: 'revoked_by'
+    }
+  },
+
+  beforeCreate: async function (values, proceed) {
+    values.email = values.email.trim().toLowerCase()
+    return proceed()
+  },
+
+  beforeUpdate: async function (values, proceed) {
+    if (values.email) {
+      values.email = values.email.trim().toLowerCase()
+    }
+    return proceed()
+  }
+}

--- a/api/models/BridgeLaunchCode.js
+++ b/api/models/BridgeLaunchCode.js
@@ -1,0 +1,41 @@
+/**
+ * BridgeLaunchCode.js
+ *
+ * Short-lived, single-use handoff from a host app session into Bridge.
+ */
+
+module.exports = {
+  tableName: 'bridge_launch_codes',
+
+  attributes: {
+    tokenHash: {
+      type: 'string',
+      required: true,
+      unique: true,
+      columnName: 'token_hash'
+    },
+
+    expiresAt: {
+      type: 'number',
+      required: true,
+      columnName: 'expires_at'
+    },
+
+    usedAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'used_at'
+    },
+
+    access: {
+      model: 'bridgeaccess',
+      required: true,
+      columnName: 'access_id'
+    },
+
+    app: {
+      model: 'app',
+      required: true
+    }
+  }
+}

--- a/api/policies/is-bridge-authenticated.js
+++ b/api/policies/is-bridge-authenticated.js
@@ -1,0 +1,14 @@
+module.exports = async function (req, res, proceed) {
+  if (req.session.userId || req.session.bridgeAccessId) {
+    return proceed()
+  }
+
+  if (req.wantsJSON && req.get('X-Inertia') !== 'true') {
+    return res.status(401).json({
+      error: 'Unauthorized',
+      message: 'Bridge authentication required.'
+    })
+  }
+
+  return res.redirect('/login')
+}

--- a/api/policies/rate-limit-bridge-exchange.js
+++ b/api/policies/rate-limit-bridge-exchange.js
@@ -1,0 +1,22 @@
+const rateLimit = require('express-rate-limit')
+
+const bridgeExchangeLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 120,
+  standardHeaders: true,
+  legacyHeaders: false,
+  validate: { trustProxy: false },
+  handler: function (_req, res) {
+    return res.status(429).json({
+      error: 'Too Many Requests',
+      message: 'Too many Bridge identity exchanges. Try again in a moment.'
+    })
+  }
+})
+
+module.exports = function (req, res, proceed) {
+  if (sails.config.environment === 'test') {
+    return proceed()
+  }
+  return bridgeExchangeLimiter(req, res, proceed)
+}

--- a/assets/js/components/bridge/BridgeDashboard.vue
+++ b/assets/js/components/bridge/BridgeDashboard.vue
@@ -20,6 +20,13 @@ const props = defineProps({
   environment: {
     type: Object,
     required: true
+  },
+  app: {
+    type: Object
+  },
+  appScoped: {
+    type: Boolean,
+    default: false
   }
 })
 
@@ -45,7 +52,11 @@ const detailCards = computed(() =>
 )
 
 function resourceUrl(identity) {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${identity}`
+  const base =
+    props.appScoped && props.app?.slug
+      ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+      : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+  return `${base}/${identity}`
 }
 
 function actionUrl(card) {

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -35,7 +35,8 @@ const props = defineProps({
   services: Array,
   backupConfigured: Boolean,
   checklist: Array,
-  sourceReadiness: Object
+  sourceReadiness: Object,
+  canManageBridge: Boolean
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
@@ -944,8 +945,31 @@ onBeforeUnmount(() => {
                       </svg>
                       Helm
                     </Link>
+                    <a
+                      v-if="app.bridgeEnabled && app.bridgeUrl"
+                      :href="app.bridgeUrl"
+                      target="_blank"
+                      rel="noopener"
+                      class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                    >
+                      <svg
+                        class="h-4 w-4 text-gray-400"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+                        />
+                      </svg>
+                      Bridge
+                    </a>
                     <Link
-                      :href="`/projects/${project.slug}/environments/${environment.slug}/bridge`"
+                      v-else
+                      :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`"
                       class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                     >
                       <svg
@@ -1126,6 +1150,26 @@ onBeforeUnmount(() => {
                         class="ml-auto h-1.5 w-1.5 rounded-full bg-emerald-500"
                       ></span>
                     </button>
+                    <Link
+                      v-if="canManageBridge"
+                      :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge/access`"
+                      class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                    >
+                      <svg
+                        class="h-4 w-4 text-gray-400"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2m7-10a4 4 0 100-8 4 4 0 000 8zm13 10v-2a4 4 0 00-3-3.87m-1-8a4 4 0 010 7.75"
+                        />
+                      </svg>
+                      Bridge access
+                    </Link>
                     <Link
                       :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/settings`"
                       class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"

--- a/assets/js/pages/projects/bridge-access.vue
+++ b/assets/js/pages/projects/bridge-access.vue
@@ -1,0 +1,536 @@
+<script setup>
+import { Head, Link, router, useForm } from '@inertiajs/vue3'
+import { computed, inject, ref } from 'vue'
+import AppLayout from '@/layouts/AppLayout.vue'
+import Breadcrumb from '@/components/Breadcrumb.vue'
+import ConfirmModal from '@/components/ConfirmModal.vue'
+
+defineOptions({
+  layout: AppLayout
+})
+
+const props = defineProps({
+  project: Object,
+  environment: Object,
+  app: Object,
+  access: Array,
+  hookDetected: Boolean
+})
+
+const toggleMobileMenu = inject('toggleMobileMenu')
+const toggleSidebar = inject('toggleSidebar')
+const sidebarCollapsed = inject('sidebarCollapsed')
+const openMenu = ref(null)
+const revoking = ref(null)
+const disabling = ref(false)
+const resending = ref(null)
+
+const basePath = computed(
+  () =>
+    `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}`
+)
+const bridgePath = computed(() => `${basePath.value}/bridge`)
+const accessPath = computed(() => `${bridgePath.value}/access`)
+
+const inviteForm = useForm({
+  email: '',
+  role: 'viewer'
+})
+
+const validEmail = computed(() =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(inviteForm.email.trim())
+)
+const canInvite = computed(
+  () => props.app.bridgeEnabled && validEmail.value && !inviteForm.processing
+)
+
+function invite() {
+  if (!canInvite.value) return
+  inviteForm
+    .transform((data) => ({
+      email: data.email.trim().toLowerCase(),
+      role: data.role
+    }))
+    .post(`${accessPath.value}/invitations`, {
+      preserveScroll: true,
+      onSuccess: () => inviteForm.reset('email')
+    })
+}
+
+function setEnabled(enabled) {
+  router.patch(
+    accessPath.value,
+    { enabled },
+    {
+      preserveScroll: true
+    }
+  )
+}
+
+function changeRole(grant, role) {
+  openMenu.value = null
+  if (grant.role === role) return
+  router.patch(
+    `${accessPath.value}/${grant.id}`,
+    { role },
+    { preserveScroll: true }
+  )
+}
+
+function resend(grant) {
+  openMenu.value = null
+  resending.value = grant.id
+  router.post(
+    `${accessPath.value}/invitations`,
+    {
+      email: grant.email,
+      role: grant.role
+    },
+    {
+      preserveScroll: true,
+      onFinish: () => {
+        resending.value = null
+      }
+    }
+  )
+}
+
+function confirmRevoke(grant) {
+  openMenu.value = null
+  revoking.value = grant
+}
+
+function revoke() {
+  router.delete(`${accessPath.value}/${revoking.value.id}`, {
+    preserveScroll: true,
+    onFinish: () => {
+      revoking.value = null
+    }
+  })
+}
+
+function disableBridge() {
+  setEnabled(false)
+  disabling.value = false
+}
+
+function closeMenus() {
+  openMenu.value = null
+}
+
+function statusLabel(grant) {
+  if (
+    grant.status === 'pending' &&
+    grant.inviteExpiresAt &&
+    grant.inviteExpiresAt < Date.now()
+  ) {
+    return 'Expired'
+  }
+  return grant.status.charAt(0).toUpperCase() + grant.status.slice(1)
+}
+
+function statusClass(grant) {
+  const status = statusLabel(grant).toLowerCase()
+  if (status === 'active') {
+    return 'bg-emerald-500'
+  }
+  if (status === 'revoked' || status === 'expired') {
+    return 'bg-gray-300 dark:bg-gray-700'
+  }
+  return 'bg-amber-400'
+}
+
+function roleLabel(role) {
+  return role.charAt(0).toUpperCase() + role.slice(1)
+}
+
+function timeAgo(timestamp) {
+  if (!timestamp) return ''
+  const seconds = Math.max(
+    0,
+    Math.floor((Date.now() - Number(timestamp)) / 1000)
+  )
+  const intervals = [
+    ['year', 31536000],
+    ['month', 2592000],
+    ['week', 604800],
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60]
+  ]
+  for (const [label, size] of intervals) {
+    const count = Math.floor(seconds / size)
+    if (count >= 1) return `${count} ${label}${count > 1 ? 's' : ''} ago`
+  }
+  return 'just now'
+}
+</script>
+
+<template>
+  <Head :title="`Bridge access - ${app.name} | Slipway`"></Head>
+  <div class="flex h-full flex-col" @click="closeMenus">
+    <header
+      class="flex items-center justify-between border-b border-gray-200 py-4 pl-4 pr-4 dark:border-gray-800 sm:pr-8"
+    >
+      <div class="flex min-w-0 items-center gap-3">
+        <button
+          type="button"
+          class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
+          aria-label="Open navigation"
+          @click.stop="toggleMobileMenu"
+        >
+          <svg
+            class="h-5 w-5"
+            viewBox="-0.5 -0.5 16 16"
+            fill="none"
+            stroke="currentColor"
+          >
+            <path
+              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+            <path d="M5.615 14.285V.715" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          class="hidden text-gray-400 dark:text-gray-500 md:block"
+          :aria-label="sidebarCollapsed ? 'Expand sidebar' : 'Collapse sidebar'"
+          @click.stop="toggleSidebar"
+        >
+          <svg
+            class="h-5 w-5"
+            viewBox="-0.5 -0.5 16 16"
+            fill="none"
+            stroke="currentColor"
+          >
+            <path
+              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
+            />
+            <path d="M5.615 14.285V.715" />
+          </svg>
+        </button>
+        <Breadcrumb
+          :items="[
+            { label: 'projects', href: '/' },
+            {
+              label: project.name.toLowerCase(),
+              href: `/projects/${project.slug}`
+            },
+            {
+              label: environment.name.toLowerCase(),
+              href: `/projects/${project.slug}/environments/${environment.slug}`
+            },
+            { label: app.name.toLowerCase(), href: basePath },
+            { label: 'bridge access' }
+          ]"
+        />
+      </div>
+    </header>
+
+    <main class="flex-1 overflow-y-auto px-4 py-8 sm:px-8 sm:py-12">
+      <div class="mx-auto max-w-3xl">
+        <div
+          class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between"
+        >
+          <div>
+            <h1 class="text-xl font-semibold text-gray-950 dark:text-white">
+              Bridge access
+            </h1>
+            <p
+              class="mt-1 max-w-xl text-sm leading-6 text-gray-500 dark:text-gray-400"
+            >
+              Invite people by email. Bridge grants access only after they sign
+              in to {{ app.name }} with that verified address.
+            </p>
+          </div>
+          <div class="flex shrink-0 items-center gap-2">
+            <a
+              v-if="app.bridgeEnabled && app.bridgeUrl"
+              :href="app.bridgeUrl"
+              target="_blank"
+              rel="noopener"
+              class="min-h-9 inline-flex items-center rounded-lg bg-gray-950 px-3.5 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100"
+            >
+              Open Bridge
+            </a>
+            <button
+              v-if="!app.bridgeEnabled"
+              type="button"
+              class="min-h-9 inline-flex items-center rounded-lg bg-gray-950 px-3.5 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100"
+              @click="setEnabled(true)"
+            >
+              Enable Bridge
+            </button>
+          </div>
+        </div>
+
+        <section
+          v-if="app.bridgeEnabled && !hookDetected"
+          class="mt-8 rounded-lg bg-amber-50 px-4 py-3 dark:bg-amber-950/30"
+          role="status"
+          data-test="bridge-hook-warning"
+        >
+          <p class="text-sm font-medium text-amber-900 dark:text-amber-200">
+            Install sails-hook-slipway, then redeploy this app.
+          </p>
+          <p class="mt-1 text-sm leading-6 text-amber-700 dark:text-amber-300">
+            The hook adds the secure <code>/bridge</code> entry point. Existing
+            dashboard Bridge tools continue to work while you update.
+          </p>
+        </section>
+
+        <section
+          v-else-if="app.bridgeEnabled"
+          class="mt-8 flex items-start gap-3 rounded-lg bg-gray-50 px-4 py-3 dark:bg-gray-900"
+          data-test="bridge-enabled-notice"
+        >
+          <span
+            class="mt-1 h-2 w-2 shrink-0 rounded-full bg-emerald-500"
+          ></span>
+          <div class="min-w-0">
+            <p class="text-sm font-medium text-gray-900 dark:text-gray-100">
+              App-local Bridge is enabled
+            </p>
+            <p
+              class="mt-0.5 text-sm leading-6 text-gray-500 dark:text-gray-400"
+            >
+              Redeploy after changing this setting so the app receives its
+              scoped exchange credential.
+            </p>
+          </div>
+        </section>
+
+        <section class="mt-10" aria-labelledby="invite-title">
+          <div>
+            <h2
+              id="invite-title"
+              class="text-sm font-semibold text-gray-950 dark:text-white"
+            >
+              Invite someone
+            </h2>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Their verified host-app email must match the invitation.
+            </p>
+          </div>
+
+          <form
+            class="mt-4 grid gap-3 sm:grid-cols-[minmax(0,1fr)_10rem_auto]"
+            @submit.prevent="invite"
+          >
+            <div>
+              <label for="bridge-invite-email" class="sr-only">
+                Email address
+              </label>
+              <input
+                id="bridge-invite-email"
+                v-model="inviteForm.email"
+                type="email"
+                autocomplete="email"
+                placeholder="editor@example.com"
+                :disabled="!app.bridgeEnabled || inviteForm.processing"
+                class="min-h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-950 placeholder-gray-400 outline-none focus:border-gray-400 focus:ring-2 focus:ring-gray-100 disabled:cursor-not-allowed disabled:bg-gray-50 dark:border-gray-800 dark:bg-gray-950 dark:text-white dark:focus:border-gray-600 dark:focus:ring-gray-900 dark:disabled:bg-gray-900"
+              />
+              <p
+                v-if="inviteForm.errors.email"
+                class="mt-1.5 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ inviteForm.errors.email }}
+              </p>
+            </div>
+            <div>
+              <label for="bridge-invite-role" class="sr-only">
+                Bridge role
+              </label>
+              <select
+                id="bridge-invite-role"
+                v-model="inviteForm.role"
+                :disabled="!app.bridgeEnabled || inviteForm.processing"
+                class="min-h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 outline-none focus:border-gray-400 focus:ring-2 focus:ring-gray-100 disabled:cursor-not-allowed disabled:bg-gray-50 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:focus:border-gray-600 dark:focus:ring-gray-900 dark:disabled:bg-gray-900"
+              >
+                <option value="viewer">Viewer</option>
+                <option value="editor">Editor</option>
+                <option value="administrator">Administrator</option>
+              </select>
+            </div>
+            <button
+              type="submit"
+              :disabled="!canInvite"
+              class="min-h-10 inline-flex items-center justify-center rounded-lg bg-gray-950 px-4 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:bg-gray-200 disabled:text-gray-500 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100 dark:disabled:bg-gray-800 dark:disabled:text-gray-500"
+            >
+              {{ inviteForm.processing ? 'Sending…' : 'Send invite' }}
+            </button>
+          </form>
+        </section>
+
+        <section class="mt-12" aria-labelledby="people-title">
+          <div class="flex items-baseline justify-between gap-4">
+            <div>
+              <h2
+                id="people-title"
+                class="text-sm font-semibold text-gray-950 dark:text-white"
+              >
+                People
+              </h2>
+              <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                {{ access.length }}
+                {{ access.length === 1 ? 'person' : 'people' }}
+              </p>
+            </div>
+          </div>
+
+          <div
+            v-if="access.length"
+            class="mt-3 divide-y divide-gray-100 dark:divide-gray-900"
+          >
+            <article
+              v-for="grant in access"
+              :key="grant.id"
+              class="min-h-16 flex items-center gap-3 py-3"
+              :data-test="`bridge-access-${grant.id}`"
+            >
+              <span
+                :class="['h-2 w-2 shrink-0 rounded-full', statusClass(grant)]"
+                :title="statusLabel(grant)"
+              ></span>
+              <div class="min-w-0 flex-1">
+                <p
+                  class="truncate text-sm font-medium text-gray-900 dark:text-gray-100"
+                >
+                  {{ grant.hostUserName || grant.email }}
+                </p>
+                <p
+                  class="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-500"
+                >
+                  <span v-if="grant.hostUserName">{{ grant.email }} · </span>
+                  {{ statusLabel(grant) }}
+                  <span v-if="grant.lastUsedAt">
+                    · used {{ timeAgo(grant.lastUsedAt) }}</span
+                  >
+                </p>
+              </div>
+              <span
+                class="hidden text-sm text-gray-500 dark:text-gray-400 sm:block"
+              >
+                {{ roleLabel(grant.role) }}
+              </span>
+              <div class="relative">
+                <button
+                  type="button"
+                  class="rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-900 dark:hover:text-gray-200"
+                  :aria-label="`Manage ${grant.email}`"
+                  :aria-expanded="openMenu === grant.id"
+                  @click.stop="
+                    openMenu = openMenu === grant.id ? null : grant.id
+                  "
+                >
+                  <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
+                    <circle cx="6" cy="12" r="1.5" />
+                    <circle cx="12" cy="12" r="1.5" />
+                    <circle cx="18" cy="12" r="1.5" />
+                  </svg>
+                </button>
+                <div
+                  v-if="openMenu === grant.id"
+                  class="absolute right-0 top-full z-20 mt-1 w-44 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-800 dark:bg-gray-900"
+                  @click.stop
+                >
+                  <p
+                    class="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-gray-400"
+                  >
+                    Role
+                  </p>
+                  <button
+                    v-for="role in ['viewer', 'editor', 'administrator']"
+                    :key="role"
+                    type="button"
+                    class="flex w-full items-center justify-between px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+                    @click="changeRole(grant, role)"
+                  >
+                    {{ roleLabel(role) }}
+                    <span v-if="grant.role === role">✓</span>
+                  </button>
+                  <button
+                    v-if="grant.status !== 'active'"
+                    type="button"
+                    :disabled="resending === grant.id"
+                    class="mt-1 w-full border-t border-gray-100 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 disabled:text-gray-400 dark:border-gray-800 dark:text-gray-300 dark:hover:bg-gray-800"
+                    @click="resend(grant)"
+                  >
+                    {{
+                      resending === grant.id
+                        ? 'Sending…'
+                        : grant.status === 'revoked'
+                        ? 'Re-invite'
+                        : 'Resend invitation'
+                    }}
+                  </button>
+                  <button
+                    v-if="grant.status !== 'revoked'"
+                    type="button"
+                    :class="[
+                      'w-full px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/30',
+                      grant.status === 'active'
+                        ? 'mt-1 border-t border-gray-100 dark:border-gray-800'
+                        : ''
+                    ]"
+                    @click="confirmRevoke(grant)"
+                  >
+                    Revoke access
+                  </button>
+                </div>
+              </div>
+            </article>
+          </div>
+
+          <div v-else class="mt-5 py-8 text-center">
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              No one has been invited yet.
+            </p>
+          </div>
+        </section>
+
+        <div
+          v-if="app.bridgeEnabled"
+          class="mt-12 flex items-center justify-between gap-4 border-t border-gray-100 pt-6 dark:border-gray-900"
+        >
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            Disabling Bridge immediately blocks new and existing Bridge
+            sessions.
+          </p>
+          <button
+            type="button"
+            class="shrink-0 text-sm font-medium text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            @click="disabling = true"
+          >
+            Disable Bridge
+          </button>
+        </div>
+      </div>
+    </main>
+
+    <ConfirmModal
+      :show="Boolean(revoking)"
+      title="Revoke Bridge access?"
+      :message="
+        revoking
+          ? `${revoking.email} will immediately lose access to this app's Bridge.`
+          : ''
+      "
+      confirm-text="Revoke access"
+      confirm-variant="danger"
+      @confirm="revoke"
+      @cancel="revoking = null"
+    />
+    <ConfirmModal
+      :show="disabling"
+      title="Disable Bridge?"
+      message="Everyone will immediately lose access to this app's Bridge. You will need to redeploy after enabling it again."
+      confirm-text="Disable Bridge"
+      confirm-variant="danger"
+      @confirm="disableBridge"
+      @cancel="disabling = false"
+    />
+  </div>
+</template>

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -20,6 +20,8 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environment: Object,
+  app: Object,
+  appScoped: Boolean,
   mode: String,
   modelIdentity: String,
   recordId: String,
@@ -34,6 +36,16 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const { toasts, toast, dismiss } = createToast()
+const bridgeBasePath = computed(() =>
+  props.appScoped && props.app?.slug
+    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+)
+const bridgeApiBasePath = computed(() =>
+  props.appScoped && props.app?.slug
+    ? `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+    : `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+)
 
 const isEdit = computed(() => props.mode === 'edit')
 
@@ -174,12 +186,10 @@ function handleSubmit() {
 
   form.values = values
   const actionUrl = isEdit.value
-    ? `/projects/${props.project.slug}/environments/${
-        props.environment.slug
-      }/bridge/${props.modelIdentity}/${encodePathSegment(
+    ? `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
         props.recordId
       )}/update`
-    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/create`
+    : `${bridgeBasePath.value}/${props.modelIdentity}/create`
 
   form.post(actionUrl, {
     onSuccess: () => {
@@ -195,7 +205,7 @@ function handleSubmit() {
 }
 
 function uploadUrl(field) {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/${field.name}/upload`
+  return `${bridgeBasePath.value}/${props.modelIdentity}/${field.name}/upload`
 }
 
 function relationshipSearchUrl(field) {
@@ -206,23 +216,21 @@ function relationshipSearchUrl(field) {
   if (isEdit.value && props.recordId !== null) {
     params.set('recordId', String(props.recordId))
   }
-  return `/api/v1/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/relationships/${encodePathSegment(
-    field.name
-  )}/options?${params.toString()}`
+  return `${bridgeApiBasePath.value}/${
+    props.modelIdentity
+  }/relationships/${encodePathSegment(field.name)}/options?${params.toString()}`
 }
 
 function bridgeUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+  return bridgeBasePath.value
 }
 function modelUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}`
+  return `${bridgeBasePath.value}/${props.modelIdentity}`
 }
 function recordUrl() {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/${encodePathSegment(props.recordId)}`
+  return `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
+    props.recordId
+  )}`
 }
 </script>
 

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -17,6 +17,8 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environment: Object,
+  app: Object,
+  appScoped: Boolean,
   modelIdentity: String,
   appRunning: Boolean,
   modelMeta: Object,
@@ -37,6 +39,11 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const { toasts, toast, dismiss } = createToast()
+const bridgeBasePath = computed(() =>
+  props.appScoped && props.app?.slug
+    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+)
 
 // Local state for UI
 const page = ref(props.currentPage)
@@ -197,7 +204,7 @@ function navigateWithParams(updates) {
   if (!params.dashboard) delete params.dashboard
 
   const query = new URLSearchParams(params).toString()
-  const basePath = `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}`
+  const basePath = `${bridgeBasePath.value}/${props.modelIdentity}`
 
   router.visit(query ? `${basePath}?${query}` : basePath, {
     preserveState: true,
@@ -255,9 +262,7 @@ function toggleSelect(id) {
 // Delete single record
 function confirmDelete() {
   deleteForm.post(
-    `/projects/${props.project.slug}/environments/${
-      props.environment.slug
-    }/bridge/${props.modelIdentity}/${encodePathSegment(
+    `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
       deleteModal.value.recordId
     )}/delete`,
     {
@@ -282,7 +287,7 @@ function confirmDelete() {
 function confirmBulkDelete() {
   bulkDeleteForm.ids = Array.from(selectedIds.value)
   bulkDeleteForm.post(
-    `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/bulk-delete`,
+    `${bridgeBasePath.value}/${props.modelIdentity}/bulk-delete`,
     {
       preserveScroll: true,
       onSuccess: () => {
@@ -314,9 +319,9 @@ function actionMenuItem(action) {
 }
 
 function customActionUrl(action) {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/actions/${encodePathSegment(action.name)}`
+  return `${bridgeBasePath.value}/${
+    props.modelIdentity
+  }/actions/${encodePathSegment(action.name)}`
 }
 
 function actionNeedsDialog(action) {
@@ -392,20 +397,20 @@ function switchDashboard(event) {
 
 // URL builders
 function bridgeUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+  return bridgeBasePath.value
 }
 function recordUrl(id) {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/${encodePathSegment(id)}`
+  return `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
+    id
+  )}`
 }
 function editUrl(id) {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/${encodePathSegment(id)}/edit`
+  return `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
+    id
+  )}/edit`
 }
 function createUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}/new`
+  return `${bridgeBasePath.value}/${props.modelIdentity}/new`
 }
 </script>
 
@@ -641,6 +646,8 @@ function createUrl() {
           :resources="dashboardResources"
           :project="project"
           :environment="environment"
+          :app="app"
+          :app-scoped="appScoped"
           class="mb-10"
         />
 

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -17,6 +17,8 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environment: Object,
+  app: Object,
+  appScoped: Boolean,
   modelIdentity: String,
   recordId: String,
   appRunning: Boolean,
@@ -30,6 +32,16 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const { toasts, toast, dismiss } = createToast()
+const bridgeBasePath = computed(() =>
+  props.appScoped && props.app?.slug
+    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+)
+const bridgeApiBasePath = computed(() =>
+  props.appScoped && props.app?.slug
+    ? `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+    : `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+)
 
 const deleteModal = ref({ show: false })
 const deleteForm = useForm({})
@@ -101,9 +113,7 @@ function fieldLabel(name) {
 
 function confirmDelete() {
   deleteForm.post(
-    `/projects/${props.project.slug}/environments/${
-      props.environment.slug
-    }/bridge/${props.modelIdentity}/${encodePathSegment(
+    `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
       props.recordId
     )}/delete`,
     {
@@ -121,9 +131,9 @@ function confirmDelete() {
 }
 
 function customActionUrl(action) {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/actions/${encodePathSegment(action.name)}`
+  return `${bridgeBasePath.value}/${
+    props.modelIdentity
+  }/actions/${encodePathSegment(action.name)}`
 }
 
 function actionNeedsDialog(action) {
@@ -169,20 +179,18 @@ function handleRecordAction(item) {
 }
 
 function bridgeUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+  return bridgeBasePath.value
 }
 function modelUrl() {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${props.modelIdentity}`
+  return `${bridgeBasePath.value}/${props.modelIdentity}`
 }
 function editUrl() {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/${encodePathSegment(props.recordId)}/edit`
+  return `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
+    props.recordId
+  )}/edit`
 }
 function relatedRecordUrl(model, id) {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${model}/${encodePathSegment(id)}`
+  return `${bridgeBasePath.value}/${model}/${encodePathSegment(id)}`
 }
 
 function relationshipOptionsUrl(relationship) {
@@ -190,17 +198,15 @@ function relationshipOptionsUrl(relationship) {
     surface: 'manage',
     recordId: String(props.recordId)
   })
-  return `/api/v1/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/relationships/${encodePathSegment(
+  return `${bridgeApiBasePath.value}/${
+    props.modelIdentity
+  }/relationships/${encodePathSegment(
     relationship.alias
   )}/options?${params.toString()}`
 }
 
 function relationshipMutationBaseUrl(relationship) {
-  return `/projects/${props.project.slug}/environments/${
-    props.environment.slug
-  }/bridge/${props.modelIdentity}/${encodePathSegment(
+  return `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
     props.recordId
   )}/relationships/${encodePathSegment(relationship.alias)}`
 }

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -11,6 +11,8 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environment: Object,
+  app: Object,
+  appScoped: Boolean,
   appRunning: Boolean,
   models: Object,
   modelsError: String,
@@ -21,6 +23,11 @@ const props = defineProps({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
+const bridgeBasePath = computed(() =>
+  props.appScoped && props.app?.slug
+    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+)
 
 // Search
 const searchQuery = ref('')
@@ -59,7 +66,7 @@ function assocCount(model) {
 }
 
 function bridgeModelUrl(identity) {
-  return `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge/${identity}`
+  return `${bridgeBasePath.value}/${identity}`
 }
 
 function refresh() {
@@ -68,15 +75,11 @@ function refresh() {
 
 function switchDashboard(event) {
   const id = event.target.value
-  router.get(
-    `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`,
-    id ? { dashboard: id } : {},
-    {
-      preserveState: true,
-      preserveScroll: true,
-      replace: true
-    }
-  )
+  router.get(bridgeBasePath.value, id ? { dashboard: id } : {}, {
+    preserveState: true,
+    preserveScroll: true,
+    replace: true
+  })
 }
 </script>
 
@@ -377,6 +380,8 @@ function switchDashboard(event) {
           :resources="models"
           :project="project"
           :environment="environment"
+          :app="app"
+          :app-scoped="appScoped"
         />
 
         <!-- Toolbar -->

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -16,6 +16,7 @@ module.exports.bootstrap = async function () {
   await sails.helpers.deploy.ensureQueueSchema()
   await sails.helpers.service.ensureVersionSchema()
   await sails.helpers.lookout.ensureObservabilitySchema()
+  await sails.helpers.bridge.ensureSchema()
 
   // Initialize CLI tokens map for Bearer token authentication
   sails.cliTokens = new Map()

--- a/config/policies.js
+++ b/config/policies.js
@@ -75,6 +75,27 @@ module.exports.policies = {
   // Telemetry ingest is public (token-verified in controller)
   'api/v1/telemetry/ingest': true,
 
+  // Bridge handoff endpoints authenticate with a dedicated app credential or
+  // a short-lived, single-use launch code.
+  'api/v1/bridge/exchange': 'rate-limit-bridge-exchange',
+  'bridge/launch': true,
+
+  // Bridge pages accept either a Slipway operator session or the dedicated,
+  // app-scoped host-user session created by bridge/launch.
+  'project/view-bridge': 'is-bridge-authenticated',
+  'project/view-bridge-model': 'is-bridge-authenticated',
+  'project/view-bridge-create': 'is-bridge-authenticated',
+  'project/view-bridge-edit': 'is-bridge-authenticated',
+  'project/view-bridge-record': 'is-bridge-authenticated',
+  'project/bridge-create-record': 'is-bridge-authenticated',
+  'project/bridge-update-record': 'is-bridge-authenticated',
+  'project/bridge-delete-record': 'is-bridge-authenticated',
+  'project/bridge-bulk-delete': 'is-bridge-authenticated',
+  'project/bridge-execute-action': 'is-bridge-authenticated',
+  'project/bridge-relationship-options': 'is-bridge-authenticated',
+  'project/bridge-update-relationship': 'is-bridge-authenticated',
+  'project/bridge-upload-field': 'is-bridge-authenticated',
+
   // Webhooks are public (signature-verified in controller)
   'api/v1/webhook/github': true,
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -341,6 +341,47 @@ module.exports.routes = {
     'project/view-dock',
 
   // Bridge UI
+  'GET /bridge/launch': 'bridge/launch',
+  'POST /api/v1/bridge/exchange': {
+    action: 'api/v1/bridge/exchange',
+    csrf: false
+  },
+  'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/access':
+    'project/view-bridge-access',
+  'PATCH /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/access':
+    'project/update-bridge-settings',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/access/invitations':
+    'project/invite-bridge-user',
+  'PATCH /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/access/:accessId':
+    'project/update-bridge-access',
+  'DELETE /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/access/:accessId':
+    'project/revoke-bridge-access',
+  'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge':
+    'project/view-bridge',
+  'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity':
+    'project/view-bridge-model',
+  'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/new':
+    'project/view-bridge-create',
+  'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/:recordId':
+    'project/view-bridge-record',
+  'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/:recordId/edit':
+    'project/view-bridge-edit',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/create':
+    'project/bridge-create-record',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/:fieldName/upload':
+    'project/bridge-upload-field',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/:recordId/update':
+    'project/bridge-update-record',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/:recordId/delete':
+    'project/bridge-delete-record',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/bulk-delete':
+    'project/bridge-bulk-delete',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/actions/:actionName':
+    'project/bridge-execute-action',
+  'GET /api/v1/projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/relationships/:relationshipAlias/options':
+    'project/bridge-relationship-options',
+  'POST /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/:recordId/relationships/:relationshipAlias/:operation':
+    'project/bridge-update-relationship',
   'GET /projects/:slug/bridge': 'project/view-bridge',
   'GET /projects/:slug/environments/:envSlug/bridge': 'project/view-bridge',
   'GET /projects/:slug/bridge/:modelIdentity': 'project/view-bridge-model',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9850,7 +9850,7 @@
     },
     "packages/hook": {
       "name": "sails-hook-slipway",
-      "version": "0.0.3",
+      "version": "0.1.0",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -1,46 +1,13 @@
 # sails-hook-slipway
 
-> The Sails hook that makes your app Slipway-aware
+The Sails hook that connects an application to Slipway.
 
-## What It Does
+It currently provides:
 
-This hook transforms any Sails app into a fully-managed application with:
-
-- **The Bridge** - Auto-generated CRUD for all your models (ship's command center)
-- **The Helm** - Production REPL with full Sails context (where you steer your app)
-- **Quest Dashboard** - Job queue management (if sails-quest installed)
-- **Content CMS** - Visual content editor (if sails-content installed)
-- **Telemetry** - OpenTelemetry instrumentation sent to Slipway
-
-## Routes
-
-| Route              | Feature                      | Condition                 |
-| ------------------ | ---------------------------- | ------------------------- |
-| `/slipway`         | Control panel dashboard      | Always                    |
-| `/slipway/bridge`  | The Bridge (data management) | Always                    |
-| `/slipway/helm`    | The Helm (REPL)              | Always                    |
-| `/slipway/quest`   | Job queue dashboard          | If sails-quest detected   |
-| `/slipway/content` | CMS interface                | If sails-content detected |
-
-## Two Access Methods
-
-### 1. Direct (via app URL)
-
-```
-myapp.example.com/slipway/bridge
-myapp.example.com/slipway/helm
-```
-
-Users go directly to your app's Bridge or Helm.
-
-### 2. Via Slipway Dashboard (centralized)
-
-```
-slipway.yourdomain.com/app/myapp/bridge
-slipway.yourdomain.com/app/myapp/helm
-```
-
-The Slipway Dashboard proxies requests, providing single sign-on across all apps.
+- automatic request, exception, Waterline, Quest, and cache telemetry for
+  Lookout; and
+- a secure app-local `/bridge` entry point for people who manage application
+  data without receiving Slipway infrastructure access.
 
 ## Installation
 
@@ -50,66 +17,139 @@ Requires Node.js 22 or newer.
 npm install sails-hook-slipway
 ```
 
-The hook auto-registers with Sails.
+Slipway detects the hook and injects its deployment credentials automatically.
+Do not copy Bridge or telemetry credentials into `config/slipway.js`.
 
-## Configuration
+## App-local Bridge
 
-```javascript
+Enable Bridge for an app from **App → Bridge access** in Slipway, then redeploy
+the app. Slipway injects a dedicated, app-scoped exchange credential into that
+deployment.
+
+People open:
+
+```text
+https://your-app.example.com/bridge
+```
+
+The hook uses the app's existing authenticated user as the identity. Slipway
+only activates an invitation when the signed-in user's verified email exactly
+matches the invited email. The account may be created after the invitation is
+sent, but it must exist and verify that address before Bridge opens. Bridge
+users are not added to the Slipway team.
+
+The default Boring Stack conventions work without app code:
+
+- model: `User`
+- session key: `userId`
+- email: `email`
+- name: `fullName`
+- verification: `emailStatus` is `verified` or `confirmed`
+
+### Custom authentication
+
+Configure one identity helper when the app uses different authentication
+conventions:
+
+```js
 // config/slipway.js
 module.exports.slipway = {
   bridge: {
-    enabled: true,
-    path: '/slipway/bridge'
-  },
-  helm: {
-    enabled: true,
-    path: '/slipway/helm',
-    readOnly: false // Set true in production
-  },
-  quest: {
-    enabled: true // Auto-disabled if sails-quest not installed
-  },
-  content: {
-    enabled: true // Auto-disabled if sails-content not installed
-  },
-  telemetry: {
-    enabled: true,
-    endpoint: process.env.SLIPWAY_TELEMETRY_URL
+    loginPath: '/sign-in',
+    identity: {
+      helper: 'bridge.identity'
+    }
   }
 }
 ```
 
-## Permissions (Sails Clearance)
+```js
+// api/helpers/bridge/identity.js
+module.exports = {
+  friendlyName: 'Resolve Bridge identity',
 
-The hook integrates with Sails Clearance for fine-grained access control:
+  inputs: {
+    req: { type: 'ref', required: true }
+  },
 
-```javascript
-{
-  'bridge:read': ['admin', 'support'],
-  'bridge:write': ['admin'],
-  'helm:access': ['admin', 'developer'],
-  'quest:retry': ['admin', 'developer'],
-  'content:publish': ['admin', 'editor']
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: async function ({ req }) {
+    const member = await Member.findOne({ id: req.session.memberId })
+    if (!member) return null
+
+    return {
+      id: member.id,
+      email: member.email,
+      fullName: member.name,
+      emailVerified: member.emailVerified === true
+    }
+  }
 }
 ```
 
-## Dev Mode
+The helper must return `emailVerified: true`. Bridge fails closed when it cannot
+prove email verification.
 
-When you run `slipway dev`, this hook provides the full experience locally:
+### Declarative identity mapping
 
-```bash
-slipway dev
+For conventional model-backed sessions with different names, map the
+attributes instead:
 
-  App:      http://localhost:1337
-  Bridge:   http://localhost:1337/slipway/bridge
-  Helm:     http://localhost:1337/slipway/helm
+```js
+module.exports.slipway = {
+  bridge: {
+    loginPath: '/login',
+    identity: {
+      model: 'member',
+      sessionKey: 'memberId',
+      emailAttribute: 'emailAddress',
+      nameAttribute: 'name',
+      emailVerifiedAttribute: 'hasVerifiedEmail'
+    }
+  }
+}
 ```
 
-## Part of the Slipway Suite
+## Security model
 
-- **Slipway Dashboard** - Can proxy to this hook's routes
-- **slipway CLI** - `slipway helm` connects to this hook
+- Bridge is disabled per app by default.
+- The exchange credential is encrypted by Slipway, scoped to one app, kept
+  server-side, and separate from the Lookout telemetry token.
+- Enabling Bridge rotates the credential, so an old container cannot activate
+  access before the required redeploy.
+- Invitations expire after seven days, store only a SHA-256 token hash, and
+  activate atomically against one host-app identity.
+- Launch codes expire after two minutes and are consumed atomically once.
+- The handoff regenerates the session before adding Bridge authorization.
+- Disabling Bridge, revoking a grant, changing the app credential, or exceeding
+  the eight-hour Bridge session lifetime invalidates access server-side.
+- Bridge roles (`viewer`, `editor`, and `administrator`) are a ceiling. The
+  target app's configured resource authorization can only narrow that access.
 
----
+## Lookout telemetry
 
-_Where your apps slide into production._
+Slipway automatically injects `SLIPWAY_TELEMETRY_URL` and
+`SLIPWAY_TELEMETRY_TOKEN` during deployment.
+
+Optional settings live under `lookout`:
+
+```js
+// config/slipway.js
+module.exports.slipway = {
+  lookout: {
+    enabled: true,
+    batchSize: 50,
+    flushInterval: 10000,
+    captureQueries: true,
+    captureExceptions: true,
+    captureQuestEvents: true,
+    captureCache: true,
+    slowQueryThreshold: 100
+  }
+}
+```
+
+Telemetry failures never break the host application.

--- a/packages/hook/index.js
+++ b/packages/hook/index.js
@@ -37,10 +37,24 @@ module.exports = function defineSlipwayHook(sails) {
 
   // Config (populated in initialize)
   let config = {}
+  let bridgeConfig = {}
 
   return {
     defaults: {
       slipway: {
+        bridge: {
+          enabled: false,
+          loginPath: '/login',
+          identity: {
+            model: 'user',
+            sessionKey: 'userId',
+            emailAttribute: 'email',
+            nameAttribute: 'fullName',
+            emailStatusAttribute: 'emailStatus',
+            emailVerifiedAttribute: 'emailVerified',
+            verifiedEmailStatuses: ['verified', 'confirmed']
+          }
+        },
         lookout: {
           enabled: true,
           batchSize: 50,
@@ -61,10 +75,25 @@ module.exports = function defineSlipwayHook(sails) {
 
       if (envUrl) sails.config.slipway.lookout.telemetryUrl = envUrl
       if (envToken) sails.config.slipway.lookout.telemetryToken = envToken
+
+      if (process.env.SLIPWAY_BRIDGE_ENABLED === 'true') {
+        sails.config.slipway.bridge.enabled = true
+      }
+      if (process.env.SLIPWAY_BRIDGE_EXCHANGE_URL) {
+        sails.config.slipway.bridge.exchangeUrl =
+          process.env.SLIPWAY_BRIDGE_EXCHANGE_URL
+      }
+      if (process.env.SLIPWAY_BRIDGE_APP_ID) {
+        sails.config.slipway.bridge.appId = process.env.SLIPWAY_BRIDGE_APP_ID
+      }
+      if (process.env.SLIPWAY_BRIDGE_SECRET) {
+        sails.config.slipway.bridge.secret = process.env.SLIPWAY_BRIDGE_SECRET
+      }
     },
 
     initialize: function (done) {
       config = sails.config.slipway.lookout
+      bridgeConfig = sails.config.slipway.bridge
 
       // Skip if not configured
       if (!config.telemetryUrl || !config.telemetryToken) {
@@ -207,6 +236,90 @@ module.exports = function defineSlipwayHook(sails) {
           }
 
           next()
+        }
+      },
+      after: {
+        'GET /bridge': async function (req, res) {
+          if (!bridgeConfig.enabled) {
+            return res.notFound()
+          }
+
+          if (
+            !bridgeConfig.exchangeUrl ||
+            !bridgeConfig.appId ||
+            !bridgeConfig.secret
+          ) {
+            sails.log.warn(
+              'sails-hook-slipway: Bridge is enabled but its Slipway exchange credentials are unavailable.'
+            )
+            return res.serverError(
+              'Bridge is not configured for this deployment. Redeploy the app from Slipway.'
+            )
+          }
+
+          let identity
+          try {
+            identity = await resolveBridgeIdentity(req)
+          } catch (error) {
+            sails.log.warn(
+              `sails-hook-slipway: Could not resolve the Bridge user: ${
+                error.message || error
+              }`
+            )
+            return res.forbidden(
+              'Bridge could not verify your host-app account.'
+            )
+          }
+
+          if (!identity) {
+            const loginPath = safeLocalPath(bridgeConfig.loginPath, '/login')
+            const returnUrl = safeLocalPath(req.originalUrl, '/bridge')
+            return res.redirect(
+              `${loginPath}?redirect=${encodeURIComponent(returnUrl)}`
+            )
+          }
+
+          if (!identity.emailVerified) {
+            return res.forbidden(
+              'Verify your host-app email address before opening Bridge.'
+            )
+          }
+
+          try {
+            const response = await requestJson({
+              url: bridgeConfig.exchangeUrl,
+              token: bridgeConfig.secret,
+              body: {
+                appId: String(bridgeConfig.appId),
+                hostUser: identity,
+                inviteToken:
+                  typeof req.query?.invite === 'string'
+                    ? req.query.invite
+                    : undefined
+              }
+            })
+
+            if (!response.launchUrl) {
+              throw new Error('Slipway did not return a Bridge launch URL.')
+            }
+
+            return res.redirect(response.launchUrl)
+          } catch (error) {
+            if (error.statusCode === 403) {
+              return res.forbidden(
+                `Your host-app account (${identity.email}) has not been invited to Bridge.`
+              )
+            }
+
+            sails.log.warn(
+              `sails-hook-slipway: Bridge exchange failed: ${
+                error.message || error
+              }`
+            )
+            return res.serverError(
+              'Bridge could not contact Slipway. Try again in a moment.'
+            )
+          }
         }
       }
     },
@@ -545,5 +658,160 @@ module.exports = function defineSlipwayHook(sails) {
     } catch {
       // Silently fail
     }
+  }
+
+  async function resolveBridgeIdentity(req) {
+    const identityConfig = bridgeConfig.identity || {}
+    if (identityConfig.helper) {
+      const helper = resolveHelper(identityConfig.helper)
+      if (!helper) {
+        throw new Error(
+          `Configured Bridge identity helper "${identityConfig.helper}" is unavailable.`
+        )
+      }
+      const resolved = await helper.with({ req })
+      return normalizeBridgeIdentity(resolved)
+    }
+
+    const sessionKey = identityConfig.sessionKey || 'userId'
+    const userId = req.session && req.session[sessionKey]
+    if (!userId) return null
+
+    const modelIdentity = String(identityConfig.model || 'user').toLowerCase()
+    const model = sails.models[modelIdentity]
+    if (!model) {
+      throw new Error(
+        `Bridge identity model "${modelIdentity}" is unavailable.`
+      )
+    }
+
+    const user = await model.findOne({ id: userId })
+    if (!user) return null
+
+    const emailAttribute = identityConfig.emailAttribute || 'email'
+    const nameAttribute = identityConfig.nameAttribute || 'fullName'
+    const statusAttribute = identityConfig.emailStatusAttribute || 'emailStatus'
+    const verifiedAttribute =
+      identityConfig.emailVerifiedAttribute || 'emailVerified'
+    const hasStatusAttribute = Boolean(model.attributes?.[statusAttribute])
+    const hasVerifiedAttribute = Boolean(model.attributes?.[verifiedAttribute])
+    const acceptedStatuses = identityConfig.verifiedEmailStatuses || [
+      'verified',
+      'confirmed'
+    ]
+    if (!hasStatusAttribute && !hasVerifiedAttribute) {
+      throw new Error(
+        `Bridge cannot prove email verification from "${modelIdentity}". Configure slipway.bridge.identity.helper.`
+      )
+    }
+
+    return normalizeBridgeIdentity({
+      id: user.id,
+      email: user[emailAttribute],
+      fullName: user[nameAttribute],
+      emailVerified:
+        (hasStatusAttribute &&
+          acceptedStatuses.includes(user[statusAttribute])) ||
+        (hasVerifiedAttribute && user[verifiedAttribute] === true)
+    })
+  }
+
+  function resolveHelper(identity) {
+    return String(identity)
+      .split('.')
+      .reduce((cursor, segment) => cursor && cursor[segment], sails.helpers)
+  }
+
+  function normalizeBridgeIdentity(identity) {
+    if (!identity || identity.id === undefined || identity.id === null) {
+      return null
+    }
+
+    const email = String(identity.email || '')
+      .trim()
+      .toLowerCase()
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      throw new Error('The Bridge identity helper returned an invalid email.')
+    }
+
+    return {
+      id: String(identity.id),
+      email,
+      fullName:
+        String(identity.fullName || '')
+          .trim()
+          .slice(0, 200) || null,
+      emailVerified: identity.emailVerified === true
+    }
+  }
+
+  function safeLocalPath(value, fallback) {
+    const path = String(value || fallback)
+    return path.startsWith('/') && !path.startsWith('//') ? path : fallback
+  }
+
+  function requestJson({ url, token, body }) {
+    return new Promise((resolve, reject) => {
+      let endpoint
+      try {
+        endpoint = new URL(url)
+      } catch {
+        return reject(new Error('The Bridge exchange URL is invalid.'))
+      }
+
+      const payload = JSON.stringify(body)
+      const transport = endpoint.protocol === 'https:' ? https : http
+      const request = transport.request(
+        {
+          hostname: endpoint.hostname,
+          port: endpoint.port,
+          path: `${endpoint.pathname}${endpoint.search}`,
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(payload),
+            Authorization: `Bearer ${token}`
+          },
+          timeout: 5000
+        },
+        (response) => {
+          let responseBody = ''
+          response.on('data', (chunk) => {
+            responseBody += chunk
+            if (responseBody.length > 64 * 1024) {
+              response.destroy(
+                new Error('The Bridge exchange response was too large.')
+              )
+            }
+          })
+          response.on('end', () => {
+            let parsed = {}
+            try {
+              parsed = responseBody ? JSON.parse(responseBody) : {}
+            } catch {
+              /* handled by the status-aware error below */
+            }
+
+            if (response.statusCode < 200 || response.statusCode >= 300) {
+              const error = new Error(
+                parsed.message ||
+                  parsed.error ||
+                  `Bridge exchange returned HTTP ${response.statusCode}.`
+              )
+              error.statusCode = response.statusCode
+              return reject(error)
+            }
+            return resolve(parsed)
+          })
+        }
+      )
+
+      request.on('error', reject)
+      request.on('timeout', () => {
+        request.destroy(new Error('Bridge exchange timed out.'))
+      })
+      request.write(payload)
+      request.end()
+    })
   }
 }

--- a/packages/hook/package.json
+++ b/packages/hook/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sails-hook-slipway",
-  "version": "0.0.3",
-  "description": "Auto-instrumentation hook for Sails.js apps deployed on Slipway. Sends request traces, exceptions, and database query metrics to your Slipway Lookout dashboard.",
+  "version": "0.1.0",
+  "description": "Connect Sails apps to Slipway with Lookout telemetry and secure app-local Bridge access.",
   "main": "index.js",
   "keywords": [
     "sails",

--- a/tests/e2e/pages/projects/bridge-access.test.js
+++ b/tests/e2e/pages/projects/bridge-access.test.js
@@ -1,0 +1,99 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('sounding')
+
+test(
+  'Bridge access manager stays minimal and legible in light and dark mode',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-access-ui',
+          name: 'Bridge Access UI'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const screenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-223-bridge-access'
+    )
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      domain: 'academy.example.com',
+      features: {
+        'sails-hook-slipway': { version: '0.1.0' }
+      }
+    })
+    await sails.models.app.updateOne({ id: app.id }).set({
+      bridgeEnabled: true
+    })
+
+    await world.create('bridgeaccess').with({
+      email: 'ada@example.com',
+      role: 'administrator',
+      status: 'active',
+      hostUserId: 'host-ada',
+      hostUserName: 'Ada Lovelace',
+      activatedAt: Date.now() - 7 * 24 * 60 * 60 * 1000,
+      lastUsedAt: Date.now() - 3 * 60 * 1000,
+      app: app.id,
+      environment: environment.id,
+      project: project.id,
+      team: current.teams.genesisTeam.id,
+      invitedBy: current.users.genesisUser.id
+    })
+    await world.create('bridgeaccess').with({
+      email: 'grace@example.com',
+      role: 'editor',
+      status: 'pending',
+      inviteTokenHash: 'a'.repeat(64),
+      inviteExpiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
+      app: app.id,
+      environment: environment.id,
+      project: project.id,
+      team: current.teams.genesisTeam.id,
+      invitedBy: current.users.genesisUser.id
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.resize(1365, 900)
+    await page.goto(
+      `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge/access`
+    )
+
+    await expect(page).toSee('Bridge access')
+    await expect(page).toSee('Ada Lovelace')
+    await expect(page).toSee('grace@example.com')
+    await expect(page).toSee('App-local Bridge is enabled')
+    expect(page).toHaveNoJavascriptErrors()
+
+    await page.screenshot(path.join(screenshotRoot, 'light.png'), {
+      fullPage: true
+    })
+
+    await page.raw
+      .getByRole('button', { name: 'Manage grace@example.com' })
+      .click()
+    await expect(page).toSee('Resend invitation')
+    await page.screenshot(path.join(screenshotRoot, 'actions.png'), {
+      fullPage: true
+    })
+
+    await page.raw.getByRole('heading', { name: 'Bridge access' }).click()
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await page.wait(100)
+    await page.screenshot(path.join(screenshotRoot, 'dark.png'), {
+      fullPage: true
+    })
+  }
+)

--- a/tests/factories/bridgeaccess.js
+++ b/tests/factories/bridgeaccess.js
@@ -1,0 +1,9 @@
+module.exports = ({ defineFactory }) =>
+  defineFactory('bridgeaccess', ({ sequence }) => ({
+    email: sequence(
+      'bridge-access-email',
+      (number) => `bridge-user-${number}@example.com`
+    ),
+    role: 'viewer',
+    status: 'pending'
+  }))

--- a/tests/functional/pages/bridge-access.test.js
+++ b/tests/functional/pages/bridge-access.test.js
@@ -1,0 +1,315 @@
+const crypto = require('node:crypto')
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'owner invites a host-app account without granting Slipway team access',
+  { world: bridgeWorld('host-bridge-invite', 'Host Bridge Invite') },
+  async ({ sails, world, request, visit, mailbox, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const email = 'editor@host-app.example'
+
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      domain: 'host-app.example',
+      features: {
+        'sails-hook-slipway': { version: '0.1.0' }
+      }
+    })
+    await sails.models.app.updateOne({ id: app.id }).set({
+      bridgeEnabled: true
+    })
+
+    const accessPath = bridgeAccessPath(project, environment, app)
+    const page = await visit.as('genesisUser')(accessPath)
+
+    expect(page).toHaveStatus(200)
+    expect(page).toBeInertiaPage('projects/bridge-access')
+    expect(page).toHaveInertiaProps({
+      'app.bridgeEnabled': true,
+      'app.bridgeUrl': 'https://host-app.example/bridge',
+      hookDetected: true
+    })
+
+    const appPage = await visit.as('genesisUser')(
+      `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`
+    )
+    expect(appPage).toHaveInertiaProps({
+      'app.bridgeUrl': 'https://host-app.example/bridge',
+      canManageBridge: true
+    })
+
+    const member = await world.create('user').with({
+      email: 'team-member@example.com',
+      team: current.teams.genesisTeam.id,
+      teamRole: 'member'
+    })
+    const memberAccess = await visit.as(member)(accessPath)
+    expect(memberAccess).toHaveStatus(302)
+    expect(memberAccess).toRedirectTo('/')
+
+    const previousMailConfig = sails.config.sounding.mail
+    sails.config.sounding.mail = {
+      ...(previousMailConfig || {}),
+      deliver: true
+    }
+
+    try {
+      const browser = await withCsrfFromPage(request, accessPath, 'genesisUser')
+      const response = await browser.request.post(`${accessPath}/invitations`, {
+        email,
+        role: 'editor'
+      })
+
+      expect(response).toHaveStatus(302)
+      expect(response).toRedirectTo(accessPath)
+
+      const access = await sails.models.bridgeaccess.findOne({
+        app: app.id,
+        email
+      })
+      const message = mailbox.latest()
+
+      expect(access.status).toBe('pending')
+      expect(access.role).toBe('editor')
+      expect(access.hostUserId).toBe(null)
+      expect(access.inviteTokenHash.length).toBe(64)
+      expect(access.inviteTokenHash.startsWith('bli_')).toBe(false)
+      expect(message.to).toContain(email)
+      expect(message.template).toBe('bridge-invite')
+      expect(message.html).toContain('https://host-app.example/bridge?invite=')
+
+      const teamUser = await sails.models.user.findOne({ email })
+      expect(teamUser).toBe(undefined)
+    } finally {
+      sails.config.sounding.mail = previousMailConfig
+    }
+  }
+)
+
+test(
+  'verified host identity activates one app-scoped, revocable Bridge session',
+  { world: bridgeWorld('host-bridge-exchange', 'Host Bridge Exchange') },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const email = 'invited@host-app.example'
+    const inviteToken = 'bli_test-invite-token'
+    const inviteTokenHash = sha256(inviteToken)
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      bridgeEnabled: true
+    })
+    const secret = await sails.helpers.bridge.ensureAppSecret.with({
+      appId: String(app.id),
+      rotate: true
+    })
+    const access = await world.create('bridgeaccess').with({
+      email,
+      role: 'viewer',
+      status: 'pending',
+      inviteTokenHash,
+      inviteExpiresAt: Date.now() + 60 * 60 * 1000,
+      app: app.id,
+      environment: environment.id,
+      project: project.id,
+      team: current.teams.genesisTeam.id,
+      invitedBy: current.users.genesisUser.id
+    })
+    const exchangePath = '/api/v1/bridge/exchange'
+    const payload = {
+      appId: String(app.id),
+      hostUser: {
+        id: 'host-user-42',
+        email,
+        fullName: 'Host Editor',
+        emailVerified: true
+      }
+    }
+
+    const wrongSecret = await request
+      .withHeaders({
+        authorization: 'Bearer slb_wrong',
+        accept: 'application/json'
+      })
+      .post(exchangePath, {
+        ...payload,
+        inviteToken
+      })
+    expect(wrongSecret).toHaveStatus(401)
+
+    const appClient = request.withHeaders({
+      authorization: `Bearer ${secret}`,
+      accept: 'application/json'
+    })
+    const unverified = await appClient.post(exchangePath, {
+      ...payload,
+      hostUser: {
+        ...payload.hostUser,
+        emailVerified: false
+      },
+      inviteToken
+    })
+    expect(unverified).toHaveStatus(400)
+
+    const missingInvitation = await appClient.post(exchangePath, payload)
+    expect(missingInvitation).toHaveStatus(403)
+
+    const exchange = await appClient.post(exchangePath, {
+      ...payload,
+      inviteToken
+    })
+    expect(exchange).toHaveStatus(201)
+    expect(exchange.data.launchUrl).toContain('/bridge/launch?code=blc_')
+
+    const activated = await sails.models.bridgeaccess.findOne({
+      id: access.id
+    })
+    expect(activated.status).toBe('active')
+    expect(activated.hostUserId).toBe('host-user-42')
+    expect(activated.hostUserName).toBe('Host Editor')
+    expect(activated.inviteTokenHash).toBe(null)
+
+    const stolenReplay = await appClient.post(exchangePath, {
+      ...payload,
+      hostUser: {
+        ...payload.hostUser,
+        id: 'different-host-user'
+      },
+      inviteToken
+    })
+    expect(stolenReplay).toHaveStatus(403)
+
+    const renewed = await appClient.post(exchangePath, payload)
+    expect(renewed).toHaveStatus(201)
+
+    const launchUrl = new URL(exchange.data.launchUrl)
+    const launchCodeValue = launchUrl.searchParams.get('code')
+    const storedLaunchCode = await sails.models.bridgelaunchcode.findOne({
+      tokenHash: sha256(launchCodeValue)
+    })
+    expect(Boolean(storedLaunchCode)).toBe(true)
+    expect(storedLaunchCode.usedAt).toBe(null)
+    expect(storedLaunchCode.expiresAt > Date.now()).toBe(true)
+    const launchPath = `${launchUrl.pathname}${launchUrl.search}`
+    const launch = await request.get(launchPath)
+    const bridgePath = bridgeAppPath(project, environment, app)
+
+    expect(launch).toHaveStatus(302)
+    expect(launch).toRedirectTo(bridgePath)
+    expect(launch.session.bridgeAccessId).toBe(access.id)
+    expect(launch.session.bridgeAppId).toBe(app.id)
+    expect(launch.session.userId).toBe(undefined)
+
+    const replay = await request.get(launchPath)
+    expect(replay).toHaveStatus(302)
+    expect(replay).toRedirectTo('/login?error=bridge_link_expired')
+
+    const bridgeClient = request.withSession(launch.session)
+    const bridge = await bridgeClient.get(bridgePath, {
+      headers: {
+        'x-inertia': 'true',
+        accept: 'text/html, application/xhtml+xml'
+      }
+    })
+    expect(bridge).toHaveStatus(200)
+    expect(bridge).toBeInertiaPage('projects/bridge')
+
+    const editorPage = await bridgeClient.get(`${bridgePath}/user/new`)
+    expect(editorPage).toHaveStatus(403)
+
+    await sails.models.bridgeaccess
+      .updateOne({ id: access.id })
+      .set({ status: 'revoked', revokedAt: Date.now() })
+
+    const revoked = await bridgeClient.get(bridgePath)
+    expect(revoked).toHaveStatus(403)
+  }
+)
+
+test(
+  'rotating an app credential invalidates Bridge sessions from old containers',
+  { world: bridgeWorld('host-bridge-rotation', 'Host Bridge Rotation') },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const secret = await enableBridge(sails, app.id)
+    const access = await world.create('bridgeaccess').with({
+      email: 'administrator@host-app.example',
+      role: 'administrator',
+      status: 'active',
+      hostUserId: 'host-admin-1',
+      activatedAt: Date.now(),
+      app: app.id,
+      environment: environment.id,
+      project: project.id,
+      team: current.teams.genesisTeam.id,
+      invitedBy: current.users.genesisUser.id
+    })
+
+    const exchange = await request
+      .withHeaders({
+        authorization: `Bearer ${secret}`,
+        accept: 'application/json'
+      })
+      .post('/api/v1/bridge/exchange', {
+        appId: String(app.id),
+        hostUser: {
+          id: 'host-admin-1',
+          email: access.email,
+          fullName: 'Host Administrator',
+          emailVerified: true
+        }
+      })
+    const launchUrl = new URL(exchange.data.launchUrl)
+    const launch = await request.get(`${launchUrl.pathname}${launchUrl.search}`)
+    const bridgePath = bridgeAppPath(project, environment, app)
+
+    await sails.helpers.bridge.ensureAppSecret.with({
+      appId: String(app.id),
+      rotate: true
+    })
+
+    const staleSession = await request
+      .withSession(launch.session)
+      .get(bridgePath)
+    expect(staleSession).toHaveStatus(403)
+  }
+)
+
+function bridgeAccessPath(project, environment, app) {
+  return `${bridgeAppPath(project, environment, app)}/access`
+}
+
+function bridgeAppPath(project, environment, app) {
+  return `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
+}
+
+async function enableBridge(sails, appId) {
+  await sails.models.app.updateOne({ id: appId }).set({
+    bridgeEnabled: true
+  })
+  return sails.helpers.bridge.ensureAppSecret.with({
+    appId: String(appId),
+    rotate: true
+  })
+}
+
+function sha256(value) {
+  return crypto.createHash('sha256').update(value).digest('hex')
+}
+
+function bridgeWorld(slug, name) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: { slug, name }
+    }
+  }
+}

--- a/tests/unit/packages/hook-bridge.test.js
+++ b/tests/unit/packages/hook-bridge.test.js
@@ -1,0 +1,238 @@
+const http = require('node:http')
+const { test } = require('sounding')
+const defineSlipwayHook = require('../../../packages/hook')
+
+test('host Bridge sends signed-in verified identity through the app credential', async ({
+  expect
+}) => {
+  const exchange = await startExchangeServer()
+  const { route } = await createBridgeRoute({
+    bridge: {
+      enabled: true,
+      exchangeUrl: exchange.url,
+      appId: '42',
+      secret: 'slb_app-secret',
+      loginPath: '/login',
+      identity: defaultIdentityConfig()
+    },
+    user: {
+      id: 'host-user-7',
+      email: 'EDITOR@EXAMPLE.COM',
+      fullName: 'Host Editor',
+      emailStatus: 'verified'
+    }
+  })
+  const response = createResponse()
+
+  try {
+    await route(
+      {
+        session: { userId: 'host-user-7' },
+        originalUrl: '/bridge?invite=bli_invitation',
+        query: { invite: 'bli_invitation' }
+      },
+      response
+    )
+
+    expect(response.status).toBe('redirect')
+    expect(response.value).toBe(
+      'https://slipway.example/bridge/launch?code=blc_once'
+    )
+    expect(exchange.request.authorization).toBe('Bearer slb_app-secret')
+    expect(exchange.request.body.appId).toBe('42')
+    expect(exchange.request.body.inviteToken).toBe('bli_invitation')
+    expect(exchange.request.body.hostUser).toEqual({
+      id: 'host-user-7',
+      email: 'editor@example.com',
+      fullName: 'Host Editor',
+      emailVerified: true
+    })
+  } finally {
+    await exchange.close()
+  }
+})
+
+test('host Bridge preserves the invitation while sending a guest through app login', async ({
+  expect
+}) => {
+  const { route } = await createBridgeRoute({
+    bridge: {
+      enabled: true,
+      exchangeUrl: 'http://127.0.0.1:1/exchange',
+      appId: '42',
+      secret: 'slb_app-secret',
+      loginPath: '/sign-in',
+      identity: defaultIdentityConfig()
+    }
+  })
+  const response = createResponse()
+
+  await route(
+    {
+      session: {},
+      originalUrl: '/bridge?invite=bli_invitation',
+      query: { invite: 'bli_invitation' }
+    },
+    response
+  )
+
+  expect(response.status).toBe('redirect')
+  expect(response.value).toBe(
+    '/sign-in?redirect=%2Fbridge%3Finvite%3Dbli_invitation'
+  )
+})
+
+test('host Bridge fails closed when the app cannot prove email verification', async ({
+  expect
+}) => {
+  const { route } = await createBridgeRoute({
+    bridge: {
+      enabled: true,
+      exchangeUrl: 'http://127.0.0.1:1/exchange',
+      appId: '42',
+      secret: 'slb_app-secret',
+      loginPath: '/login',
+      identity: defaultIdentityConfig()
+    },
+    user: {
+      id: 'host-user-7',
+      email: 'editor@example.com',
+      fullName: 'Host Editor'
+    },
+    userAttributes: {
+      id: {},
+      email: {},
+      fullName: {}
+    }
+  })
+  const response = createResponse()
+
+  await route(
+    {
+      session: { userId: 'host-user-7' },
+      originalUrl: '/bridge',
+      query: {}
+    },
+    response
+  )
+
+  expect(response.status).toBe('forbidden')
+  expect(response.value).toBe('Bridge could not verify your host-app account.')
+})
+
+async function createBridgeRoute({
+  bridge,
+  user = null,
+  userAttributes = {
+    id: {},
+    email: {},
+    fullName: {},
+    emailStatus: {}
+  }
+}) {
+  const sails = {
+    config: {
+      slipway: {
+        bridge,
+        lookout: {
+          enabled: true
+        }
+      }
+    },
+    log: {
+      verbose: () => {},
+      info: () => {},
+      warn: () => {}
+    },
+    models: {
+      user: {
+        attributes: userAttributes,
+        findOne: async ({ id }) =>
+          user && String(user.id) === String(id) ? user : null
+      }
+    },
+    helpers: {},
+    after: () => {},
+    on: () => {}
+  }
+  const hook = defineSlipwayHook(sails)
+
+  await new Promise((resolve, reject) => {
+    hook.initialize((error) => (error ? reject(error) : resolve()))
+  })
+
+  return {
+    route: hook.routes.after['GET /bridge']
+  }
+}
+
+function createResponse() {
+  return {
+    status: null,
+    value: null,
+    redirect(value) {
+      this.status = 'redirect'
+      this.value = value
+      return value
+    },
+    forbidden(value) {
+      this.status = 'forbidden'
+      this.value = value
+      return value
+    },
+    notFound(value) {
+      this.status = 'notFound'
+      this.value = value
+      return value
+    },
+    serverError(value) {
+      this.status = 'serverError'
+      this.value = value
+      return value
+    }
+  }
+}
+
+function defaultIdentityConfig() {
+  return {
+    model: 'user',
+    sessionKey: 'userId',
+    emailAttribute: 'email',
+    nameAttribute: 'fullName',
+    emailStatusAttribute: 'emailStatus',
+    emailVerifiedAttribute: 'emailVerified',
+    verifiedEmailStatuses: ['verified', 'confirmed']
+  }
+}
+
+function startExchangeServer() {
+  return new Promise((resolve, reject) => {
+    const request = {}
+    const server = http.createServer((incoming, response) => {
+      const chunks = []
+      incoming.on('data', (chunk) => chunks.push(chunk))
+      incoming.on('end', () => {
+        request.authorization = incoming.headers.authorization
+        request.body = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+        response.writeHead(201, { 'content-type': 'application/json' })
+        response.end(
+          JSON.stringify({
+            launchUrl: 'https://slipway.example/bridge/launch?code=blc_once'
+          })
+        )
+      })
+    })
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      resolve({
+        url: `http://127.0.0.1:${address.port}/exchange`,
+        request,
+        close: () =>
+          new Promise((done, fail) =>
+            server.close((error) => (error ? fail(error) : done()))
+          )
+      })
+    })
+  })
+}

--- a/views/emails/bridge-invite.ejs
+++ b/views/emails/bridge-invite.ejs
@@ -1,0 +1,19 @@
+<div style="padding: 32px 32px 28px;">
+  <h2 style="margin: 0 0 12px; color: #18181b; font-size: 20px; font-weight: 600; line-height: 1.3;">
+    You&rsquo;re invited to <%= appName %> Bridge
+  </h2>
+  <p style="color: #52525b; font-size: 14px; line-height: 1.7; margin: 0 0 24px;">
+    <strong style="color: #18181b;"><%= inviterName %></strong> invited you to manage <strong style="color: #18181b;"><%= projectName %></strong> as a <%= role %>.
+  </p>
+  <p style="color: #52525b; font-size: 14px; line-height: 1.7; margin: 0 0 24px;">
+    Sign in to the application with this email address. Bridge uses the application&rsquo;s account as your identity and does not give you access to Slipway infrastructure.
+  </p>
+  <div style="margin-bottom: 28px;">
+    <a href="<%= inviteUrl %>" style="display: inline-block; background-color: #18181b; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 8px; font-size: 14px; font-weight: 600; line-height: 1;">Open Bridge</a>
+  </div>
+  <p style="color: #a1a1aa; font-size: 12px; line-height: 1.6; margin: 0 0 18px;">
+    This invitation expires in <%= expiresIn %>. If the button does not work, paste this link into your browser:<br>
+    <a href="<%= inviteUrl %>" style="color: #3b82f6; word-break: break-all; font-size: 12px;"><%= inviteUrl %></a>
+  </p>
+  <p style="color: #a1a1aa; font-size: 12px; margin: 0;">&mdash; Slippy</p>
+</div>


### PR DESCRIPTION
## Summary
- expose an opt-in /bridge entry from deployed Sails apps through sails-hook-slipway
- authenticate verified host-app identities with app-scoped invitations and viewer/editor/administrator roles
- add atomic invitation activation, single-use launch codes, dedicated sessions, revocation, auditing, and credential rotation
- keep dashboard Bridge behavior and legacy routes compatible
- add the minimal light/dark Bridge access manager and app-level navigation

## Verification
- 191 unit tests
- 55 functional tests
- 22 browser tests
- npm run lint
- npm run check:consistency
- npm pack --dry-run ./packages/hook

Closes #223