### PR TITLE
feat(bridge): add filters and saved lenses

### DIFF
--- a/api/controllers/project/bridge-relationship-options.js
+++ b/api/controllers/project/bridge-relationship-options.js
@@ -27,7 +27,7 @@ module.exports = {
     surface: {
       type: 'string',
       defaultsTo: 'create',
-      isIn: ['create', 'edit', 'manage']
+      isIn: ['create', 'edit', 'filter', 'manage']
     },
     recordId: {
       type: 'string'
@@ -75,7 +75,7 @@ module.exports = {
         projectSlug: slug,
         environmentSlug: envSlug,
         ...(appSlug ? { appSlug } : {}),
-        requiredRole: 'editor',
+        requiredRole: surface === 'filter' ? 'viewer' : 'editor',
         requireRunning: true
       })
     } catch (error) {
@@ -84,7 +84,7 @@ module.exports = {
       throw { badRequest: { error: 'App is not running' } }
     }
     const { environment, app, actor } = resolved
-    if (surface !== 'create' && !recordId) {
+    if (['edit', 'manage'].includes(surface) && !recordId) {
       throw {
         badRequest: {
           error: 'A record identifier is required for this relationship.'
@@ -97,14 +97,23 @@ module.exports = {
         containerName: app.containerName,
         environmentId: environment.id,
         modelIdentity,
-        action: surface === 'create' ? 'create' : 'update',
+        action:
+          surface === 'create'
+            ? 'create'
+            : surface === 'filter'
+            ? 'viewAny'
+            : 'update',
         actor,
         ...(recordId ? { recordId } : {})
       })
       const relationship = loaded.resource.relationships?.[relationshipAlias]
       if (
         !relationship ||
-        (surface !== 'manage' &&
+        (surface === 'filter' &&
+          (relationship.type !== 'model' ||
+            !loaded.resource.filters.includes(relationshipAlias))) ||
+        (surface !== 'filter' &&
+          surface !== 'manage' &&
           (relationship.type !== 'model' ||
             !loaded.resource[surface].includes(relationshipAlias))) ||
         (surface === 'manage' &&

--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -35,6 +35,14 @@ module.exports = {
       type: 'string',
       defaultsTo: ''
     },
+    filters: {
+      type: 'string',
+      defaultsTo: ''
+    },
+    lens: {
+      type: 'string',
+      defaultsTo: ''
+    },
     dashboard: {
       type: 'string',
       defaultsTo: ''
@@ -62,6 +70,8 @@ module.exports = {
     perPage,
     sort,
     search,
+    filters,
+    lens,
     dashboard
   }) {
     let resolved
@@ -90,6 +100,11 @@ module.exports = {
     let normalizedPerPage = perPage
     let normalizedSort = sort
     let normalizedSearch = search
+    let normalizedFilters = {}
+    let columns = []
+    let lenses = []
+    let activeLens = null
+    let filterDefinitions = {}
     let dashboards = []
     let dashboardResources = {}
     let activeDashboard = null
@@ -154,49 +169,41 @@ module.exports = {
             page,
             perPage,
             sort,
-            search
+            search,
+            filters,
+            lens
           })
 
         normalizedPage = normalizedQuery.page
         normalizedPerPage = normalizedQuery.perPage
         normalizedSort = normalizedQuery.sort
         normalizedSearch = normalizedQuery.search
+        normalizedFilters = normalizedQuery.filters
+        columns = normalizedQuery.columns
+        activeLens = normalizedQuery.lens
+        filterDefinitions = normalizedQuery.filterDefinitions
+        lenses = Object.values(modelMeta.lenses || {}).map((definition) => ({
+          id: definition.id,
+          label: definition.label,
+          default: definition.default
+        }))
 
-        const queryCode = `
-          const identity = ${JSON.stringify(modelMeta.identity)};
-          const where = ${JSON.stringify(normalizedQuery.where)};
-          const criteria = ${JSON.stringify(normalizedQuery.criteria)};
-          const model = sails.models[identity];
-          if (!model) throw new Error('Configured Bridge model is unavailable.');
-
-          const total = await model.count(where);
-          const records = await model.find(criteria);
-          return { records, total };
-        `
-        const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
-          queryCode
-        )
-        const result = await sails.helpers.bridge.executeInContainer(
-          app.containerName,
-          wrappedCode
-        )
-
-        if (result.success) {
-          try {
-            const data = JSON.parse(result.output)
-            records = await sails.helpers.bridge.redactResourceRecords.with({
-              records: data.records || [],
-              resource: modelMeta,
-              surface: 'list'
-            })
-            total = data.total || 0
-            totalPages = Math.ceil(total / normalizedPerPage)
-          } catch (parseError) {
-            error = 'Failed to parse records: ' + parseError.message
-          }
-        } else {
-          error = result.error || 'Failed to fetch records'
-        }
+        const data = await sails.helpers.bridge.queryResource.with({
+          containerName: app.containerName,
+          resource: modelMeta,
+          query: normalizedQuery,
+          actor
+        })
+        records = await sails.helpers.bridge.redactResourceRecords.with({
+          records: data.records || [],
+          resource: {
+            ...modelMeta,
+            list: normalizedQuery.select
+          },
+          surface: 'list'
+        })
+        total = data.total || 0
+        totalPages = Math.ceil(total / normalizedPerPage)
       } catch (err) {
         error = err.message
       }
@@ -227,6 +234,17 @@ module.exports = {
         perPage: normalizedPerPage,
         sort: normalizedSort,
         search: normalizedSearch,
+        filterState: normalizedFilters,
+        filterDefinitions,
+        columns,
+        lenses,
+        activeLens: activeLens
+          ? {
+              id: activeLens.id,
+              label: activeLens.label,
+              default: activeLens.default
+            }
+          : null,
         error,
         dashboards,
         dashboardResources,

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -25,6 +25,20 @@ module.exports = {
 
   fn: async function ({ models, config }) {
     const contract = normalizeBridgeResourceContract({ models, config })
+    for (const [identity, resource] of Object.entries(contract.resources)) {
+      const filterContract =
+        await sails.helpers.bridge.normalizeResourceFilters.with({
+          resource,
+          filters: {}
+        })
+      resource.filterDefinitions = filterContract.definitions
+      resource.lenses = await sails.helpers.bridge.normalizeResourceLenses.with(
+        {
+          resource,
+          lenses: config.resources?.[identity]?.lenses
+        }
+      )
+    }
     contract.dashboards =
       await sails.helpers.bridge.normalizeDashboardContract.with({
         dashboard: config.dashboard,
@@ -123,6 +137,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'create',
     'edit',
     'filters',
+    'lenses',
     'sort',
     'hidden',
     'actions',

--- a/api/helpers/bridge/normalize-resource-filters.js
+++ b/api/helpers/bridge/normalize-resource-filters.js
@@ -1,0 +1,432 @@
+module.exports = {
+  friendlyName: 'Normalize Bridge resource filters',
+
+  description:
+    'Build a type-aware filter contract and safe Waterline where criteria for a Bridge resource.',
+
+  inputs: {
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    filters: {
+      type: 'ref',
+      defaultsTo: {}
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ resource, filters }) {
+    const definitions = buildDefinitions(resource)
+    const values = parseFilters(filters)
+    const normalized = {}
+    const clauses = []
+
+    if (Object.keys(values).length > 12) {
+      throw filterError('Bridge accepts no more than 12 active filters.')
+    }
+
+    for (const [field, rawValue] of Object.entries(values)) {
+      const definition = definitions[field]
+      if (!definition) {
+        throw filterError(`Bridge filter "${field}" is unavailable.`)
+      }
+      const result = normalizeFilterValue(definition, rawValue)
+      if (!result) continue
+      normalized[field] = result.value
+      clauses.push(result.where)
+    }
+
+    return {
+      definitions,
+      filters: normalized,
+      where: combineClauses(clauses)
+    }
+  }
+}
+
+const TEXT_FIELD_TYPES = new Set([
+  'text',
+  'textarea',
+  'richtext',
+  'email',
+  'url'
+])
+const DATE_FIELD_TYPES = new Set(['date', 'datetime', 'timestamp'])
+const SUPPORTED_FIELD_TYPES = new Set([
+  ...TEXT_FIELD_TYPES,
+  ...DATE_FIELD_TYPES,
+  'number',
+  'currency',
+  'boolean',
+  'select',
+  'belongsTo'
+])
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype'])
+
+function buildDefinitions(resource) {
+  const definitions = {}
+
+  for (const field of resource.filters || []) {
+    if (!isSafeIdentifier(field)) {
+      throw filterError(`Bridge filter "${field}" is invalid.`)
+    }
+    const attribute = resource.attributes?.[field]
+    if (
+      !attribute ||
+      attribute.encrypt ||
+      attribute.protect ||
+      attribute.field?.visibility?.filter === false
+    ) {
+      throw filterError(`Bridge filter "${field}" is unavailable.`)
+    }
+
+    const type = attribute.field?.type || attribute.type || 'text'
+    if (!SUPPORTED_FIELD_TYPES.has(type)) {
+      throw filterError(
+        `Bridge filter "${field}" uses unsupported field type "${type}".`
+      )
+    }
+
+    const relationship = resource.relationships?.[field]
+    if (
+      type === 'belongsTo' &&
+      (!relationship || relationship.type !== 'model')
+    ) {
+      throw filterError(
+        `Bridge filter "${field}" does not reference an available belongs-to relationship.`
+      )
+    }
+
+    const nullable = attribute.allowNull === true || attribute.required !== true
+    definitions[field] = {
+      field,
+      label: attribute.label || humanize(field),
+      type,
+      valueType: attribute.type,
+      defaultOperator: defaultOperator(type),
+      operators: operatorsFor(type, nullable),
+      nullable,
+      ...(Array.isArray(attribute.field?.options)
+        ? { options: attribute.field.options }
+        : {}),
+      ...(relationship
+        ? {
+            relationship: {
+              resource: relationship.resource,
+              primaryKey: relationship.primaryKey,
+              title: relationship.title,
+              searchable: relationship.searchable === true
+            }
+          }
+        : {})
+    }
+  }
+
+  return definitions
+}
+
+function parseFilters(filters) {
+  let value = filters
+  if (typeof value === 'string') {
+    if (value.length > 12_000) {
+      throw filterError('Bridge filters are too large.')
+    }
+    if (!value.trim()) return {}
+    try {
+      value = JSON.parse(value)
+    } catch {
+      throw filterError('Bridge filters must contain valid JSON.')
+    }
+  }
+
+  if (value === undefined || value === null || value === '') return {}
+  if (!isPlainObject(value)) {
+    throw filterError('Bridge filters must be an object.')
+  }
+
+  for (const key of Object.keys(value)) {
+    if (!isSafeIdentifier(key)) {
+      throw filterError(`Bridge filter "${key}" is invalid.`)
+    }
+  }
+  return value
+}
+
+function normalizeFilterValue(definition, rawValue) {
+  if (
+    rawValue === undefined ||
+    rawValue === '' ||
+    (rawValue === null && definition.nullable !== true)
+  ) {
+    return null
+  }
+
+  const input = isPlainObject(rawValue)
+    ? rawValue
+    : { operator: definition.defaultOperator, value: rawValue }
+  const operator = String(
+    input.operator || inferOperator(definition.type, input)
+  )
+  if (!definition.operators.includes(operator)) {
+    throw filterError(
+      `Bridge filter "${definition.field}" does not support "${operator}".`
+    )
+  }
+
+  if (operator === 'isNull') {
+    return {
+      value: { operator },
+      where: { [definition.field]: null }
+    }
+  }
+  if (operator === 'isNotNull') {
+    return {
+      value: { operator },
+      where: { [definition.field]: { '!=': null } }
+    }
+  }
+
+  if (operator === 'between') {
+    const fromValue = input.from ?? input.min
+    const toValue = input.to ?? input.max
+    const from = normalizeBound(definition, fromValue)
+    const to = normalizeBound(definition, toValue, { upper: true })
+    if (from === undefined && to === undefined) return null
+    if (from !== undefined && to !== undefined && from > to) {
+      throw filterError(
+        `Bridge filter "${definition.field}" starts after it ends.`
+      )
+    }
+
+    const range = {}
+    if (from !== undefined) range['>='] = from
+    if (to !== undefined) range['<='] = to
+    return {
+      value: {
+        operator,
+        ...(from !== undefined
+          ? { from: serializeBound(definition, from) }
+          : {}),
+        ...(to !== undefined ? { to: serializeBound(definition, to) } : {})
+      },
+      where: { [definition.field]: range }
+    }
+  }
+
+  const value = normalizeScalar(definition, input.value)
+  if (value === undefined) return null
+  if (operator === 'contains') {
+    return {
+      value: { operator, value },
+      where: { [definition.field]: { contains: value } }
+    }
+  }
+  return {
+    value: { operator, value },
+    where: { [definition.field]: value }
+  }
+}
+
+function normalizeScalar(definition, rawValue) {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return undefined
+  }
+
+  if (TEXT_FIELD_TYPES.has(definition.type)) {
+    return boundedString(definition.field, rawValue)
+  }
+  if (definition.type === 'boolean') {
+    if (rawValue === true || rawValue === 'true' || rawValue === 1) return true
+    if (rawValue === false || rawValue === 'false' || rawValue === 0) {
+      return false
+    }
+    throw filterError(
+      `Bridge filter "${definition.field}" must be true or false.`
+    )
+  }
+  if (definition.type === 'number' || definition.type === 'currency') {
+    const value = Number(rawValue)
+    if (!Number.isFinite(value)) {
+      throw filterError(`Bridge filter "${definition.field}" must be a number.`)
+    }
+    return value
+  }
+  if (DATE_FIELD_TYPES.has(definition.type)) {
+    return normalizeDate(definition, rawValue)
+  }
+  if (definition.type === 'select') {
+    const option = (definition.options || []).find((candidate) =>
+      Object.is(candidate.value, coerceOptionValue(rawValue, candidate.value))
+    )
+    if (!option || option.disabled === true) {
+      throw filterError(
+        `Bridge filter "${definition.field}" must use an available option.`
+      )
+    }
+    return option.value
+  }
+  if (definition.type === 'belongsTo') {
+    if (definition.valueType === 'number') {
+      const number = Number(rawValue)
+      if (!Number.isFinite(number)) {
+        throw filterError(
+          `Bridge filter "${definition.field}" has an invalid identifier.`
+        )
+      }
+      return number
+    }
+    return boundedString(definition.field, rawValue)
+  }
+
+  throw filterError(`Bridge filter "${definition.field}" is unsupported.`)
+}
+
+function normalizeBound(definition, rawValue, { upper = false } = {}) {
+  if (rawValue === undefined || rawValue === null || rawValue === '') {
+    return undefined
+  }
+  const value = normalizeScalar(definition, rawValue)
+  if (
+    upper &&
+    ['datetime', 'timestamp'].includes(definition.type) &&
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(String(rawValue).trim())
+  ) {
+    return definition.valueType === 'number'
+      ? value + 59_999
+      : new Date(new Date(value).getTime() + 59_999).toISOString()
+  }
+  return value
+}
+
+function normalizeDate(definition, rawValue) {
+  const value = String(rawValue).trim()
+  if (definition.type === 'date' && !isValidDateOnly(value)) {
+    throw filterError(
+      `Bridge filter "${definition.field}" must be a valid date.`
+    )
+  }
+  const date = new Date(
+    definition.type === 'date' && /^\d{4}-\d{2}-\d{2}$/.test(value)
+      ? `${value}T00:00:00.000Z`
+      : value
+  )
+  if (Number.isNaN(date.getTime())) {
+    throw filterError(
+      `Bridge filter "${definition.field}" must be a valid date.`
+    )
+  }
+  if (definition.type === 'date') return value.slice(0, 10)
+  return definition.valueType === 'number' ? date.getTime() : date.toISOString()
+}
+
+function isValidDateOnly(value) {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false
+  const [year, month, day] = value.split('-').map(Number)
+  const date = new Date(Date.UTC(year, month - 1, day))
+  return (
+    date.getUTCFullYear() === year &&
+    date.getUTCMonth() === month - 1 &&
+    date.getUTCDate() === day
+  )
+}
+
+function serializeBound(definition, value) {
+  if (!DATE_FIELD_TYPES.has(definition.type)) return value
+  if (definition.type === 'date') return String(value)
+  return new Date(value).toISOString()
+}
+
+function coerceOptionValue(rawValue, optionValue) {
+  if (typeof optionValue === 'boolean') {
+    if (rawValue === 'true') return true
+    if (rawValue === 'false') return false
+  }
+  if (typeof optionValue === 'number' && rawValue !== '') {
+    const number = Number(rawValue)
+    if (Number.isFinite(number)) return number
+  }
+  if (optionValue === null && rawValue === null) return null
+  return rawValue
+}
+
+function boundedString(field, value) {
+  const string = String(value).trim()
+  if (!string) return undefined
+  if (string.length > 200) {
+    throw filterError(
+      `Bridge filter "${field}" must be no longer than 200 characters.`
+    )
+  }
+  return string
+}
+
+function defaultOperator(type) {
+  if (TEXT_FIELD_TYPES.has(type)) return 'contains'
+  if (type === 'number' || type === 'currency' || DATE_FIELD_TYPES.has(type)) {
+    return 'between'
+  }
+  return 'equals'
+}
+
+function operatorsFor(type, nullable) {
+  const operators = TEXT_FIELD_TYPES.has(type)
+    ? ['contains', 'equals']
+    : type === 'number' || type === 'currency' || DATE_FIELD_TYPES.has(type)
+    ? ['between', 'equals']
+    : ['equals']
+  if (nullable) operators.push('isNull', 'isNotNull')
+  return operators
+}
+
+function inferOperator(type, input) {
+  if (type === 'number' || type === 'currency' || DATE_FIELD_TYPES.has(type)) {
+    if (
+      input.from !== undefined ||
+      input.to !== undefined ||
+      input.min !== undefined ||
+      input.max !== undefined
+    ) {
+      return 'between'
+    }
+  }
+  return defaultOperator(type)
+}
+
+function combineClauses(clauses) {
+  if (clauses.length === 0) return {}
+  if (clauses.length === 1) return clauses[0]
+  return { and: clauses }
+}
+
+function humanize(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function isSafeIdentifier(value) {
+  return (
+    typeof value === 'string' &&
+    /^[A-Za-z][A-Za-z0-9_]*$/.test(value) &&
+    !UNSAFE_KEYS.has(value)
+  )
+}
+
+function filterError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_FILTER_INVALID'
+  return error
+}

--- a/api/helpers/bridge/normalize-resource-lenses.js
+++ b/api/helpers/bridge/normalize-resource-lenses.js
@@ -1,0 +1,247 @@
+module.exports = {
+  friendlyName: 'Normalize Bridge resource lenses',
+
+  description:
+    'Validate named Bridge resource views, including fixed filters, columns, ordering, and optional query helpers.',
+
+  inputs: {
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    lenses: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ resource, lenses }) {
+    if (lenses === undefined) return {}
+    if (!isPlainObject(lenses)) {
+      throw lensError(
+        `Bridge resource "${resource.identity}".lenses must be an object.`
+      )
+    }
+
+    const entries = Object.entries(lenses)
+    if (entries.length > 20) {
+      throw lensError(
+        `Bridge resource "${resource.identity}" supports at most 20 lenses.`
+      )
+    }
+
+    const allowedColumns = Object.keys(resource.attributes || {}).filter(
+      (field) => {
+        const attribute = resource.attributes[field]
+        return (
+          !attribute.encrypt &&
+          !attribute.protect &&
+          attribute.field?.visibility?.list !== false
+        )
+      }
+    )
+    const normalized = {}
+    let defaultLens = null
+
+    for (const [id, raw] of entries) {
+      if (!isSafeSlug(id)) {
+        throw lensError(
+          `Bridge resource "${resource.identity}".lenses contains invalid key "${id}".`
+        )
+      }
+      if (!isPlainObject(raw)) {
+        throw lensError(
+          `Bridge lens "${resource.identity}.${id}" must be an object.`
+        )
+      }
+      rejectUnknownKeys(
+        raw,
+        ['label', 'filters', 'columns', 'sort', 'helper', 'default'],
+        `Bridge lens "${resource.identity}.${id}"`
+      )
+
+      const label = readLabel(raw.label) || humanize(id)
+      if (raw.default !== undefined && typeof raw.default !== 'boolean') {
+        throw lensError(
+          `Bridge lens "${resource.identity}.${id}".default must be a boolean.`
+        )
+      }
+      if (raw.default === true) {
+        if (defaultLens) {
+          throw lensError(
+            `Bridge resource "${resource.identity}" may define only one default lens.`
+          )
+        }
+        defaultLens = id
+      }
+
+      const columns = normalizeColumns({
+        resource,
+        lensId: id,
+        value: raw.columns,
+        allowed: allowedColumns
+      })
+      const sort = normalizeSort({
+        resource,
+        lensId: id,
+        value: raw.sort,
+        allowed: columns
+      })
+      const fixed = await sails.helpers.bridge.normalizeResourceFilters.with({
+        resource,
+        filters: raw.filters || {}
+      })
+      const helper = normalizeHelper(resource.identity, id, raw.helper)
+
+      normalized[id] = {
+        id,
+        label,
+        default: raw.default === true,
+        filters: fixed.filters,
+        columns,
+        sort,
+        ...(helper ? { helper } : {})
+      }
+    }
+
+    return normalized
+  }
+}
+
+function normalizeColumns({ resource, lensId, value, allowed }) {
+  if (value === undefined) return [...resource.list]
+  if (!Array.isArray(value) || value.length === 0) {
+    throw lensError(
+      `Bridge lens "${resource.identity}.${lensId}".columns must be a non-empty array.`
+    )
+  }
+
+  const columns = []
+  for (const field of value) {
+    if (typeof field !== 'string' || !allowed.includes(field)) {
+      throw lensError(
+        `Bridge lens "${resource.identity}.${lensId}".columns references unavailable field "${field}".`
+      )
+    }
+    if (!columns.includes(field)) columns.push(field)
+  }
+  return columns
+}
+
+function normalizeSort({ resource, lensId, value, allowed }) {
+  if (value === undefined) {
+    const field =
+      (allowed.includes(resource.sort.field) &&
+      resource.attributes[resource.sort.field]?.field?.sortable !== false
+        ? resource.sort.field
+        : null) ||
+      allowed.find(
+        (candidate) => resource.attributes[candidate]?.field?.sortable !== false
+      )
+    if (!field) {
+      throw lensError(
+        `Bridge lens "${resource.identity}.${lensId}" must include a sortable column.`
+      )
+    }
+    return {
+      field,
+      direction: field === resource.sort.field ? resource.sort.direction : 'ASC'
+    }
+  }
+  if (!isPlainObject(value)) {
+    throw lensError(
+      `Bridge lens "${resource.identity}.${lensId}".sort must be an object.`
+    )
+  }
+  rejectUnknownKeys(
+    value,
+    ['field', 'direction'],
+    `Bridge lens "${resource.identity}.${lensId}".sort`
+  )
+  const field = value.field
+  if (
+    typeof field !== 'string' ||
+    !allowed.includes(field) ||
+    resource.attributes[field]?.field?.sortable === false
+  ) {
+    throw lensError(
+      `Bridge lens "${resource.identity}.${lensId}".sort.field must reference a sortable lens column.`
+    )
+  }
+  const direction = String(value.direction || 'DESC').toUpperCase()
+  if (!['ASC', 'DESC'].includes(direction)) {
+    throw lensError(
+      `Bridge lens "${resource.identity}.${lensId}".sort.direction must be ASC or DESC.`
+    )
+  }
+  return { field, direction }
+}
+
+function normalizeHelper(resourceIdentity, lensId, value) {
+  if (value === undefined) return ''
+  if (
+    typeof value !== 'string' ||
+    !value.split('.').every((part) => isSafeIdentifier(part))
+  ) {
+    throw lensError(
+      `Bridge lens "${resourceIdentity}.${lensId}".helper must be a safe Sails helper identity.`
+    )
+  }
+  return value
+}
+
+function readLabel(value) {
+  if (value === undefined) return ''
+  if (typeof value !== 'string' || !value.trim() || value.trim().length > 80) {
+    throw lensError('Bridge lens labels must contain 1 to 80 characters.')
+  }
+  return value.trim()
+}
+
+function rejectUnknownKeys(value, allowed, path) {
+  for (const key of Object.keys(value)) {
+    if (!allowed.includes(key)) {
+      throw lensError(`${path} contains unsupported option "${key}".`)
+    }
+  }
+}
+
+function humanize(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function isSafeIdentifier(value) {
+  return (
+    typeof value === 'string' &&
+    /^[A-Za-z][A-Za-z0-9_]*$/.test(value) &&
+    !['__proto__', 'constructor', 'prototype'].includes(value)
+  )
+}
+
+function isSafeSlug(value) {
+  return (
+    typeof value === 'string' &&
+    /^[A-Za-z][A-Za-z0-9_-]*$/.test(value) &&
+    !['__proto__', 'constructor', 'prototype'].includes(value)
+  )
+}
+
+function lensError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_LENS_INVALID'
+  return error
+}

--- a/api/helpers/bridge/normalize-resource-query.js
+++ b/api/helpers/bridge/normalize-resource-query.js
@@ -24,6 +24,14 @@ module.exports = {
     search: {
       type: 'string',
       defaultsTo: ''
+    },
+    filters: {
+      type: 'ref',
+      defaultsTo: {}
+    },
+    lens: {
+      type: 'string',
+      defaultsTo: ''
     }
   },
 
@@ -33,21 +41,47 @@ module.exports = {
     }
   },
 
-  fn: async function ({ resource, page, perPage, sort, search }) {
+  fn: async function ({
+    resource,
+    page,
+    perPage,
+    sort,
+    search,
+    filters,
+    lens
+  }) {
     const safePage = Math.max(1, Math.floor(page || 1))
     const safePerPage = Math.min(100, Math.max(1, Math.floor(perPage || 20)))
     const primaryKey = resource.primaryKey || 'id'
-    const selectable = Array.from(
-      new Set([primaryKey, ...(resource.list || [])])
-    ).filter((field) => resource.attributes?.[field])
+    const requestedLens = String(lens || '').trim()
+    const defaultLens = Object.values(resource.lenses || {}).find(
+      (definition) => definition.default
+    )
+    const activeLens =
+      requestedLens === '__all'
+        ? null
+        : requestedLens
+        ? resource.lenses?.[requestedLens]
+        : defaultLens || null
+    if (requestedLens && requestedLens !== '__all' && !activeLens) {
+      const error = new Error(`Bridge lens "${requestedLens}" is unavailable.`)
+      error.code = 'BRIDGE_LENS_INVALID'
+      throw error
+    }
+
+    const columns = activeLens?.columns || resource.list || []
+    const selectable = Array.from(new Set([primaryKey, ...columns])).filter(
+      (field) => resource.attributes?.[field]
+    )
     const sortable = new Set(
-      selectable.filter(
+      columns.filter(
         (field) => resource.attributes[field]?.field?.sortable !== false
       )
     )
 
-    let sortField = resource.sort?.field || primaryKey
-    let sortDirection = resource.sort?.direction || 'DESC'
+    const defaultSort = activeLens?.sort || resource.sort
+    let sortField = defaultSort?.field || primaryKey
+    let sortDirection = defaultSort?.direction || 'DESC'
     const requestedSort = String(sort || '').trim()
     if (requestedSort) {
       const match = requestedSort.match(
@@ -68,7 +102,7 @@ module.exports = {
         !resource.attributes[field].encrypt &&
         !resource.attributes[field].protect
     )
-    const where =
+    const searchWhere =
       searchValue && searchFields.length > 0
         ? {
             or: searchFields.map((field) => ({
@@ -76,6 +110,21 @@ module.exports = {
             }))
           }
         : {}
+    const fixedFilters =
+      await sails.helpers.bridge.normalizeResourceFilters.with({
+        resource,
+        filters: activeLens?.filters || {}
+      })
+    const activeFilters =
+      await sails.helpers.bridge.normalizeResourceFilters.with({
+        resource,
+        filters
+      })
+    const where = combineWhere([
+      searchWhere,
+      fixedFilters.where,
+      activeFilters.where
+    ])
 
     return {
       page: safePage,
@@ -83,6 +132,10 @@ module.exports = {
       search: searchValue,
       sort: `${sortField} ${sortDirection}`,
       select: selectable,
+      columns,
+      filters: activeFilters.filters,
+      filterDefinitions: activeFilters.definitions,
+      lens: activeLens,
       where,
       criteria: {
         where,
@@ -93,4 +146,13 @@ module.exports = {
       }
     }
   }
+}
+
+function combineWhere(clauses) {
+  const present = clauses.filter(
+    (clause) => clause && Object.keys(clause).length > 0
+  )
+  if (present.length === 0) return {}
+  if (present.length === 1) return present[0]
+  return { and: present }
 }

--- a/api/helpers/bridge/query-resource.js
+++ b/api/helpers/bridge/query-resource.js
@@ -1,0 +1,150 @@
+module.exports = {
+  friendlyName: 'Query Bridge resource',
+
+  description:
+    'Run a normalized Bridge resource query through Waterline or a configured target-app lens helper.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    query: {
+      type: 'ref',
+      required: true
+    },
+    actor: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, resource, query, actor }) {
+    const helper = query.lens?.helper || ''
+    const queryCode = helper
+      ? buildHelperQuery({ resource, query, actor, helper })
+      : buildWaterlineQuery({ resource, query })
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(queryCode)
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      const error = new Error(
+        result.error ||
+          `Failed to query ${resource.label || resource.identity}.`
+      )
+      error.code = 'BRIDGE_RESOURCE_QUERY_FAILED'
+      throw error
+    }
+
+    let output
+    try {
+      output = JSON.parse(result.output)
+    } catch (cause) {
+      const error = new Error('Failed to parse the Bridge resource query.')
+      error.code = 'BRIDGE_RESOURCE_QUERY_FAILED'
+      error.cause = cause
+      throw error
+    }
+
+    if (
+      !output ||
+      !Array.isArray(output.records) ||
+      output.records.length > query.perPage ||
+      !Number.isSafeInteger(Number(output.total)) ||
+      Number(output.total) < 0
+    ) {
+      const error = new Error(
+        'A Bridge lens helper must return { records, total }.'
+      )
+      error.code = 'BRIDGE_RESOURCE_QUERY_FAILED'
+      throw error
+    }
+
+    return {
+      records: output.records,
+      total: Number(output.total)
+    }
+  }
+}
+
+function buildWaterlineQuery({ resource, query }) {
+  return `
+    const identity = ${JSON.stringify(resource.identity)};
+    const where = ${JSON.stringify(query.where)};
+    const criteria = ${JSON.stringify(query.criteria)};
+    const model = sails.models[identity];
+    if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+    const total = await model.count(where);
+    const records = await model.find(criteria);
+    return { records, total };
+  `
+}
+
+function buildHelperQuery({ resource, query, actor, helper }) {
+  return `
+    const helperIdentity = ${JSON.stringify(helper)};
+    const actor = ${JSON.stringify(actor)};
+    const resource = ${JSON.stringify({
+      identity: resource.identity,
+      primaryKey: resource.primaryKey,
+      label: resource.label,
+      singularLabel: resource.singularLabel
+    })};
+    const query = ${JSON.stringify({
+      page: query.page,
+      perPage: query.perPage,
+      search: query.search,
+      filters: query.filters,
+      where: query.where,
+      criteria: query.criteria,
+      columns: query.columns,
+      sort: query.sort
+    })};
+
+    function resolveHelper(identity) {
+      let helper = sails.helpers;
+      for (const segment of identity.split('.')) {
+        helper = helper && helper[segment];
+      }
+      if (!helper || typeof helper.with !== 'function') {
+        throw new Error(
+          'Configured Bridge lens helper "' + identity + '" is unavailable.'
+        );
+      }
+      return helper;
+    }
+
+    const result = await resolveHelper(helperIdentity).with({
+      actor,
+      resource,
+      query
+    });
+    if (
+      !result ||
+      !Array.isArray(result.records) ||
+      result.records.length > query.perPage ||
+      !Number.isSafeInteger(Number(result.total)) ||
+      Number(result.total) < 0
+    ) {
+      throw new Error('A Bridge lens helper must return { records, total }.');
+    }
+    return {
+      records: result.records,
+      total: Number(result.total)
+    };
+  `
+}

--- a/assets/js/components/bridge/BridgeFilterMenu.vue
+++ b/assets/js/components/bridge/BridgeFilterMenu.vue
@@ -1,0 +1,448 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import BridgeRelationshipSelect from '@/components/bridge/BridgeRelationshipSelect.vue'
+
+const props = defineProps({
+  definitions: {
+    type: Object,
+    default: () => ({})
+  },
+  modelValue: {
+    type: Object,
+    default: () => ({})
+  },
+  relationshipBaseUrl: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['apply'])
+
+const root = ref(null)
+const trigger = ref(null)
+const panel = ref(null)
+const open = ref(false)
+const draft = ref({})
+const initialSerialized = ref('{}')
+
+const filters = computed(() => Object.values(props.definitions || {}))
+const activeCount = computed(() => Object.keys(props.modelValue || {}).length)
+const hasDraft = computed(() => Object.keys(serializeDraft()).length > 0)
+const changed = computed(
+  () => stableStringify(serializeDraft()) !== initialSerialized.value
+)
+
+watch(
+  () => props.modelValue,
+  () => {
+    if (!open.value) resetDraft()
+  },
+  { deep: true, immediate: true }
+)
+
+function blankFilter(definition) {
+  return {
+    operator: definition.defaultOperator,
+    value: '',
+    from: '',
+    to: ''
+  }
+}
+
+function resetDraft() {
+  const next = {}
+  for (const definition of filters.value) {
+    const current = props.modelValue?.[definition.field]
+    next[definition.field] = current
+      ? {
+          ...blankFilter(definition),
+          ...current,
+          from: toInputDate(definition, current.from),
+          to: toInputDate(definition, current.to)
+        }
+      : blankFilter(definition)
+  }
+  draft.value = next
+  initialSerialized.value = stableStringify(serializeDraft())
+}
+
+async function show() {
+  resetDraft()
+  open.value = true
+  await nextTick()
+  panel.value?.querySelector('select, input, button:not([disabled])')?.focus()
+}
+
+function hide({ restoreFocus = false } = {}) {
+  open.value = false
+  resetDraft()
+  if (restoreFocus) nextTick(() => trigger.value?.focus())
+}
+
+function toggle() {
+  if (open.value) hide()
+  else show()
+}
+
+function apply() {
+  emit('apply', serializeDraft())
+  open.value = false
+  nextTick(() => trigger.value?.focus())
+}
+
+function clear() {
+  draft.value = Object.fromEntries(
+    filters.value.map((definition) => [
+      definition.field,
+      blankFilter(definition)
+    ])
+  )
+}
+
+function clearAndApply() {
+  clear()
+  emit('apply', {})
+  open.value = false
+  nextTick(() => trigger.value?.focus())
+}
+
+function serializeDraft() {
+  const values = {}
+  for (const definition of filters.value) {
+    const state = draft.value[definition.field]
+    if (!state) continue
+
+    if (['isNull', 'isNotNull'].includes(state.operator)) {
+      values[definition.field] = { operator: state.operator }
+      continue
+    }
+    if (state.operator === 'between') {
+      if (hasValue(state.from) || hasValue(state.to)) {
+        values[definition.field] = {
+          operator: 'between',
+          ...(hasValue(state.from) ? { from: state.from } : {}),
+          ...(hasValue(state.to) ? { to: state.to } : {})
+        }
+      }
+      continue
+    }
+    if (hasValue(state.value)) {
+      values[definition.field] = {
+        operator: state.operator,
+        value: state.value
+      }
+    }
+  }
+  return values
+}
+
+function hasValue(value) {
+  return value !== '' && value !== null && value !== undefined
+}
+
+function supportsValue(definition) {
+  return !['isNull', 'isNotNull'].includes(
+    draft.value[definition.field]?.operator
+  )
+}
+
+function isRange(definition) {
+  return draft.value[definition.field]?.operator === 'between'
+}
+
+function isText(definition) {
+  return ['text', 'textarea', 'richtext', 'email', 'url'].includes(
+    definition.type
+  )
+}
+
+function inputType(definition) {
+  if (definition.type === 'date') return 'date'
+  if (['datetime', 'timestamp'].includes(definition.type)) {
+    return 'datetime-local'
+  }
+  return 'number'
+}
+
+function operatorLabel(operator) {
+  return (
+    {
+      contains: 'Contains',
+      equals: 'Is',
+      between: 'Between',
+      isNull: 'Is empty',
+      isNotNull: 'Is not empty'
+    }[operator] || operator
+  )
+}
+
+function fieldId(definition, suffix) {
+  return `bridge-filter-${definition.field}-${suffix}`.replace(
+    /[^A-Za-z0-9_-]/g,
+    '-'
+  )
+}
+
+function relationshipUrl(definition) {
+  if (!props.relationshipBaseUrl) return ''
+  return `${props.relationshipBaseUrl}/${encodeURIComponent(
+    definition.field
+  )}/options?surface=filter`
+}
+
+function toInputDate(definition, value) {
+  if (!value || !['datetime', 'timestamp'].includes(definition.type)) {
+    return value || ''
+  }
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  const offset = date.getTimezoneOffset() * 60_000
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16)
+}
+
+function stableStringify(value) {
+  return JSON.stringify(
+    Object.fromEntries(
+      Object.entries(value || {}).sort(([left], [right]) =>
+        left.localeCompare(right)
+      )
+    )
+  )
+}
+
+function handleDocumentPointerDown(event) {
+  if (open.value && root.value && !root.value.contains(event.target)) {
+    hide()
+  }
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape' && open.value) {
+    event.preventDefault()
+    hide({ restoreFocus: true })
+  }
+}
+
+onMounted(() => {
+  document.addEventListener('pointerdown', handleDocumentPointerDown)
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onBeforeUnmount(() => {
+  document.removeEventListener('pointerdown', handleDocumentPointerDown)
+  document.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<template>
+  <div ref="root" class="relative" data-test="bridge-filter-menu">
+    <button
+      ref="trigger"
+      type="button"
+      :aria-expanded="open"
+      aria-haspopup="dialog"
+      aria-controls="bridge-filter-panel"
+      class="inline-flex h-8 items-center gap-1.5 rounded-md px-2.5 text-sm font-medium text-gray-600 transition-colors hover:bg-gray-100 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 motion-reduce:transition-none dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white dark:focus-visible:ring-gray-700"
+      data-test="bridge-filter-toggle"
+      @click="toggle"
+    >
+      <svg
+        class="h-4 w-4"
+        viewBox="0 0 20 20"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="1.5"
+        aria-hidden="true"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M3.5 5.25h13M5.75 10h8.5M8 14.75h4"
+        />
+      </svg>
+      Filter
+      <span
+        v-if="activeCount"
+        class="min-w-4 flex h-4 items-center justify-center rounded-full bg-gray-900 px-1 text-[10px] font-semibold text-white dark:bg-white dark:text-gray-900"
+      >
+        {{ activeCount }}
+      </span>
+    </button>
+
+    <form
+      v-if="open"
+      id="bridge-filter-panel"
+      ref="panel"
+      role="dialog"
+      aria-label="Filter records"
+      class="absolute left-0 z-40 mt-2 w-[22rem] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-xl shadow-gray-900/10 dark:border-gray-700 dark:bg-gray-900 dark:shadow-black/30"
+      data-test="bridge-filter-panel"
+      @submit.prevent="apply"
+    >
+      <div class="flex items-center justify-between px-4 pb-2 pt-3.5">
+        <p class="text-sm font-semibold text-gray-900 dark:text-white">
+          Filter records
+        </p>
+        <button
+          v-if="hasDraft"
+          type="button"
+          class="text-xs font-medium text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          @click="clear"
+        >
+          Clear
+        </button>
+      </div>
+
+      <div class="max-h-[28rem] space-y-4 overflow-y-auto px-4 py-2">
+        <div
+          v-for="definition in filters"
+          :key="definition.field"
+          class="space-y-1.5"
+        >
+          <div class="flex items-center justify-between gap-3">
+            <label
+              :for="fieldId(definition, 'operator')"
+              class="truncate text-xs font-medium text-gray-600 dark:text-gray-300"
+            >
+              {{ definition.label }}
+            </label>
+            <select
+              :id="fieldId(definition, 'operator')"
+              v-model="draft[definition.field].operator"
+              class="border-0 bg-transparent py-0 pl-1 pr-5 text-right text-xs text-gray-500 focus:ring-0 dark:bg-gray-900 dark:text-gray-400"
+            >
+              <option
+                v-for="operator in definition.operators"
+                :key="operator"
+                :value="operator"
+              >
+                {{ operatorLabel(operator) }}
+              </option>
+            </select>
+          </div>
+
+          <div v-if="supportsValue(definition)">
+            <div
+              v-if="isRange(definition)"
+              class="grid grid-cols-[1fr_auto_1fr] items-center gap-2"
+            >
+              <label :for="fieldId(definition, 'from')" class="sr-only">
+                {{ definition.label }} from
+              </label>
+              <input
+                :id="fieldId(definition, 'from')"
+                v-model="draft[definition.field].from"
+                :type="inputType(definition)"
+                :step="
+                  ['number', 'currency'].includes(definition.type)
+                    ? 'any'
+                    : undefined
+                "
+                placeholder="From"
+                class="focus:border-brand min-w-0 border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              />
+              <span class="text-xs text-gray-400 dark:text-gray-500">to</span>
+              <label :for="fieldId(definition, 'to')" class="sr-only">
+                {{ definition.label }} to
+              </label>
+              <input
+                :id="fieldId(definition, 'to')"
+                v-model="draft[definition.field].to"
+                :type="inputType(definition)"
+                :step="
+                  ['number', 'currency'].includes(definition.type)
+                    ? 'any'
+                    : undefined
+                "
+                placeholder="To"
+                class="focus:border-brand min-w-0 border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              />
+            </div>
+
+            <input
+              v-else-if="isText(definition)"
+              :id="fieldId(definition, 'value')"
+              v-model="draft[definition.field].value"
+              type="text"
+              :aria-label="`${definition.label} value`"
+              :placeholder="`${operatorLabel(
+                draft[definition.field].operator
+              )}…`"
+              class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            />
+
+            <select
+              v-else-if="definition.type === 'boolean'"
+              :id="fieldId(definition, 'value')"
+              v-model="draft[definition.field].value"
+              :aria-label="`${definition.label} value`"
+              class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-0 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+            >
+              <option value="">Choose…</option>
+              <option value="true">Yes</option>
+              <option value="false">No</option>
+            </select>
+
+            <select
+              v-else-if="definition.type === 'select'"
+              :id="fieldId(definition, 'value')"
+              v-model="draft[definition.field].value"
+              :aria-label="`${definition.label} value`"
+              class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-0 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+            >
+              <option value="">Choose…</option>
+              <option
+                v-for="option in definition.options || []"
+                :key="String(option.value)"
+                :value="option.value"
+                :disabled="option.disabled"
+              >
+                {{ option.label }}
+              </option>
+            </select>
+
+            <BridgeRelationshipSelect
+              v-else-if="definition.type === 'belongsTo'"
+              :id="fieldId(definition, 'value')"
+              :label="definition.label"
+              v-model="draft[definition.field].value"
+              :search-url="relationshipUrl(definition)"
+              :searchable="definition.relationship?.searchable !== false"
+            />
+
+            <input
+              v-else
+              :id="fieldId(definition, 'value')"
+              v-model="draft[definition.field].value"
+              :type="inputType(definition)"
+              :aria-label="`${definition.label} value`"
+              step="any"
+              class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            />
+          </div>
+        </div>
+      </div>
+
+      <div
+        class="flex items-center justify-between border-t border-gray-100 px-4 py-3 dark:border-gray-800"
+      >
+        <button
+          type="button"
+          class="text-xs font-medium text-gray-500 hover:text-gray-900 disabled:cursor-default disabled:opacity-40 dark:text-gray-400 dark:hover:text-white"
+          :disabled="activeCount === 0"
+          @click="clearAndApply"
+        >
+          Reset filters
+        </button>
+        <button
+          type="submit"
+          :disabled="!changed"
+          class="rounded-md bg-gray-900 px-3 py-1.5 text-xs font-semibold text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+        >
+          Apply
+        </button>
+      </div>
+    </form>
+  </div>
+</template>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -9,6 +9,7 @@ import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
+import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
 
 defineOptions({
   layout: AppLayout
@@ -29,6 +30,11 @@ const props = defineProps({
   perPage: Number,
   sort: String,
   search: String,
+  filterState: Object,
+  filterDefinitions: Object,
+  columns: Array,
+  lenses: Array,
+  activeLens: Object,
   error: String,
   dashboards: Array,
   dashboardResources: Object,
@@ -44,11 +50,22 @@ const bridgeBasePath = computed(() =>
     ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
     : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
 )
+const relationshipBaseUrl = computed(() => {
+  const appPath =
+    props.appScoped && props.app?.slug ? `/apps/${props.app.slug}` : ''
+  return `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}${appPath}/bridge/${props.modelIdentity}/relationships`
+})
+const defaultLens = computed(() =>
+  (props.lenses || []).find((definition) => definition.default)
+)
+const allRecordsLensValue = computed(() => (defaultLens.value ? '__all' : ''))
 
 // Local state for UI
 const page = ref(props.currentPage)
 const sortValue = ref(props.sort)
 const searchInput = ref(props.search)
+const filtersValue = ref(props.filterState || {})
+const lensValue = ref(props.activeLens?.id || allRecordsLensValue.value)
 const selectedIds = ref(new Set())
 const selectAll = ref(false)
 const deleteModal = ref({ show: false, recordId: null })
@@ -182,6 +199,31 @@ watch(searchInput, (val) => {
     navigateWithParams({ search: val, page: 1 })
   }, 300)
 })
+watch(
+  () => props.filterState,
+  (value) => {
+    filtersValue.value = value || {}
+  },
+  { deep: true }
+)
+watch(
+  () => props.activeLens,
+  (value) => {
+    lensValue.value = value?.id || allRecordsLensValue.value
+  }
+)
+watch(
+  () => props.sort,
+  (value) => {
+    sortValue.value = value
+  }
+)
+watch(
+  () => props.currentPage,
+  (value) => {
+    page.value = value
+  }
+)
 
 // Navigate with updated params
 function navigateWithParams(updates) {
@@ -189,6 +231,8 @@ function navigateWithParams(updates) {
     page: updates.page ?? page.value,
     sort: updates.sort ?? sortValue.value,
     search: updates.search ?? searchInput.value,
+    filters: JSON.stringify(updates.filters ?? filtersValue.value),
+    lens: updates.lens ?? lensValue.value,
     dashboard:
       updates.dashboard ??
       (props.dashboards?.length > 1 ? props.activeDashboard?.id : '')
@@ -199,8 +243,16 @@ function navigateWithParams(updates) {
   const defaultSort = props.modelMeta
     ? `${props.modelMeta.sort.field} ${props.modelMeta.sort.direction}`
     : ''
-  if (params.sort === defaultSort) delete params.sort
+  if (!params.sort || params.sort === defaultSort) delete params.sort
   if (!params.search) delete params.search
+  if (params.filters === '{}') delete params.filters
+  if (
+    !params.lens ||
+    params.lens === defaultLens.value?.id ||
+    (params.lens === '__all' && !defaultLens.value)
+  ) {
+    delete params.lens
+  }
   if (!params.dashboard) delete params.dashboard
 
   const query = new URLSearchParams(params).toString()
@@ -215,8 +267,29 @@ function navigateWithParams(updates) {
 // Visible columns
 const visibleColumns = computed(() => {
   if (!props.modelMeta) return []
-  return props.modelMeta.list || []
+  return props.columns || props.modelMeta.list || []
 })
+const hasScopedQuery = computed(
+  () =>
+    Boolean(props.search) ||
+    Object.keys(props.filterState || {}).length > 0 ||
+    Boolean(props.activeLens)
+)
+
+function applyFilters(filters) {
+  filtersValue.value = filters
+  page.value = 1
+  navigateWithParams({ filters, page: 1 })
+}
+
+function switchLens(event) {
+  const lens = event.target.value
+  lensValue.value = lens
+  filtersValue.value = {}
+  sortValue.value = ''
+  page.value = 1
+  navigateWithParams({ lens, filters: {}, sort: '', page: 1 })
+}
 
 // Sort handling
 const sortAttr = computed(() => sortValue.value.split(' ')[0])
@@ -568,8 +641,29 @@ function createUrl() {
             v-if="(modelMeta?.search || []).length > 0"
             v-model="searchInput"
             type="text"
+            aria-label="Search records"
             placeholder="Search records..."
             class="w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 dark:focus:border-gray-600 sm:w-64"
+          />
+          <select
+            v-if="lenses?.length > 0"
+            :value="lensValue"
+            aria-label="Saved view"
+            class="rounded-md border-0 bg-transparent py-1 pl-2 pr-7 text-sm text-gray-600 focus:ring-1 focus:ring-gray-300 dark:bg-gray-950 dark:text-gray-300 dark:focus:ring-gray-700"
+            data-test="bridge-lens-select"
+            @change="switchLens"
+          >
+            <option :value="allRecordsLensValue">All records</option>
+            <option v-for="lens in lenses" :key="lens.id" :value="lens.id">
+              {{ lens.label }}
+            </option>
+          </select>
+          <BridgeFilterMenu
+            v-if="Object.keys(filterDefinitions || {}).length > 0"
+            :definitions="filterDefinitions"
+            :model-value="filtersValue"
+            :relationship-base-url="relationshipBaseUrl"
+            @apply="applyFilters"
           />
           <Transition
             enter-active-class="transition ease-out duration-150"
@@ -750,7 +844,9 @@ function createUrl() {
                   "
                   class="px-4 py-12 text-center text-sm text-gray-500 dark:text-gray-400"
                 >
-                  {{ search ? 'No matching records.' : 'No records yet.' }}
+                  {{
+                    hasScopedQuery ? 'No matching records.' : 'No records yet.'
+                  }}
                 </td>
               </tr>
             </tbody>

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -133,6 +133,103 @@ module.exports.slipway = {
 
 A resource can also be removed from Bridge with `false` or `hidden: true`.
 
+## Filters and saved lenses
+
+Bridge exposes filters only when a resource opts fields into its `filters`
+array. The field contract determines the control and the Waterline operator:
+
+| Field type                         | Bridge filter                        |
+| ---------------------------------- | ------------------------------------ |
+| text, textarea, rich text, URL     | contains or exact match              |
+| boolean and select                 | exact match                          |
+| number and currency                | exact value or range                 |
+| date, datetime, and timestamp      | exact value or range                 |
+| belongs-to relationship            | authorized, searchable record picker |
+| nullable fields of supported types | is empty or is not empty             |
+
+```js
+module.exports.slipway = {
+  bridge: {
+    resources: {
+      lesson: {
+        search: ['title', 'slug'],
+        filters: ['title', 'published', 'creator', 'createdAt'],
+        lenses: {
+          published: {
+            label: 'Published lessons',
+            filters: {
+              published: true
+            },
+            columns: ['title', 'creator', 'published', 'createdAt'],
+            sort: {
+              field: 'createdAt',
+              direction: 'DESC'
+            }
+          },
+          drafts: {
+            label: 'Draft lessons',
+            filters: {
+              published: false
+            },
+            columns: ['title', 'creator', 'createdAt'],
+            sort: {
+              field: 'createdAt',
+              direction: 'DESC'
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+A lens is a named resource view. It can fix filters, choose columns, and set a
+default sort while still allowing a Bridge user to add another filter or
+search. Filter, lens, search, sort, and page state are encoded in the URL, so a
+view can be bookmarked or shared with another authorized Bridge user.
+
+For a specialized view that cannot be represented with ordinary Waterline
+criteria, configure a target-app helper:
+
+```js
+recentSignups: {
+  label: 'Recent signups',
+  columns: ['fullName', 'email', 'createdAt'],
+  helper: 'bridge.lenses.recentSignups'
+}
+```
+
+```js
+// api/helpers/bridge/lenses/recent-signups.js
+module.exports = {
+  friendlyName: 'Load recent Bridge signups',
+
+  inputs: {
+    actor: { type: 'ref', required: true },
+    resource: { type: 'ref', required: true },
+    query: { type: 'ref', required: true }
+  },
+
+  fn: async function ({ query }) {
+    const records = await User.find(query.criteria)
+    const total = await User.count(query.where)
+    return { records, total }
+  }
+}
+```
+
+The helper runs inside the target application and receives the authenticated
+actor plus a normalized, bounded query. It must return `{ records, total }`.
+Bridge still applies the resource's visible-column allowlist before rendering
+the result.
+
+Search, filter, and lens input is never interpolated into executable code.
+Bridge validates configured fields, operators, values, relationship access,
+columns, sorting, and helper identities before serializing criteria for the
+target app. Fields hidden from the list or filter surfaces cannot be requested
+through a lens or a forged URL.
+
 ## Dashboards
 
 Bridge can turn the resource directory into an application-specific dashboard

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -43,6 +43,9 @@ test(
     const actionScreenshotRoot = path.resolve(
       '.tmp/screenshots/issue-221-bridge-actions'
     )
+    const filterScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-224-bridge-filters'
+    )
 
     fs.mkdirSync(screenshotRoot, { recursive: true })
     fs.mkdirSync(identifierScreenshotRoot, { recursive: true })
@@ -50,6 +53,7 @@ test(
     fs.mkdirSync(fieldEngineScreenshotRoot, { recursive: true })
     fs.mkdirSync(relationshipScreenshotRoot, { recursive: true })
     fs.mkdirSync(actionScreenshotRoot, { recursive: true })
+    fs.mkdirSync(filterScreenshotRoot, { recursive: true })
 
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: resourceMetadata(),
@@ -101,6 +105,7 @@ test(
     let persistedCourseRecord = record
     let createdValues
     let updatedValues
+    const resourceQueries = []
 
     await sails.models.app
       .updateOne({ id: app.id })
@@ -251,6 +256,10 @@ test(
         })
       }
       if (code.includes('const total = await model.count(where);')) {
+        resourceQueries.push({
+          where: readEmbeddedValue(code, 'where'),
+          criteria: readEmbeddedValue(code, 'criteria')
+        })
         return successfulResult({
           records,
           total: records.length
@@ -282,6 +291,17 @@ test(
             : {})
         }
         return successfulResult({ record: persistedCourseRecord })
+      }
+      if (
+        code.includes('const helperIdentity =') &&
+        code.includes('A Bridge lens helper must return')
+      ) {
+        const query = readEmbeddedValue(code, 'query')
+        expect(query.columns).toEqual(['title', 'price', 'createdAt'])
+        return successfulResult({
+          records,
+          total: records.length
+        })
       }
       if (code.includes('const helperIdentity =')) {
         const helperIdentity = readEmbeddedValue(code, 'helperIdentity')
@@ -403,6 +423,82 @@ test(
         { fullPage: true }
       )
       await page.raw.emulateMedia({ colorScheme: 'light' })
+
+      await page.raw.locator('[data-test="bridge-filter-toggle"]').click()
+      await page.raw
+        .locator('[data-test="bridge-filter-panel"]')
+        .waitFor({ state: 'visible' })
+      await page.screenshot(
+        path.join(filterScreenshotRoot, 'filter-menu-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(filterScreenshotRoot, 'filter-menu-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw.locator('#bridge-filter-title-value').fill('production')
+      await page.raw
+        .locator('#bridge-filter-published-value')
+        .selectOption('true')
+      await page.raw.locator('#bridge-filter-creator-value').click()
+      await page.wait('text=Ada Lovelace')
+      await page.screenshot(
+        path.join(filterScreenshotRoot, 'belongs-to-filter-light.png'),
+        { fullPage: true }
+      )
+      await page.raw
+        .getByRole('option', { name: 'Ada Lovelace', exact: true })
+        .click()
+      await page.raw.getByRole('button', { name: 'Apply' }).click()
+      await page.raw.waitForURL((url) => url.searchParams.has('filters'))
+      expect(
+        JSON.parse(new URL(page.raw.url()).searchParams.get('filters'))
+      ).toEqual({
+        title: { operator: 'contains', value: 'production' },
+        published: { operator: 'equals', value: 'true' },
+        creator: { operator: 'equals', value: creatorId }
+      })
+      expect(resourceQueries.at(-1).where).toEqual({
+        and: [
+          { title: { contains: 'production' } },
+          { published: true },
+          { creator: creatorId }
+        ]
+      })
+      expect(
+        await page.raw
+          .locator('[data-test="bridge-filter-toggle"] span')
+          .textContent()
+      ).toBe('3')
+      await page.screenshot(
+        path.join(filterScreenshotRoot, 'active-filters-light.png'),
+        { fullPage: true }
+      )
+
+      await page.raw
+        .locator('[data-test="bridge-lens-select"]')
+        .selectOption('recent')
+      await page.raw.waitForURL(
+        (url) => url.searchParams.get('lens') === 'recent'
+      )
+      expect(new URL(page.raw.url()).searchParams.has('filters')).toBe(false)
+      await expect(page).toSee('Recently active')
+      await page.screenshot(
+        path.join(filterScreenshotRoot, 'saved-lens-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(filterScreenshotRoot, 'saved-lens-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .locator('[data-test="bridge-lens-select"]')
+        .selectOption('')
+      await page.raw.waitForURL((url) => !url.searchParams.has('lens'))
 
       const resourceActionsButton = page.raw.getByRole('button', {
         name: 'Actions for Courses'
@@ -911,6 +1007,36 @@ function resourceConfig() {
           'published',
           'creator'
         ],
+        filters: ['title', 'price', 'published', 'creator', 'createdAt'],
+        lenses: {
+          published: {
+            label: 'Published courses',
+            filters: { published: true },
+            columns: ['title', 'price', 'published', 'createdAt'],
+            sort: {
+              field: 'createdAt',
+              direction: 'DESC'
+            }
+          },
+          drafts: {
+            label: 'Draft courses',
+            filters: { published: false },
+            columns: ['title', 'price', 'createdAt'],
+            sort: {
+              field: 'createdAt',
+              direction: 'DESC'
+            }
+          },
+          recent: {
+            label: 'Recently active',
+            columns: ['title', 'price', 'createdAt'],
+            sort: {
+              field: 'createdAt',
+              direction: 'DESC'
+            },
+            helper: 'bridge.lenses.recentCourses'
+          }
+        },
         sort: {
           field: 'createdAt',
           direction: 'DESC'

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -754,6 +754,183 @@ test('Bridge query normalization treats sort and search as data', async ({
   })
 })
 
+test('Bridge compiles type-aware filters and saved lenses into safe criteria', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          search: ['title'],
+          list: ['title', 'published', 'creator', 'createdAt'],
+          filters: ['title', 'published', 'creator', 'createdAt'],
+          lenses: {
+            published: {
+              label: 'Published courses',
+              filters: { published: true },
+              columns: ['title', 'creator', 'published', 'createdAt'],
+              sort: { field: 'createdAt', direction: 'DESC' },
+              default: true
+            },
+            recent: {
+              label: 'Recent courses',
+              columns: ['title', 'createdAt'],
+              sort: { field: 'createdAt', direction: 'DESC' },
+              helper: 'bridge.lenses.recentCourses'
+            }
+          }
+        }
+      }
+    }
+  })
+  const resource = contract.resources.course
+
+  expect(resource.filterDefinitions.title.type).toBe('text')
+  expect(resource.filterDefinitions.published.type).toBe('boolean')
+  expect(resource.filterDefinitions.creator.type).toBe('belongsTo')
+  expect(resource.filterDefinitions.createdAt.type).toBe('timestamp')
+  expect(resource.lenses.published.filters).toEqual({
+    published: { operator: 'equals', value: true }
+  })
+  expect(resource.lenses.recent.helper).toBe('bridge.lenses.recentCourses')
+
+  const query = await sails.helpers.bridge.normalizeResourceQuery.with({
+    resource,
+    page: 2,
+    perPage: 25,
+    lens: 'published',
+    search: 'Sails',
+    filters: JSON.stringify({
+      title: { operator: 'contains', value: 'production' },
+      creator: { operator: 'equals', value: '42' },
+      createdAt: {
+        operator: 'between',
+        from: '2026-07-01T00:00',
+        to: '2026-07-31T23:59'
+      }
+    })
+  })
+
+  expect(query.lens.id).toBe('published')
+  expect(query.columns).toEqual(['title', 'creator', 'published', 'createdAt'])
+  expect(query.sort).toBe('createdAt DESC')
+  expect(query.select).toEqual([
+    'id',
+    'title',
+    'creator',
+    'published',
+    'createdAt'
+  ])
+  expect(query.where).toEqual({
+    and: [
+      { or: [{ title: { contains: 'Sails' } }] },
+      { published: true },
+      {
+        and: [
+          { title: { contains: 'production' } },
+          { creator: 42 },
+          {
+            createdAt: {
+              '>=': Date.parse('2026-07-01T00:00'),
+              '<=': Date.parse('2026-07-31T23:59') + 59_999
+            }
+          }
+        ]
+      }
+    ]
+  })
+  expect(query.criteria.skip).toBe(25)
+})
+
+test('Bridge filters preserve false values and support null checks', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          filters: ['published', 'description']
+        }
+      }
+    }
+  })
+  const resource = contract.resources.course
+  const query = await sails.helpers.bridge.normalizeResourceQuery.with({
+    resource,
+    filters: {
+      published: { operator: 'equals', value: false },
+      description: { operator: 'isNotNull' }
+    }
+  })
+
+  expect(query.filters).toEqual({
+    published: { operator: 'equals', value: false },
+    description: { operator: 'isNotNull' }
+  })
+  expect(query.where).toEqual({
+    and: [{ published: false }, { description: { '!=': null } }]
+  })
+})
+
+test('Bridge rejects forged filters and invalid lens configuration', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          filters: ['published']
+        }
+      }
+    }
+  })
+  let forgedFilterError
+  let invalidLensError
+
+  try {
+    await sails.helpers.bridge.normalizeResourceQuery.with({
+      resource: contract.resources.course,
+      filters: {
+        password: { operator: 'equals', value: 'secret' }
+      }
+    })
+  } catch (error) {
+    forgedFilterError = error
+  }
+
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            filters: ['published'],
+            lenses: {
+              unsafe: {
+                filters: { password: 'secret' }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    invalidLensError = error
+  }
+
+  expect(forgedFilterError.code).toBe('BRIDGE_FILTER_INVALID')
+  expect(forgedFilterError.message).toBe(
+    'Bridge filter "password" is unavailable.'
+  )
+  expect(invalidLensError.code).toBe('BRIDGE_FILTER_INVALID')
+})
+
 test('Bridge rejects forged mutation fields before container execution', async ({
   sails,
   expect


### PR DESCRIPTION
## Summary

- add type-aware, allowlisted Bridge filters for text, boolean, select, numeric, date, timestamp, relationship, and null criteria
- add URL-persisted saved lenses with fixed filters, visible columns, sort order, defaults, and optional custom helpers
- keep the UI minimal with one view selector and one filter popover across light and dark modes
- harden Bridge criteria, relationship lookup, result redaction, and pagination bounds
- document the resource contract and cover the behavior with unit, functional, and browser trials

## Why

Bridge needs production-grade ways to narrow and reuse record views without exposing arbitrary Waterline criteria or crowding the resource interface.

## Impact

This makes large Bridge resources faster to operate, safer to expose to app teams, and easier to revisit through shareable, durable URLs.

## Verification

- `npm run lint`
- 194 unit trials
- 55 functional trials
- 22 end-to-end/browser trials
- focused Bridge filter and saved-lens browser coverage

Closes #224