### PR TITLE
feat(bridge): add reusable managed uploads

### DIFF
--- a/api/controllers/project/bridge-upload-field.js
+++ b/api/controllers/project/bridge-upload-field.js
@@ -1,12 +1,15 @@
 const crypto = require('node:crypto')
 const path = require('node:path')
 
-const IMAGE_EXTENSIONS = {
+const MIME_EXTENSIONS = {
   'image/avif': '.avif',
   'image/gif': '.gif',
   'image/jpeg': '.jpg',
   'image/png': '.png',
-  'image/webp': '.webp'
+  'image/webp': '.webp',
+  'video/mp4': '.mp4',
+  'video/quicktime': '.mov',
+  'video/webm': '.webm'
 }
 
 module.exports = {
@@ -40,6 +43,10 @@ module.exports = {
     recordId: {
       type: 'string'
     },
+    values: {
+      type: 'string',
+      defaultsTo: '{}'
+    },
     file: {
       type: 'ref',
       required: true
@@ -67,7 +74,8 @@ module.exports = {
     appSlug,
     modelIdentity,
     fieldName,
-    recordId
+    recordId,
+    values
   }) {
     let resolved
     try {
@@ -109,7 +117,12 @@ module.exports = {
     const fieldType = attribute?.field?.type
     if (
       !loaded.resource[surface]?.includes(fieldName) ||
-      !['file', 'image', 'upload'].includes(fieldType) ||
+      !(
+        ['file', 'image', 'upload'].includes(fieldType) ||
+        (fieldType === 'richtext' &&
+          attribute.field.format?.toLowerCase() === 'markdown' &&
+          attribute.field.upload?.kind === 'image')
+      ) ||
       attribute.field.upload?.storage !== 'bridge'
     ) {
       throw {
@@ -128,15 +141,44 @@ module.exports = {
     }
 
     const upload = attribute.field.upload
-    const directory = [
-      'bridge',
-      `teams/${safeSegment(project.team)}`,
-      `projects/${safeSegment(project.id)}`,
-      `environments/${safeSegment(environment.id)}`,
-      safeSegment(modelIdentity),
-      safeSegment(fieldName),
-      upload.directory
-    ]
+    let uploadValues
+    let objectPathConfig
+    try {
+      uploadValues = parseUploadValues(values)
+      await sails.helpers.bridge.authorizeRelationshipValues.with({
+        containerName: app.containerName,
+        environmentId: environment.id,
+        resource: loaded.resource,
+        actor,
+        values: uploadValues
+      })
+      objectPathConfig =
+        await sails.helpers.bridge.resolveUploadObjectPath.with({
+          containerName: app.containerName,
+          resource: loaded.resource,
+          resources: loaded.contract?.models || {
+            [loaded.resource.identity]: loaded.resource
+          },
+          upload,
+          values: uploadValues,
+          ...(recordId ? { recordId: loaded.recordId } : {})
+        })
+    } catch (error) {
+      throw { badRequest: { message: error.message } }
+    }
+
+    const namespace =
+      upload.scope === 'bucket'
+        ? []
+        : [
+            'bridge',
+            `teams/${safeSegment(project.team)}`,
+            `projects/${safeSegment(project.id)}`,
+            `environments/${safeSegment(environment.id)}`,
+            safeSegment(modelIdentity),
+            safeSegment(fieldName)
+          ]
+    const directory = [...namespace, objectPathConfig.directory]
       .filter(Boolean)
       .join('/')
     const objectId = crypto.randomUUID()
@@ -162,9 +204,12 @@ module.exports = {
               return
             }
             const extension =
-              IMAGE_EXTENSIONS[incoming.type] ||
+              MIME_EXTENSIONS[incoming.type] ||
               safeExtension(incoming.filename || '')
-            proceed(null, `${objectId}${extension}`)
+            proceed(
+              null,
+              `${objectPathConfig.filename || objectId}${extension}`
+            )
           }
         },
         (error, files) => {
@@ -190,7 +235,7 @@ module.exports = {
     }
 
     const fileName = String(uploadedFiles[0].fd).split('/').pop()
-    const objectPath = `${directory}/${fileName}`
+    const objectPath = [directory, fileName].filter(Boolean).join('/')
     const url = `${storage.publicUrl.replace(/\/$/, '')}/${objectPath}`
     const receipt = await sails.helpers.bridge.createUploadReceipt.with({
       url,
@@ -232,6 +277,29 @@ function safeExtension(filename) {
 
 function safeSegment(value) {
   return String(value).replace(/[^A-Za-z0-9._-]/g, '-')
+}
+
+function parseUploadValues(value) {
+  if (value === undefined || value === null || value === '') value = '{}'
+  if (typeof value !== 'string' || value.length > 64 * 1024) {
+    throw new Error('Bridge upload context is invalid.')
+  }
+
+  let parsed
+  try {
+    parsed = JSON.parse(value || '{}')
+  } catch {
+    throw new Error('Bridge upload context is invalid.')
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    Array.isArray(parsed) ||
+    ![Object.prototype, null].includes(Object.getPrototypeOf(parsed))
+  ) {
+    throw new Error('Bridge upload context is invalid.')
+  }
+  return parsed
 }
 
 function formatBytes(bytes) {

--- a/api/helpers/bridge/get-upload-storage-config.js
+++ b/api/helpers/bridge/get-upload-storage-config.js
@@ -31,27 +31,28 @@ module.exports = {
       // A malformed optional global setting must not expose or replace scoped values.
     }
 
-    const values = {
-      ...onlyBridgeValues(globalEnvVars),
-      ...onlyBridgeValues(environment.envVars),
-      ...onlyBridgeValues(app.envVars)
-    }
-    const provider = String(values.BRIDGE_STORAGE_PROVIDER || '').toLowerCase()
+    const scopes = [
+      storageValues(globalEnvVars),
+      storageValues(environment.envVars),
+      storageValues(app.envVars)
+    ]
+    const provider = resolveProvider(scopes)
     if (!['r2', 's3'].includes(provider)) {
       throw storageError(
-        'Set BRIDGE_STORAGE_PROVIDER to "r2" or "s3" for this app, environment, or Slipway instance.'
+        'Set BRIDGE_STORAGE_PROVIDER to "r2" or "s3", or configure a complete conventional R2_ or S3_ credential set.'
       )
     }
 
-    const prefix = provider === 'r2' ? 'BRIDGE_R2_' : 'BRIDGE_S3_'
     const config = {
       provider,
-      key: values[`${prefix}ACCESS_KEY`],
-      secret: values[`${prefix}SECRET_KEY`],
-      bucket: values[`${prefix}BUCKET`],
-      endpoint: values[`${prefix}ENDPOINT`],
-      publicUrl: values[`${prefix}PUBLIC_URL`],
-      region: values[`${prefix}REGION`] || (provider === 'r2' ? 'auto' : null)
+      key: resolveStorageValue(scopes, provider, 'ACCESS_KEY'),
+      secret: resolveStorageValue(scopes, provider, 'SECRET_KEY'),
+      bucket: resolveStorageValue(scopes, provider, 'BUCKET'),
+      endpoint: resolveStorageValue(scopes, provider, 'ENDPOINT'),
+      publicUrl: resolveStorageValue(scopes, provider, 'PUBLIC_URL'),
+      region:
+        resolveStorageValue(scopes, provider, 'REGION') ||
+        (provider === 'r2' ? 'auto' : null)
     }
 
     const missing = ['key', 'secret', 'bucket'].filter(
@@ -82,11 +83,60 @@ module.exports = {
   }
 }
 
-function onlyBridgeValues(value) {
+function storageValues(value) {
   if (!isPlainObject(value)) return {}
   return Object.fromEntries(
-    Object.entries(value).filter(([key]) => key.startsWith('BRIDGE_'))
+    Object.entries(value).filter(
+      ([key]) =>
+        key.startsWith('BRIDGE_') ||
+        key.startsWith('R2_') ||
+        key.startsWith('S3_')
+    )
   )
+}
+
+function resolveProvider(scopes) {
+  const configured = String(
+    resolveScopedValue(scopes, ['BRIDGE_STORAGE_PROVIDER']) || ''
+  ).toLowerCase()
+  if (configured) return configured
+
+  const hasR2 = hasCredentials(scopes, 'r2')
+  const hasS3 = hasCredentials(scopes, 's3')
+  if (hasR2 && hasS3) {
+    throw storageError(
+      'Both R2 and S3 credentials are configured. Set BRIDGE_STORAGE_PROVIDER explicitly.'
+    )
+  }
+  if (hasR2) return 'r2'
+  if (hasS3) return 's3'
+  return ''
+}
+
+function hasCredentials(scopes, provider) {
+  const required = ['ACCESS_KEY', 'SECRET_KEY', 'BUCKET']
+  if (provider === 'r2') required.push('ENDPOINT')
+  return required.every((name) =>
+    readString(resolveStorageValue(scopes, provider, name))
+  )
+}
+
+function resolveStorageValue(scopes, provider, suffix) {
+  const name = provider === 'r2' ? 'R2' : 'S3'
+  return resolveScopedValue(scopes, [
+    `BRIDGE_${name}_${suffix}`,
+    `${name}_${suffix}`
+  ])
+}
+
+function resolveScopedValue(scopes, names) {
+  for (let index = scopes.length - 1; index >= 0; index--) {
+    for (const name of names) {
+      const value = scopes[index][name]
+      if (readString(value)) return value
+    }
+  }
+  return undefined
 }
 
 function storageError(message) {

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -250,6 +250,9 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       resources
     )
   }
+  for (const [identity, resource] of Object.entries(resources)) {
+    validateUploadTemplateReferences(identity, resource, resources)
+  }
 
   return {
     schemaVersion: SCHEMA_VERSION,
@@ -512,6 +515,32 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
             )}.`
           )
         }
+        if (
+          fieldOptions[name].upload !== undefined &&
+          !['file', 'image', 'upload', 'richtext'].includes(normalizedType)
+        ) {
+          throw new Error(
+            `Bridge field "${identity}.${name}".upload requires a file, image, upload, or Markdown rich-text field.`
+          )
+        }
+        if (
+          normalizedType === 'richtext' &&
+          fieldOptions[name].upload !== undefined &&
+          String(fieldOptions[name].format || '').toLowerCase() !== 'markdown'
+        ) {
+          throw new Error(
+            `Bridge field "${identity}.${name}".upload requires rich-text format "markdown".`
+          )
+        }
+        if (
+          normalizedType === 'richtext' &&
+          fieldOptions[name].upload?.kind !== undefined &&
+          fieldOptions[name].upload.kind !== 'image'
+        ) {
+          throw new Error(
+            `Bridge field "${identity}.${name}".upload.kind must be "image" for Markdown rich text.`
+          )
+        }
       }
       validateFieldOptions(identity, name, fieldOptions[name].options)
       validateCurrency(identity, name, fieldOptions[name].currency)
@@ -583,6 +612,15 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       }
       if (['file', 'image', 'upload'].includes(safeField.type)) {
         safeField.upload = normalizeUpload(safeField.type, rawField.upload)
+      } else if (
+        safeField.type === 'richtext' &&
+        safeField.format?.toLowerCase() === 'markdown' &&
+        rawField.upload
+      ) {
+        safeField.upload = normalizeUpload('image', {
+          ...rawField.upload,
+          kind: 'image'
+        })
       }
 
       attributes[name] = {
@@ -1507,10 +1545,26 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     }
     rejectUnknownKeys(
       upload,
-      ['kind', 'storage', 'directory', 'store', 'accept', 'maxBytes'],
+      [
+        'kind',
+        'storage',
+        'scope',
+        'directory',
+        'filename',
+        'store',
+        'accept',
+        'maxBytes'
+      ],
       `Bridge field "${identity}.${name}".upload`
     )
-    for (const option of ['kind', 'storage', 'directory', 'store']) {
+    for (const option of [
+      'kind',
+      'storage',
+      'scope',
+      'directory',
+      'filename',
+      'store'
+    ]) {
       assertOptionalString(
         upload[option],
         `Bridge field "${identity}.${name}".upload.${option}`
@@ -1526,6 +1580,14 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         `Bridge field "${identity}.${name}".upload.storage must be "bridge".`
       )
     }
+    if (
+      upload.scope !== undefined &&
+      !['environment', 'bucket'].includes(upload.scope)
+    ) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.scope must be "environment" or "bucket".`
+      )
+    }
     if (upload.store !== undefined && upload.store !== 'url') {
       throw new Error(
         `Bridge field "${identity}.${name}".upload.store must be "url".`
@@ -1533,12 +1595,18 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     }
     if (
       upload.directory !== undefined &&
-      !/^[A-Za-z0-9](?:[A-Za-z0-9_-]|\/(?=[A-Za-z0-9]))*$/.test(
-        upload.directory
-      )
+      !isSafeUploadPathTemplate(upload.directory, { allowSlash: true })
     ) {
       throw new Error(
-        `Bridge field "${identity}.${name}".upload.directory must be a safe relative object path.`
+        `Bridge field "${identity}.${name}".upload.directory must be a safe relative object-path template.`
+      )
+    }
+    if (
+      upload.filename !== undefined &&
+      !isSafeUploadPathTemplate(upload.filename, { allowSlash: false })
+    ) {
+      throw new Error(
+        `Bridge field "${identity}.${name}".upload.filename must be a safe filename template without an extension.`
       )
     }
     if (
@@ -1583,13 +1651,92 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     return {
       kind,
       storage: upload.storage || 'bridge',
+      scope: upload.scope || 'environment',
       directory: readString(upload.directory) || '',
+      filename: readString(upload.filename) || '',
       store: upload.store || 'url',
       accept,
       maxBytes:
         upload.maxBytes ||
         (kind === 'image' ? 5 * 1024 * 1024 : 100 * 1024 * 1024)
     }
+  }
+
+  function isSafeUploadPathTemplate(value, { allowSlash }) {
+    if (
+      typeof value !== 'string' ||
+      !value.trim() ||
+      value.length > 512 ||
+      value.startsWith('/') ||
+      value.endsWith('/') ||
+      value.includes('..') ||
+      (!allowSlash && value.includes('/'))
+    ) {
+      return false
+    }
+
+    const tokens = value.match(/\{[^{}]+\}/g) || []
+    if (
+      tokens.some(
+        (token) =>
+          !/^\{[A-Za-z][A-Za-z0-9]*(?:\.[A-Za-z][A-Za-z0-9]*)?(?:\|slug)?\}$/.test(
+            token
+          )
+      )
+    ) {
+      return false
+    }
+
+    const withoutTokens = value.replace(/\{[^{}]+\}/g, 'value')
+    if (/[{}]/.test(withoutTokens)) return false
+
+    return allowSlash
+      ? /^[A-Za-z0-9._-]+(?:\/[A-Za-z0-9._-]+)*$/.test(withoutTokens)
+      : /^[A-Za-z0-9_-]+$/.test(withoutTokens)
+  }
+
+  function validateUploadTemplateReferences(identity, resource, resources) {
+    for (const [name, attribute] of Object.entries(resource.attributes)) {
+      const upload = attribute.field?.upload
+      if (!upload) continue
+
+      for (const template of [upload.directory, upload.filename]) {
+        for (const match of String(template || '').matchAll(
+          /\{([A-Za-z][A-Za-z0-9]*)(?:\.([A-Za-z][A-Za-z0-9]*))?(?:\|slug)?\}/g
+        )) {
+          const root = match[1]
+          const nestedField = match[2]
+          let referencedAttribute
+
+          if (nestedField) {
+            const relationship = resource.relationships?.[root]
+            const related = relationship
+              ? resources[relationship.resource]
+              : null
+            referencedAttribute = related?.attributes?.[nestedField]
+          } else {
+            referencedAttribute = resource.attributes?.[root]
+          }
+
+          if (!isSafeUploadPathAttribute(referencedAttribute)) {
+            throw new Error(
+              `Bridge field "${identity}.${name}".upload path reference "${match[0]}" must use an available, non-sensitive scalar field.`
+            )
+          }
+        }
+      }
+    }
+  }
+
+  function isSafeUploadPathAttribute(attribute) {
+    return Boolean(
+      attribute &&
+        attribute.sensitive !== true &&
+        attribute.encrypt !== true &&
+        attribute.protect !== true &&
+        !attribute.field?.relation &&
+        !['json', 'ref'].includes(attribute.type)
+    )
   }
 
   function isSafeComponentName(value) {

--- a/api/helpers/bridge/resolve-upload-object-path.js
+++ b/api/helpers/bridge/resolve-upload-object-path.js
@@ -1,0 +1,293 @@
+const TOKEN_PATTERN =
+  /\{([A-Za-z][A-Za-z0-9]*)(?:\.([A-Za-z][A-Za-z0-9]*))?(\|slug)?\}/g
+
+module.exports = {
+  friendlyName: 'Resolve Bridge upload object path',
+
+  description:
+    'Resolve an authorized upload path template from record and relationship values.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    resources: {
+      type: 'ref',
+      required: true
+    },
+    upload: {
+      type: 'ref',
+      required: true
+    },
+    values: {
+      type: 'ref',
+      defaultsTo: {}
+    },
+    recordId: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({
+    containerName,
+    resource,
+    resources,
+    upload,
+    values,
+    recordId
+  }) {
+    const directoryTemplate = upload.directory || ''
+    const filenameTemplate = upload.filename || ''
+    const references = uniqueReferences([
+      ...readReferences(directoryTemplate),
+      ...readReferences(filenameTemplate)
+    ])
+
+    if (references.length === 0) {
+      return {
+        directory: directoryTemplate,
+        filename: filenameTemplate
+      }
+    }
+
+    const definitions = references.map((reference) =>
+      describeReference({ reference, resource, resources })
+    )
+    const directFields = definitions
+      .filter(({ relation }) => !relation)
+      .map(({ field }) => field)
+    const relationshipAliases = definitions
+      .filter(({ relation }) => relation)
+      .map(({ relation }) => relation)
+    const selectedFields = Array.from(
+      new Set([...directFields, ...relationshipAliases])
+    )
+    const criteria =
+      recordId === undefined || recordId === null
+        ? null
+        : { [resource.primaryKey]: recordId }
+
+    const code = `
+      const identity = ${JSON.stringify(resource.identity)};
+      const criteria = ${JSON.stringify(criteria)};
+      const submittedValues = ${JSON.stringify(values || {})};
+      const selectedFields = ${JSON.stringify(selectedFields)};
+      const definitions = ${JSON.stringify(definitions)};
+      const model = sails.models[identity];
+      if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+      let storedValues = {};
+      if (criteria) {
+        const query = model.findOne(criteria);
+        const record = selectedFields.length > 0
+          ? await query.select(selectedFields)
+          : await query;
+        if (!record) throw new Error('The Bridge record no longer exists.');
+        storedValues = record;
+      }
+
+      const effectiveValues = { ...storedValues, ...submittedValues };
+      const resolved = {};
+
+      for (const definition of definitions) {
+        if (!definition.relation) {
+          resolved[definition.key] = effectiveValues[definition.field];
+          continue;
+        }
+
+        let relatedId = effectiveValues[definition.relation];
+        if (
+          relatedId &&
+          typeof relatedId === 'object' &&
+          Object.prototype.hasOwnProperty.call(relatedId, definition.primaryKey)
+        ) {
+          relatedId = relatedId[definition.primaryKey];
+        }
+        if (relatedId === undefined || relatedId === null || relatedId === '') {
+          resolved[definition.key] = null;
+          continue;
+        }
+
+        const relatedModel = sails.models[definition.identity];
+        if (!relatedModel) {
+          throw new Error('Configured Bridge relationship model is unavailable.');
+        }
+        const related = await relatedModel
+          .findOne({ [definition.primaryKey]: relatedId })
+          .select([definition.primaryKey, definition.field]);
+        resolved[definition.key] = related
+          ? related[definition.field]
+          : null;
+      }
+
+      return { resolved };
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(code)
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+    if (!result.success) {
+      throw uploadPathError(
+        result.error || 'Bridge could not resolve the upload path.'
+      )
+    }
+
+    let data
+    try {
+      data = JSON.parse(result.output)
+    } catch (cause) {
+      const error = uploadPathError(
+        'Bridge could not read the resolved upload path.'
+      )
+      error.cause = cause
+      throw error
+    }
+
+    const resolved = data.resolved || {}
+    const directory = renderTemplate(directoryTemplate, definitions, resolved)
+    const filename = renderTemplate(filenameTemplate, definitions, resolved)
+    if (directory.length + filename.length > 900) {
+      throw uploadPathError('The resolved Bridge upload path is too long.')
+    }
+
+    return { directory, filename }
+  }
+}
+
+function readReferences(template) {
+  const references = []
+  for (const match of String(template || '').matchAll(TOKEN_PATTERN)) {
+    references.push({
+      key: match[0],
+      root: match[1],
+      field: match[2] || match[1],
+      relation: match[2] ? match[1] : null,
+      slug: Boolean(match[3])
+    })
+  }
+  return references
+}
+
+function uniqueReferences(references) {
+  return Array.from(
+    new Map(references.map((reference) => [reference.key, reference])).values()
+  )
+}
+
+function describeReference({ reference, resource, resources }) {
+  if (!reference.relation) {
+    const attribute = resource.attributes?.[reference.field]
+    const association = resource.associations?.find(
+      (candidate) => candidate.alias === reference.field
+    )
+    assertPathAttribute(attribute, association, reference.key)
+    return reference
+  }
+
+  const relationship = resource.relationships?.[reference.relation]
+  const relatedResource = relationship
+    ? resources?.[relationship.resource]
+    : null
+  const attribute = relatedResource?.attributes?.[reference.field]
+  const association = relatedResource?.associations?.find(
+    (candidate) => candidate.alias === reference.field
+  )
+  if (!relationship || !relatedResource) {
+    throw uploadPathError(
+      `Bridge upload path reference "${reference.key}" uses an unavailable relationship.`
+    )
+  }
+  assertPathAttribute(attribute, association, reference.key)
+
+  return {
+    ...reference,
+    identity: relatedResource.identity,
+    primaryKey: relatedResource.primaryKey
+  }
+}
+
+function assertPathAttribute(attribute, association, reference) {
+  if (
+    !attribute ||
+    association ||
+    attribute.sensitive === true ||
+    attribute.encrypt === true ||
+    attribute.protect === true ||
+    ['json', 'ref'].includes(attribute.type)
+  ) {
+    throw uploadPathError(
+      `Bridge upload path reference "${reference}" is not a safe scalar field.`
+    )
+  }
+}
+
+function renderTemplate(template, definitions, values) {
+  if (!template) return ''
+  let output = template
+  for (const definition of definitions) {
+    if (!output.includes(definition.key)) continue
+    const value = values[definition.key]
+    if (value === undefined || value === null || String(value).trim() === '') {
+      throw uploadPathError(
+        `Complete ${humanize(
+          definition.relation || definition.field
+        )} before uploading this file.`
+      )
+    }
+    const segment = definition.slug ? slugify(value) : safeObjectSegment(value)
+    if (!segment) {
+      throw uploadPathError(
+        `${humanize(
+          definition.relation || definition.field
+        )} cannot be used in an upload path.`
+      )
+    }
+    output = output.split(definition.key).join(segment)
+  }
+  return output
+}
+
+function slugify(value) {
+  return String(value)
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/&/g, ' and ')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 180)
+}
+
+function safeObjectSegment(value) {
+  return String(value)
+    .trim()
+    .normalize('NFKC')
+    .replace(/[^A-Za-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 180)
+}
+
+function humanize(value) {
+  return String(value)
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .replace(/^./, (character) => character.toUpperCase())
+}
+
+function uploadPathError(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_UPLOAD_PATH_INVALID'
+  return error
+}

--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -43,6 +43,10 @@ const props = defineProps({
   uploadUrl: {
     type: String,
     default: ''
+  },
+  uploadValues: {
+    type: Object,
+    default: () => ({})
   }
 })
 
@@ -120,6 +124,33 @@ const accept = computed(() =>
 const maxBytes = computed(
   () => attribute.value.field?.upload?.maxBytes || 5 * 1024 * 1024
 )
+const uploadPathValues = computed(() => {
+  const upload = attribute.value.field?.upload || {}
+  const templates = [upload.directory, upload.filename]
+    .filter(Boolean)
+    .join('/')
+  const roots = Array.from(
+    templates.matchAll(
+      /\{([A-Za-z][A-Za-z0-9]*)(?:\.[A-Za-z][A-Za-z0-9]*)?(?:\|slug)?\}/g
+    ),
+    (match) => match[1]
+  )
+  return Object.fromEntries(
+    Array.from(new Set(roots))
+      .filter((name) =>
+        Object.prototype.hasOwnProperty.call(props.uploadValues, name)
+      )
+      .map((name) => [name, props.uploadValues[name]])
+  )
+})
+const richTextUploadsConfigured = computed(
+  () =>
+    type.value === 'richtext' &&
+    attribute.value.field?.format?.toLowerCase() === 'markdown' &&
+    attribute.value.field?.upload?.kind === 'image' &&
+    attribute.value.field?.upload?.storage === 'bridge' &&
+    Boolean(props.uploadUrl)
+)
 const uploadHint = computed(() => {
   const accepted = attribute.value.field?.upload?.accept || []
   const labels = accepted.map((value) => {
@@ -193,6 +224,7 @@ async function uploadFile(event) {
   try {
     const data = new FormData()
     data.append('file', file)
+    data.append('values', JSON.stringify(uploadPathValues.value))
     if (props.isEdit && props.recordId !== null) {
       data.append('recordId', String(props.recordId))
     }
@@ -485,6 +517,12 @@ function defaultPlaceholder(fieldType) {
         :aria-labelledby="`${fieldId}-label`"
         :aria-describedby="describedBy"
         :required="attribute.required"
+        :uploads-configured="richTextUploadsConfigured"
+        :upload-url="uploadUrl"
+        upload-field-name="file"
+        :upload-accept="attribute.field?.upload?.accept || []"
+        :max-upload-bytes="attribute.field?.upload?.maxBytes"
+        :upload-values="uploadPathValues"
         deny-raw-html
         @update:model-value="update"
         @blur="handleBlur"

--- a/assets/js/components/content/MarkdownEditor.vue
+++ b/assets/js/components/content/MarkdownEditor.vue
@@ -27,6 +27,28 @@ const props = defineProps({
     type: String,
     default: ''
   },
+  uploadFieldName: {
+    type: String,
+    default: 'image'
+  },
+  uploadAccept: {
+    type: Array,
+    default: () => [
+      'image/avif',
+      'image/gif',
+      'image/jpeg',
+      'image/png',
+      'image/webp'
+    ]
+  },
+  maxUploadBytes: {
+    type: Number,
+    default: 5 * 1024 * 1024
+  },
+  uploadValues: {
+    type: Object,
+    default: () => ({})
+  },
   variant: {
     type: String,
     default: 'document',
@@ -147,13 +169,7 @@ const editor = useEditor({
       placeholder: props.placeholder
     }),
     FileHandler.configure({
-      allowedMimeTypes: [
-        'image/avif',
-        'image/gif',
-        'image/jpeg',
-        'image/png',
-        'image/webp'
-      ],
+      allowedMimeTypes: props.uploadAccept,
       consumePasteEvent: true,
       onPaste: (currentEditor, files) => {
         void uploadImages(files, null, currentEditor)
@@ -423,8 +439,11 @@ function showUploadMessage(message, { kind = 'status', timeout = 0 } = {}) {
 }
 
 async function uploadImages(files, position, currentEditor) {
-  const images = Array.from(files || []).filter((file) =>
-    file.type.startsWith('image/')
+  const images = Array.from(files || []).filter(
+    (file) =>
+      file.type.startsWith('image/') &&
+      (props.uploadAccept.length === 0 ||
+        props.uploadAccept.includes(file.type))
   )
   if (images.length === 0) return
 
@@ -445,12 +464,17 @@ async function uploadImages(files, position, currentEditor) {
 
   try {
     for (const file of images) {
-      if (file.size > 5 * 1024 * 1024) {
-        throw new Error(`${file.name} is larger than 5 MB.`)
+      if (file.size > props.maxUploadBytes) {
+        throw new Error(
+          `${file.name} is larger than ${formatUploadBytes(
+            props.maxUploadBytes
+          )}.`
+        )
       }
 
       const formData = new FormData()
-      formData.append('image', file)
+      formData.append(props.uploadFieldName, file)
+      formData.append('values', JSON.stringify(props.uploadValues))
       const response = await fetch(props.uploadUrl, {
         method: 'POST',
         body: formData
@@ -461,7 +485,7 @@ async function uploadImages(files, position, currentEditor) {
         throw new Error(result.message || 'The image could not be uploaded.')
       }
 
-      const imageUrl = normalizeImageUrl(result.imageUrl)
+      const imageUrl = normalizeImageUrl(result.imageUrl || result.url)
       if (!imageUrl) throw new Error('The upload returned an unsafe image URL.')
 
       currentEditor
@@ -483,6 +507,13 @@ async function uploadImages(files, position, currentEditor) {
   } finally {
     uploading.value = false
   }
+}
+
+function formatUploadBytes(bytes) {
+  if (bytes >= 1024 * 1024) {
+    return `${Math.round(bytes / (1024 * 1024))} MB`
+  }
+  return `${Math.round(bytes / 1024)} KB`
 }
 
 onBeforeUnmount(() => {

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -438,6 +438,7 @@ function recordUrl() {
               :association-options="assocOptions[field.name] || []"
               :association-search-url="relationshipSearchUrl(field)"
               :upload-url="uploadUrl(field)"
+              :upload-values="formValues"
               @update:model-value="updateField(field, $event)"
               @blur="validateAndRemember(field)"
               @clear-error="clearFieldError(field)"

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -80,7 +80,14 @@ module.exports.slipway = {
             label: 'Course description',
             type: 'richtext',
             format: 'markdown',
-            help: 'The public course description.'
+            help: 'The public course description.',
+            upload: {
+              kind: 'image',
+              storage: 'bridge',
+              directory: 'courses/descriptions',
+              store: 'url',
+              maxBytes: 10485760
+            }
           },
           thumbnailUrl: {
             label: 'Thumbnail',
@@ -666,7 +673,9 @@ Set `type: 'richtext'` and `format: 'markdown'` to use Bridge's TipTap editor:
 - Markdown shortcuts such as `## ` and `- ` format as the editor types;
 - selecting text opens the minimal bold, italic, link, strikethrough, and
   inline-code menu;
-- the **Markdown** control exposes the source directly; and
+- the **Markdown** control exposes the source directly;
+- an optional image upload contract lets paste and drop stream images through
+  the same app-scoped R2/S3 boundary used by ordinary upload fields; and
 - unsupported Markdown stays in source mode rather than being silently
   rewritten.
 
@@ -893,6 +902,21 @@ BRIDGE_R2_PUBLIC_URL=https://cdn.example.com
 BRIDGE_R2_REGION=auto
 ```
 
+When an app already has a complete conventional R2 configuration, Bridge
+detects and reuses `R2_ACCESS_KEY`, `R2_SECRET_KEY`, `R2_BUCKET`, and
+`R2_ENDPOINT`. R2 region defaults to `auto`, so the app only needs to add its
+canonical public origin:
+
+```text
+BRIDGE_R2_PUBLIC_URL=https://cdn.example.com
+```
+
+App values override environment values, which override instance-global
+values. Within each scope, explicit `BRIDGE_R2_*` values take precedence when
+Bridge should use a different bucket. The same fallback is available for a
+complete conventional `S3_` credential set. If both conventional providers
+are present, set `BRIDGE_STORAGE_PROVIDER` explicitly.
+
 The S3 provider uses the same names with `BRIDGE_S3_`:
 
 ```text
@@ -923,3 +947,29 @@ The subsequent create or update accepts the URL only when its receipt matches
 the current actor, project, environment, resource, and field. The target model
 stores only the URL. A browser therefore cannot forge a different remote URL
 or reuse a receipt across apps or fields.
+
+Uploads use an environment-scoped namespace by default. An app that owns a
+dedicated bucket can opt into its established bucket-root layout with safe
+field templates:
+
+```js
+upload: {
+  kind: 'file',
+  storage: 'bridge',
+  scope: 'bucket',
+  directory: '{course.slug}/{chapter.title|slug}',
+  filename: '{title|slug}',
+  store: 'url',
+  accept: ['video/mp4'],
+  maxBytes: 2 * 1024 * 1024 * 1024
+}
+```
+
+`directory` may reference a scalar field such as `{title}` or a scalar field
+on a belongs-to relationship such as `{course.slug}`. Add `|slug` to normalize
+a value into a lowercase URL-safe segment. `filename` is an extension-free
+stem; Bridge derives the extension from the accepted file type. Every
+reference is validated against the resource contract, related records are
+loaded from the target app, missing context blocks the upload, and the final
+path is sanitized against traversal. `scope: 'bucket'` is explicit because it
+intentionally omits Slipway's default team/project/environment namespace.

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -46,6 +46,9 @@ test(
     const filterScreenshotRoot = path.resolve(
       '.tmp/screenshots/issue-224-bridge-filters'
     )
+    const sailscastsScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-225-sailscasts-bridge-parity'
+    )
 
     fs.mkdirSync(screenshotRoot, { recursive: true })
     fs.mkdirSync(identifierScreenshotRoot, { recursive: true })
@@ -54,6 +57,7 @@ test(
     fs.mkdirSync(relationshipScreenshotRoot, { recursive: true })
     fs.mkdirSync(actionScreenshotRoot, { recursive: true })
     fs.mkdirSync(filterScreenshotRoot, { recursive: true })
+    fs.mkdirSync(sailscastsScreenshotRoot, { recursive: true })
 
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: resourceMetadata(),
@@ -105,6 +109,7 @@ test(
     let persistedCourseRecord = record
     let createdValues
     let updatedValues
+    let inlineUploadRequestBody = ''
     const resourceQueries = []
 
     await sails.models.app
@@ -372,6 +377,25 @@ test(
                 <text x="48" y="90" fill="#fff" font-family="system-ui" font-size="24" font-weight="600">Build a production Sails app</text>
               </svg>
             `
+          })
+        }
+      )
+      await page.raw.route(
+        '**/bridge/course/description/upload',
+        async (route) => {
+          inlineUploadRequestBody = route.request().postData() || ''
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              url: 'https://cdn.example.com/courses/descriptions/release-diagram.png',
+              receipt: 'signed-inline-image-receipt',
+              file: {
+                name: 'release-diagram.png',
+                size: 68,
+                type: 'image/png'
+              }
+            })
           })
         }
       )
@@ -714,6 +738,65 @@ test(
       )
       expect(await descriptionSource.inputValue()).toContain(
         '**Boring releases are good.**'
+      )
+      await page.raw
+        .getByRole('button', {
+          name: 'Edit Course description as Visual'
+        })
+        .click()
+      await descriptionEditor.click()
+      await page.raw.keyboard.press('ControlOrMeta+End')
+      await page.raw.keyboard.press('Enter')
+      await descriptionEditor.evaluate((element) => {
+        const bytes = Uint8Array.from(
+          atob(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADElEQVR42mNk+M/wHwAF/gL+Xhc4VQAAAABJRU5ErkJggg=='
+          ),
+          (character) => character.charCodeAt(0)
+        )
+        const clipboard = new DataTransfer()
+        clipboard.items.add(
+          new File([bytes], 'release-diagram.png', { type: 'image/png' })
+        )
+        element.dispatchEvent(
+          new ClipboardEvent('paste', {
+            bubbles: true,
+            cancelable: true,
+            clipboardData: clipboard
+          })
+        )
+      })
+      const inlineImage = descriptionEditor.locator(
+        'img[src="https://cdn.example.com/courses/descriptions/release-diagram.png"]'
+      )
+      await inlineImage.waitFor({ state: 'visible' })
+      expect(inlineUploadRequestBody).toContain('Ship a durable course')
+      await page.screenshot(
+        path.join(
+          sailscastsScreenshotRoot,
+          'richtext-inline-image-upload-light.png'
+        ),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(
+          sailscastsScreenshotRoot,
+          'richtext-inline-image-upload-dark.png'
+        ),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .getByRole('button', {
+          name: 'Edit Course description as Markdown'
+        })
+        .click()
+      expect(await descriptionSource.inputValue()).toContain(
+        '**Boring releases are good.**'
+      )
+      expect(await descriptionSource.inputValue()).toContain(
+        'https://cdn.example.com/courses/descriptions/release-diagram.png'
       )
       const createdMarkdown = await descriptionSource.inputValue()
       await descriptionSource.fill(
@@ -1123,7 +1206,15 @@ function resourceConfig() {
             label: 'Course description',
             type: 'richtext',
             format: 'markdown',
-            help: 'The public description shown on the course page.'
+            help: 'The public description shown on the course page.',
+            upload: {
+              kind: 'image',
+              storage: 'bridge',
+              directory: '{title|slug}/descriptions',
+              store: 'url',
+              accept: ['image/png'],
+              maxBytes: 10 * 1024 * 1024
+            }
           },
           thumbnailUrl: {
             label: 'Thumbnail',

--- a/tests/unit/controllers/bridge-upload-field.test.js
+++ b/tests/unit/controllers/bridge-upload-field.test.js
@@ -1,0 +1,251 @@
+const { test } = require('sounding')
+const bridgeUploadField = require('../../../api/controllers/project/bridge-upload-field')
+
+test('Bridge streams inline Markdown images through the configured field boundary', async ({
+  sails,
+  expect
+}) => {
+  const originals = {
+    resolveRequest: sails.helpers.bridge.resolveRequest,
+    loadResource: sails.helpers.bridge.loadResource,
+    getUploadStorageConfig: sails.helpers.bridge.getUploadStorageConfig,
+    createUploadReceipt: sails.helpers.bridge.createUploadReceipt
+  }
+  let uploadOptions
+
+  sails.helpers.bridge.resolveRequest = helper(async () => ({
+    project: { id: 12, team: 7 },
+    environment: { id: 13 },
+    app: { id: 14, containerName: 'sailscasts-web' },
+    actor: { id: 15, email: 'editor@sailscasts.com' },
+    actorId: 15
+  }))
+  sails.helpers.bridge.loadResource = helper(async () => ({
+    resource: {
+      identity: 'lesson',
+      create: ['title', 'description'],
+      edit: ['title', 'description'],
+      attributes: {
+        description: {
+          label: 'Description',
+          field: {
+            type: 'richtext',
+            format: 'markdown',
+            upload: {
+              kind: 'image',
+              storage: 'bridge',
+              directory: 'lessons/descriptions',
+              store: 'url',
+              accept: ['image/png'],
+              maxBytes: 10 * 1024 * 1024
+            }
+          }
+        }
+      }
+    }
+  }))
+  sails.helpers.bridge.getUploadStorageConfig = helper(async () => ({
+    provider: 'r2',
+    key: 'test-key',
+    secret: 'test-secret',
+    bucket: 'sailscasts',
+    endpoint: 'https://account.r2.cloudflarestorage.com',
+    publicUrl: 'https://cdn.sailscasts.test',
+    region: 'auto'
+  }))
+  sails.helpers.bridge.createUploadReceipt = helper(
+    async () => 'signed-inline-image-receipt'
+  )
+
+  const req = {
+    file(name) {
+      expect(name).toBe('file')
+      return {
+        upload(options, done) {
+          uploadOptions = options
+          options.saveAs(
+            {
+              type: 'image/png',
+              filename: 'deployment-diagram.png'
+            },
+            (error, generatedName) => {
+              if (error) return done(error)
+              done(null, [
+                {
+                  fd: `/tmp/${generatedName}`,
+                  filename: 'deployment-diagram.png',
+                  size: 2048,
+                  type: 'image/png'
+                }
+              ])
+            }
+          )
+        }
+      }
+    }
+  }
+
+  try {
+    const result = await bridgeUploadField.fn.call(
+      { req },
+      {
+        slug: 'sailscasts',
+        envSlug: 'production',
+        appSlug: 'web',
+        modelIdentity: 'lesson',
+        fieldName: 'description'
+      }
+    )
+
+    expect(uploadOptions.maxBytes).toBe(10 * 1024 * 1024)
+    expect(uploadOptions.dirname).toContain(
+      'bridge/teams/7/projects/12/environments/13/lesson/description/lessons/descriptions'
+    )
+    expect(result.url).toContain('https://cdn.sailscasts.test/bridge/')
+    expect(result.url).toContain('/lesson/description/lessons/descriptions/')
+    expect(result.receipt).toBe('signed-inline-image-receipt')
+  } finally {
+    sails.helpers.bridge.resolveRequest = originals.resolveRequest
+    sails.helpers.bridge.loadResource = originals.loadResource
+    sails.helpers.bridge.getUploadStorageConfig =
+      originals.getUploadStorageConfig
+    sails.helpers.bridge.createUploadReceipt = originals.createUploadReceipt
+  }
+})
+
+test('Bridge writes an explicitly configured video path at the bucket root using the accepted MIME extension', async ({
+  sails,
+  expect
+}) => {
+  const originals = {
+    resolveRequest: sails.helpers.bridge.resolveRequest,
+    loadResource: sails.helpers.bridge.loadResource,
+    getUploadStorageConfig: sails.helpers.bridge.getUploadStorageConfig,
+    authorizeRelationshipValues:
+      sails.helpers.bridge.authorizeRelationshipValues,
+    resolveUploadObjectPath: sails.helpers.bridge.resolveUploadObjectPath,
+    createUploadReceipt: sails.helpers.bridge.createUploadReceipt
+  }
+  let uploadOptions
+  let receivedValues
+
+  sails.helpers.bridge.resolveRequest = helper(async () => ({
+    project: { id: 12, team: 7 },
+    environment: { id: 13 },
+    app: { id: 14, containerName: 'course-web' },
+    actor: { id: 15, email: 'editor@example.com' },
+    actorId: 15
+  }))
+  sails.helpers.bridge.loadResource = helper(async () => {
+    const resource = {
+      identity: 'lesson',
+      create: ['title', 'videoUrl'],
+      edit: ['title', 'videoUrl'],
+      attributes: {
+        videoUrl: {
+          label: 'Video',
+          field: {
+            type: 'upload',
+            upload: {
+              kind: 'file',
+              storage: 'bridge',
+              scope: 'bucket',
+              directory: 'courses/introduction',
+              filename: '{title|slug}',
+              store: 'url',
+              accept: ['video/mp4'],
+              maxBytes: 2 * 1024 * 1024 * 1024
+            }
+          }
+        }
+      }
+    }
+    return {
+      resource,
+      contract: { models: { lesson: resource } }
+    }
+  })
+  sails.helpers.bridge.getUploadStorageConfig = helper(async () => ({
+    provider: 'r2',
+    key: 'test-key',
+    secret: 'test-secret',
+    bucket: 'courses',
+    endpoint: 'https://account.r2.cloudflarestorage.com',
+    publicUrl: 'https://assets.example.com',
+    region: 'auto'
+  }))
+  sails.helpers.bridge.authorizeRelationshipValues = helper(async () => {})
+  sails.helpers.bridge.resolveUploadObjectPath = helper(async ({ values }) => {
+    receivedValues = values
+    return {
+      directory: 'courses/introduction',
+      filename: 'course-assumptions'
+    }
+  })
+  sails.helpers.bridge.createUploadReceipt = helper(
+    async () => 'signed-video-receipt'
+  )
+
+  const req = {
+    file() {
+      return {
+        upload(options, done) {
+          uploadOptions = options
+          options.saveAs(
+            {
+              type: 'video/mp4',
+              filename: 'untrusted-name.exe'
+            },
+            (error, generatedName) => {
+              if (error) return done(error)
+              done(null, [
+                {
+                  fd: `courses/introduction/${generatedName}`,
+                  filename: 'untrusted-name.exe',
+                  size: 4096,
+                  type: 'video/mp4'
+                }
+              ])
+            }
+          )
+        }
+      }
+    }
+  }
+
+  try {
+    const result = await bridgeUploadField.fn.call(
+      { req },
+      {
+        slug: 'courses',
+        envSlug: 'production',
+        appSlug: 'web',
+        modelIdentity: 'lesson',
+        fieldName: 'videoUrl',
+        values: JSON.stringify({ title: 'Course assumptions' })
+      }
+    )
+
+    expect(receivedValues).toEqual({ title: 'Course assumptions' })
+    expect(uploadOptions.dirname).toBe('courses/introduction')
+    expect(result.url).toBe(
+      'https://assets.example.com/courses/introduction/course-assumptions.mp4'
+    )
+    expect(result.receipt).toBe('signed-video-receipt')
+  } finally {
+    sails.helpers.bridge.resolveRequest = originals.resolveRequest
+    sails.helpers.bridge.loadResource = originals.loadResource
+    sails.helpers.bridge.getUploadStorageConfig =
+      originals.getUploadStorageConfig
+    sails.helpers.bridge.authorizeRelationshipValues =
+      originals.authorizeRelationshipValues
+    sails.helpers.bridge.resolveUploadObjectPath =
+      originals.resolveUploadObjectPath
+    sails.helpers.bridge.createUploadReceipt = originals.createUploadReceipt
+  }
+})
+
+function helper(fn) {
+  fn.with = fn
+  return fn
+}

--- a/tests/unit/helpers/bridge/field-engine.test.js
+++ b/tests/unit/helpers/bridge/field-engine.test.js
@@ -35,7 +35,9 @@ test('Bridge normalizes typed fields and resolves currency for display', async (
   expect(course.attributes.thumbnailUrl.field.upload).toEqual({
     kind: 'image',
     storage: 'bridge',
+    scope: 'environment',
     directory: 'courses/thumbnails',
+    filename: '',
     store: 'url',
     accept: [
       'image/avif',
@@ -220,7 +222,7 @@ test('Bridge upload receipts bind URLs to the actor and field', async ({
   }
 })
 
-test('Bridge upload storage uses only scoped BRIDGE_ settings', async ({
+test('Bridge upload storage applies app scope before credential aliases', async ({
   sails,
   expect
 }) => {
@@ -245,7 +247,8 @@ test('Bridge upload storage uses only scoped BRIDGE_ settings', async ({
       },
       app: {
         envVars: {
-          BRIDGE_R2_ACCESS_KEY: 'app-key'
+          BRIDGE_R2_ACCESS_KEY: 'app-key',
+          R2_SECRET_KEY: 'app-conventional-secret'
         }
       }
     })
@@ -253,10 +256,45 @@ test('Bridge upload storage uses only scoped BRIDGE_ settings', async ({
     expect(storage).toEqual({
       provider: 'r2',
       key: 'app-key',
-      secret: 'global-secret',
+      secret: 'app-conventional-secret',
       bucket: 'environment-bucket',
       endpoint: 'https://account.r2.cloudflarestorage.com',
       publicUrl: 'https://cdn.example.com',
+      region: 'auto'
+    })
+  } finally {
+    sails.helpers.setting.get = originalSettingGet
+  }
+})
+
+test('Bridge detects conventional app-scoped R2 credentials and only needs its public URL', async ({
+  sails,
+  expect
+}) => {
+  const originalSettingGet = sails.helpers.setting.get
+  sails.helpers.setting.get = async () => '{}'
+
+  try {
+    const storage = await sails.helpers.bridge.getUploadStorageConfig.with({
+      environment: { envVars: {} },
+      app: {
+        envVars: {
+          R2_ACCESS_KEY: 'sailscasts-key',
+          R2_SECRET_KEY: 'sailscasts-secret',
+          R2_BUCKET: 'sailscasts',
+          R2_ENDPOINT: 'https://account.r2.cloudflarestorage.com',
+          BRIDGE_R2_PUBLIC_URL: 'https://assets.sailscasts.com'
+        }
+      }
+    })
+
+    expect(storage).toEqual({
+      provider: 'r2',
+      key: 'sailscasts-key',
+      secret: 'sailscasts-secret',
+      bucket: 'sailscasts',
+      endpoint: 'https://account.r2.cloudflarestorage.com',
+      publicUrl: 'https://assets.sailscasts.com',
       region: 'auto'
     })
   } finally {

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -207,7 +207,9 @@ test('Bridge represents a fully configured content resource', async ({
   expect(resource.attributes.thumbnailUrl.field.upload).toEqual({
     kind: 'image',
     storage: 'bridge',
+    scope: 'environment',
     directory: 'courses/thumbnails',
+    filename: '',
     store: 'url',
     accept: [
       'image/avif',
@@ -218,6 +220,179 @@ test('Bridge represents a fully configured content resource', async ({
     ],
     maxBytes: 5 * 1024 * 1024
   })
+})
+
+test('Bridge gives Markdown rich text an app-scoped inline image upload contract', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          create: ['title', 'description'],
+          edit: ['title', 'description'],
+          fields: {
+            description: {
+              type: 'richtext',
+              format: 'markdown',
+              upload: {
+                kind: 'image',
+                storage: 'bridge',
+                directory: 'courses/descriptions',
+                store: 'url',
+                accept: ['image/jpeg', 'image/png', 'image/webp'],
+                maxBytes: 10 * 1024 * 1024
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  expect(contract.resources.course.attributes.description.field.upload).toEqual(
+    {
+      kind: 'image',
+      storage: 'bridge',
+      scope: 'environment',
+      directory: 'courses/descriptions',
+      filename: '',
+      store: 'url',
+      accept: ['image/jpeg', 'image/png', 'image/webp'],
+      maxBytes: 10 * 1024 * 1024
+    }
+  )
+
+  let fileKindError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            fields: {
+              description: {
+                type: 'richtext',
+                format: 'markdown',
+                upload: {
+                  kind: 'file'
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    fileKindError = error
+  }
+
+  expect(fileKindError.message).toContain(
+    'upload.kind must be "image" for Markdown rich text'
+  )
+})
+
+test('Bridge normalizes generic bucket-root upload path templates', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: modelMetadata(),
+    config: {
+      resources: {
+        course: {
+          create: ['title', 'thumbnailUrl', 'creator'],
+          edit: ['title', 'thumbnailUrl', 'creator'],
+          fields: {
+            thumbnailUrl: {
+              type: 'upload',
+              upload: {
+                kind: 'image',
+                scope: 'bucket',
+                directory: '{creator.fullName|slug}/{title|slug}',
+                filename: '{title|slug}'
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  expect(
+    contract.resources.course.attributes.thumbnailUrl.field.upload
+  ).toEqual({
+    kind: 'image',
+    storage: 'bridge',
+    scope: 'bucket',
+    directory: '{creator.fullName|slug}/{title|slug}',
+    filename: '{title|slug}',
+    store: 'url',
+    accept: [
+      'image/avif',
+      'image/gif',
+      'image/jpeg',
+      'image/png',
+      'image/webp'
+    ],
+    maxBytes: 5 * 1024 * 1024
+  })
+
+  let traversalError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            fields: {
+              thumbnailUrl: {
+                type: 'upload',
+                upload: {
+                  directory: '../{title|slug}'
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    traversalError = error
+  }
+
+  expect(traversalError.message).toContain(
+    'must be a safe relative object-path template'
+  )
+
+  let referenceError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            fields: {
+              thumbnailUrl: {
+                type: 'upload',
+                upload: {
+                  directory: '{missing.slug}'
+                }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (error) {
+    referenceError = error
+  }
+
+  expect(referenceError.message).toContain(
+    'path reference "{missing.slug}" must use an available, non-sensitive scalar field'
+  )
 })
 
 test('Bridge preserves UUID primary keys and derives belongs-to identifier types', async ({

--- a/tests/unit/helpers/bridge/upload-path.test.js
+++ b/tests/unit/helpers/bridge/upload-path.test.js
@@ -1,0 +1,155 @@
+const { test } = require('sounding')
+
+test('Bridge resolves reusable upload path templates from fields and relationships', async ({
+  sails,
+  expect
+}) => {
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  let executedCode = ''
+  sails.helpers.bridge.buildSailsWrapper = async (code) => code
+  sails.helpers.bridge.executeInContainer = async (_containerName, code) => {
+    executedCode = code
+    return {
+      success: true,
+      output: JSON.stringify({
+        resolved: {
+          '{workspace.slug}': 'acme-studio',
+          '{folder.title|slug}': 'Brand Assets',
+          '{title|slug}': 'Summer Campaign'
+        }
+      })
+    }
+  }
+
+  try {
+    const result = await sails.helpers.bridge.resolveUploadObjectPath.with({
+      containerName: 'content-web',
+      resource: documentResource(),
+      resources: resources(),
+      upload: {
+        directory: '{workspace.slug}/{folder.title|slug}',
+        filename: '{title|slug}'
+      },
+      values: {
+        title: 'Summer Campaign',
+        workspace: 'workspace-1',
+        folder: 'folder-1'
+      }
+    })
+
+    expect(result).toEqual({
+      directory: 'acme-studio/brand-assets',
+      filename: 'summer-campaign'
+    })
+    expect(executedCode).toContain('sails.models[definition.identity]')
+    expect(executedCode).toContain('"workspace-1"')
+    expect(executedCode).toContain('"folder-1"')
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+test('Bridge upload templates fail safely when required context is missing', async ({
+  sails,
+  expect
+}) => {
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  sails.helpers.bridge.buildSailsWrapper = async (code) => code
+  sails.helpers.bridge.executeInContainer = async () => ({
+    success: true,
+    output: JSON.stringify({
+      resolved: {
+        '{workspace.slug}': null,
+        '{title|slug}': 'A document'
+      }
+    })
+  })
+
+  try {
+    let receivedError
+    try {
+      await sails.helpers.bridge.resolveUploadObjectPath.with({
+        containerName: 'content-web',
+        resource: documentResource(),
+        resources: resources(),
+        upload: {
+          directory: '{workspace.slug}',
+          filename: '{title|slug}'
+        },
+        values: { title: 'A document' }
+      })
+    } catch (error) {
+      receivedError = error
+    }
+
+    expect(receivedError.code).toBe('BRIDGE_UPLOAD_PATH_INVALID')
+    expect(receivedError.message).toBe(
+      'Complete Workspace before uploading this file.'
+    )
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+function documentResource() {
+  return {
+    identity: 'document',
+    primaryKey: 'id',
+    attributes: {
+      id: { type: 'string' },
+      title: { type: 'string', sensitive: false },
+      workspace: { type: 'string' },
+      folder: { type: 'string' }
+    },
+    associations: [
+      {
+        alias: 'workspace',
+        type: 'model',
+        model: 'workspace'
+      },
+      {
+        alias: 'folder',
+        type: 'model',
+        model: 'folder'
+      }
+    ],
+    relationships: {
+      workspace: {
+        alias: 'workspace',
+        resource: 'workspace'
+      },
+      folder: {
+        alias: 'folder',
+        resource: 'folder'
+      }
+    }
+  }
+}
+
+function resources() {
+  return {
+    document: documentResource(),
+    workspace: {
+      identity: 'workspace',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string' },
+        slug: { type: 'string', sensitive: false }
+      },
+      associations: []
+    },
+    folder: {
+      identity: 'folder',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string' },
+        title: { type: 'string', sensitive: false }
+      },
+      associations: []
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- add reusable Bridge upload path templates backed by record fields and authorized relationships
- reuse conventional R2 or S3 credentials with app, environment, and global precedence
- support explicit bucket-root uploads while preserving safe environment-scoped defaults
- add inline image uploads to Bridge Markdown fields
- validate upload paths, MIME types, limits, relationship context, and signed upload receipts
- add unit, controller, and browser coverage plus internal contract documentation

## Impact

Bridge can now manage images and large media without host applications building their own upload UI. Applications keep ordinary URL model attributes and can opt into their existing object-storage hierarchy without exposing credentials to the browser.

## Validation

- `npm run test:unit` — 201 passed
- Bridge upload controller — 2 passed
- Bridge upload path resolver — 2 passed
- Bridge resource contract E2E — 1 passed
- `npm run lint`
- `npm run check:consistency`
- `git diff --check`

Closes #225
