### PR TITLE
feat(helm): run selected editor source

### DIFF
--- a/api/controllers/api/v1/app/execute-code.js
+++ b/api/controllers/api/v1/app/execute-code.js
@@ -18,6 +18,18 @@ module.exports = {
       required: true,
       description: 'JavaScript code to execute'
     },
+    sourceStartLine: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
+    sourceStartColumn: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
     appSlug: {
       type: 'string',
       description: 'Target app slug (defaults to default app)'
@@ -39,7 +51,14 @@ module.exports = {
     }
   },
 
-  fn: async function ({ projectSlug, environmentSlug, code, appSlug }) {
+  fn: async function ({
+    projectSlug,
+    environmentSlug,
+    code,
+    sourceStartLine,
+    sourceStartColumn,
+    appSlug
+  }) {
     const user = await User.findOne({ id: this.req.session.userId })
 
     const project = await Project.findOne({ slug: projectSlug }).populate(
@@ -71,6 +90,11 @@ module.exports = {
       throw { badRequest: 'App is not running.' }
     }
 
-    return sails.helpers.helm.executeInContainer(app.containerName, code)
+    return sails.helpers.helm.executeInContainer(
+      app.containerName,
+      code,
+      sourceStartLine,
+      sourceStartColumn
+    )
   }
 }

--- a/api/controllers/api/v1/bosun/eval.js
+++ b/api/controllers/api/v1/bosun/eval.js
@@ -9,6 +9,18 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'JavaScript code to evaluate'
+    },
+    sourceStartLine: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
+    sourceStartColumn: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
     }
   },
 
@@ -21,11 +33,11 @@ module.exports = {
     }
   },
 
-  fn: async function ({ code }) {
+  fn: async function ({ code, sourceStartLine, sourceStartColumn }) {
     if (!code.trim()) {
       throw { badRequest: 'Code cannot be empty.' }
     }
 
-    return sails.helpers.helm.evaluate(code)
+    return sails.helpers.helm.evaluate(code, sourceStartLine, sourceStartColumn)
   }
 }

--- a/api/helpers/helm/evaluate.js
+++ b/api/helpers/helm/evaluate.js
@@ -8,6 +8,18 @@ module.exports = {
     source: {
       type: 'string',
       required: true
+    },
+    sourceStartLine: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
+    sourceStartColumn: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
     }
   },
 
@@ -17,10 +29,12 @@ module.exports = {
     }
   },
 
-  fn: async function ({ source }) {
+  fn: async function ({ source, sourceStartLine, sourceStartColumn }) {
     return sails.helpers.helm.run.with({
       command: process.execPath,
       source,
+      sourceStartLine,
+      sourceStartColumn,
       bootstrapSails: true
     })
   }

--- a/api/helpers/helm/execute-in-container.js
+++ b/api/helpers/helm/execute-in-container.js
@@ -12,6 +12,18 @@ module.exports = {
     source: {
       type: 'string',
       required: true
+    },
+    sourceStartLine: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
+    sourceStartColumn: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
     }
   },
 
@@ -21,13 +33,20 @@ module.exports = {
     }
   },
 
-  fn: async function ({ containerName, source }) {
+  fn: async function ({
+    containerName,
+    source,
+    sourceStartLine,
+    sourceStartColumn
+  }) {
     const dockerPath = sails.config.docker?.binaryPath || 'docker'
 
     return sails.helpers.helm.run.with({
       command: dockerPath,
       args: ['exec', '-i', containerName, 'node'],
       source,
+      sourceStartLine,
+      sourceStartColumn,
       bootstrapSails: true
     })
   }

--- a/api/helpers/helm/prepare-source.js
+++ b/api/helpers/helm/prepare-source.js
@@ -14,6 +14,18 @@ module.exports = {
     maxSourceBytes: {
       type: 'number',
       min: 1
+    },
+    sourceStartLine: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
+    sourceStartColumn: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
     }
   },
 
@@ -23,9 +35,16 @@ module.exports = {
     }
   },
 
-  fn: async function ({ source, maxSourceBytes }) {
+  fn: async function ({
+    source,
+    maxSourceBytes,
+    sourceStartLine,
+    sourceStartColumn
+  }) {
     return helmRuntime.prepareSource(source, {
-      maxSourceBytes: maxSourceBytes || sails.config.custom.helm.maxSourceBytes
+      maxSourceBytes: maxSourceBytes || sails.config.custom.helm.maxSourceBytes,
+      sourceStartLine,
+      sourceStartColumn
     })
   }
 }

--- a/api/helpers/helm/run.js
+++ b/api/helpers/helm/run.js
@@ -21,6 +21,18 @@ module.exports = {
       type: 'string',
       required: true
     },
+    sourceStartLine: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
+    sourceStartColumn: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1,
+      max: 1000000
+    },
     bootstrapSails: {
       type: 'boolean',
       defaultsTo: true
@@ -37,7 +49,15 @@ module.exports = {
     }
   },
 
-  fn: async function ({ command, args, source, bootstrapSails, timeoutMs }) {
+  fn: async function ({
+    command,
+    args,
+    source,
+    sourceStartLine,
+    sourceStartColumn,
+    bootstrapSails,
+    timeoutMs
+  }) {
     const limits = sails.config.custom.helm
     const startedAt = Date.now()
     let prepared
@@ -45,6 +65,8 @@ module.exports = {
     try {
       prepared = await sails.helpers.helm.prepareSource.with({
         source,
+        sourceStartLine,
+        sourceStartColumn,
         maxSourceBytes: limits.maxSourceBytes
       })
     } catch (error) {
@@ -55,6 +77,8 @@ module.exports = {
     const runnerSource = helmRuntime.buildRunnerSource({
       preparedSource: prepared.source,
       finalExpression: prepared.finalExpression,
+      sourceStartLine,
+      sourceStartColumn,
       bootstrapSails,
       timeoutMs: executionTimeoutMs,
       maxLogBytes: limits.maxLogBytes,

--- a/api/lib/helm-runtime.js
+++ b/api/lib/helm-runtime.js
@@ -3,16 +3,28 @@ const acorn = require('acorn')
 const START_MARKER = '___SLIPWAY_HELM_RESULT_START___'
 const END_MARKER = '___SLIPWAY_HELM_RESULT_END___'
 const VIRTUAL_FILENAME = 'helm-input.js'
+const MAX_SOURCE_COORDINATE = 1_000_000
 
-function prepareSource(source, { maxSourceBytes = 64 * 1024 } = {}) {
+function prepareSource(
+  source,
+  {
+    maxSourceBytes = 64 * 1024,
+    sourceStartLine = 1,
+    sourceStartColumn = 1
+  } = {}
+) {
   const submittedSource = String(source || '')
   const sourceBytes = Buffer.byteLength(submittedSource)
+  const origin = normalizeSourceOrigin({
+    sourceStartLine,
+    sourceStartColumn
+  })
 
   if (!submittedSource.trim()) {
     throw sourceError('Code cannot be empty.', {
       name: 'HelmSourceError',
-      line: 1,
-      column: 1
+      line: origin.line,
+      column: origin.column
     })
   }
 
@@ -21,8 +33,8 @@ function prepareSource(source, { maxSourceBytes = 64 * 1024 } = {}) {
       `Code exceeds the ${formatBytes(maxSourceBytes)} Helm source limit.`,
       {
         name: 'HelmSourceError',
-        line: 1,
-        column: 1
+        line: origin.line,
+        column: origin.column
       }
     )
   }
@@ -44,10 +56,11 @@ function prepareSource(source, { maxSourceBytes = 64 * 1024 } = {}) {
       Math.max(1, (error.loc?.line || 2) - 1)
     )
     const column = (error.loc?.column || 0) + 1
+    const location = mapSourceLocation(line, column, origin)
     throw sourceError(cleanParserMessage(error.message), {
       name: error.name || 'SyntaxError',
-      line,
-      column,
+      line: location.line,
+      column: location.column,
       cause: error
     })
   }
@@ -75,8 +88,11 @@ function prepareSource(source, { maxSourceBytes = 64 * 1024 } = {}) {
       replacement +
       submittedSource.slice(statementEnd),
     finalExpression: {
-      line: finalStatement.loc.start.line - 1,
-      column: finalStatement.loc.start.column + 1,
+      ...mapSourceLocation(
+        finalStatement.loc.start.line - 1,
+        finalStatement.loc.start.column + 1,
+        origin
+      ),
       addedColumns: 'return ('.length
     }
   }
@@ -85,6 +101,8 @@ function prepareSource(source, { maxSourceBytes = 64 * 1024 } = {}) {
 function buildRunnerSource({
   preparedSource,
   finalExpression,
+  sourceStartLine = 1,
+  sourceStartColumn = 1,
   bootstrapSails = true,
   timeoutMs = 30000,
   maxLogBytes = 64 * 1024,
@@ -93,6 +111,8 @@ function buildRunnerSource({
   return `(${helmSubprocessMain.toString()})(${JSON.stringify({
     preparedSource,
     finalExpression,
+    sourceStartLine,
+    sourceStartColumn,
     bootstrapSails,
     timeoutMs,
     maxLogBytes,
@@ -156,6 +176,41 @@ function sourceError(message, { name, line, column, cause }) {
   error.line = line
   error.column = column
   return error
+}
+
+function normalizeSourceOrigin({ sourceStartLine, sourceStartColumn }) {
+  return {
+    line: normalizeSourceCoordinate(sourceStartLine, 'line'),
+    column: normalizeSourceCoordinate(sourceStartColumn, 'column')
+  }
+}
+
+function normalizeSourceCoordinate(value, label) {
+  const coordinate = Number(value)
+
+  if (
+    !Number.isSafeInteger(coordinate) ||
+    coordinate < 1 ||
+    coordinate > MAX_SOURCE_COORDINATE
+  ) {
+    throw sourceError(
+      `Source start ${label} must be an integer between 1 and ${MAX_SOURCE_COORDINATE}.`,
+      {
+        name: 'HelmSourceError',
+        line: 1,
+        column: 1
+      }
+    )
+  }
+
+  return coordinate
+}
+
+function mapSourceLocation(line, column, origin) {
+  return {
+    line: origin.line + line - 1,
+    column: line === 1 ? origin.column + column - 1 : column
+  }
 }
 
 function cleanParserMessage(message) {
@@ -304,10 +359,11 @@ async function helmSubprocessMain(options) {
       if (model.globalId) context[model.globalId] = model
     }
 
-    const wrappedSource = `(async function () {\n${options.preparedSource}\n})()`
+    const firstLinePadding = ' '.repeat(options.sourceStartColumn - 1)
+    const wrappedSource = `(async function () {\n${firstLinePadding}${options.preparedSource}\n})()`
     const script = new vm.Script(wrappedSource, {
       filename: options.filename,
-      lineOffset: -1,
+      lineOffset: options.sourceStartLine - 2,
       displayErrors: true
     })
     const sandbox = vm.createContext(context)

--- a/assets/js/components/CodeEditor.vue
+++ b/assets/js/components/CodeEditor.vue
@@ -15,8 +15,14 @@ import {
   indentOnInput,
   syntaxHighlighting
 } from '@codemirror/language'
-import { Compartment, EditorState } from '@codemirror/state'
 import {
+  Compartment,
+  EditorState,
+  StateEffect,
+  StateField
+} from '@codemirror/state'
+import {
+  Decoration,
   EditorView,
   drawSelection,
   keymap,
@@ -50,15 +56,40 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['update:modelValue', 'submit'])
+const emit = defineEmits(['update:modelValue', 'submit', 'selection-change'])
 
 const editorHost = ref(null)
 const languageCompartment = new Compartment()
 const appearanceCompartment = new Compartment()
 const editableCompartment = new Compartment()
+const setExecutedRange = StateEffect.define()
+const executedRangeMark = Decoration.mark({ class: 'cm-executed-range' })
+const executedRangeField = StateField.define({
+  create() {
+    return Decoration.none
+  },
+  update(decorations, transaction) {
+    let nextDecorations = decorations.map(transaction.changes)
+
+    for (const effect of transaction.effects) {
+      if (!effect.is(setExecutedRange)) continue
+      const range = effect.value
+      nextDecorations =
+        range && range.from < range.to
+          ? Decoration.set([executedRangeMark.range(range.from, range.to)])
+          : Decoration.none
+    }
+
+    return nextDecorations
+  },
+  provide(field) {
+    return EditorView.decorations.from(field)
+  }
+})
 let view
 let darkModeQuery
 let applyingExternalValue = false
+let executedRangeTimer
 
 const editorStyle = computed(() => ({
   '--code-editor-min-height': props.minHeight,
@@ -259,6 +290,58 @@ function submitKeymap() {
   ]
 }
 
+function getExecutionSnapshot(state = view?.state) {
+  if (!state) return null
+
+  const selection = state.selection.main
+  const hasSelection = !selection.empty
+  const from = hasSelection ? selection.from : 0
+  const to = hasSelection ? selection.to : state.doc.length
+  const source = state.sliceDoc(from, to)
+  const startLine = hasSelection ? state.doc.lineAt(from) : state.doc.line(1)
+
+  return {
+    source,
+    from,
+    to,
+    hasSelection,
+    hasExecutableSource: Boolean(source.trim()),
+    startLine: startLine.number,
+    startColumn: hasSelection ? from - startLine.from + 1 : 1
+  }
+}
+
+function emitSelectionChange(state) {
+  const snapshot = getExecutionSnapshot(state)
+  if (!snapshot) return
+
+  emit('selection-change', {
+    hasSelection: snapshot.hasSelection,
+    hasExecutableSelection:
+      snapshot.hasSelection && snapshot.hasExecutableSource
+  })
+}
+
+function highlightExecution(snapshot = getExecutionSnapshot()) {
+  if (!view || !snapshot) return
+
+  window.clearTimeout(executedRangeTimer)
+  view.dispatch({
+    effects: setExecutedRange.of({
+      from: snapshot.from,
+      to: snapshot.to
+    })
+  })
+  executedRangeTimer = window.setTimeout(() => {
+    if (!view) return
+    view.dispatch({ effects: setExecutedRange.of(null) })
+  }, 700)
+}
+
+function focus() {
+  view?.focus()
+}
+
 function handleColorSchemeChange() {
   if (!view) return
   view.dispatch({
@@ -277,6 +360,7 @@ onMounted(() => {
       extensions: [
         history(),
         drawSelection(),
+        executedRangeField,
         indentOnInput(),
         bracketMatching(),
         EditorView.lineWrapping,
@@ -291,12 +375,17 @@ onMounted(() => {
         appearanceCompartment.of(appearanceExtension()),
         editableCompartment.of(editableExtension()),
         EditorView.updateListener.of((update) => {
-          if (!update.docChanged || applyingExternalValue) return
-          emit('update:modelValue', update.state.doc.toString())
+          if (update.docChanged && !applyingExternalValue) {
+            emit('update:modelValue', update.state.doc.toString())
+          }
+          if (update.docChanged || update.selectionSet) {
+            emitSelectionChange(update.state)
+          }
         })
       ]
     })
   })
+  emitSelectionChange(view.state)
 })
 
 watch(
@@ -336,7 +425,14 @@ watch(
 
 onBeforeUnmount(() => {
   darkModeQuery?.removeEventListener('change', handleColorSchemeChange)
+  window.clearTimeout(executedRangeTimer)
   view?.destroy()
+})
+
+defineExpose({
+  focus,
+  getExecutionSnapshot,
+  highlightExecution
 })
 </script>
 
@@ -377,6 +473,11 @@ onBeforeUnmount(() => {
 
 .code-editor :deep(.cm-content:focus-visible) {
   outline: none;
+}
+
+.code-editor :deep(.cm-executed-range) {
+  background: color-mix(in srgb, var(--color-brand-500) 14%, transparent);
+  box-shadow: inset 0 -1px color-mix(in srgb, var(--color-brand-500) 45%, transparent);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -117,6 +117,21 @@ const helmResults = ref(null)
 const helmError = ref(null)
 const helmLoading = ref(false)
 const helmHistory = ref([])
+const helmEditor = ref(null)
+const helmSelection = ref({
+  hasSelection: false,
+  hasExecutableSelection: false
+})
+const helmRunLabel = computed(() =>
+  helmSelection.value.hasSelection ? 'Run selection' : 'Run'
+)
+const canExecuteHelm = computed(() => {
+  if (helmLoading.value) return false
+  if (helmSelection.value.hasSelection) {
+    return helmSelection.value.hasExecutableSelection
+  }
+  return Boolean(helmCode.value.trim())
+})
 
 // Toast state
 const toasts = ref([])
@@ -210,8 +225,11 @@ async function executeQuery() {
 }
 
 async function executeHelm() {
-  if (!helmCode.value.trim() || helmLoading.value) return
+  const execution = helmEditor.value?.getExecutionSnapshot()
+  if (!execution?.hasExecutableSource || !canExecuteHelm.value) return
 
+  helmEditor.value.highlightExecution(execution)
+  helmEditor.value.focus()
   helmLoading.value = true
   helmError.value = null
   helmResults.value = null
@@ -220,7 +238,11 @@ async function executeHelm() {
     const response = await fetch('/api/v1/bosun/eval', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ code: helmCode.value })
+      body: JSON.stringify({
+        code: execution.source,
+        sourceStartLine: execution.startLine,
+        sourceStartColumn: execution.startColumn
+      })
     })
 
     let data
@@ -247,11 +269,11 @@ async function executeHelm() {
     if (!data.success) helmError.value = formatHelmError(data.error)
 
     // Add to history (deduplicate)
-    const c = helmCode.value.trim()
-    helmHistory.value = [c, ...helmHistory.value.filter((h) => h !== c)].slice(
-      0,
-      20
-    )
+    const executedSource = execution.source
+    helmHistory.value = [
+      executedSource,
+      ...helmHistory.value.filter((source) => source !== executedSource)
+    ].slice(0, 20)
   } catch (err) {
     helmError.value = err.message || 'Network error'
   } finally {
@@ -885,6 +907,7 @@ onUnmounted(() => {
         <!-- Helm editor -->
         <CodeEditor
           v-else
+          ref="helmEditor"
           v-model="helmCode"
           language="javascript"
           aria-label="Bosun Helm code"
@@ -892,6 +915,7 @@ onUnmounted(() => {
           height="fill"
           submit-on-mod-enter
           placeholder="// Access Slipway models and helpers&#10;await User.find()"
+          @selection-change="helmSelection = $event"
           @submit="executeHelm"
         />
       </div>
@@ -959,16 +983,26 @@ onUnmounted(() => {
           </div>
         </div>
         <button
+          data-test="bosun-console-run"
           @click="executeCurrentMode"
           :disabled="
             consoleMode === 'sql'
               ? consoleLoading || !sqlQuery.trim()
-              : helmLoading || !helmCode.trim()
+              : !canExecuteHelm
+          "
+          :title="
+            consoleMode === 'helm'
+              ? `${helmRunLabel} · ${
+                  navigator?.platform?.includes('Mac') ? '⌘' : 'Ctrl'
+                }+Enter`
+              : 'Run · ⌘+Enter'
           "
           class="rounded-md bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
         >
           <span v-if="consoleLoading || helmLoading">Running...</span>
-          <span v-else>Run</span>
+          <span v-else>{{
+            consoleMode === 'helm' ? helmRunLabel : 'Run'
+          }}</span>
         </button>
       </div>
 

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Link, Head, usePage } from '@inertiajs/vue3'
-import { inject, ref, computed, onMounted } from 'vue'
+import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
@@ -25,12 +25,30 @@ const output = ref('')
 const error = ref('')
 const running = ref(false)
 const history = ref([])
+const editor = ref(null)
+const editorSelection = ref({
+  hasSelection: false,
+  hasExecutableSelection: false
+})
 
 const isRunning = computed(() => props.appStatus === 'running')
+const runLabel = computed(() =>
+  editorSelection.value.hasSelection ? 'Run selection' : 'Run'
+)
+const canExecute = computed(() => {
+  if (!isRunning.value || running.value) return false
+  if (editorSelection.value.hasSelection) {
+    return editorSelection.value.hasExecutableSelection
+  }
+  return Boolean(code.value.trim())
+})
 
 async function execute() {
-  if (!code.value.trim() || running.value) return
+  const execution = editor.value?.getExecutionSnapshot()
+  if (!execution?.hasExecutableSource || !canExecute.value) return
 
+  editor.value.highlightExecution(execution)
+  editor.value.focus()
   running.value = true
   output.value = ''
   error.value = ''
@@ -44,7 +62,11 @@ async function execute() {
           'Content-Type': 'application/json',
           'x-csrf-token': page.props._csrf || ''
         },
-        body: JSON.stringify({ code: code.value })
+        body: JSON.stringify({
+          code: execution.source,
+          sourceStartLine: execution.startLine,
+          sourceStartColumn: execution.startColumn
+        })
       }
     )
 
@@ -62,7 +84,7 @@ async function execute() {
 
     // Add to history
     history.value.unshift({
-      code: code.value,
+      code: execution.source,
       output: output.value,
       error: error.value,
       success: result.success,
@@ -363,11 +385,11 @@ function highlightJSON(str) {
         <button
           data-test="helm-run"
           @click="execute"
-          :disabled="running || !isRunning"
+          :disabled="!canExecute"
           class="flex items-center space-x-1.5 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 sm:px-3"
-          :title="
-            (navigator?.platform?.includes('Mac') ? '⌘' : 'Ctrl') + '+Enter'
-          "
+          :title="`${runLabel} · ${
+            navigator?.platform?.includes('Mac') ? '⌘' : 'Ctrl'
+          }+Enter`"
         >
           <SlippyLoader v-if="running" size="h-3 w-3" />
           <svg v-else class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
@@ -376,7 +398,7 @@ function highlightJSON(str) {
             />
           </svg>
           <span class="hidden sm:inline">{{
-            running ? 'Running' : 'Run'
+            running ? 'Running' : runLabel
           }}</span>
         </button>
 
@@ -420,6 +442,7 @@ function highlightJSON(str) {
         >
           <!-- Editor area -->
           <CodeEditor
+            ref="editor"
             v-model="code"
             language="javascript"
             aria-label="Helm JavaScript"
@@ -428,6 +451,7 @@ function highlightJSON(str) {
             :disabled="!isRunning"
             submit-on-mod-enter
             placeholder="// Enter JavaScript code..."
+            @selection-change="editorSelection = $event"
             @submit="execute"
           />
         </div>
@@ -483,6 +507,7 @@ function highlightJSON(str) {
             <button
               v-for="(entry, i) in history"
               :key="i"
+              data-test="helm-history-entry"
               @click="loadFromHistory(entry)"
               class="flex w-full items-center justify-between border-b border-gray-100 px-4 py-2 text-left hover:bg-gray-50 dark:border-gray-800/50 dark:hover:bg-gray-800/50"
             >

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -122,6 +122,20 @@ async function proveOutputScrollsAndEditorStillRuns({ page, expect }) {
   expect(page).toHaveNoSmoke()
 }
 
+async function selectFromSecondLine(page, { toDocumentEnd = true } = {}) {
+  await page.key('ControlOrMeta+Home')
+  await page.key('ArrowDown')
+  await page.key('Home')
+  if (!toDocumentEnd) {
+    // CodeMirror's first Home press stops after indentation. Pressing it again
+    // selects from the true start of a whitespace-only line.
+    await page.key('Home')
+  }
+  await page.raw.keyboard.down('Shift')
+  await page.key(toDocumentEnd ? 'ControlOrMeta+End' : 'End')
+  await page.raw.keyboard.up('Shift')
+}
+
 test(
   'Helm keeps its editor visible while oversized output scrolls on desktop',
   { browser: true, world: helmWorld('helm-layout-desktop') },
@@ -197,9 +211,13 @@ test(
       status: 'running',
       containerName: 'sounding-helm-error-app'
     })
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
     await login.withPassword('genesisUser', page, {
       password: current.auth.genesisUserPassword
     })
+    await updateCheckFinished
     await page.raw.route(
       `**/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`,
       async (route) => {
@@ -240,6 +258,221 @@ test(
       "TypeError: Cannot read properties of null (reading 'publicId') (2:9)"
     )
     expect(errorText.includes('[object Object]')).toBe(false)
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'project Helm runs the selected source and keeps it ready to rerun',
+  {
+    browser: true,
+    world: helmWorld('helm-selection-project')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const projectSlug = current.projects.deploymentTarget.slug
+    const environmentSlug = current.environments.production.slug
+    const endpoint = `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`
+    const submitted = []
+    const selectedSource = [
+      'await Creator.find()',
+      '  .where({ isActive: true })',
+      '  .limit(2)'
+    ].join('\n')
+    const documentSource = [
+      'const outsideSelection = "must not run"',
+      selectedSource
+    ].join('\n')
+
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'sounding-helm-selection-app'
+    })
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route(`**${endpoint}`, async (route) => {
+      submitted.push(route.request().postDataJSON())
+      await new Promise((resolve) => setTimeout(resolve, 80))
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          value: [{ id: 1 }],
+          logs: [],
+          output: JSON.stringify([{ id: 1 }], null, 2),
+          error: null,
+          durationMs: 6,
+          truncated: false
+        })
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+    )
+    await page.fill('@helm-editor', documentSource)
+    await selectFromSecondLine(page)
+
+    expect(await page.script(() => window.getSelection().toString())).toBe(
+      selectedSource
+    )
+    expect(
+      await page.raw.locator('[data-test="helm-run"]').textContent()
+    ).toContain('Run selection')
+    await page.screenshot('.tmp/issue-268-project-helm-selection-light.png')
+
+    await page.click('@helm-run')
+    expect((await page.raw.locator('.cm-executed-range').count()) > 0).toBe(
+      true
+    )
+    await page.wait('@helm-output')
+
+    expect(submitted[0]).toEqual({
+      code: selectedSource,
+      sourceStartLine: 2,
+      sourceStartColumn: 1
+    })
+    expect(await page.script(() => window.getSelection().toString())).toBe(
+      selectedSource
+    )
+    expect(
+      await page.script(
+        () =>
+          document.activeElement?.matches('[data-test="helm-editor"]') === true
+      )
+    ).toBe(true)
+    const historyText = await page.raw
+      .locator('[data-test="helm-history-entry"]')
+      .first()
+      .textContent()
+    expect(historyText).toContain('await Creator.find()')
+    expect(historyText.includes('outsideSelection')).toBe(false)
+
+    const rerun = page.raw.waitForRequest(
+      (request) =>
+        request.method() === 'POST' && request.url().includes(endpoint)
+    )
+    await page.key('ControlOrMeta+Enter')
+    expect((await rerun).postDataJSON()).toEqual(submitted[0])
+    await page.wait(750)
+    expect(await page.raw.locator('.cm-executed-range').count()).toBe(0)
+
+    const whitespaceDocument = [
+      'const outsideSelection = true',
+      '   ',
+      'await Creator.find()'
+    ].join('\n')
+    await page.fill('@helm-editor', whitespaceDocument)
+    await selectFromSecondLine(page, { toDocumentEnd: false })
+    expect(await page.script(() => window.getSelection().toString())).toBe(
+      '   '
+    )
+    expect(
+      await page.raw.locator('[data-test="helm-run"]').textContent()
+    ).toContain('Run selection')
+    expect(await page.raw.locator('[data-test="helm-run"]').isDisabled()).toBe(
+      true
+    )
+    const submissionCount = submitted.length
+    await page.key('ControlOrMeta+Enter')
+    await page.wait(100)
+    expect(submitted.length).toBe(submissionCount)
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'Bosun Helm applies the same selection contract in dark mode',
+  {
+    browser: true,
+    world: helmWorld('helm-selection-bosun')
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const submitted = []
+    const selectedSource = [
+      'await User.find()',
+      '  .where({ isSuperAdmin: true })',
+      '  .limit(1)'
+    ].join('\n')
+    const documentSource = [
+      'const outsideSelection = "must not run"',
+      selectedSource
+    ].join('\n')
+
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route('**/api/v1/bosun/eval', async (route) => {
+      submitted.push(route.request().postDataJSON())
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          value: [{ id: 1 }],
+          logs: [],
+          output: JSON.stringify([{ id: 1 }], null, 2),
+          error: null,
+          durationMs: 4,
+          truncated: false
+        })
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inDarkMode()
+    await page.goto('/bosun?tab=console&mode=helm')
+    await page.fill('@bosun-helm-editor', documentSource)
+    await selectFromSecondLine(page)
+
+    expect(await page.script(() => window.getSelection().toString())).toBe(
+      selectedSource
+    )
+    expect(
+      await page.raw.locator('[data-test="bosun-console-run"]').textContent()
+    ).toContain('Run selection')
+    await page.screenshot('.tmp/issue-268-bosun-helm-selection-dark.png')
+
+    const execution = page.raw.waitForRequest(
+      (request) =>
+        request.method() === 'POST' &&
+        request.url().includes('/api/v1/bosun/eval')
+    )
+    await page.key('ControlOrMeta+Enter')
+    expect((await execution).postDataJSON()).toEqual({
+      code: selectedSource,
+      sourceStartLine: 2,
+      sourceStartColumn: 1
+    })
+    await page.raw
+      .locator('[data-test="bosun-console-run"]')
+      .filter({ hasText: 'Run selection' })
+      .waitFor()
+
+    expect(submitted.length).toBe(1)
+    expect(await page.script(() => window.getSelection().toString())).toBe(
+      selectedSource
+    )
+    expect(
+      await page.script(
+        () =>
+          document.activeElement?.matches('[data-test="bosun-helm-editor"]') ===
+          true
+      )
+    ).toBe(true)
     expect(page).toHaveNoSmoke()
   }
 )

--- a/tests/functional/api/helm.test.js
+++ b/tests/functional/api/helm.test.js
@@ -20,20 +20,30 @@ test(
   },
   async ({ sails, request, expect }) => {
     const originalEvaluate = sails.helpers.helm.evaluate
-    let submittedSource
-    sails.helpers.helm.evaluate = async (source) => {
-      submittedSource = source
+    let invocation
+    sails.helpers.helm.evaluate = async (
+      source,
+      sourceStartLine,
+      sourceStartColumn
+    ) => {
+      invocation = { source, sourceStartLine, sourceStartColumn }
       return RESULT
     }
 
     try {
       const dashboard = await withCsrfFromPage(request, '/bosun', 'genesisUser')
       const response = await dashboard.request.post('/api/v1/bosun/eval', {
-        code: 'await User.find()'
+        code: 'await User.find()',
+        sourceStartLine: 7,
+        sourceStartColumn: 3
       })
 
       expect(response).toHaveStatus(200)
-      expect(submittedSource).toBe('await User.find()')
+      expect(invocation).toEqual({
+        source: 'await User.find()',
+        sourceStartLine: 7,
+        sourceStartColumn: 3
+      })
       expect(response).toHaveJsonPath('success', true)
       expect(response).toHaveJsonPath('value.0.id', 1)
       expect(response).toHaveJsonPath('logs.0', 'querying')
@@ -67,8 +77,18 @@ test(
       status: 'running',
       containerName: 'shared-helm-contract-web'
     })
-    sails.helpers.helm.executeInContainer = async (containerName, source) => {
-      invocation = { containerName, source }
+    sails.helpers.helm.executeInContainer = async (
+      containerName,
+      source,
+      sourceStartLine,
+      sourceStartColumn
+    ) => {
+      invocation = {
+        containerName,
+        source,
+        sourceStartLine,
+        sourceStartColumn
+      }
       return RESULT
     }
 
@@ -83,14 +103,18 @@ test(
       const response = await dashboard.request.post(
         `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`,
         {
-          code: 'await Creator.find()'
+          code: 'await Creator.find()',
+          sourceStartLine: 11,
+          sourceStartColumn: 5
         }
       )
 
       expect(response).toHaveStatus(200)
       expect(invocation).toEqual({
         containerName: 'shared-helm-contract-web',
-        source: 'await Creator.find()'
+        source: 'await Creator.find()',
+        sourceStartLine: 11,
+        sourceStartColumn: 5
       })
       expect(response).toHaveJsonPath('success', true)
       expect(response).toHaveJsonPath('value.0.id', 1)

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -229,6 +229,42 @@ test('Helm maps syntax and runtime failures to helm-input.js', async ({
   expect(rejectedPromise.error.line).toBe(1)
 })
 
+test('Helm maps selected source failures back to the original editor', async ({
+  sails,
+  expect
+}) => {
+  const firstLineFailure = await runHelm(sails, 'null.publicId', {
+    sourceStartLine: 12,
+    sourceStartColumn: 5
+  })
+  expect(firstLineFailure.success).toBe(false)
+  expect(firstLineFailure.error.line).toBe(12)
+  expect(firstLineFailure.error.column).toBe(10)
+  expect(firstLineFailure.error.stack).toContain('helm-input.js:12:10')
+
+  const laterLineFailure = await runHelm(
+    sails,
+    'const creator = null\ncreator.publicId',
+    {
+      sourceStartLine: 20,
+      sourceStartColumn: 7
+    }
+  )
+  expect(laterLineFailure.success).toBe(false)
+  expect(laterLineFailure.error.line).toBe(21)
+  expect(laterLineFailure.error.column).toBe(9)
+  expect(laterLineFailure.error.stack).toContain('helm-input.js:21:9')
+
+  const syntaxFailure = await runHelm(sails, 'const = 1', {
+    sourceStartLine: 30,
+    sourceStartColumn: 4
+  })
+  expect(syntaxFailure.success).toBe(false)
+  expect(syntaxFailure.error.line).toBe(30)
+  expect(syntaxFailure.error.column).toBe(10)
+  expect(syntaxFailure.error.stack).toContain('helm-input.js:30:10')
+})
+
 test('Helm enforces synchronous, asynchronous, source, and output bounds', async ({
   sails,
   expect
@@ -271,19 +307,25 @@ test('project Helm and Bosun Helm delegate to the same bounded runner', async ({
   sails.helpers.helm.run = fakeRun
 
   try {
-    const bosunResult = await sails.helpers.helm.evaluate('1 + 1')
+    const bosunResult = await sails.helpers.helm.evaluate('1 + 1', 4, 2)
     const projectResult = await sails.helpers.helm.executeInContainer(
       'web-production',
-      '1 + 1'
+      '1 + 1',
+      8,
+      3
     )
 
     expect(bosunResult.output).toBe('ready')
     expect(projectResult.output).toBe('ready')
     expect(calls[0].command).toBe(process.execPath)
     expect(calls[0].source).toBe('1 + 1')
+    expect(calls[0].sourceStartLine).toBe(4)
+    expect(calls[0].sourceStartColumn).toBe(2)
     expect(calls[0].bootstrapSails).toBe(true)
     expect(calls[1].args).toEqual(['exec', '-i', 'web-production', 'node'])
     expect(calls[1].source).toBe('1 + 1')
+    expect(calls[1].sourceStartLine).toBe(8)
+    expect(calls[1].sourceStartColumn).toBe(3)
     expect(calls[1].bootstrapSails).toBe(true)
   } finally {
     sails.helpers.helm.run = originalRun


### PR DESCRIPTION
## What changed

- run the current CodeMirror selection in project Helm and Bosun Helm, falling back to the full document only when no selection exists
- preserve the selection’s original line and column through the API and shared parser-backed runtime
- keep editor focus and selection for quick reruns, briefly mark the executed range, and record the exact executed source in history
- disable execution for whitespace-only selections so code outside the selection cannot run unexpectedly
- keep the existing minimal Helm layout; the Run button only changes to “Run selection” when applicable

## Why

Helm should support a fast select → run → adjust → rerun workflow without silently including surrounding definitions or reporting diagnostics against the wrong source position.

## Verification

- `npm run lint`
- `npm run check:consistency`
- 209 unit trials
- 57 functional trials
- 25 browser trials
- focused Helm browser suite: 5/5
- light and dark UI screenshots inspected

Fixes #268