### PR TITLE
feat(helm): add structured result views

### DIFF
--- a/assets/js/components/ActionMenu.vue
+++ b/assets/js/components/ActionMenu.vue
@@ -16,6 +16,11 @@ const props = defineProps({
     default: 'horizontal',
     validator: (value) => ['horizontal', 'vertical'].includes(value)
   },
+  placement: {
+    type: String,
+    default: 'bottom',
+    validator: (value) => ['top', 'bottom'].includes(value)
+  },
   disabled: Boolean,
   testId: {
     type: String,
@@ -148,7 +153,10 @@ onUnmounted(() =>
       ref="menu"
       role="menu"
       :data-test="testId"
-      class="min-w-44 absolute right-0 top-full z-30 mt-1 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+      :class="[
+        'min-w-44 absolute right-0 z-30 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900',
+        placement === 'top' ? 'bottom-full mb-1' : 'top-full mt-1'
+      ]"
       @click.stop
       @keydown="handleKeydown"
     >

--- a/assets/js/components/HelmResultTreeNode.vue
+++ b/assets/js/components/HelmResultTreeNode.vue
@@ -1,0 +1,118 @@
+<script setup>
+import { computed } from 'vue'
+import { helmScalarPresentation, isHelmBranch } from '@/lib/helmResult'
+
+const props = defineProps({
+  name: {
+    type: [String, Number],
+    required: true
+  },
+  value: {
+    default: null
+  },
+  depth: {
+    type: Number,
+    default: 0
+  }
+})
+
+const branch = computed(() => isHelmBranch(props.value))
+const entries = computed(() =>
+  branch.value ? Object.entries(props.value) : []
+)
+const branchSummary = computed(() => {
+  const count = entries.value.length
+  if (Array.isArray(props.value)) {
+    return count === 0 ? '[]' : `Array(${count})`
+  }
+  return count === 0 ? '{}' : `{${count}}`
+})
+const scalar = computed(() => helmScalarPresentation(props.value))
+
+function scalarClasses(type) {
+  return {
+    boolean: 'text-blue-600 dark:text-blue-400',
+    date: 'text-cyan-600 dark:text-cyan-400',
+    number: 'text-purple-600 dark:text-purple-400',
+    bigint: 'text-purple-600 dark:text-purple-400',
+    null: 'italic text-gray-400 dark:text-gray-600',
+    string: 'text-amber-600 dark:text-amber-400',
+    undefined: 'italic text-gray-400 dark:text-gray-600'
+  }[type]
+}
+</script>
+
+<template>
+  <li class="min-w-max">
+    <details v-if="branch" class="helm-tree-branch">
+      <summary
+        class="flex cursor-pointer list-none items-center gap-1 rounded-sm py-0.5 pr-2 font-mono text-xs leading-5 text-gray-700 outline-none hover:bg-gray-50 focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-300 dark:hover:bg-gray-900 dark:focus-visible:ring-gray-700"
+      >
+        <svg
+          class="helm-tree-chevron h-3 w-3 shrink-0 text-gray-400 transition-transform motion-reduce:transition-none dark:text-gray-600"
+          fill="none"
+          viewBox="0 0 12 12"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="m4.5 2.5 3.5 3.5-3.5 3.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1.25"
+          />
+        </svg>
+        <span class="text-pink-600 dark:text-pink-400">{{ name }}</span>
+        <span aria-hidden="true" class="text-gray-400 dark:text-gray-600"
+          >:</span
+        >
+        <span class="text-gray-500 dark:text-gray-500">{{
+          branchSummary
+        }}</span>
+      </summary>
+      <ul
+        v-if="entries.length"
+        class="ml-1.5 space-y-0 border-l border-gray-100 pl-3 dark:border-gray-800"
+      >
+        <HelmResultTreeNode
+          v-for="([key, entryValue], index) in entries"
+          :key="`${depth}-${key}-${index}`"
+          :name="key"
+          :value="entryValue"
+          :depth="depth + 1"
+        />
+      </ul>
+    </details>
+
+    <div
+      v-else
+      class="flex min-w-0 items-start gap-1 py-0.5 pl-4 pr-2 font-mono text-xs leading-5"
+    >
+      <span class="shrink-0 text-pink-600 dark:text-pink-400">{{ name }}</span>
+      <span aria-hidden="true" class="shrink-0 text-gray-400 dark:text-gray-600"
+        >:</span
+      >
+      <time
+        v-if="scalar.datetime"
+        :datetime="scalar.datetime"
+        :title="scalar.title"
+        :class="scalarClasses(scalar.type)"
+        class="break-all"
+        >{{ scalar.text }}</time
+      >
+      <span
+        v-else
+        :title="scalar.title"
+        :class="scalarClasses(scalar.type)"
+        class="max-w-80 sm:max-w-96 min-w-0 truncate"
+        >{{ scalar.text }}</span
+      >
+    </div>
+  </li>
+</template>
+
+<style scoped>
+.helm-tree-branch[open] > summary .helm-tree-chevron {
+  transform: rotate(90deg);
+}
+</style>

--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -1,0 +1,454 @@
+<script setup>
+import { computed, ref, watch } from 'vue'
+import ActionMenu from '@/components/ActionMenu.vue'
+import HelmResultTreeNode from '@/components/HelmResultTreeNode.vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
+import ToastContainer from '@/components/ToastContainer.vue'
+import Tooltip from '@/components/Tooltip.vue'
+import { highlightJSON } from '@/lib/highlightJSON'
+import {
+  formatHelmError,
+  helmRowsToCsv,
+  helmScalarPresentation,
+  helmTableColumns,
+  isHelmBranch,
+  isHelmTableValue,
+  rawHelmValue,
+  serializeHelmValue
+} from '@/lib/helmResult'
+
+const props = defineProps({
+  result: {
+    type: Object,
+    default: null
+  },
+  error: {
+    type: String,
+    default: ''
+  },
+  loading: Boolean,
+  clearable: Boolean,
+  emptyText: {
+    type: String,
+    default: 'Run JavaScript to see results'
+  },
+  testId: {
+    type: String,
+    default: 'helm'
+  }
+})
+
+const emit = defineEmits(['clear'])
+const activeView = ref('raw')
+const logsOpen = ref(false)
+const toasts = ref([])
+let toastId = 0
+
+const value = computed(() => props.result?.value)
+const tableCompatible = computed(
+  () => props.result?.success && isHelmTableValue(value.value)
+)
+const columns = computed(() => helmTableColumns(value.value))
+const rows = computed(() => (tableCompatible.value ? value.value : []))
+const presentedRows = computed(() =>
+  rows.value.map((row) =>
+    columns.value.map((column) => ({
+      column,
+      ...helmScalarPresentation(row[column])
+    }))
+  )
+)
+const numericColumns = computed(
+  () =>
+    new Set(
+      columns.value.filter((column, columnIndex) => {
+        const populated = presentedRows.value
+          .map((row) => row[columnIndex]?.type)
+          .filter((type) => !['null', 'undefined'].includes(type))
+        return (
+          populated.length > 0 &&
+          populated.every((type) => ['number', 'bigint'].includes(type))
+        )
+      })
+    )
+)
+const structured = computed(
+  () => props.result?.success && isHelmBranch(value.value)
+)
+const views = computed(() => {
+  if (!props.result?.success) return []
+  if (tableCompatible.value) return ['table', 'tree', 'raw']
+  if (structured.value) return ['tree', 'raw']
+  return ['raw']
+})
+const rawText = computed(() => rawHelmValue(value.value))
+const rawHighlighted = computed(() =>
+  structured.value ? highlightJSON(value.value) : ''
+)
+const treeEntries = computed(() =>
+  structured.value ? Object.entries(value.value) : []
+)
+const errorText = computed(
+  () =>
+    props.error ||
+    (props.result && !props.result.success
+      ? formatHelmError(props.result.error)
+      : '')
+)
+const logs = computed(() =>
+  Array.isArray(props.result?.logs) ? props.result.logs : []
+)
+const metadata = computed(() => {
+  if (!props.result) return []
+
+  const items = []
+  if (tableCompatible.value) {
+    items.push(`${rows.value.length} row${rows.value.length === 1 ? '' : 's'}`)
+  } else {
+    items.push(props.result.success ? 'Success' : 'Error')
+  }
+  if (props.result.truncated) items.push('Truncated')
+  if (Number.isFinite(props.result.durationMs)) {
+    items.push(`${props.result.durationMs}ms`)
+  }
+  return items
+})
+const actionItems = computed(() => {
+  const items = []
+  if (props.result?.success) {
+    items.push({ key: 'copy-json', label: 'Copy as JSON' })
+    if (tableCompatible.value) {
+      items.push({ key: 'export-csv', label: 'Export CSV' })
+    }
+  }
+  if (props.clearable && (props.result || props.error)) {
+    items.push({ key: 'clear', label: 'Clear result' })
+  }
+  return items
+})
+
+watch(
+  () => props.result,
+  () => {
+    activeView.value = tableCompatible.value
+      ? 'table'
+      : structured.value
+      ? 'tree'
+      : 'raw'
+    logsOpen.value = Boolean(
+      logs.value.length && props.result?.success === false
+    )
+  },
+  { immediate: true }
+)
+
+function scalarClasses(type) {
+  return {
+    boolean: 'text-blue-600 dark:text-blue-400',
+    date: 'text-cyan-600 dark:text-cyan-400',
+    number: 'text-purple-600 dark:text-purple-400',
+    bigint: 'text-purple-600 dark:text-purple-400',
+    null: 'italic text-gray-400 dark:text-gray-600',
+    string: 'text-gray-700 dark:text-gray-300',
+    undefined: 'italic text-gray-400 dark:text-gray-600'
+  }[type]
+}
+
+async function handleAction(item) {
+  if (item.key === 'copy-json') {
+    await navigator.clipboard.writeText(serializeHelmValue(value.value))
+    notify('Copied JSON to clipboard')
+    return
+  }
+  if (item.key === 'export-csv') {
+    downloadCsv()
+    notify('Exported helm-result.csv')
+    return
+  }
+  if (item.key === 'clear') emit('clear')
+}
+
+function downloadCsv() {
+  const csv = helmRowsToCsv(rows.value, columns.value)
+  const blob = new Blob([`\uFEFF${csv}`], {
+    type: 'text/csv;charset=utf-8'
+  })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = 'helm-result.csv'
+  link.click()
+  URL.revokeObjectURL(url)
+}
+
+function notify(message) {
+  const id = ++toastId
+  toasts.value.push({ id, message, type: 'success' })
+  setTimeout(() => dismissToast(id), 3500)
+}
+
+function dismissToast(id) {
+  toasts.value = toasts.value.filter((toast) => toast.id !== id)
+}
+</script>
+
+<template>
+  <div class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+    <div
+      :data-test="`${testId}-output-scroll`"
+      class="relative min-h-0 min-w-0 flex-1 overflow-auto bg-white dark:bg-gray-950"
+    >
+      <div
+        v-if="loading"
+        class="flex h-full items-center justify-center"
+        aria-live="polite"
+        aria-label="Running Helm"
+      >
+        <SlippyLoader size="h-4 w-4" />
+      </div>
+
+      <template v-else-if="result || errorText">
+        <pre
+          v-if="errorText"
+          :data-test="`${testId}-error`"
+          class="m-4 whitespace-pre-wrap rounded-md bg-red-50 px-3 py-2 font-mono text-sm leading-6 text-red-700 dark:bg-red-950/30 dark:text-red-400"
+          >{{ errorText }}</pre
+        >
+
+        <div
+          v-else-if="activeView === 'table'"
+          :data-test="`${testId}-output`"
+          class="min-w-max"
+        >
+          <table
+            :data-test="`${testId}-result-table`"
+            class="min-w-full font-mono text-sm"
+          >
+            <caption class="sr-only">
+              Helm returned records
+            </caption>
+            <thead class="sticky top-0 z-10">
+              <tr
+                class="border-b border-gray-200 bg-gray-50/95 dark:border-gray-800 dark:bg-gray-900/95"
+              >
+                <th
+                  v-for="column in columns"
+                  :key="column"
+                  scope="col"
+                  :class="[
+                    'whitespace-nowrap px-4 py-2 text-xs font-medium text-gray-500 dark:text-gray-400',
+                    numericColumns.has(column) ? 'text-right' : 'text-left'
+                  ]"
+                >
+                  {{ column }}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr
+                v-for="(row, rowIndex) in presentedRows"
+                :key="rowIndex"
+                class="border-b border-gray-100 last:border-b-0 hover:bg-gray-50/70 dark:border-gray-900 dark:hover:bg-gray-900/40"
+              >
+                <td
+                  v-for="cell in row"
+                  :key="cell.column"
+                  :class="[
+                    'max-w-96 whitespace-nowrap px-4 py-2',
+                    scalarClasses(cell.type),
+                    ['number', 'bigint'].includes(cell.type)
+                      ? 'text-right tabular-nums'
+                      : ''
+                  ]"
+                >
+                  <time
+                    v-if="cell.datetime"
+                    :datetime="cell.datetime"
+                    :title="cell.title"
+                    class="block truncate"
+                    >{{ cell.text }}</time
+                  >
+                  <span v-else :title="cell.title" class="block truncate">{{
+                    cell.text
+                  }}</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+
+        <div
+          v-else-if="activeView === 'tree'"
+          :data-test="`${testId}-output`"
+          class="p-4"
+        >
+          <ul :data-test="`${testId}-result-tree`" class="min-w-max space-y-0">
+            <HelmResultTreeNode
+              v-for="([key, entryValue], index) in treeEntries"
+              :key="`${key}-${index}`"
+              :name="key"
+              :value="entryValue"
+            />
+          </ul>
+          <code
+            v-if="treeEntries.length === 0"
+            class="font-mono text-xs text-gray-500 dark:text-gray-400"
+            >{{ Array.isArray(value) ? '[]' : '{}' }}</code
+          >
+        </div>
+
+        <div v-else :data-test="`${testId}-output`" class="p-4">
+          <pre
+            v-if="structured"
+            :data-test="`${testId}-result-raw`"
+            class="whitespace-pre-wrap font-mono text-xs leading-5 text-gray-700 dark:text-gray-300"
+            v-html="rawHighlighted"
+          ></pre>
+          <pre
+            v-else
+            :data-test="`${testId}-result-raw`"
+            class="whitespace-pre-wrap font-mono text-sm leading-6 text-gray-700 dark:text-gray-300"
+            >{{ rawText }}</pre
+          >
+        </div>
+      </template>
+
+      <div
+        v-else
+        class="flex h-full items-center justify-center px-4 text-center text-sm text-gray-500 dark:text-gray-400"
+      >
+        {{ emptyText }}
+      </div>
+    </div>
+
+    <details
+      v-if="logs.length"
+      :open="logsOpen"
+      :data-test="`${testId}-logs`"
+      class="shrink-0 border-t border-gray-200 bg-gray-50/70 dark:border-gray-800 dark:bg-gray-900/40"
+      @toggle="logsOpen = $event.currentTarget.open"
+    >
+      <summary
+        class="cursor-pointer px-4 py-2 text-xs font-medium text-gray-500 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-300 dark:text-gray-400 dark:focus-visible:ring-gray-700"
+      >
+        Console
+        <span class="font-normal text-gray-400 dark:text-gray-600"
+          >{{ logs.length }} line{{ logs.length === 1 ? '' : 's' }}</span
+        >
+      </summary>
+      <pre
+        class="max-h-40 overflow-auto whitespace-pre-wrap px-4 pb-3 font-mono text-xs leading-5 text-gray-600 dark:text-gray-400"
+        >{{ logs.join('\n') }}</pre
+      >
+    </details>
+
+    <footer
+      v-if="result"
+      :data-test="`${testId}-result-status`"
+      class="min-h-10 flex shrink-0 items-center justify-between gap-3 border-t border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-800 dark:bg-gray-900/50"
+    >
+      <div class="flex min-w-0 items-center gap-3">
+        <div
+          v-if="views.length > 1"
+          class="flex shrink-0 overflow-hidden rounded-md border border-gray-300 dark:border-gray-700"
+          role="group"
+          aria-label="Result view"
+        >
+          <Tooltip
+            v-for="view in views"
+            :key="view"
+            :text="`${view[0].toUpperCase()}${view.slice(1)} view`"
+            position="top"
+          >
+            <button
+              type="button"
+              :data-test="`${testId}-view-${view}`"
+              :aria-label="`${view[0].toUpperCase()}${view.slice(1)} view`"
+              :aria-pressed="activeView === view"
+              :class="[
+                'flex h-7 w-8 items-center justify-center outline-none transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-400 motion-reduce:transition-none dark:focus-visible:ring-gray-600',
+                view !== views[0]
+                  ? 'border-l border-gray-300 dark:border-gray-700'
+                  : '',
+                activeView === view
+                  ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+              ]"
+              @click="activeView = view"
+            >
+              <svg
+                v-if="view === 'table'"
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M3.75 5.25h16.5v13.5H3.75V5.25Zm0 4.5h16.5M9 5.25v13.5"
+                />
+              </svg>
+              <svg
+                v-else-if="view === 'tree'"
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.5"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M5.25 4.5v15m0-10.5h3.5m-3.5 6h3.5M8.75 7.5h10v3h-10v-3Zm0 6h10v3h-10v-3Z"
+                />
+              </svg>
+              <span
+                v-else
+                class="font-mono text-xs font-bold leading-none"
+                aria-hidden="true"
+                >{}</span
+              >
+            </button>
+          </Tooltip>
+        </div>
+
+        <p
+          class="truncate text-xs text-gray-500 dark:text-gray-400"
+          aria-live="polite"
+        >
+          <template v-for="(item, index) in metadata" :key="item">
+            <span
+              :class="
+                item === 'Truncated'
+                  ? 'font-medium text-amber-600 dark:text-amber-400'
+                  : ''
+              "
+              >{{ item }}</span
+            >
+            <span
+              v-if="index < metadata.length - 1"
+              aria-hidden="true"
+              class="mx-1 text-gray-300 dark:text-gray-700"
+              >&middot;</span
+            >
+          </template>
+        </p>
+      </div>
+
+      <ActionMenu
+        v-if="actionItems.length"
+        :items="actionItems"
+        :test-id="`${testId}-result-actions`"
+        label="Result actions"
+        placement="top"
+        @select="handleAction"
+      />
+    </footer>
+
+    <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
+  </div>
+</template>

--- a/assets/js/components/ToastContainer.vue
+++ b/assets/js/components/ToastContainer.vue
@@ -25,6 +25,8 @@ const colors = {
   <Teleport to="body">
     <div
       class="fixed bottom-4 right-4 z-50 flex flex-col-reverse space-y-2 space-y-reverse"
+      aria-live="polite"
+      aria-atomic="false"
     >
       <TransitionGroup
         enter-active-class="transition duration-300 ease-out"
@@ -45,6 +47,7 @@ const colors = {
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
+            aria-hidden="true"
           >
             <path
               stroke-linecap="round"
@@ -59,12 +62,14 @@ const colors = {
           <button
             @click="emit('dismiss', toast.id)"
             class="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            :aria-label="`Dismiss ${toast.message}`"
           >
             <svg
               class="h-4 w-4"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
+              aria-hidden="true"
             >
               <path
                 stroke-linecap="round"

--- a/assets/js/components/bridge/BridgeDashboard.vue
+++ b/assets/js/components/bridge/BridgeDashboard.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { computed } from 'vue'
 import { Link } from '@inertiajs/vue3'
-import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
+import ActionMenu from '@/components/ActionMenu.vue'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 
 const props = defineProps({
@@ -165,7 +165,7 @@ function partitionWidth(card, value) {
         </p>
       </div>
 
-      <BridgeActionMenu
+      <ActionMenu
         :items="quickActions"
         label="Quick actions"
         orientation="vertical"

--- a/assets/js/lib/helmResult.js
+++ b/assets/js/lib/helmResult.js
@@ -1,0 +1,137 @@
+const TYPED_SCALAR_TYPES = new Set([
+  'BigInt',
+  'Date',
+  'Function',
+  'Number',
+  'Symbol',
+  'undefined'
+])
+
+function isObject(value) {
+  return value !== null && typeof value === 'object'
+}
+
+export function isTypedHelmScalar(value) {
+  return (
+    isObject(value) &&
+    typeof value.type === 'string' &&
+    TYPED_SCALAR_TYPES.has(value.type)
+  )
+}
+
+export function isHelmBranch(value) {
+  return isObject(value) && !isTypedHelmScalar(value)
+}
+
+export function isHelmTableValue(value) {
+  if (!Array.isArray(value) || value.length === 0) return false
+
+  const firstColumns = Object.keys(value[0] || {})
+  if (firstColumns.length === 0) return false
+  const stableColumns = [...firstColumns].sort().join('\u0000')
+
+  return value.every((row) => {
+    if (!isObject(row) || Array.isArray(row) || isTypedHelmScalar(row)) {
+      return false
+    }
+
+    if ([...Object.keys(row)].sort().join('\u0000') !== stableColumns) {
+      return false
+    }
+
+    return firstColumns.every((column) => !isHelmBranch(row[column]))
+  })
+}
+
+export function helmTableColumns(value) {
+  return isHelmTableValue(value) ? Object.keys(value[0]) : []
+}
+
+export function serializeHelmValue(value) {
+  const serialized = JSON.stringify(value, null, 2)
+  return serialized === undefined ? 'undefined' : serialized
+}
+
+export function rawHelmValue(value) {
+  if (typeof value === 'string') return value
+  if (isTypedHelmScalar(value) && value.type === 'undefined') return 'undefined'
+  return serializeHelmValue(value)
+}
+
+export function helmScalarPresentation(value) {
+  if (value === null) {
+    return { text: 'NULL', type: 'null', title: 'null' }
+  }
+
+  if (isTypedHelmScalar(value)) {
+    if (value.type === 'undefined') {
+      return { text: 'undefined', type: 'undefined', title: 'undefined' }
+    }
+
+    const text =
+      value.type === 'BigInt'
+        ? `${value.value}n`
+        : value.type === 'Function'
+        ? `[Function ${value.name || 'anonymous'}]`
+        : value.type === 'Symbol'
+        ? `Symbol(${value.value || ''})`
+        : String(value.value)
+
+    return {
+      text,
+      type: value.type.toLowerCase(),
+      title: text,
+      datetime: value.type === 'Date' ? value.value : undefined
+    }
+  }
+
+  if (typeof value === 'string') {
+    return { text: value, type: 'string', title: value }
+  }
+  if (typeof value === 'number') {
+    return { text: String(value), type: 'number', title: String(value) }
+  }
+  if (typeof value === 'boolean') {
+    return { text: String(value), type: 'boolean', title: String(value) }
+  }
+  if (value === undefined) {
+    return { text: 'undefined', type: 'undefined', title: 'undefined' }
+  }
+
+  const text = serializeHelmValue(value)
+  return { text, type: 'object', title: text }
+}
+
+export function formatHelmError(error, fallback = 'Execution failed') {
+  if (!error) return fallback
+  if (typeof error === 'string') return error
+
+  const location =
+    error.line && error.column ? ` (${error.line}:${error.column})` : ''
+  return `${error.name || 'Error'}: ${error.message || fallback}${location}`
+}
+
+export function helmRowsToCsv(rows, columns) {
+  return [
+    columns.map(csvCell).join(','),
+    ...rows.map((row) =>
+      columns.map((column) => csvCell(row[column])).join(',')
+    )
+  ].join('\n')
+}
+
+function csvCell(value) {
+  const presentation = helmScalarPresentation(value)
+  let text = presentation.type === 'null' ? '' : presentation.text
+
+  // Prevent spreadsheet applications from interpreting returned text as a
+  // formula when the exported CSV is opened.
+  if (presentation.type === 'string' && /^[\t\r ]*[=+\-@]/.test(text)) {
+    text = `'${text}`
+  }
+
+  if (/[",\r\n]/.test(text)) {
+    return `"${text.replace(/"/g, '""')}"`
+  }
+  return text
+}

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -16,10 +16,11 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
+import HelmResultViewer from '@/components/HelmResultViewer.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
 import { highlightJSON } from '@/lib/highlightJSON'
-import { highlightJS } from '@/lib/highlightJS'
 import { highlightLogLine } from '@/lib/highlightLog'
+import { formatHelmError } from '@/lib/helmResult'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 
 defineOptions({
@@ -143,36 +144,9 @@ function showToast(message, type = 'success') {
   setTimeout(() => dismissToast(id), 5000)
 }
 
-function formatHelmError(error) {
-  if (!error) return 'Evaluation failed'
-  if (typeof error === 'string') return error
-
-  const location =
-    error.line && error.column ? ` (${error.line}:${error.column})` : ''
-  return `${error.name || 'Error'}: ${
-    error.message || 'Evaluation failed'
-  }${location}`
-}
-
 function dismissToast(id) {
   toasts.value = toasts.value.filter((t) => t.id !== id)
 }
-
-// Format Helm output — try to parse as JSON for syntax highlighting, fall back to plain text
-const highlightedHelmOutput = computed(() => {
-  if (!helmResults.value?.output) return ''
-  const raw = helmResults.value.output
-  try {
-    const parsed = JSON.parse(raw)
-    // Only highlight objects/arrays — primitives display as plain text
-    if (typeof parsed === 'object' && parsed !== null) {
-      return highlightJSON(parsed)
-    }
-  } catch {
-    // Not valid JSON — highlight as JS (handles util.inspect output too)
-  }
-  return highlightJS(raw)
-})
 
 async function executeQuery() {
   if (!sqlQuery.value.trim() || consoleLoading.value) return
@@ -360,13 +334,6 @@ function downloadFile(content, filename, mimeType) {
 function exportAction(fn) {
   fn()
   showExportMenu.value = false
-}
-
-function copyHelmOutput() {
-  navigator.clipboard.writeText(
-    helmResults.value?.output || formatHelmError(helmResults.value?.error) || ''
-  )
-  showToast('Copied to clipboard')
 }
 
 async function fetchDiff() {
@@ -1007,7 +974,7 @@ onUnmounted(() => {
       </div>
 
       <!-- Results -->
-      <div class="flex-1 overflow-auto">
+      <div class="flex min-h-0 flex-1 flex-col overflow-hidden">
         <!-- ─── SQL Results ─── -->
         <template v-if="consoleMode === 'sql'">
           <!-- Error -->
@@ -1105,56 +1072,18 @@ onUnmounted(() => {
         </template>
 
         <!-- ─── Helm Results ─── -->
-        <template v-else>
-          <!-- Loading -->
-          <div
-            v-if="helmLoading"
-            class="flex h-full items-center justify-center"
-          >
-            <SlippyLoader size="h-5 w-5" />
-          </div>
-
-          <!-- Error -->
-          <div v-else-if="helmError" class="p-4">
-            <div
-              class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/30"
-            >
-              <pre
-                class="whitespace-pre-wrap font-mono text-sm text-red-600 dark:text-red-400"
-                >{{ helmError }}</pre
-              >
-            </div>
-            <pre
-              v-if="helmResults?.output"
-              class="mt-3 whitespace-pre-wrap font-mono text-sm text-gray-700 dark:text-gray-300"
-              >{{ helmResults.output }}</pre
-            >
-          </div>
-
-          <!-- Results output -->
-          <div v-else-if="helmResults" class="p-4">
-            <pre
-              class="whitespace-pre-wrap font-mono text-sm text-gray-700 dark:text-gray-300"
-              v-html="highlightedHelmOutput"
-            ></pre>
-          </div>
-
-          <!-- Empty state -->
-          <div
-            v-else
-            class="flex h-full items-center justify-center text-sm text-gray-500 dark:text-gray-400"
-          >
-            Run JavaScript to see results
-          </div>
-        </template>
+        <HelmResultViewer
+          v-else
+          :result="helmResults"
+          :error="helmError || ''"
+          :loading="helmLoading"
+          test-id="bosun-helm"
+        />
       </div>
 
       <!-- Status bar -->
       <div
-        v-if="
-          (consoleMode === 'sql' && consoleResults) ||
-          (consoleMode === 'helm' && helmResults)
-        "
+        v-if="consoleMode === 'sql' && consoleResults"
         class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-800 dark:bg-gray-900/50"
       >
         <!-- SQL status bar content -->
@@ -1319,37 +1248,6 @@ onUnmounted(() => {
               </div>
             </div>
           </div>
-        </template>
-
-        <!-- Helm status bar content -->
-        <template v-else>
-          <span
-            v-if="helmResults"
-            class="text-xs text-gray-500 dark:text-gray-400"
-          >
-            {{ helmResults.success ? 'Success' : 'Error' }}
-            &middot; {{ helmResults.durationMs }}ms
-          </span>
-          <Tooltip v-if="helmResults" text="Copy output" position="top">
-            <button
-              @click="copyHelmOutput"
-              class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
-            >
-              <svg
-                class="h-4 w-4"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-                stroke-width="1.5"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  d="M15.666 3.888A2.25 2.25 0 0013.5 2.25h-3c-1.03 0-1.9.693-2.166 1.638m7.332 0c.055.194.084.4.084.612v0a.75.75 0 01-.75.75H9.75a.75.75 0 01-.75-.75v0c0-.212.03-.418.084-.612m7.332 0c.646.049 1.288.11 1.927.184 1.1.128 1.907 1.077 1.907 2.185V19.5a2.25 2.25 0 01-2.25 2.25H6.75A2.25 2.25 0 014.5 19.5V6.257c0-1.108.806-2.057 1.907-2.185a48.208 48.208 0 011.927-.184"
-                />
-              </svg>
-            </button>
-          </Tooltip>
         </template>
       </div>
     </div>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -6,7 +6,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
-import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
+import ActionMenu from '@/components/ActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
@@ -680,7 +680,7 @@ function createUrl() {
               <span class="text-xs text-gray-500 dark:text-gray-400"
                 >{{ selectedIds.size }} selected</span
               >
-              <BridgeActionMenu
+              <ActionMenu
                 :items="bulkMenuItems"
                 :disabled="quickActionForm.processing"
                 label="Actions for selected records"
@@ -711,7 +711,7 @@ function createUrl() {
             class="text-xs text-gray-500 dark:text-gray-400"
             >{{ total.toLocaleString() }} records</span
           >
-          <BridgeActionMenu
+          <ActionMenu
             :items="resourceMenuItems"
             :disabled="quickActionForm.processing"
             :label="`Actions for ${modelMeta?.label || modelIdentity}`"

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -7,7 +7,7 @@ import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 import BridgeCollectionManager from '@/components/bridge/BridgeCollectionManager.vue'
-import BridgeActionMenu from '@/components/bridge/BridgeActionMenu.vue'
+import ActionMenu from '@/components/ActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 
 defineOptions({
@@ -357,7 +357,7 @@ function relationshipMutationBaseUrl(relationship) {
           >
         </nav>
       </div>
-      <BridgeActionMenu
+      <ActionMenu
         v-if="record"
         :items="recordMenuItems"
         :disabled="quickActionForm.processing"

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -4,6 +4,7 @@ import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
+import HelmResultViewer from '@/components/HelmResultViewer.vue'
 
 defineOptions({
   layout: AppLayout
@@ -21,8 +22,8 @@ const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 
 const code = ref('// Access your Sails models, helpers, and config\n')
-const output = ref('')
-const error = ref('')
+const executionResult = ref(null)
+const requestError = ref('')
 const running = ref(false)
 const history = ref([])
 const editor = ref(null)
@@ -50,8 +51,8 @@ async function execute() {
   editor.value.highlightExecution(execution)
   editor.value.focus()
   running.value = true
-  output.value = ''
-  error.value = ''
+  executionResult.value = null
+  requestError.value = ''
 
   try {
     const response = await fetch(
@@ -70,23 +71,27 @@ async function execute() {
       }
     )
 
-    const result = await response.json()
-
-    if (result.success) {
-      output.value = result.output || '(no output)'
-      error.value = ''
-    } else {
-      output.value = ''
-      error.value = [result.output, formatHelmError(result.error)]
-        .filter(Boolean)
-        .join('\n')
+    const responseText = await response.text()
+    let result
+    try {
+      result = JSON.parse(responseText)
+    } catch {
+      throw new Error(responseText || 'Execution failed')
     }
+
+    if (!response.ok) {
+      throw new Error(
+        result.message ||
+          result.error?.message ||
+          result.error ||
+          'Execution failed'
+      )
+    }
+    executionResult.value = result
 
     // Add to history
     history.value.unshift({
       code: execution.source,
-      output: output.value,
-      error: error.value,
       success: result.success,
       time: new Date()
     })
@@ -96,23 +101,10 @@ async function execute() {
       history.value = history.value.slice(0, 20)
     }
   } catch (err) {
-    error.value = err.message
+    requestError.value = err.message || 'Network error'
   } finally {
     running.value = false
   }
-}
-
-function formatHelmError(executionError) {
-  if (!executionError) return 'Execution failed'
-  if (typeof executionError === 'string') return executionError
-
-  const location =
-    executionError.line && executionError.column
-      ? ` (${executionError.line}:${executionError.column})`
-      : ''
-  return `${executionError.name || 'Error'}: ${
-    executionError.message || 'Execution failed'
-  }${location}`
 }
 
 function loadFromHistory(entry) {
@@ -120,108 +112,12 @@ function loadFromHistory(entry) {
 }
 
 function clearExecutionOutput() {
-  output.value = ''
-  error.value = ''
+  executionResult.value = null
+  requestError.value = ''
 }
 
-// JSON/output syntax highlighting
-const highlightedOutput = computed(() => {
-  if (!output.value) return ''
-  return highlightJSON(output.value)
-})
-
-function highlightJSON(str) {
-  const escapeHtml = (s) =>
-    s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-
-  // Simple JSON tokenizer
-  const tokens = []
-  let i = 0
-
-  while (i < str.length) {
-    // String
-    if (str[i] === '"') {
-      let end = i + 1
-      while (end < str.length && str[end] !== '"') {
-        if (str[end] === '\\') end++
-        end++
-      }
-      if (end < str.length) end++
-      tokens.push({ type: 'string', value: str.slice(i, end) })
-      i = end
-      continue
-    }
-
-    // Number
-    if (/[-\d]/.test(str[i])) {
-      let end = i
-      if (str[end] === '-') end++
-      while (end < str.length && /[\d.eE+-]/.test(str[end])) end++
-      if (end > i) {
-        tokens.push({ type: 'number', value: str.slice(i, end) })
-        i = end
-        continue
-      }
-    }
-
-    // Boolean/null
-    if (str.slice(i, i + 4) === 'true') {
-      tokens.push({ type: 'boolean', value: 'true' })
-      i += 4
-      continue
-    }
-    if (str.slice(i, i + 5) === 'false') {
-      tokens.push({ type: 'boolean', value: 'false' })
-      i += 5
-      continue
-    }
-    if (str.slice(i, i + 4) === 'null') {
-      tokens.push({ type: 'null', value: 'null' })
-      i += 4
-      continue
-    }
-
-    // Punctuation
-    if (/[{}\[\]:,]/.test(str[i])) {
-      tokens.push({ type: 'punctuation', value: str[i] })
-      i++
-      continue
-    }
-
-    // Whitespace
-    if (/\s/.test(str[i])) {
-      let end = i
-      while (end < str.length && /\s/.test(str[end])) end++
-      tokens.push({ type: 'whitespace', value: str.slice(i, end) })
-      i = end
-      continue
-    }
-
-    // Other
-    tokens.push({ type: 'other', value: str[i] })
-    i++
-  }
-
-  return tokens
-    .map((t) => {
-      const escaped = escapeHtml(t.value)
-      switch (t.type) {
-        case 'string':
-          // Check if it's a key (followed by colon after whitespace)
-          return `<span class="text-cyan-600 dark:text-cyan-400">${escaped}</span>`
-        case 'number':
-          return `<span class="text-orange-600 dark:text-orange-400">${escaped}</span>`
-        case 'boolean':
-          return `<span class="text-purple-600 dark:text-purple-400">${escaped}</span>`
-        case 'null':
-          return `<span class="text-gray-400 dark:text-gray-500">${escaped}</span>`
-        case 'punctuation':
-          return `<span class="text-gray-500 dark:text-gray-400">${escaped}</span>`
-        default:
-          return escaped
-      }
-    })
-    .join('')
+function clearHistory() {
+  history.value = []
 }
 </script>
 <template>
@@ -462,47 +358,34 @@ function highlightJSON(str) {
         data-test="helm-output-panel"
         class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-gray-950"
       >
-        <div
-          data-test="helm-output-scroll"
-          class="relative min-h-0 min-w-0 flex-1 overflow-auto p-4 font-mono text-sm leading-6"
-        >
-          <!-- Output -->
-          <pre
-            v-if="output"
-            data-test="helm-output"
-            class="whitespace-pre-wrap"
-            v-html="highlightedOutput"
-          ></pre>
-          <!-- Error -->
-          <pre
-            v-else-if="error"
-            data-test="helm-error"
-            class="whitespace-pre-wrap text-red-600 dark:text-red-400"
-            >{{ error }}</pre
-          >
-          <!-- Running indicator -->
-          <div
-            v-else-if="running"
-            class="flex items-center space-x-2 text-gray-400 dark:text-gray-500"
-          >
-            <SlippyLoader size="h-4 w-4" />
-          </div>
-
-          <!-- Clear button (floating) -->
-          <button
-            v-if="output || error"
-            @click="clearExecutionOutput"
-            class="absolute right-3 top-3 text-xs text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
-          >
-            clear
-          </button>
-        </div>
+        <HelmResultViewer
+          :result="executionResult"
+          :error="requestError"
+          :loading="running"
+          clearable
+          test-id="helm"
+          @clear="clearExecutionOutput"
+        />
 
         <!-- History (collapsible at bottom) -->
         <div
           v-if="history.length > 0"
+          data-test="helm-history"
           class="shrink-0 border-t border-gray-100 dark:border-gray-800"
         >
+          <div class="flex items-center justify-between px-4 py-1.5">
+            <span class="text-xs text-gray-400 dark:text-gray-500"
+              >Recent runs</span
+            >
+            <button
+              type="button"
+              data-test="helm-clear-history"
+              class="text-xs text-gray-500 outline-none hover:text-gray-900 focus-visible:rounded focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-400 dark:hover:text-white dark:focus-visible:ring-gray-700"
+              @click="clearHistory"
+            >
+              Clear
+            </button>
+          </div>
           <div class="max-h-32 overflow-y-auto">
             <button
               v-for="(entry, i) in history"

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -1,4 +1,5 @@
 const { test } = require('sounding')
+const { readFile } = require('node:fs/promises')
 
 function helmWorld(slug) {
   return {
@@ -47,13 +48,27 @@ async function openHelmWithMockedExecution({ sails, world, login, page }) {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify({
-          success: true,
-          output:
-            executionCount === 1
-              ? oversizedOutput()
-              : JSON.stringify({ ready: true }, null, 2)
-        })
+        body: JSON.stringify(
+          executionCount === 1
+            ? {
+                success: true,
+                value: JSON.parse(oversizedOutput()),
+                logs: [],
+                output: oversizedOutput(),
+                error: null,
+                durationMs: 14,
+                truncated: false
+              }
+            : {
+                success: true,
+                value: { ready: true },
+                logs: [],
+                output: JSON.stringify({ ready: true }, null, 2),
+                error: null,
+                durationMs: 3,
+                truncated: false
+              }
+        )
       })
     }
   )
@@ -117,7 +132,12 @@ async function proveOutputScrollsAndEditorStillRuns({ page, expect }) {
   expect(
     (
       await page.raw.locator('[data-test="helm-output"]').textContent()
-    ).includes('"ready": true')
+    ).includes('ready')
+  ).toBe(true)
+  expect(
+    (
+      await page.raw.locator('[data-test="helm-output"]').textContent()
+    ).includes('true')
   ).toBe(true)
   expect(page).toHaveNoSmoke()
 }
@@ -253,11 +273,205 @@ test(
     const errorText = await page.raw
       .locator('[data-test="helm-error"]')
       .textContent()
-    expect(errorText).toContain('checking creator')
     expect(errorText).toContain(
       "TypeError: Cannot read properties of null (reading 'publicId') (2:9)"
     )
     expect(errorText.includes('[object Object]')).toBe(false)
+    expect(
+      await page.raw.locator('[data-test="helm-logs"]').textContent()
+    ).toContain('checking creator')
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'Helm presents structured values as minimal table, tree, and raw views',
+  {
+    browser: true,
+    world: helmWorld('helm-structured-results')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const projectSlug = current.projects.deploymentTarget.slug
+    const environmentSlug = current.environments.production.slug
+    const endpoint = `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`
+
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'sounding-helm-structured-app'
+    })
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw
+      .context()
+      .grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.raw.route(`**${endpoint}`, async (route) => {
+      const { code } = route.request().postDataJSON()
+      const result = code.includes('nested')
+        ? nestedHelmResult()
+        : {
+            ...flatHelmResult(),
+            logs: []
+          }
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(result)
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+    )
+    await page.fill('@helm-editor', 'await Creator.find().limit(3)')
+    await page.click('@helm-run')
+    await page.wait('@helm-result-table')
+
+    expect(
+      await page.raw.locator('[data-test="helm-result-table"] tbody tr').count()
+    ).toBe(3)
+    expect(
+      await page.raw.locator('[data-test="helm-result-status"]').textContent()
+    ).toContain('3 rows')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-view-table"]')
+        .getAttribute('aria-pressed')
+    ).toBe('true')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-view-table"]')
+        .getAttribute('aria-label')
+    ).toBe('Table view')
+    expect(await page.raw.locator('[data-test="helm-logs"]').count()).toBe(0)
+    await page.screenshot('.tmp/issue-269-project-table-light.png')
+    await page.hover('@helm-view-table')
+    await page.wait(200)
+    expect(page).toSee('Table view')
+    await page.screenshot('.tmp/issue-269-project-view-tooltip-light.png')
+    await page.hover('@helm-editor')
+
+    await page.click('@helm-result-actions-trigger')
+    await page.screenshot('.tmp/issue-269-project-actions-light.png')
+    await page.click('@helm-result-actions-copy-json')
+    expect(await page.script(() => navigator.clipboard.readText())).toBe(
+      JSON.stringify(flatHelmResult().value, null, 2)
+    )
+    await page.raw
+      .getByText('Copied JSON to clipboard', { exact: true })
+      .locator('..')
+      .getByRole('button')
+      .click()
+
+    await page.click('@helm-result-actions-trigger')
+    const downloadStarted = page.raw.waitForEvent('download')
+    await page.click('@helm-result-actions-export-csv')
+    const download = await downloadStarted
+    expect(download.suggestedFilename()).toBe('helm-result.csv')
+    const csv = await readFile(await download.path(), 'utf8')
+    expect(csv.replace(/^\uFEFF/, '')).toContain("3,Grace Hopper,false,,,'=2+2")
+    await page.raw
+      .getByText('Exported helm-result.csv', { exact: true })
+      .locator('..')
+      .getByRole('button')
+      .click()
+    await page.wait(100)
+
+    await page.inDarkMode()
+    await page.click('@helm-editor')
+    await page.key('ControlOrMeta+a')
+    await page.raw.keyboard.type(
+      "console.log('Loaded the course and its chapters.')\n// Return nested course data\nawait Course.findOne().populate('chapters')"
+    )
+    await page.click('@helm-run')
+    await page.wait('@helm-result-tree')
+
+    const tree = page.raw.locator('[data-test="helm-result-tree"]')
+    await tree.locator('summary').filter({ hasText: 'course' }).click()
+    await tree.locator('summary').filter({ hasText: 'chapters' }).click()
+    await tree.locator('summary').filter({ hasText: '0' }).click()
+    expect(
+      await page.raw.locator('[data-test="helm-result-status"]').textContent()
+    ).toContain('Truncated')
+    await page.screenshot('.tmp/issue-269-project-tree-dark.png')
+
+    await page.click('@helm-view-raw')
+    await page.raw.locator('[data-test="helm-logs"] summary').click()
+    expect(
+      (await page.raw
+        .locator('[data-test="helm-logs"]')
+        .getAttribute('open')) === null
+    ).toBe(false)
+    const consoleBox = await page.raw
+      .locator('[data-test="helm-logs"]')
+      .boundingBox()
+    const statusBox = await page.raw
+      .locator('[data-test="helm-result-status"]')
+      .boundingBox()
+    expect(consoleBox.y < statusBox.y).toBe(true)
+    expect(consoleBox.height < 200).toBe(true)
+    expect(await page.raw.locator('[data-helm-xss]').count()).toBe(0)
+    expect(
+      await page.raw.locator('[data-test="helm-result-raw"]').textContent()
+    ).toContain('<img data-helm-xss')
+    await page.screenshot('.tmp/issue-269-project-raw-console-dark.png')
+    expect(
+      await page.raw.locator('[data-test="helm-history-entry"]').count()
+    ).toBe(2)
+    await page.click('@helm-clear-history')
+    expect(await page.raw.locator('[data-test="helm-history"]').count()).toBe(0)
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'Bosun Helm uses the same structured result viewer in dark mode',
+  {
+    browser: true,
+    world: helmWorld('helm-structured-bosun')
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route('**/api/v1/bosun/eval', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(flatHelmResult())
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inDarkMode()
+    await page.goto('/bosun?tab=console&mode=helm')
+    await page.fill('@bosun-helm-editor', 'await User.find().limit(3)')
+    await page.click('@bosun-console-run')
+    await page.wait('@bosun-helm-result-table')
+
+    expect(
+      await page.raw
+        .locator('[data-test="bosun-helm-result-table"] tbody tr')
+        .count()
+    ).toBe(3)
+    expect(
+      await page.raw
+        .locator('[data-test="bosun-helm-result-status"]')
+        .textContent()
+    ).toContain('3 rows')
+    await page.screenshot('.tmp/issue-269-bosun-table-dark.png')
     expect(page).toHaveNoSmoke()
   }
 )
@@ -388,6 +602,87 @@ test(
     expect(page).toHaveNoSmoke()
   }
 )
+
+function flatHelmResult() {
+  return {
+    success: true,
+    value: [
+      {
+        id: 1,
+        name: 'Ada Lovelace',
+        active: true,
+        lastSeenAt: {
+          type: 'Date',
+          value: '2026-07-29T09:24:00.000Z'
+        },
+        bio: null,
+        formula: 'plain text'
+      },
+      {
+        id: 2,
+        name: 'Linus Torvalds',
+        active: true,
+        lastSeenAt: {
+          type: 'Date',
+          value: '2026-07-29T10:16:00.000Z'
+        },
+        bio: 'Maintains a carefully bounded result viewer.',
+        formula: 'also plain'
+      },
+      {
+        id: 3,
+        name: 'Grace Hopper',
+        active: false,
+        lastSeenAt: null,
+        bio: null,
+        formula: '=2+2'
+      }
+    ],
+    logs: ['Fetched creators from the primary datastore.'],
+    output: 'Fetched creators from the primary datastore.',
+    error: null,
+    durationMs: 18,
+    truncated: false
+  }
+}
+
+function nestedHelmResult() {
+  return {
+    success: true,
+    value: {
+      course: {
+        title: 'Building production Sails applications',
+        published: true,
+        chapters: [
+          {
+            title: 'A reliable deployment path',
+            lessons: 6,
+            description:
+              '<img data-helm-xss src=x onerror="document.body.dataset.pwned=true">'
+          },
+          {
+            title: 'Making failures boring',
+            lessons: 4,
+            description: 'Logs, health checks, cutover, and rollback.'
+          }
+        ],
+        updatedAt: {
+          type: 'Date',
+          value: '2026-07-29T12:00:00.000Z'
+        }
+      },
+      release: {
+        version: '0.0.52',
+        ready: true
+      }
+    },
+    logs: ['Loaded the course and its chapters.'],
+    output: 'Loaded the course and its chapters.',
+    error: null,
+    durationMs: 23,
+    truncated: true
+  }
+}
 
 test(
   'Bosun Helm applies the same selection contract in dark mode',


### PR DESCRIPTION
## Summary
- add shared table, tree, and raw result views for Project Helm and Bosun Helm
- keep console output separate and bounded above the bottom result controls
- add safe JSON copy, compatible CSV export, clearable recent runs, and Dock-style view controls
- preserve typed values, truncation metadata, and inert returned HTML

## Verification
- npm run lint
- npm run test:unit (209 passing)
- npm run test:functional (57 passing)
- npx sounding test tests/e2e/pages/projects/helm.test.js --test-concurrency=1 (7 passing)

Closes #269