### PR TITLE
feat(helm): show execution errors inline

### DIFF
--- a/api/lib/helm-runtime.js
+++ b/api/lib/helm-runtime.js
@@ -164,6 +164,7 @@ function normalizeHostError(error) {
       line && column
         ? `${name}: ${message}\n    at ${VIRTUAL_FILENAME}:${line}:${column}`
         : error?.stack || null,
+    filename: line && column ? VIRTUAL_FILENAME : null,
     line,
     column
   }
@@ -730,7 +731,14 @@ async function helmSubprocessMain(options) {
       }
     }
 
-    return { name, message, stack, line, column }
+    return {
+      name,
+      message,
+      stack,
+      filename: line && column ? runtimeOptions.filename : null,
+      line,
+      column
+    }
   }
 
   function truncateEnvelope(serialized, result, maxBytes) {

--- a/assets/js/components/CodeEditor.vue
+++ b/assets/js/components/CodeEditor.vue
@@ -15,6 +15,7 @@ import {
   indentOnInput,
   syntaxHighlighting
 } from '@codemirror/language'
+import { setDiagnostics } from '@codemirror/lint'
 import {
   Compartment,
   EditorState,
@@ -24,6 +25,7 @@ import {
 import {
   Decoration,
   EditorView,
+  WidgetType,
   drawSelection,
   keymap,
   placeholder as editorPlaceholder
@@ -63,7 +65,33 @@ const languageCompartment = new Compartment()
 const appearanceCompartment = new Compartment()
 const editableCompartment = new Compartment()
 const setExecutedRange = StateEffect.define()
+const setInlineDiagnostic = StateEffect.define()
 const executedRangeMark = Decoration.mark({ class: 'cm-executed-range' })
+
+class InlineDiagnosticWidget extends WidgetType {
+  constructor(message) {
+    super()
+    this.message = message
+  }
+
+  eq(other) {
+    return other.message === this.message
+  }
+
+  toDOM() {
+    const label = document.createElement('span')
+    label.className = 'cm-inline-diagnostic'
+    label.textContent = this.message
+    label.title = this.message
+    label.setAttribute('aria-hidden', 'true')
+    return label
+  }
+
+  ignoreEvent() {
+    return true
+  }
+}
+
 const executedRangeField = StateField.define({
   create() {
     return Decoration.none
@@ -78,6 +106,34 @@ const executedRangeField = StateField.define({
         range && range.from < range.to
           ? Decoration.set([executedRangeMark.range(range.from, range.to)])
           : Decoration.none
+    }
+
+    return nextDecorations
+  },
+  provide(field) {
+    return EditorView.decorations.from(field)
+  }
+})
+const inlineDiagnosticField = StateField.define({
+  create() {
+    return Decoration.none
+  },
+  update(decorations, transaction) {
+    let nextDecorations = transaction.docChanged
+      ? Decoration.none
+      : decorations.map(transaction.changes)
+
+    for (const effect of transaction.effects) {
+      if (!effect.is(setInlineDiagnostic)) continue
+      const diagnostic = effect.value
+      nextDecorations = diagnostic
+        ? Decoration.set([
+            Decoration.widget({
+              widget: new InlineDiagnosticWidget(diagnostic.message),
+              side: 1
+            }).range(diagnostic.position)
+          ])
+        : Decoration.none
     }
 
     return nextDecorations
@@ -338,6 +394,98 @@ function highlightExecution(snapshot = getExecutionSnapshot()) {
   }, 700)
 }
 
+function showDiagnostic(diagnostic) {
+  if (!view) return
+
+  const range = resolveDiagnosticRange(view.state, diagnostic)
+  if (!range) {
+    clearDiagnostics()
+    return
+  }
+
+  const message = String(diagnostic.message || 'Execution failed')
+  view.dispatch(
+    setDiagnostics(view.state, [
+      {
+        from: range.from,
+        to: range.to,
+        severity: 'error',
+        source: diagnostic.source || 'Helm',
+        message
+      }
+    ]),
+    {
+      effects: [
+        setInlineDiagnostic.of({
+          position: range.lineTo,
+          message
+        }),
+        EditorView.scrollIntoView(range.from, { y: 'center' })
+      ]
+    }
+  )
+}
+
+function clearDiagnostics() {
+  if (!view) return
+  view.dispatch(setDiagnostics(view.state, []), {
+    effects: setInlineDiagnostic.of(null)
+  })
+}
+
+function resolveDiagnosticRange(state, diagnostic) {
+  const lineNumber = Number(diagnostic?.line)
+  const columnNumber = Number(diagnostic?.column)
+  if (
+    !Number.isSafeInteger(lineNumber) ||
+    !Number.isSafeInteger(columnNumber) ||
+    lineNumber < 1 ||
+    lineNumber > state.doc.lines ||
+    columnNumber < 1
+  ) {
+    return null
+  }
+
+  let line = state.doc.line(lineNumber)
+  let from = Math.min(line.to, line.from + columnNumber - 1)
+
+  if (from === line.to) {
+    const lastCodeOffset = line.text.search(/\s*$/) - 1
+    if (lastCodeOffset >= 0) {
+      from = line.from + lastCodeOffset
+    } else {
+      for (
+        let previousLine = lineNumber - 1;
+        previousLine >= 1;
+        previousLine--
+      ) {
+        const candidate = state.doc.line(previousLine)
+        const candidateOffset = candidate.text.search(/\s*$/) - 1
+        if (candidateOffset < 0) continue
+        line = candidate
+        from = candidate.from + candidateOffset
+        break
+      }
+    }
+  }
+
+  let to = Math.min(line.to, from + 1)
+  if (/[\w$]/.test(state.sliceDoc(from, to))) {
+    while (from > line.from && /[\w$]/.test(state.sliceDoc(from - 1, from))) {
+      from--
+    }
+    while (to < line.to && /[\w$]/.test(state.sliceDoc(to, to + 1))) {
+      to++
+    }
+  }
+
+  return {
+    from,
+    to,
+    lineTo: line.to
+  }
+}
+
 function focus() {
   view?.focus()
 }
@@ -361,6 +509,7 @@ onMounted(() => {
         history(),
         drawSelection(),
         executedRangeField,
+        inlineDiagnosticField,
         indentOnInput(),
         bracketMatching(),
         EditorView.lineWrapping,
@@ -430,9 +579,11 @@ onBeforeUnmount(() => {
 })
 
 defineExpose({
+  clearDiagnostics,
   focus,
   getExecutionSnapshot,
-  highlightExecution
+  highlightExecution,
+  showDiagnostic
 })
 </script>
 
@@ -480,9 +631,36 @@ defineExpose({
   box-shadow: inset 0 -1px color-mix(in srgb, var(--color-brand-500) 45%, transparent);
 }
 
+.code-editor :deep(.cm-lintRange-error) {
+  background-image: none;
+  text-decoration: underline wavy var(--color-red-500);
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+}
+
+.code-editor :deep(.cm-inline-diagnostic) {
+  display: inline-block;
+  max-width: min(24rem, 45vw);
+  margin-left: 0.75rem;
+  overflow: hidden;
+  color: var(--color-red-600);
+  font-family: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji';
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1rem;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 @media (prefers-color-scheme: dark) {
   .code-editor :deep(.cm-editor.cm-focused) {
     outline-color: var(--color-brand-800);
+  }
+
+  .code-editor :deep(.cm-inline-diagnostic) {
+    color: var(--color-red-400);
   }
 }
 </style>

--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -7,7 +7,6 @@ import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { highlightJSON } from '@/lib/highlightJSON'
 import {
-  formatHelmError,
   helmRowsToCsv,
   helmScalarPresentation,
   helmTableColumns,
@@ -88,12 +87,30 @@ const rawHighlighted = computed(() =>
 const treeEntries = computed(() =>
   structured.value ? Object.entries(value.value) : []
 )
+const structuredError = computed(() =>
+  props.result && !props.result.success && props.result.error
+    ? props.result.error
+    : null
+)
 const errorText = computed(
   () =>
     props.error ||
-    (props.result && !props.result.success
-      ? formatHelmError(props.result.error)
+    (structuredError.value
+      ? `${structuredError.value.name || 'Error'}: ${
+          structuredError.value.message || 'Execution failed'
+        }`
       : '')
+)
+const errorLocation = computed(() => {
+  const line = structuredError.value?.line
+  const column = structuredError.value?.column
+  if (!Number.isSafeInteger(line) || !Number.isSafeInteger(column)) return ''
+  return `Line ${line}, column ${column}`
+})
+const errorStack = computed(() =>
+  typeof structuredError.value?.stack === 'string'
+    ? structuredError.value.stack
+    : ''
 )
 const logs = computed(() =>
   Array.isArray(props.result?.logs) ? props.result.logs : []
@@ -208,12 +225,42 @@ function dismissToast(id) {
       </div>
 
       <template v-else-if="result || errorText">
-        <pre
+        <div
           v-if="errorText"
           :data-test="`${testId}-error`"
-          class="m-4 whitespace-pre-wrap rounded-md bg-red-50 px-3 py-2 font-mono text-sm leading-6 text-red-700 dark:bg-red-950/30 dark:text-red-400"
-          >{{ errorText }}</pre
+          class="px-4 py-3"
+          role="alert"
         >
+          <p
+            :data-test="`${testId}-error-summary`"
+            class="text-sm font-medium leading-5 text-red-700 dark:text-red-400"
+          >
+            {{ errorText }}
+          </p>
+          <p
+            v-if="errorLocation"
+            :data-test="`${testId}-error-location`"
+            class="mt-1 font-mono text-xs text-gray-500 dark:text-gray-400"
+          >
+            {{ errorLocation }}
+          </p>
+          <details
+            v-if="errorStack"
+            :data-test="`${testId}-error-stack`"
+            class="mt-3 text-xs"
+          >
+            <summary
+              class="w-fit cursor-pointer text-gray-500 outline-none hover:text-gray-700 focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-400 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
+            >
+              Stack trace
+            </summary>
+            <pre
+              :data-test="`${testId}-error-stack-content`"
+              class="mt-2 max-h-52 overflow-auto whitespace-pre-wrap font-mono leading-5 text-gray-600 dark:text-gray-400"
+              >{{ errorStack }}</pre
+            >
+          </details>
+        </div>
 
         <div
           v-else-if="activeView === 'table'"

--- a/assets/js/lib/helmResult.js
+++ b/assets/js/lib/helmResult.js
@@ -6,6 +6,7 @@ const TYPED_SCALAR_TYPES = new Set([
   'Symbol',
   'undefined'
 ])
+const HELM_INPUT_FILENAME = 'helm-input.js'
 
 function isObject(value) {
   return value !== null && typeof value === 'object'
@@ -109,6 +110,27 @@ export function formatHelmError(error, fallback = 'Execution failed') {
   const location =
     error.line && error.column ? ` (${error.line}:${error.column})` : ''
   return `${error.name || 'Error'}: ${error.message || fallback}${location}`
+}
+
+export function helmEditorDiagnostic(error) {
+  if (
+    !error ||
+    typeof error !== 'object' ||
+    error.filename !== HELM_INPUT_FILENAME ||
+    !Number.isSafeInteger(error.line) ||
+    !Number.isSafeInteger(error.column) ||
+    error.line < 1 ||
+    error.column < 1
+  ) {
+    return null
+  }
+
+  return {
+    line: error.line,
+    column: error.column,
+    message: `${error.name || 'Error'}: ${error.message || 'Execution failed'}`,
+    source: 'Helm'
+  }
 }
 
 export function helmRowsToCsv(rows, columns) {

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -20,7 +20,7 @@ import HelmResultViewer from '@/components/HelmResultViewer.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
 import { highlightJSON } from '@/lib/highlightJSON'
 import { highlightLogLine } from '@/lib/highlightLog'
-import { formatHelmError } from '@/lib/helmResult'
+import { formatHelmError, helmEditorDiagnostic } from '@/lib/helmResult'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 
 defineOptions({
@@ -203,6 +203,7 @@ async function executeHelm() {
   if (!execution?.hasExecutableSource || !canExecuteHelm.value) return
 
   helmEditor.value.highlightExecution(execution)
+  helmEditor.value.clearDiagnostics()
   helmEditor.value.focus()
   helmLoading.value = true
   helmError.value = null
@@ -231,6 +232,8 @@ async function executeHelm() {
     }
 
     if (!response.ok) {
+      const diagnostic = helmEditorDiagnostic(data?.error)
+      if (diagnostic) helmEditor.value.showDiagnostic(diagnostic)
       helmError.value =
         data?.message ||
         (data?.error ? formatHelmError(data.error) : null) ||
@@ -240,7 +243,8 @@ async function executeHelm() {
     }
 
     helmResults.value = data
-    if (!data.success) helmError.value = formatHelmError(data.error)
+    const diagnostic = helmEditorDiagnostic(data.error)
+    if (diagnostic) helmEditor.value.showDiagnostic(diagnostic)
 
     // Add to history (deduplicate)
     const executedSource = execution.source
@@ -254,6 +258,8 @@ async function executeHelm() {
     helmLoading.value = false
   }
 }
+
+watch(helmCode, () => helmEditor.value?.clearDiagnostics())
 
 function executeCurrentMode() {
   if (consoleMode.value === 'helm') {

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { Link, Head, usePage } from '@inertiajs/vue3'
-import { inject, ref, computed } from 'vue'
+import { inject, ref, computed, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import HelmResultViewer from '@/components/HelmResultViewer.vue'
+import { helmEditorDiagnostic } from '@/lib/helmResult'
 
 defineOptions({
   layout: AppLayout
@@ -49,6 +50,7 @@ async function execute() {
   if (!execution?.hasExecutableSource || !canExecute.value) return
 
   editor.value.highlightExecution(execution)
+  editor.value.clearDiagnostics()
   editor.value.focus()
   running.value = true
   executionResult.value = null
@@ -80,6 +82,8 @@ async function execute() {
     }
 
     if (!response.ok) {
+      const diagnostic = helmEditorDiagnostic(result.error)
+      if (diagnostic) editor.value.showDiagnostic(diagnostic)
       throw new Error(
         result.message ||
           result.error?.message ||
@@ -88,6 +92,8 @@ async function execute() {
       )
     }
     executionResult.value = result
+    const diagnostic = helmEditorDiagnostic(result.error)
+    if (diagnostic) editor.value.showDiagnostic(diagnostic)
 
     // Add to history
     history.value.unshift({
@@ -114,11 +120,14 @@ function loadFromHistory(entry) {
 function clearExecutionOutput() {
   executionResult.value = null
   requestError.value = ''
+  editor.value?.clearDiagnostics()
 }
 
 function clearHistory() {
   history.value = []
 }
+
+watch(code, () => editor.value?.clearDiagnostics())
 </script>
 <template>
   <Head

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lang-sql": "^6.10.0",
         "@codemirror/language": "^6.12.4",
+        "@codemirror/lint": "^6.9.7",
         "@codemirror/state": "^6.7.1",
         "@codemirror/view": "^6.43.6",
         "@inertiajs/vue3": "^3.4.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-sql": "^6.10.0",
     "@codemirror/language": "^6.12.4",
+    "@codemirror/lint": "^6.9.7",
     "@codemirror/state": "^6.7.1",
     "@codemirror/view": "^6.43.6",
     "@inertiajs/vue3": "^3.4.0",

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -217,15 +217,18 @@ test(
 )
 
 test(
-  'Helm renders structured runtime errors as source-oriented text',
+  'project Helm pins syntax and selected runtime failures to their source',
   {
     browser: true,
-    world: helmWorld('helm-structured-error')
+    world: helmWorld('helm-inline-diagnostics')
   },
   async ({ sails, world, login, page, expect }) => {
     const current = world.current
     const projectSlug = current.projects.deploymentTarget.slug
     const environmentSlug = current.environments.production.slug
+    const endpoint = `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`
+    const submitted = []
+    let runtimeAttempts = 0
 
     await sails.models.app.updateOne({ id: current.apps.web.id }).set({
       status: 'running',
@@ -238,48 +241,231 @@ test(
       password: current.auth.genesisUserPassword
     })
     await updateCheckFinished
-    await page.raw.route(
-      `**/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`,
-      async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            success: false,
-            value: null,
-            logs: ['checking creator'],
-            output: 'checking creator',
-            error: {
-              name: 'TypeError',
-              message: "Cannot read properties of null (reading 'publicId')",
-              stack: 'TypeError at helm-input.js:2:9',
-              line: 2,
-              column: 9
-            },
-            durationMs: 4,
-            truncated: false
-          })
-        })
-      }
-    )
+    await page.raw.route(`**${endpoint}`, async (route) => {
+      const request = route.request().postDataJSON()
+      submitted.push(request)
 
+      let result
+      if (request.code.includes('const broken =')) {
+        result = failedHelmResult({
+          name: 'SyntaxError',
+          message: 'Unexpected end of input',
+          line: 2,
+          column: 1,
+          frames: ['    at new Script (node:vm:117:7)'],
+          durationMs: 2
+        })
+      } else if (request.code.includes('creator.publicId')) {
+        runtimeAttempts += 1
+        result =
+          runtimeAttempts === 1
+            ? failedHelmResult({
+                name: 'TypeError',
+                message: "Cannot read properties of null (reading 'publicId')",
+                line: 3,
+                column: 9,
+                logs: ['checking creator'],
+                frames: ['    at node:vm:134:12'],
+                durationMs: 4
+              })
+            : {
+                success: true,
+                value: { recovered: true },
+                logs: [],
+                output: JSON.stringify({ recovered: true }, null, 2),
+                error: null,
+                durationMs: 3,
+                truncated: false
+              }
+      } else {
+        result = flatHelmResult()
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(result)
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
     await page.goto(
       `/projects/${projectSlug}/environments/${environmentSlug}/helm`
     )
-    await page.fill('@helm-editor', 'const creator = null\ncreator.publicId')
+    await page.fill('@helm-editor', 'const broken =\n')
     await page.click('@helm-run')
     await page.wait('@helm-error')
 
-    const errorText = await page.raw
-      .locator('[data-test="helm-error"]')
-      .textContent()
-    expect(errorText).toContain(
-      "TypeError: Cannot read properties of null (reading 'publicId') (2:9)"
+    expect(
+      await page.raw.locator('[data-test="helm-error-summary"]').textContent()
+    ).toBe('SyntaxError: Unexpected end of input')
+    expect(
+      await page.raw.locator('[data-test="helm-error-location"]').textContent()
+    ).toBe('Line 2, column 1')
+    expect(await page.raw.locator('.cm-inline-diagnostic').textContent()).toBe(
+      'SyntaxError: Unexpected end of input'
     )
-    expect(errorText.includes('[object Object]')).toBe(false)
+    expect(await page.raw.locator('.cm-lintRange-error').textContent()).toBe(
+      '='
+    )
+    expect(
+      await page.raw
+        .locator('[data-test="helm-error-stack"]')
+        .getAttribute('open')
+    ).toBe(null)
+    expect(
+      await page.raw
+        .locator('[data-test="helm-error-stack-content"]')
+        .isVisible()
+    ).toBe(false)
+    await page.screenshot('.tmp/issue-270-project-syntax-light.png')
+
+    await page.raw.locator('[data-test="helm-error-stack"] summary').click()
+    expect(
+      await page.raw
+        .locator('[data-test="helm-error-stack-content"]')
+        .isVisible()
+    ).toBe(true)
+    expect(
+      await page.raw
+        .locator('[data-test="helm-error-stack-content"]')
+        .textContent()
+    ).toContain('node:vm:117:7')
+    await page.screenshot('.tmp/issue-270-project-stack-light.png')
+
+    const documentSource = [
+      'const outsideSelection = true',
+      'const creator = null',
+      'creator.publicId'
+    ].join('\n')
+    const selectedSource = ['const creator = null', 'creator.publicId'].join(
+      '\n'
+    )
+    await page.fill('@helm-editor', documentSource)
+    expect(await page.raw.locator('.cm-lintRange-error').count()).toBe(0)
+    expect(await page.raw.locator('.cm-inline-diagnostic').count()).toBe(0)
+    await selectFromSecondLine(page)
+    await page.inDarkMode()
+    await page.click('@helm-run')
+    await page.wait('@helm-error')
+
+    expect(submitted[1]).toEqual({
+      code: selectedSource,
+      sourceStartLine: 2,
+      sourceStartColumn: 1
+    })
+    expect(await page.raw.locator('.cm-lintRange-error').textContent()).toBe(
+      'publicId'
+    )
+    expect(
+      await page.raw.locator('[data-test="helm-error-location"]').textContent()
+    ).toBe('Line 3, column 9')
     expect(
       await page.raw.locator('[data-test="helm-logs"]').textContent()
     ).toContain('checking creator')
+    await page.screenshot('.tmp/issue-270-project-selection-runtime-dark.png')
+
+    await page.key('ControlOrMeta+Enter')
+    await page.wait('@helm-output')
+    expect(submitted[2]).toEqual({
+      code: selectedSource,
+      sourceStartLine: 2,
+      sourceStartColumn: 1
+    })
+    expect(await page.raw.locator('.cm-lintRange-error').count()).toBe(0)
+    expect(await page.raw.locator('.cm-inline-diagnostic').count()).toBe(0)
+    expect(
+      await page.raw.locator('[data-test="helm-output"]').textContent()
+    ).toContain('recovered')
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'Bosun Helm uses the same inline diagnostics for rejected promises',
+  {
+    browser: true,
+    world: helmWorld('helm-inline-diagnostics-bosun')
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const submitted = []
+
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route('**/api/v1/bosun/eval', async (route) => {
+      const request = route.request().postDataJSON()
+      submitted.push(request)
+      const rejected = request.code.includes('Promise.reject')
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          rejected
+            ? failedHelmResult({
+                message: 'No user',
+                line: 1,
+                column: 26,
+                frames: ['    at node:vm:134:12']
+              })
+            : {
+                success: true,
+                value: { ready: true },
+                logs: [],
+                output: JSON.stringify({ ready: true }, null, 2),
+                error: null,
+                durationMs: 2,
+                truncated: false
+              }
+        )
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inDarkMode()
+    await page.goto('/bosun?tab=console&mode=helm')
+    await page.fill(
+      '@bosun-helm-editor',
+      "await Promise.reject(new Error('No user'))"
+    )
+    await page.click('@bosun-console-run')
+    await page.wait('@bosun-helm-error')
+
+    expect(submitted[0]).toEqual({
+      code: "await Promise.reject(new Error('No user'))",
+      sourceStartLine: 1,
+      sourceStartColumn: 1
+    })
+    expect(await page.raw.locator('.cm-lintRange-error').textContent()).toBe(
+      'Error'
+    )
+    expect(await page.raw.locator('.cm-inline-diagnostic').textContent()).toBe(
+      'Error: No user'
+    )
+    expect(
+      await page.raw
+        .locator('[data-test="bosun-helm-error-summary"]')
+        .textContent()
+    ).toBe('Error: No user')
+    expect(
+      await page.raw
+        .locator('[data-test="bosun-helm-error-stack"]')
+        .getAttribute('open')
+    ).toBe(null)
+    await page.screenshot('.tmp/issue-270-bosun-rejection-dark.png')
+
+    await page.fill('@bosun-helm-editor', 'return { ready: true }')
+    expect(await page.raw.locator('.cm-lintRange-error').count()).toBe(0)
+    expect(await page.raw.locator('.cm-inline-diagnostic').count()).toBe(0)
+    await page.click('@bosun-console-run')
+    await page.wait('@bosun-helm-output')
+    expect(await page.raw.locator('.cm-lintRange-error').count()).toBe(0)
     expect(page).toHaveNoSmoke()
   }
 )
@@ -642,6 +828,37 @@ function flatHelmResult() {
     output: 'Fetched creators from the primary datastore.',
     error: null,
     durationMs: 18,
+    truncated: false
+  }
+}
+
+function failedHelmResult({
+  name = 'Error',
+  message,
+  line,
+  column,
+  logs = [],
+  frames = [],
+  durationMs = 3
+}) {
+  return {
+    success: false,
+    value: null,
+    logs,
+    output: logs.join('\n') || null,
+    error: {
+      name,
+      message,
+      stack: [
+        `${name}: ${message}`,
+        `    at helm-input.js:${line}:${column}`,
+        ...frames
+      ].join('\n'),
+      filename: 'helm-input.js',
+      line,
+      column
+    },
+    durationMs,
     truncated: false
   }
 }

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -206,6 +206,7 @@ test('Helm maps syntax and runtime failures to helm-input.js', async ({
   const syntaxFailure = await runHelm(sails, 'const broken =\n')
   expect(syntaxFailure.success).toBe(false)
   expect(syntaxFailure.error.name).toBe('SyntaxError')
+  expect(syntaxFailure.error.filename).toBe('helm-input.js')
   expect(syntaxFailure.error.line).toBe(2)
   expect(syntaxFailure.error.column).toBe(1)
   expect(syntaxFailure.error.stack).toContain('helm-input.js:2:1')
@@ -216,6 +217,7 @@ test('Helm maps syntax and runtime failures to helm-input.js', async ({
   )
   expect(runtimeFailure.success).toBe(false)
   expect(runtimeFailure.error.name).toBe('TypeError')
+  expect(runtimeFailure.error.filename).toBe('helm-input.js')
   expect(runtimeFailure.error.line).toBe(2)
   expect(runtimeFailure.error.column).toBe(9)
   expect(runtimeFailure.error.stack).toContain('helm-input.js:2:9')
@@ -226,6 +228,7 @@ test('Helm maps syntax and runtime failures to helm-input.js', async ({
   )
   expect(rejectedPromise.success).toBe(false)
   expect(rejectedPromise.error.message).toBe('rejected')
+  expect(rejectedPromise.error.filename).toBe('helm-input.js')
   expect(rejectedPromise.error.line).toBe(1)
 })
 
@@ -238,6 +241,7 @@ test('Helm maps selected source failures back to the original editor', async ({
     sourceStartColumn: 5
   })
   expect(firstLineFailure.success).toBe(false)
+  expect(firstLineFailure.error.filename).toBe('helm-input.js')
   expect(firstLineFailure.error.line).toBe(12)
   expect(firstLineFailure.error.column).toBe(10)
   expect(firstLineFailure.error.stack).toContain('helm-input.js:12:10')
@@ -251,6 +255,7 @@ test('Helm maps selected source failures back to the original editor', async ({
     }
   )
   expect(laterLineFailure.success).toBe(false)
+  expect(laterLineFailure.error.filename).toBe('helm-input.js')
   expect(laterLineFailure.error.line).toBe(21)
   expect(laterLineFailure.error.column).toBe(9)
   expect(laterLineFailure.error.stack).toContain('helm-input.js:21:9')
@@ -260,6 +265,7 @@ test('Helm maps selected source failures back to the original editor', async ({
     sourceStartColumn: 4
   })
   expect(syntaxFailure.success).toBe(false)
+  expect(syntaxFailure.error.filename).toBe('helm-input.js')
   expect(syntaxFailure.error.line).toBe(30)
   expect(syntaxFailure.error.column).toBe(10)
   expect(syntaxFailure.error.stack).toContain('helm-input.js:30:10')


### PR DESCRIPTION
## Summary

- attach structured Helm failures to the exact CodeMirror token that produced them
- preserve full-document coordinates when running a selection
- keep the result pane focused on the source-level message and location, with the full stack available on demand
- clear stale diagnostics after edits and successful runs in both Project Helm and Bosun

## Impact

Helm failures now point developers directly to their code instead of leading with generated VM or wrapper frames. The strict `helm-input.js` contract prevents infrastructure failures from being misattributed to submitted source.

## Verification

- `npx sounding test tests/unit/helpers/helm/runtime.test.js --test-concurrency=1`
- `npx sounding test tests/functional/api/helm.test.js --test-concurrency=1`
- `npx sounding test tests/e2e/pages/projects/helm.test.js --test-concurrency=1`
- `npm run lint`
- Sounding screenshots reviewed in light and dark mode

Closes #270