### PR TITLE
feat(helm): add cancellation and execution status

### DIFF
--- a/api/controllers/api/v1/app/execute-code.js
+++ b/api/controllers/api/v1/app/execute-code.js
@@ -18,6 +18,12 @@ module.exports = {
       required: true,
       description: 'JavaScript code to execute'
     },
+    executionId: {
+      type: 'string',
+      required: true,
+      regex:
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    },
     sourceStartLine: {
       type: 'number',
       defaultsTo: 1,
@@ -55,6 +61,7 @@ module.exports = {
     projectSlug,
     environmentSlug,
     code,
+    executionId,
     sourceStartLine,
     sourceStartColumn,
     appSlug
@@ -90,11 +97,23 @@ module.exports = {
       throw { badRequest: 'App is not running.' }
     }
 
-    return sails.helpers.helm.executeInContainer(
-      app.containerName,
-      code,
-      sourceStartLine,
-      sourceStartColumn
+    const execution = sails.helpers.helm.beginExecution(
+      executionId,
+      this.req,
+      this.res
     )
+
+    try {
+      return await sails.helpers.helm.executeInContainer(
+        app.containerName,
+        code,
+        sourceStartLine,
+        sourceStartColumn,
+        executionId,
+        execution.signal
+      )
+    } finally {
+      execution.release()
+    }
   }
 }

--- a/api/controllers/api/v1/bosun/eval.js
+++ b/api/controllers/api/v1/bosun/eval.js
@@ -10,6 +10,12 @@ module.exports = {
       required: true,
       description: 'JavaScript code to evaluate'
     },
+    executionId: {
+      type: 'string',
+      required: true,
+      regex:
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    },
     sourceStartLine: {
       type: 'number',
       defaultsTo: 1,
@@ -33,11 +39,31 @@ module.exports = {
     }
   },
 
-  fn: async function ({ code, sourceStartLine, sourceStartColumn }) {
+  fn: async function ({
+    code,
+    executionId,
+    sourceStartLine,
+    sourceStartColumn
+  }) {
     if (!code.trim()) {
       throw { badRequest: 'Code cannot be empty.' }
     }
 
-    return sails.helpers.helm.evaluate(code, sourceStartLine, sourceStartColumn)
+    const execution = sails.helpers.helm.beginExecution(
+      executionId,
+      this.req,
+      this.res
+    )
+
+    try {
+      return await sails.helpers.helm.evaluate(
+        code,
+        sourceStartLine,
+        sourceStartColumn,
+        execution.signal
+      )
+    } finally {
+      execution.release()
+    }
   }
 }

--- a/api/controllers/api/v1/helm/cancel-execution.js
+++ b/api/controllers/api/v1/helm/cancel-execution.js
@@ -1,0 +1,29 @@
+module.exports = {
+  friendlyName: 'Cancel Helm execution',
+
+  description: 'Stop an active Helm execution owned by the current user.',
+
+  inputs: {
+    executionId: {
+      type: 'string',
+      required: true,
+      regex:
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    }
+  },
+
+  exits: {
+    success: {
+      statusCode: 200
+    }
+  },
+
+  fn: async function ({ executionId }) {
+    return {
+      cancelled: await sails.helpers.helm.cancelExecution(
+        executionId,
+        this.req.session.userId
+      )
+    }
+  }
+}

--- a/api/helpers/helm/begin-execution.js
+++ b/api/helpers/helm/begin-execution.js
@@ -1,0 +1,54 @@
+const helmExecutions = require('../../lib/helm-executions')
+
+module.exports = {
+  friendlyName: 'Begin Helm execution',
+
+  description:
+    'Register a user-scoped Helm execution and cancel it if its request disconnects.',
+
+  sync: true,
+
+  inputs: {
+    executionId: {
+      type: 'string',
+      required: true
+    },
+    req: {
+      type: 'ref',
+      required: true
+    },
+    res: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: function ({ executionId, req, res }) {
+    const execution = helmExecutions.register({
+      executionId,
+      userId: req.session.userId
+    })
+    const onResponseClose = () => {
+      if (!res.writableEnded) {
+        execution.abort(
+          'Helm execution was cancelled after its request closed.'
+        )
+      }
+    }
+    res.once('close', onResponseClose)
+
+    return {
+      signal: execution.signal,
+      release() {
+        res.off('close', onResponseClose)
+        execution.release()
+      }
+    }
+  }
+}

--- a/api/helpers/helm/cancel-execution.js
+++ b/api/helpers/helm/cancel-execution.js
@@ -1,0 +1,33 @@
+const helmExecutions = require('../../lib/helm-executions')
+
+module.exports = {
+  friendlyName: 'Cancel Helm execution',
+
+  description:
+    'Cancel an active Helm execution when it belongs to the requesting user.',
+
+  inputs: {
+    executionId: {
+      type: 'string',
+      required: true
+    },
+    userId: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'boolean'
+    }
+  },
+
+  fn: async function ({ executionId, userId }) {
+    return await helmExecutions.cancel({
+      executionId,
+      userId,
+      message: 'Helm execution was cancelled by the user.'
+    })
+  }
+}

--- a/api/helpers/helm/evaluate.js
+++ b/api/helpers/helm/evaluate.js
@@ -20,6 +20,10 @@ module.exports = {
       defaultsTo: 1,
       min: 1,
       max: 1000000
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal for user cancellation.'
     }
   },
 
@@ -29,13 +33,14 @@ module.exports = {
     }
   },
 
-  fn: async function ({ source, sourceStartLine, sourceStartColumn }) {
+  fn: async function ({ source, sourceStartLine, sourceStartColumn, signal }) {
     return sails.helpers.helm.run.with({
       command: process.execPath,
       source,
       sourceStartLine,
       sourceStartColumn,
-      bootstrapSails: true
+      bootstrapSails: true,
+      signal
     })
   }
 }

--- a/api/helpers/helm/execute-in-container.js
+++ b/api/helpers/helm/execute-in-container.js
@@ -24,6 +24,16 @@ module.exports = {
       defaultsTo: 1,
       min: 1,
       max: 1000000
+    },
+    executionId: {
+      type: 'string',
+      required: true,
+      regex:
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal for user cancellation.'
     }
   },
 
@@ -37,17 +47,52 @@ module.exports = {
     containerName,
     source,
     sourceStartLine,
-    sourceStartColumn
+    sourceStartColumn,
+    executionId,
+    signal
   }) {
     const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    let stopPromise
+    const stopContainerExecution = () => {
+      stopPromise ||= sails.helpers.helm.stopContainerExecution
+        .with({
+          containerName,
+          executionId
+        })
+        .catch(() => false)
+    }
 
-    return sails.helpers.helm.run.with({
-      command: dockerPath,
-      args: ['exec', '-i', containerName, 'node'],
-      source,
-      sourceStartLine,
-      sourceStartColumn,
-      bootstrapSails: true
-    })
+    if (signal) {
+      if (signal.aborted) stopContainerExecution()
+      else
+        signal.addEventListener('abort', stopContainerExecution, {
+          once: true
+        })
+    }
+
+    try {
+      return await sails.helpers.helm.run.with({
+        command: dockerPath,
+        args: [
+          'exec',
+          '-i',
+          '-e',
+          `SLIPWAY_HELM_EXECUTION_ID=${executionId}`,
+          containerName,
+          'node'
+        ],
+        source,
+        sourceStartLine,
+        sourceStartColumn,
+        bootstrapSails: true,
+        executionId,
+        signal
+      })
+    } finally {
+      if (signal) {
+        signal.removeEventListener('abort', stopContainerExecution)
+      }
+      if (stopPromise) await stopPromise
+    }
   }
 }

--- a/api/helpers/helm/run.js
+++ b/api/helpers/helm/run.js
@@ -40,6 +40,13 @@ module.exports = {
     timeoutMs: {
       type: 'number',
       min: 1
+    },
+    executionId: {
+      type: 'string'
+    },
+    signal: {
+      type: 'ref',
+      description: 'Optional AbortSignal for user cancellation.'
     }
   },
 
@@ -56,7 +63,9 @@ module.exports = {
     sourceStartLine,
     sourceStartColumn,
     bootstrapSails,
-    timeoutMs
+    timeoutMs,
+    executionId,
+    signal
   }) {
     const limits = sails.config.custom.helm
     const startedAt = Date.now()
@@ -82,7 +91,8 @@ module.exports = {
       bootstrapSails,
       timeoutMs: executionTimeoutMs,
       maxLogBytes: limits.maxLogBytes,
-      maxResultBytes: limits.maxResultBytes
+      maxResultBytes: limits.maxResultBytes,
+      executionId
     })
 
     try {
@@ -96,26 +106,39 @@ module.exports = {
         maxStdoutBytes: limits.maxProcessOutputBytes,
         maxStderrBytes: limits.maxProcessStderrBytes,
         captureStdout: true,
-        killGraceMs: limits.killGraceMs
+        killGraceMs: limits.killGraceMs,
+        signal
       })
 
       const result = helmRuntime.parseRunnerOutput(processResult.stdout)
       result.truncated ||=
         processResult.stdoutTruncated || processResult.stderrTruncated
-      return result
+      return helmRuntime.withResultMetadata(result)
     } catch (error) {
+      const partialLogs = helmRuntime.parseRunnerLogs(error?.stdout)
       const failure = helmRuntime.createFailureResult(
         normalizeProcessError(error, executionTimeoutMs),
-        Date.now() - startedAt
+        Date.now() - startedAt,
+        {
+          logs: partialLogs,
+          logsPartial: partialLogs.length > 0
+        }
       )
       failure.truncated =
         error?.stdoutTruncated === true || error?.stderrTruncated === true
-      return failure
+      return helmRuntime.withResultMetadata(failure)
     }
   }
 }
 
 function normalizeProcessError(error, timeoutMs) {
+  if (error?.code === 'HELM_CANCELLED' || error?.code === 'PROCESS_ABORTED') {
+    const cancelledError = new Error('Helm execution was cancelled.')
+    cancelledError.name = 'CancelledError'
+    cancelledError.code = 'HELM_CANCELLED'
+    return cancelledError
+  }
+
   if (error?.code !== 'PROCESS_TIMEOUT') return error
 
   const timeoutError = new Error(

--- a/api/helpers/helm/stop-container-execution.js
+++ b/api/helpers/helm/stop-container-execution.js
@@ -1,0 +1,71 @@
+const STOP_SCRIPT = `
+const fs = require('node:fs')
+const executionId = process.argv[1]
+const pidFile = '/tmp/slipway-helm-' + executionId + '.pid'
+
+try {
+  const pid = Number(fs.readFileSync(pidFile, 'utf8'))
+  const environment = fs.readFileSync('/proc/' + pid + '/environ')
+  const marker = Buffer.from('SLIPWAY_HELM_EXECUTION_ID=' + executionId + '\\0')
+
+  if (Number.isSafeInteger(pid) && pid > 1 && environment.includes(marker)) {
+    process.kill(pid, 'SIGKILL')
+  }
+} catch (error) {
+  if (!['ENOENT', 'ESRCH'].includes(error.code)) throw error
+} finally {
+  try {
+    fs.unlinkSync(pidFile)
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error
+  }
+}
+`
+
+module.exports = {
+  friendlyName: 'Stop container Helm execution',
+
+  description:
+    'Terminate the exact Helm Node process still running inside an app container.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    executionId: {
+      type: 'string',
+      required: true,
+      regex:
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'boolean'
+    }
+  },
+
+  fn: async function ({ containerName, executionId }) {
+    const limits = sails.config.custom.helm
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+
+    try {
+      await sails.helpers.streams.runProcess.with({
+        command: dockerPath,
+        args: ['exec', containerName, 'node', '-e', STOP_SCRIPT, executionId],
+        timeoutMs: Math.max(1000, limits.killGraceMs * 4),
+        maxOutputBytes: 1024,
+        maxStderrBytes: 4096,
+        killGraceMs: limits.killGraceMs
+      })
+      return true
+    } catch (error) {
+      sails.log.warn(
+        `Could not stop Helm execution ${executionId} in ${containerName}: ${error.message}`
+      )
+      return false
+    }
+  }
+}

--- a/api/helpers/streams/run-process.js
+++ b/api/helpers/streams/run-process.js
@@ -193,6 +193,10 @@ module.exports = {
     } catch (error) {
       terminate(child, killGraceMs)
       await Promise.allSettled([closePromise, inputPromise, outputPromise])
+      error.stdout = stdout.value()
+      error.stdoutTruncated = stdout.truncated()
+      error.stderr ||= stderr.value()
+      error.stderrTruncated ||= stderr.truncated()
       throw error
     } finally {
       interruption.cleanup()
@@ -245,8 +249,14 @@ function createInterruption({ signal, timeoutMs, onInterrupt }) {
   timeout.unref()
 
   const onAbort = () => {
-    const error = new Error('Process was cancelled.')
-    error.code = 'PROCESS_ABORTED'
+    const signalReason = signal?.reason
+    const error =
+      signalReason instanceof Error &&
+      typeof signalReason.code === 'string' &&
+      signalReason.code
+        ? signalReason
+        : new Error('Process was cancelled.')
+    error.code = error.code || 'PROCESS_ABORTED'
     interrupt(error)
   }
 

--- a/api/lib/helm-executions.js
+++ b/api/lib/helm-executions.js
@@ -1,0 +1,58 @@
+const activeExecutions = new Map()
+
+function register({ executionId, userId }) {
+  const key = String(executionId)
+  if (activeExecutions.has(key)) {
+    const error = new Error('A Helm execution with this ID is already active.')
+    error.code = 'HELM_EXECUTION_EXISTS'
+    throw error
+  }
+
+  const controller = new AbortController()
+  let markCompleted
+  const completed = new Promise((resolve) => {
+    markCompleted = resolve
+  })
+  const execution = {
+    completed,
+    controller,
+    userId: String(userId)
+  }
+  activeExecutions.set(key, execution)
+
+  return {
+    signal: controller.signal,
+    abort(message) {
+      abortExecution(controller, message)
+    },
+    release() {
+      if (activeExecutions.get(key) === execution) {
+        activeExecutions.delete(key)
+      }
+      markCompleted()
+    }
+  }
+}
+
+async function cancel({ executionId, userId, message }) {
+  const execution = activeExecutions.get(String(executionId))
+  if (!execution || execution.userId !== String(userId)) return false
+
+  abortExecution(execution.controller, message)
+  await execution.completed
+  return true
+}
+
+function abortExecution(controller, message) {
+  if (controller.signal.aborted) return
+
+  const error = new Error(message || 'Helm execution was cancelled.')
+  error.name = 'CancelledError'
+  error.code = 'HELM_CANCELLED'
+  controller.abort(error)
+}
+
+module.exports = {
+  cancel,
+  register
+}

--- a/api/lib/helm-runtime.js
+++ b/api/lib/helm-runtime.js
@@ -2,6 +2,7 @@ const acorn = require('acorn')
 
 const START_MARKER = '___SLIPWAY_HELM_RESULT_START___'
 const END_MARKER = '___SLIPWAY_HELM_RESULT_END___'
+const LOG_MARKER = '___SLIPWAY_HELM_LOG___'
 const VIRTUAL_FILENAME = 'helm-input.js'
 const MAX_SOURCE_COORDINATE = 1_000_000
 
@@ -106,7 +107,8 @@ function buildRunnerSource({
   bootstrapSails = true,
   timeoutMs = 30000,
   maxLogBytes = 64 * 1024,
-  maxResultBytes = 128 * 1024
+  maxResultBytes = 128 * 1024,
+  executionId
 }) {
   return `(${helmSubprocessMain.toString()})(${JSON.stringify({
     preparedSource,
@@ -117,8 +119,10 @@ function buildRunnerSource({
     timeoutMs,
     maxLogBytes,
     maxResultBytes,
+    executionId,
     startMarker: START_MARKER,
     endMarker: END_MARKER,
+    logMarker: LOG_MARKER,
     filename: VIRTUAL_FILENAME
   })})`
 }
@@ -138,17 +142,36 @@ function parseRunnerOutput(stdout) {
   return JSON.parse(payload)
 }
 
-function createFailureResult(error, durationMs = 0) {
+function parseRunnerLogs(stdout) {
+  return String(stdout || '')
+    .split('\n')
+    .filter((line) => line.startsWith(LOG_MARKER))
+    .map((line) => {
+      try {
+        return JSON.parse(line.slice(LOG_MARKER.length))
+      } catch {
+        return null
+      }
+    })
+    .filter((line) => typeof line === 'string')
+}
+
+function createFailureResult(
+  error,
+  durationMs = 0,
+  { logs = [], logsPartial = false } = {}
+) {
   const normalized = normalizeHostError(error)
-  return {
+  return withResultMetadata({
     success: false,
     value: null,
-    logs: [],
-    output: null,
+    logs,
+    output: logs.join('\n') || null,
     error: normalized,
     durationMs,
-    truncated: false
-  }
+    truncated: false,
+    logsPartial
+  })
 }
 
 function normalizeHostError(error) {
@@ -166,7 +189,28 @@ function normalizeHostError(error) {
         : error?.stack || null,
     filename: line && column ? VIRTUAL_FILENAME : null,
     line,
-    column
+    column,
+    code: error?.code || null
+  }
+}
+
+function withResultMetadata(result) {
+  const output =
+    typeof result.output === 'string' ? result.output : result.output || ''
+  const errorCode = result.error?.code
+
+  return {
+    ...result,
+    status: result.success
+      ? 'success'
+      : errorCode === 'HELM_TIMEOUT'
+      ? 'timeout'
+      : errorCode === 'HELM_CANCELLED'
+      ? 'cancelled'
+      : 'error',
+    rowCount: Array.isArray(result.value) ? result.value.length : null,
+    outputBytes: Buffer.byteLength(String(output)),
+    logsPartial: result.logsPartial === true
   }
 }
 
@@ -228,6 +272,7 @@ function formatBytes(bytes) {
 }
 
 async function helmSubprocessMain(options) {
+  const fs = require('node:fs')
   const vm = require('node:vm')
   const startedAt = Date.now()
   let sailsApp
@@ -237,6 +282,13 @@ async function helmSubprocessMain(options) {
   const logs = []
   let logBytes = 0
   let logsTruncated = false
+  const pidFile = options.executionId
+    ? `/tmp/slipway-helm-${options.executionId}.pid`
+    : null
+
+  if (pidFile) {
+    fs.writeFileSync(pidFile, String(process.pid), { mode: 0o600 })
+  }
 
   const timeoutError = () => {
     const error = new Error(
@@ -305,6 +357,9 @@ async function helmSubprocessMain(options) {
       logs.push(bounded.value)
       logBytes += separatorBytes + Buffer.byteLength(bounded.value)
       logsTruncated ||= bounded.truncated
+      process.stdout.write(
+        `${options.logMarker}${JSON.stringify(bounded.value)}\n`
+      )
     }
 
     const context = {
@@ -381,15 +436,18 @@ async function helmSubprocessMain(options) {
 
     if (value !== undefined) outputParts.push(valueResult.output)
 
-    sendResult({
-      success: true,
-      value: valueResult.value,
-      logs,
-      output: outputParts.join('\n') || '(no output)',
-      error: null,
-      durationMs: Date.now() - startedAt,
-      truncated: logsTruncated || valueResult.truncated
-    })
+    sendResult(
+      completeResult({
+        success: true,
+        value: valueResult.value,
+        logs,
+        output: outputParts.join('\n') || '(no output)',
+        error: null,
+        durationMs: Date.now() - startedAt,
+        truncated: logsTruncated || valueResult.truncated,
+        logsPartial: false
+      })
+    )
   } catch (error) {
     sendResult(failureResult(isVmTimeout(error) ? timeoutError() : error))
   } finally {
@@ -398,14 +456,31 @@ async function helmSubprocessMain(options) {
   }
 
   function failureResult(error) {
-    return {
+    return completeResult({
       success: false,
       value: null,
       logs,
       output: logs.join('\n') || null,
       error: normalizeRuntimeError(error, options),
       durationMs: Date.now() - startedAt,
-      truncated: logsTruncated
+      truncated: logsTruncated,
+      logsPartial: false
+    })
+  }
+
+  function completeResult(result) {
+    return {
+      ...result,
+      status: result.success
+        ? 'success'
+        : result.error?.code === 'HELM_TIMEOUT'
+        ? 'timeout'
+        : result.error?.code === 'HELM_CANCELLED'
+        ? 'cancelled'
+        : 'error',
+      rowCount: Array.isArray(result.value) ? result.value.length : null,
+      outputBytes: Buffer.byteLength(String(result.output || '')),
+      logsPartial: result.logsPartial === true
     }
   }
 
@@ -438,6 +513,16 @@ async function helmSubprocessMain(options) {
         ])
       } catch {
         // The process is isolated and must still terminate if lowering fails.
+      }
+    }
+
+    if (pidFile) {
+      try {
+        fs.unlinkSync(pidFile)
+      } catch (error) {
+        if (error.code !== 'ENOENT') {
+          // Process isolation still makes termination the safe final state.
+        }
       }
     }
 
@@ -737,7 +822,8 @@ async function helmSubprocessMain(options) {
       stack,
       filename: line && column ? runtimeOptions.filename : null,
       line,
-      column
+      column,
+      code: safeString(readErrorProperty(error, 'code', ''), '') || null
     }
   }
 
@@ -787,7 +873,11 @@ async function helmSubprocessMain(options) {
             }
           : null,
         durationMs: result.durationMs,
-        truncated: true
+        truncated: true,
+        status: result.status,
+        rowCount: result.rowCount,
+        outputBytes: result.outputBytes,
+        logsPartial: result.logsPartial
       }),
       truncated: true
     }
@@ -873,10 +963,13 @@ async function helmSubprocessMain(options) {
 
 module.exports = {
   END_MARKER,
+  LOG_MARKER,
   START_MARKER,
   VIRTUAL_FILENAME,
   buildRunnerSource,
   createFailureResult,
+  parseRunnerLogs,
   parseRunnerOutput,
-  prepareSource
+  prepareSource,
+  withResultMetadata
 }

--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, ref, watch } from 'vue'
+import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import HelmResultTreeNode from '@/components/HelmResultTreeNode.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
@@ -41,6 +41,9 @@ const emit = defineEmits(['clear'])
 const activeView = ref('raw')
 const logsOpen = ref(false)
 const toasts = ref([])
+const runningDurationMs = ref(0)
+let runningStartedAt = 0
+let runningTimer
 let toastId = 0
 
 const value = computed(() => props.result?.value)
@@ -96,9 +99,11 @@ const errorText = computed(
   () =>
     props.error ||
     (structuredError.value
-      ? `${structuredError.value.name || 'Error'}: ${
-          structuredError.value.message || 'Execution failed'
-        }`
+      ? ['cancelled', 'timeout'].includes(props.result?.status)
+        ? structuredError.value.message || 'Execution stopped.'
+        : `${structuredError.value.name || 'Error'}: ${
+            structuredError.value.message || 'Execution failed'
+          }`
       : '')
 )
 const errorLocation = computed(() => {
@@ -118,17 +123,60 @@ const logs = computed(() =>
 const metadata = computed(() => {
   if (!props.result) return []
 
-  const items = []
-  if (tableCompatible.value) {
-    items.push(`${rows.value.length} row${rows.value.length === 1 ? '' : 's'}`)
-  } else {
-    items.push(props.result.success ? 'Success' : 'Error')
+  const status =
+    props.result.status || (props.result.success ? 'success' : 'error')
+  const labels = {
+    cancelled: 'Cancelled',
+    error: 'Error',
+    success: 'Success',
+    timeout: 'Timed out'
   }
-  if (props.result.truncated) items.push('Truncated')
+  const items = [
+    {
+      label: labels[status] || labels.error,
+      tone:
+        status === 'success'
+          ? 'success'
+          : status === 'cancelled'
+          ? 'neutral'
+          : status === 'timeout'
+          ? 'warning'
+          : 'danger'
+    }
+  ]
+  const rowCount = Number.isSafeInteger(props.result.rowCount)
+    ? props.result.rowCount
+    : tableCompatible.value
+    ? rows.value.length
+    : null
+  if (rowCount !== null) {
+    items.push({
+      label: `${rowCount} row${rowCount === 1 ? '' : 's'}`
+    })
+  }
+  const outputBytes = Number.isFinite(props.result.outputBytes)
+    ? props.result.outputBytes
+    : new TextEncoder().encode(String(props.result.output || '')).length
+  items.push({ label: formatBytes(outputBytes) })
+  if (props.result.truncated) {
+    items.push({ label: 'Truncated', tone: 'warning' })
+  }
+  if (props.result.logsPartial) {
+    items.push({ label: 'Partial console', tone: 'warning' })
+  }
   if (Number.isFinite(props.result.durationMs)) {
-    items.push(`${props.result.durationMs}ms`)
+    items.push({ label: formatDuration(props.result.durationMs) })
   }
   return items
+})
+const errorSummaryClasses = computed(() => {
+  if (props.result?.status === 'cancelled') {
+    return 'text-gray-700 dark:text-gray-300'
+  }
+  if (props.result?.status === 'timeout') {
+    return 'text-amber-700 dark:text-amber-400'
+  }
+  return 'text-red-700 dark:text-red-400'
 })
 const actionItems = computed(() => {
   const items = []
@@ -158,6 +206,46 @@ watch(
   },
   { immediate: true }
 )
+
+watch(
+  () => props.loading,
+  (loading) => {
+    clearInterval(runningTimer)
+    runningTimer = null
+
+    if (!loading) return
+    runningStartedAt = performance.now()
+    runningDurationMs.value = 0
+    runningTimer = setInterval(() => {
+      runningDurationMs.value = Math.round(performance.now() - runningStartedAt)
+    }, 100)
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => clearInterval(runningTimer))
+
+function formatDuration(durationMs) {
+  if (durationMs < 1000) return `${Math.max(0, Math.round(durationMs))}ms`
+  return `${(durationMs / 1000).toFixed(durationMs < 10000 ? 1 : 0)}s`
+}
+
+function formatBytes(bytes) {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function metadataClasses(tone) {
+  return {
+    danger: 'font-medium text-red-600 dark:text-red-400',
+    neutral: 'font-medium text-gray-600 dark:text-gray-300',
+    success: 'font-medium text-green-600 dark:text-green-400',
+    warning: 'font-medium text-amber-600 dark:text-amber-400'
+  }[tone]
+}
 
 function scalarClasses(type) {
   return {
@@ -217,11 +305,14 @@ function dismissToast(id) {
     >
       <div
         v-if="loading"
-        class="flex h-full items-center justify-center"
+        class="flex h-full items-center justify-center gap-2 text-sm text-gray-500 dark:text-gray-400"
         aria-live="polite"
         aria-label="Running Helm"
       >
         <SlippyLoader size="h-4 w-4" />
+        <span :data-test="`${testId}-running-status`"
+          >Running &middot; {{ formatDuration(runningDurationMs) }}</span
+        >
       </div>
 
       <template v-else-if="result || errorText">
@@ -229,11 +320,11 @@ function dismissToast(id) {
           v-if="errorText"
           :data-test="`${testId}-error`"
           class="px-4 py-3"
-          role="alert"
+          :role="result?.status === 'cancelled' ? 'status' : 'alert'"
         >
           <p
             :data-test="`${testId}-error-summary`"
-            class="text-sm font-medium leading-5 text-red-700 dark:text-red-400"
+            :class="['text-sm font-medium leading-5', errorSummaryClasses]"
           >
             {{ errorText }}
           </p>
@@ -380,7 +471,8 @@ function dismissToast(id) {
       >
         Console
         <span class="font-normal text-gray-400 dark:text-gray-600"
-          >{{ logs.length }} line{{ logs.length === 1 ? '' : 's' }}</span
+          >{{ logs.length }} line{{ logs.length === 1 ? '' : 's'
+          }}{{ result?.logsPartial ? ' · partial' : '' }}</span
         >
       </summary>
       <pre
@@ -467,15 +559,11 @@ function dismissToast(id) {
           class="truncate text-xs text-gray-500 dark:text-gray-400"
           aria-live="polite"
         >
-          <template v-for="(item, index) in metadata" :key="item">
-            <span
-              :class="
-                item === 'Truncated'
-                  ? 'font-medium text-amber-600 dark:text-amber-400'
-                  : ''
-              "
-              >{{ item }}</span
-            >
+          <template
+            v-for="(item, index) in metadata"
+            :key="`${item.label}-${index}`"
+          >
+            <span :class="metadataClasses(item.tone)">{{ item.label }}</span>
             <span
               v-if="index < metadata.length - 1"
               aria-hidden="true"

--- a/assets/js/lib/helmExecution.js
+++ b/assets/js/lib/helmExecution.js
@@ -1,0 +1,49 @@
+export async function cancelHelmExecution(executionId, csrfToken = '') {
+  const response = await fetch(
+    `/api/v1/helm/executions/${executionId}/cancel`,
+    {
+      method: 'POST',
+      headers: csrfToken ? { 'x-csrf-token': csrfToken } : {}
+    }
+  )
+  const text = await response.text()
+  let result
+
+  try {
+    result = text ? JSON.parse(text) : {}
+  } catch {
+    throw new Error(text || 'Could not stop Helm execution.')
+  }
+
+  if (!response.ok) {
+    throw new Error(
+      result.message || result.error || 'Could not stop Helm execution.'
+    )
+  }
+
+  return result.cancelled === true
+}
+
+export function cancelledHelmResult(durationMs) {
+  return {
+    success: false,
+    status: 'cancelled',
+    value: null,
+    logs: [],
+    output: null,
+    outputBytes: 0,
+    rowCount: null,
+    error: {
+      name: 'CancelledError',
+      message: 'Helm execution was cancelled.',
+      stack: null,
+      filename: null,
+      line: null,
+      column: null,
+      code: 'HELM_CANCELLED'
+    },
+    durationMs,
+    truncated: false,
+    logsPartial: false
+  }
+}

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Head } from '@inertiajs/vue3'
+import { Head, usePage } from '@inertiajs/vue3'
 import {
   ref,
   computed,
@@ -22,6 +22,7 @@ import { highlightJSON } from '@/lib/highlightJSON'
 import { highlightLogLine } from '@/lib/highlightLog'
 import { formatHelmError, helmEditorDiagnostic } from '@/lib/helmResult'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
 
 defineOptions({
   layout: AppLayout
@@ -38,6 +39,7 @@ const props = defineProps({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
+const page = usePage()
 
 // ─── Tab management (matches Dock pattern: init from URL, sync via watcher) ───
 const validTabs = ['overview', 'environment', 'console', 'migrate', 'activity']
@@ -117,12 +119,15 @@ const helmCode = ref('// Access Slipway models and helpers\nawait User.find()')
 const helmResults = ref(null)
 const helmError = ref(null)
 const helmLoading = ref(false)
+const helmStopping = ref(false)
 const helmHistory = ref([])
 const helmEditor = ref(null)
 const helmSelection = ref({
   hasSelection: false,
   hasExecutableSelection: false
 })
+let helmExecutionSequence = 0
+let activeHelmExecution = null
 const helmRunLabel = computed(() =>
   helmSelection.value.hasSelection ? 'Run selection' : 'Run'
 )
@@ -205,7 +210,14 @@ async function executeHelm() {
   helmEditor.value.highlightExecution(execution)
   helmEditor.value.clearDiagnostics()
   helmEditor.value.focus()
+  const currentExecution = {
+    id: crypto.randomUUID(),
+    sequence: ++helmExecutionSequence,
+    startedAt: performance.now()
+  }
+  activeHelmExecution = currentExecution
   helmLoading.value = true
+  helmStopping.value = false
   helmError.value = null
   helmResults.value = null
 
@@ -214,6 +226,7 @@ async function executeHelm() {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
+        executionId: currentExecution.id,
         code: execution.source,
         sourceStartLine: execution.startLine,
         sourceStartColumn: execution.startColumn
@@ -232,6 +245,7 @@ async function executeHelm() {
     }
 
     if (!response.ok) {
+      if (activeHelmExecution?.sequence !== currentExecution.sequence) return
       const diagnostic = helmEditorDiagnostic(data?.error)
       if (diagnostic) helmEditor.value.showDiagnostic(diagnostic)
       helmError.value =
@@ -241,6 +255,8 @@ async function executeHelm() {
         'Evaluation failed'
       return
     }
+
+    if (activeHelmExecution?.sequence !== currentExecution.sequence) return
 
     helmResults.value = data
     const diagnostic = helmEditorDiagnostic(data.error)
@@ -253,9 +269,45 @@ async function executeHelm() {
       ...helmHistory.value.filter((source) => source !== executedSource)
     ].slice(0, 20)
   } catch (err) {
+    if (activeHelmExecution?.sequence !== currentExecution.sequence) return
     helmError.value = err.message || 'Network error'
   } finally {
+    if (activeHelmExecution?.sequence === currentExecution.sequence) {
+      helmLoading.value = false
+      helmStopping.value = false
+    }
+  }
+}
+
+async function stopHelmExecution() {
+  const currentExecution = activeHelmExecution
+  if (!currentExecution || !helmLoading.value || helmStopping.value) return
+
+  helmStopping.value = true
+  helmError.value = null
+
+  try {
+    const cancelled = await cancelHelmExecution(
+      currentExecution.id,
+      page.props._csrf || ''
+    )
+    if (!cancelled) {
+      throw new Error('This Helm execution has already finished.')
+    }
+    if (activeHelmExecution?.sequence !== currentExecution.sequence) return
+    if (!helmLoading.value && helmResults.value?.status === 'cancelled') return
+
+    helmResults.value = cancelledHelmResult(
+      Math.round(performance.now() - currentExecution.startedAt)
+    )
     helmLoading.value = false
+  } catch (error) {
+    if (activeHelmExecution?.sequence !== currentExecution.sequence) return
+    helmError.value = error.message || 'Could not stop Helm execution.'
+  } finally {
+    if (activeHelmExecution?.sequence === currentExecution.sequence) {
+      helmStopping.value = false
+    }
   }
 }
 
@@ -263,7 +315,8 @@ watch(helmCode, () => helmEditor.value?.clearDiagnostics())
 
 function executeCurrentMode() {
   if (consoleMode.value === 'helm') {
-    executeHelm()
+    if (helmLoading.value) stopHelmExecution()
+    else executeHelm()
   } else {
     executeQuery()
   }
@@ -904,8 +957,9 @@ onUnmounted(() => {
           >
             <button
               @click="consoleMode = 'sql'"
+              :disabled="consoleLoading || helmLoading"
               :class="[
-                'rounded px-2 py-0.5 text-xs font-medium transition-colors',
+                'rounded px-2 py-0.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
                 consoleMode === 'sql'
                   ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
                   : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
@@ -915,8 +969,9 @@ onUnmounted(() => {
             </button>
             <button
               @click="consoleMode = 'helm'"
+              :disabled="consoleLoading || helmLoading"
               :class="[
-                'rounded px-2 py-0.5 text-xs font-medium transition-colors',
+                'rounded px-2 py-0.5 text-xs font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50',
                 consoleMode === 'helm'
                   ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
                   : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
@@ -961,6 +1016,8 @@ onUnmounted(() => {
           :disabled="
             consoleMode === 'sql'
               ? consoleLoading || !sqlQuery.trim()
+              : helmLoading
+              ? helmStopping
               : !canExecuteHelm
           "
           :title="
@@ -970,9 +1027,29 @@ onUnmounted(() => {
                 }+Enter`
               : 'Run · ⌘+Enter'
           "
-          class="rounded-md bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+          :class="[
+            'flex items-center gap-1.5 rounded-md px-4 py-1.5 text-sm font-medium text-white disabled:opacity-50',
+            consoleMode === 'helm' && helmLoading
+              ? 'bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500'
+              : 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
+          ]"
         >
-          <span v-if="consoleLoading || helmLoading">Running...</span>
+          <SlippyLoader
+            v-if="consoleLoading || helmStopping"
+            size="h-3.5 w-3.5"
+          />
+          <svg
+            v-else-if="consoleMode === 'helm' && helmLoading"
+            class="h-3.5 w-3.5"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            aria-hidden="true"
+          >
+            <rect x="5" y="5" width="10" height="10" rx="1" />
+          </svg>
+          <span v-if="consoleLoading">Running...</span>
+          <span v-else-if="helmStopping">Stopping...</span>
+          <span v-else-if="consoleMode === 'helm' && helmLoading">Stop</span>
           <span v-else>{{
             consoleMode === 'helm' ? helmRunLabel : 'Run'
           }}</span>

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -6,6 +6,7 @@ import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import HelmResultViewer from '@/components/HelmResultViewer.vue'
 import { helmEditorDiagnostic } from '@/lib/helmResult'
+import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
 
 defineOptions({
   layout: AppLayout
@@ -26,12 +27,15 @@ const code = ref('// Access your Sails models, helpers, and config\n')
 const executionResult = ref(null)
 const requestError = ref('')
 const running = ref(false)
+const stopping = ref(false)
 const history = ref([])
 const editor = ref(null)
 const editorSelection = ref({
   hasSelection: false,
   hasExecutableSelection: false
 })
+let executionSequence = 0
+let activeExecution = null
 
 const isRunning = computed(() => props.appStatus === 'running')
 const runLabel = computed(() =>
@@ -52,7 +56,16 @@ async function execute() {
   editor.value.highlightExecution(execution)
   editor.value.clearDiagnostics()
   editor.value.focus()
+  const currentExecution = {
+    id: crypto.randomUUID(),
+    sequence: ++executionSequence,
+    startedAt: performance.now(),
+    source: execution.source,
+    historyRecorded: false
+  }
+  activeExecution = currentExecution
   running.value = true
+  stopping.value = false
   executionResult.value = null
   requestError.value = ''
 
@@ -66,6 +79,7 @@ async function execute() {
           'x-csrf-token': page.props._csrf || ''
         },
         body: JSON.stringify({
+          executionId: currentExecution.id,
           code: execution.source,
           sourceStartLine: execution.startLine,
           sourceStartColumn: execution.startColumn
@@ -91,26 +105,80 @@ async function execute() {
           'Execution failed'
       )
     }
+    if (activeExecution?.sequence !== currentExecution.sequence) return
+
     executionResult.value = result
     const diagnostic = helmEditorDiagnostic(result.error)
     if (diagnostic) editor.value.showDiagnostic(diagnostic)
 
-    // Add to history
-    history.value.unshift({
-      code: execution.source,
-      success: result.success,
-      time: new Date()
-    })
-
-    // Keep only last 20 entries
-    if (history.value.length > 20) {
-      history.value = history.value.slice(0, 20)
-    }
+    recordHistory(currentExecution, result)
   } catch (err) {
+    if (activeExecution?.sequence !== currentExecution.sequence) return
     requestError.value = err.message || 'Network error'
   } finally {
-    running.value = false
+    if (activeExecution?.sequence === currentExecution.sequence) {
+      running.value = false
+      stopping.value = false
+    }
   }
+}
+
+async function stopExecution() {
+  const currentExecution = activeExecution
+  if (!currentExecution || !running.value || stopping.value) return
+
+  stopping.value = true
+  requestError.value = ''
+
+  try {
+    const cancelled = await cancelHelmExecution(
+      currentExecution.id,
+      page.props._csrf || ''
+    )
+    if (!cancelled) {
+      throw new Error('This Helm execution has already finished.')
+    }
+    if (activeExecution?.sequence !== currentExecution.sequence) return
+    if (!running.value && executionResult.value?.status === 'cancelled') return
+
+    const result = cancelledHelmResult(
+      Math.round(performance.now() - currentExecution.startedAt)
+    )
+    executionResult.value = result
+    recordHistory(currentExecution, result)
+    running.value = false
+  } catch (error) {
+    if (activeExecution?.sequence !== currentExecution.sequence) return
+    requestError.value = error.message || 'Could not stop Helm execution.'
+  } finally {
+    if (activeExecution?.sequence === currentExecution.sequence) {
+      stopping.value = false
+    }
+  }
+}
+
+function runOrStop() {
+  if (running.value) stopExecution()
+  else execute()
+}
+
+function historyStatusClass(entry) {
+  if (entry.status === 'cancelled') return 'bg-gray-400'
+  if (entry.status === 'timeout' || entry.truncated) return 'bg-amber-500'
+  return entry.success ? 'bg-green-500' : 'bg-red-500'
+}
+
+function recordHistory(execution, result) {
+  if (execution.historyRecorded) return
+  execution.historyRecorded = true
+  history.value.unshift({
+    code: execution.source,
+    success: result.success,
+    status: result.status,
+    truncated: result.truncated,
+    time: new Date()
+  })
+  history.value = history.value.slice(0, 20)
 }
 
 function loadFromHistory(entry) {
@@ -289,21 +357,39 @@ watch(code, () => editor.value?.clearDiagnostics())
         <!-- Run button -->
         <button
           data-test="helm-run"
-          @click="execute"
-          :disabled="!canExecute"
-          class="flex items-center space-x-1.5 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 sm:px-3"
-          :title="`${runLabel} · ${
-            navigator?.platform?.includes('Mac') ? '⌘' : 'Ctrl'
-          }+Enter`"
+          @click="runOrStop"
+          :disabled="running ? stopping : !canExecute"
+          :class="[
+            'flex items-center space-x-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-white disabled:opacity-50 sm:px-3',
+            running
+              ? 'bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500'
+              : 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
+          ]"
+          :title="
+            running
+              ? 'Stop execution'
+              : `${runLabel} · ${
+                  navigator?.platform?.includes('Mac') ? '⌘' : 'Ctrl'
+                }+Enter`
+          "
         >
-          <SlippyLoader v-if="running" size="h-3 w-3" />
+          <SlippyLoader v-if="stopping" size="h-3 w-3" />
+          <svg
+            v-else-if="running"
+            class="h-3 w-3"
+            fill="currentColor"
+            viewBox="0 0 20 20"
+            aria-hidden="true"
+          >
+            <rect x="5" y="5" width="10" height="10" rx="1" />
+          </svg>
           <svg v-else class="h-3 w-3" fill="currentColor" viewBox="0 0 20 20">
             <path
               d="M6.3 2.841A1.5 1.5 0 004 4.11V15.89a1.5 1.5 0 002.3 1.269l9.344-5.89a1.5 1.5 0 000-2.538L6.3 2.84z"
             />
           </svg>
           <span class="hidden sm:inline">{{
-            running ? 'Running' : runLabel
+            stopping ? 'Stopping' : running ? 'Stop' : runLabel
           }}</span>
         </button>
 
@@ -416,7 +502,7 @@ watch(code, () => editor.value?.clearDiagnostics())
               <span
                 :class="[
                   'ml-2 h-1.5 w-1.5 shrink-0 rounded-full',
-                  entry.success ? 'bg-green-500' : 'bg-red-500'
+                  historyStatusClass(entry)
                 ]"
               ></span>
             </button>

--- a/config/routes.js
+++ b/config/routes.js
@@ -471,6 +471,8 @@ module.exports.routes = {
   'GET /api/v1/bosun/diff': 'api/v1/bosun/get-diff',
   'POST /api/v1/bosun/migrate': 'api/v1/bosun/apply-migration',
   'POST /api/v1/bosun/eval': 'api/v1/bosun/eval',
+  'POST /api/v1/helm/executions/:executionId/cancel':
+    'api/v1/helm/cancel-execution',
   'GET /api/v1/bosun/activity': 'api/v1/bosun/get-activity',
   'PATCH /api/v1/bosun/env': 'api/v1/bosun/update-env',
   'GET /api/v1/bosun/logs/stream': 'api/v1/bosun/stream-instance-logs',

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -350,7 +350,7 @@ test(
     await page.click('@helm-run')
     await page.wait('@helm-error')
 
-    expect(submitted[1]).toEqual({
+    expectHelmSubmission(expect, submitted[1], {
       code: selectedSource,
       sourceStartLine: 2,
       sourceStartColumn: 1
@@ -368,7 +368,7 @@ test(
 
     await page.key('ControlOrMeta+Enter')
     await page.wait('@helm-output')
-    expect(submitted[2]).toEqual({
+    expectHelmSubmission(expect, submitted[2], {
       code: selectedSource,
       sourceStartLine: 2,
       sourceStartColumn: 1
@@ -437,7 +437,7 @@ test(
     await page.click('@bosun-console-run')
     await page.wait('@bosun-helm-error')
 
-    expect(submitted[0]).toEqual({
+    expectHelmSubmission(expect, submitted[0], {
       code: "await Promise.reject(new Error('No user'))",
       sourceStartLine: 1,
       sourceStartColumn: 1
@@ -735,7 +735,7 @@ test(
     )
     await page.wait('@helm-output')
 
-    expect(submitted[0]).toEqual({
+    expectHelmSubmission(expect, submitted[0], {
       code: selectedSource,
       sourceStartLine: 2,
       sourceStartColumn: 1
@@ -761,7 +761,13 @@ test(
         request.method() === 'POST' && request.url().includes(endpoint)
     )
     await page.key('ControlOrMeta+Enter')
-    expect((await rerun).postDataJSON()).toEqual(submitted[0])
+    const rerunSubmission = (await rerun).postDataJSON()
+    expectHelmSubmission(expect, rerunSubmission, {
+      code: selectedSource,
+      sourceStartLine: 2,
+      sourceStartColumn: 1
+    })
+    expect(rerunSubmission.executionId === submitted[0].executionId).toBe(false)
     await page.wait(750)
     expect(await page.raw.locator('.cm-executed-range').count()).toBe(0)
 
@@ -964,7 +970,7 @@ test(
         request.url().includes('/api/v1/bosun/eval')
     )
     await page.key('ControlOrMeta+Enter')
-    expect((await execution).postDataJSON()).toEqual({
+    expectHelmSubmission(expect, (await execution).postDataJSON(), {
       code: selectedSource,
       sourceStartLine: 2,
       sourceStartColumn: 1
@@ -988,3 +994,240 @@ test(
     expect(page).toHaveNoSmoke()
   }
 )
+
+test(
+  'project Helm stops work, reports cancellation, and ignores a late older response',
+  {
+    browser: true,
+    world: helmWorld('helm-cancellation-project')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const projectSlug = current.projects.deploymentTarget.slug
+    const environmentSlug = current.environments.production.slug
+    const endpoint = `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`
+    let executionCount = 0
+    let releaseFirstExecution
+    const firstExecutionCancelled = new Promise((resolve) => {
+      releaseFirstExecution = resolve
+    })
+
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'sounding-helm-cancellation-app'
+    })
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route(`**${endpoint}`, async (route) => {
+      executionCount += 1
+
+      if (executionCount === 1) {
+        await firstExecutionCancelled
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(
+            cancelledResult(['loaded creator 1'], {
+              durationMs: 640,
+              logsPartial: true
+            })
+          )
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          status: 'success',
+          value: 'newer result',
+          logs: [],
+          output: 'newer result',
+          outputBytes: 12,
+          rowCount: null,
+          error: null,
+          durationMs: 18,
+          truncated: false,
+          logsPartial: false
+        })
+      })
+    })
+    await page.raw.route(
+      '**/api/v1/helm/executions/*/cancel',
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ cancelled: true })
+        })
+        setTimeout(releaseFirstExecution, 350)
+      }
+    )
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+    )
+    await page.fill(
+      '@helm-editor',
+      "console.log('loaded creator 1')\nawait new Promise(() => {})"
+    )
+    await page.click('@helm-run')
+    await page.raw
+      .locator('[data-test="helm-run"]')
+      .filter({ hasText: 'Stop' })
+      .waitFor()
+    expect(
+      await page.raw.locator('[data-test="helm-running-status"]').textContent()
+    ).toContain('Running')
+    await page.wait(250)
+    await page.screenshot('.tmp/issue-271-project-running-stop-light.png')
+
+    await page.click('@helm-run')
+    await page.raw.locator('[data-test="helm-result-status"]').waitFor()
+    expect(
+      await page.raw.locator('[data-test="helm-result-status"]').textContent()
+    ).toContain('Cancelled')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-history-entry"] span')
+        .last()
+        .getAttribute('class')
+    ).toContain('bg-gray-400')
+    await page.screenshot('.tmp/issue-271-project-cancelled-light.png')
+
+    await page.fill('@helm-editor', "'newer result'")
+    await page.click('@helm-run')
+    await page.wait('@helm-output')
+    expect(
+      await page.raw.locator('[data-test="helm-output"]').textContent()
+    ).toContain('newer result')
+    await page.wait(500)
+    expect(
+      await page.raw.locator('[data-test="helm-output"]').textContent()
+    ).toContain('newer result')
+    expect(executionCount).toBe(2)
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'Bosun Helm shows the same stopped and partial-console states in dark mode',
+  {
+    browser: true,
+    world: helmWorld('helm-cancellation-bosun')
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    let releaseExecution
+    const executionCancelled = new Promise((resolve) => {
+      releaseExecution = resolve
+    })
+
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route('**/api/v1/bosun/eval', async (route) => {
+      await executionCancelled
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          cancelledResult(['found 12 users'], {
+            durationMs: 812,
+            logsPartial: true
+          })
+        )
+      })
+    })
+    await page.raw.route(
+      '**/api/v1/helm/executions/*/cancel',
+      async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ cancelled: true })
+        })
+        setTimeout(releaseExecution, 100)
+      }
+    )
+
+    await page.resize(1440, 900)
+    await page.inDarkMode()
+    await page.goto('/bosun?tab=console&mode=helm')
+    await page.fill(
+      '@bosun-helm-editor',
+      "console.log('found 12 users')\nawait new Promise(() => {})"
+    )
+    await page.click('@bosun-console-run')
+    await page.raw
+      .locator('[data-test="bosun-console-run"]')
+      .filter({ hasText: 'Stop' })
+      .waitFor()
+    await page.wait(250)
+    await page.screenshot('.tmp/issue-271-bosun-running-stop-dark.png')
+
+    await page.click('@bosun-console-run')
+    await page.raw
+      .locator('[data-test="bosun-helm-result-status"]')
+      .filter({ hasText: 'Partial console' })
+      .waitFor()
+    expect(
+      await page.raw
+        .locator('[data-test="bosun-helm-result-status"]')
+        .textContent()
+    ).toContain('Cancelled')
+    expect(
+      await page.raw.locator('[data-test="bosun-helm-logs"]').textContent()
+    ).toContain('partial')
+    await page.screenshot('.tmp/issue-271-bosun-cancelled-dark.png')
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+function cancelledResult(logs, overrides = {}) {
+  return {
+    success: false,
+    status: 'cancelled',
+    value: null,
+    logs,
+    output: logs.join('\n') || null,
+    outputBytes: Buffer.byteLength(logs.join('\n')),
+    rowCount: null,
+    error: {
+      name: 'CancelledError',
+      message: 'Helm execution was cancelled.',
+      stack: null,
+      filename: null,
+      line: null,
+      column: null,
+      code: 'HELM_CANCELLED'
+    },
+    durationMs: 0,
+    truncated: false,
+    logsPartial: false,
+    ...overrides
+  }
+}
+
+function expectHelmSubmission(expect, actual, expected) {
+  expect({
+    code: actual.code,
+    sourceStartLine: actual.sourceStartLine,
+    sourceStartColumn: actual.sourceStartColumn
+  }).toEqual(expected)
+  expect(typeof actual.executionId).toBe('string')
+  expect(actual.executionId.length).toBe(36)
+}

--- a/tests/functional/api/helm.test.js
+++ b/tests/functional/api/helm.test.js
@@ -8,7 +8,11 @@ const RESULT = {
   output: 'querying\n[\n  {\n    "id": 1\n  }\n]',
   error: null,
   durationMs: 12,
-  truncated: false
+  truncated: false,
+  status: 'success',
+  rowCount: 1,
+  outputBytes: 36,
+  logsPartial: false
 }
 
 test(
@@ -33,6 +37,7 @@ test(
     try {
       const dashboard = await withCsrfFromPage(request, '/bosun', 'genesisUser')
       const response = await dashboard.request.post('/api/v1/bosun/eval', {
+        executionId: 'a019d7ef-c88c-44b6-b88e-bb2d27e21f14',
         code: 'await User.find()',
         sourceStartLine: 7,
         sourceStartColumn: 3
@@ -104,6 +109,7 @@ test(
         `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`,
         {
           code: 'await Creator.find()',
+          executionId: '6e0f9e7a-0f32-4a57-b253-2f86276427bc',
           sourceStartLine: 11,
           sourceStartColumn: 5
         }
@@ -123,6 +129,38 @@ test(
       expect(response).toHaveJsonPath('truncated', false)
     } finally {
       sails.helpers.helm.executeInContainer = originalExecute
+    }
+  }
+)
+
+test(
+  'Helm cancellation delegates with the current user and does not expose ownership',
+  {
+    world: {
+      name: 'configured-slipway'
+    }
+  },
+  async ({ sails, request, expect }) => {
+    const originalCancel = sails.helpers.helm.cancelExecution
+    const calls = []
+    sails.helpers.helm.cancelExecution = (executionId, userId) => {
+      calls.push({ executionId, userId })
+      return true
+    }
+
+    try {
+      const dashboard = await withCsrfFromPage(request, '/bosun', 'genesisUser')
+      const response = await dashboard.request.post(
+        '/api/v1/helm/executions/ab6e36f8-4700-45e8-961a-13380634764b/cancel'
+      )
+
+      expect(response).toHaveStatus(200)
+      expect(response).toHaveJsonPath('cancelled', true)
+      expect(calls.length).toBe(1)
+      expect(calls[0].executionId).toBe('ab6e36f8-4700-45e8-961a-13380634764b')
+      expect(Boolean(calls[0].userId)).toBe(true)
+    } finally {
+      sails.helpers.helm.cancelExecution = originalCancel
     }
   }
 )

--- a/tests/unit/helpers/helm/executions.test.js
+++ b/tests/unit/helpers/helm/executions.test.js
@@ -1,0 +1,78 @@
+const { test } = require('sounding')
+const { EventEmitter } = require('node:events')
+
+const helmExecutions = require('../../../../api/lib/helm-executions')
+
+test('Helm execution cancellation is scoped to its owning user', async ({
+  expect
+}) => {
+  const execution = helmExecutions.register({
+    executionId: 'ad993ae4-c0b8-4ef8-8292-26321ed33eb7',
+    userId: 'owner-1'
+  })
+
+  try {
+    expect(
+      await helmExecutions.cancel({
+        executionId: 'ad993ae4-c0b8-4ef8-8292-26321ed33eb7',
+        userId: 'other-user'
+      })
+    ).toBe(false)
+    expect(execution.signal.aborted).toBe(false)
+
+    const cancellation = helmExecutions.cancel({
+      executionId: 'ad993ae4-c0b8-4ef8-8292-26321ed33eb7',
+      userId: 'owner-1'
+    })
+    expect(execution.signal.aborted).toBe(true)
+    expect(execution.signal.reason.code).toBe('HELM_CANCELLED')
+    execution.release()
+    expect(await cancellation).toBe(true)
+  } finally {
+    execution.release()
+  }
+})
+
+test('Helm execution IDs cannot be reused while active', async ({ expect }) => {
+  const first = helmExecutions.register({
+    executionId: '1650a071-a3cd-4b9c-b5f9-35283c2dbb03',
+    userId: 'owner-1'
+  })
+
+  try {
+    let error
+    try {
+      helmExecutions.register({
+        executionId: '1650a071-a3cd-4b9c-b5f9-35283c2dbb03',
+        userId: 'owner-1'
+      })
+    } catch (caughtError) {
+      error = caughtError
+    }
+
+    expect(error.code).toBe('HELM_EXECUTION_EXISTS')
+  } finally {
+    first.release()
+  }
+})
+
+test('Helm execution stops when its requesting client disconnects', async ({
+  sails,
+  expect
+}) => {
+  const response = new EventEmitter()
+  response.writableEnded = false
+  const execution = sails.helpers.helm.beginExecution(
+    'e1c2455b-bfe9-432a-adbb-93762b8a9b0a',
+    { session: { userId: 'owner-1' } },
+    response
+  )
+
+  try {
+    response.emit('close')
+    expect(execution.signal.aborted).toBe(true)
+    expect(execution.signal.reason.code).toBe('HELM_CANCELLED')
+  } finally {
+    execution.release()
+  }
+})

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -36,6 +36,9 @@ await Creator.find({
     'subscriptionProvider',
     'subscriptionStatus'
   ])
+  expect(result.status).toBe('success')
+  expect(result.rowCount).toBe(1)
+  expect(result.outputBytes).toBe(Buffer.byteLength(result.output))
 })
 
 test('Helm understands normal JavaScript syntax around return words', async ({
@@ -281,6 +284,8 @@ test('Helm enforces synchronous, asynchronous, source, and output bounds', async
 
     expect(result.success).toBe(false)
     expect(result.error.name).toBe('TimeoutError')
+    expect(result.error.code).toBe('HELM_TIMEOUT')
+    expect(result.status).toBe('timeout')
     expect(Date.now() - startedAt < 2000).toBe(true)
   }
 
@@ -297,6 +302,61 @@ test('Helm enforces synchronous, asynchronous, source, and output bounds', async
   expect(oversized.truncated).toBe(true)
   expect(oversized.value.type).toBe('truncated')
   expect(Buffer.byteLength(oversized.output) < 128 * 1024).toBe(true)
+  expect(oversized.outputBytes).toBe(Buffer.byteLength(oversized.output))
+})
+
+test('Helm cancellation stops work and preserves bounded partial console output', async ({
+  sails,
+  expect
+}) => {
+  const controller = new AbortController()
+  const operation = runHelm(
+    sails,
+    `
+console.log('before cancellation')
+await new Promise(() => {})
+`,
+    { signal: controller.signal, timeoutMs: 5000 }
+  )
+
+  setTimeout(() => {
+    const error = new Error('Helm execution was cancelled by the user.')
+    error.name = 'CancelledError'
+    error.code = 'HELM_CANCELLED'
+    controller.abort(error)
+  }, 100)
+
+  const result = await operation
+
+  expect(result.success).toBe(false)
+  expect(result.status).toBe('cancelled')
+  expect(result.error.code).toBe('HELM_CANCELLED')
+  expect(result.logs).toEqual(['before cancellation'])
+  expect(result.logsPartial).toBe(true)
+  expect(result.output).toBe('before cancellation')
+  expect(result.outputBytes).toBe(Buffer.byteLength(result.output))
+  expect(result.durationMs < 2000).toBe(true)
+
+  const synchronousController = new AbortController()
+  const synchronousOperation = runHelm(
+    sails,
+    "console.log('before loop')\nwhile (true) {}",
+    {
+      signal: synchronousController.signal,
+      timeoutMs: 5000
+    }
+  )
+  setTimeout(() => {
+    const error = new Error('Helm execution was cancelled by the user.')
+    error.name = 'CancelledError'
+    error.code = 'HELM_CANCELLED'
+    synchronousController.abort(error)
+  }, 100)
+
+  const synchronousResult = await synchronousOperation
+  expect(synchronousResult.status).toBe('cancelled')
+  expect(synchronousResult.logs).toEqual(['before loop'])
+  expect(synchronousResult.durationMs < 2000).toBe(true)
 })
 
 test('project Helm and Bosun Helm delegate to the same bounded runner', async ({
@@ -318,7 +378,8 @@ test('project Helm and Bosun Helm delegate to the same bounded runner', async ({
       'web-production',
       '1 + 1',
       8,
-      3
+      3,
+      '3f759945-d02c-4e39-a468-189462be6a87'
     )
 
     expect(bosunResult.output).toBe('ready')
@@ -328,13 +389,71 @@ test('project Helm and Bosun Helm delegate to the same bounded runner', async ({
     expect(calls[0].sourceStartLine).toBe(4)
     expect(calls[0].sourceStartColumn).toBe(2)
     expect(calls[0].bootstrapSails).toBe(true)
-    expect(calls[1].args).toEqual(['exec', '-i', 'web-production', 'node'])
+    expect(calls[1].args).toEqual([
+      'exec',
+      '-i',
+      '-e',
+      'SLIPWAY_HELM_EXECUTION_ID=3f759945-d02c-4e39-a468-189462be6a87',
+      'web-production',
+      'node'
+    ])
     expect(calls[1].source).toBe('1 + 1')
     expect(calls[1].sourceStartLine).toBe(8)
     expect(calls[1].sourceStartColumn).toBe(3)
     expect(calls[1].bootstrapSails).toBe(true)
   } finally {
     sails.helpers.helm.run = originalRun
+  }
+})
+
+test('project Helm cancellation also stops the exact container execution', async ({
+  sails,
+  expect
+}) => {
+  const originalRun = sails.helpers.helm.run
+  const originalStop = sails.helpers.helm.stopContainerExecution
+  const runCalls = []
+  const stopCalls = []
+  const fakeRun = async (options) => {
+    runCalls.push(options)
+    return {
+      success: false,
+      status: 'cancelled',
+      error: { code: 'HELM_CANCELLED' }
+    }
+  }
+  const fakeStop = async (options) => {
+    stopCalls.push(options)
+    return true
+  }
+  fakeRun.with = fakeRun
+  fakeStop.with = fakeStop
+  sails.helpers.helm.run = fakeRun
+  sails.helpers.helm.stopContainerExecution = fakeStop
+  const controller = new AbortController()
+  const error = new Error('cancelled')
+  error.code = 'HELM_CANCELLED'
+  controller.abort(error)
+
+  try {
+    const result = await sails.helpers.helm.executeInContainer.with({
+      containerName: 'web-production',
+      source: 'while (true) {}',
+      executionId: 'e8788ac1-6bda-4226-953d-4842423a9516',
+      signal: controller.signal
+    })
+
+    expect(result.status).toBe('cancelled')
+    expect(runCalls[0].signal).toBe(controller.signal)
+    expect(stopCalls).toEqual([
+      {
+        containerName: 'web-production',
+        executionId: 'e8788ac1-6bda-4226-953d-4842423a9516'
+      }
+    ])
+  } finally {
+    sails.helpers.helm.run = originalRun
+    sails.helpers.helm.stopContainerExecution = originalStop
   }
 })
 


### PR DESCRIPTION
Closes #271

Adds user-scoped cancellation to Project Helm and Bosun Helm, explicitly terminates in-container work, preserves bounded partial console output, and prevents late responses from replacing newer runs.

The result viewer now reports success, error, timeout, or cancellation alongside duration, row count, serialized output size, and truncation state. Run becomes a minimal destructive Stop action while work is active.

Verified with 213 unit trials, 58 functional trials, 30 browser trials, and Prettier.