### PR TITLE
feat(helm): add Sails-aware completions

### DIFF
--- a/api/controllers/api/v1/bosun/get-helm-completions.js
+++ b/api/controllers/api/v1/bosun/get-helm-completions.js
@@ -1,0 +1,29 @@
+module.exports = {
+  friendlyName: 'Get Bosun Helm completions',
+
+  description:
+    'Return secret-free Sails completion metadata for the Slipway instance.',
+
+  exits: {
+    success: {
+      statusCode: 200
+    }
+  },
+
+  fn: async function () {
+    this.res.set('Cache-Control', 'private, no-store')
+
+    try {
+      return await sails.helpers.helm.getCompletions()
+    } catch {
+      return {
+        available: false,
+        version: 1,
+        truncated: false,
+        models: [],
+        helpers: [],
+        config: []
+      }
+    }
+  }
+}

--- a/api/controllers/api/v1/helm/get-project-completions.js
+++ b/api/controllers/api/v1/helm/get-project-completions.js
@@ -1,0 +1,75 @@
+module.exports = {
+  friendlyName: 'Get project Helm completions',
+
+  description:
+    'Return secret-free Sails completion metadata from the environment default app.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      statusCode: 200
+    },
+    notFound: {
+      statusCode: 404
+    },
+    forbidden: {
+      statusCode: 403
+    }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug }) {
+    const user = await User.findOne({ id: this.req.session.userId })
+    const project = await Project.findOne({ slug: projectSlug }).populate(
+      'team'
+    )
+
+    if (!project) throw 'notFound'
+    if (project.team.id !== user.team) throw 'forbidden'
+
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug: environmentSlug
+    })
+    if (!environment) throw 'notFound'
+
+    const app =
+      (await App.findOne({ environment: environment.id, isDefault: true })) ||
+      (await App.findOne({ environment: environment.id }))
+
+    this.res.set('Cache-Control', 'private, no-store')
+
+    if (!app || app.status !== 'running' || !app.containerName) {
+      return {
+        available: false,
+        version: 1,
+        truncated: false,
+        models: [],
+        helpers: [],
+        config: []
+      }
+    }
+
+    try {
+      return await sails.helpers.helm.getCompletions(app.containerName)
+    } catch {
+      return {
+        available: false,
+        version: 1,
+        truncated: false,
+        models: [],
+        helpers: [],
+        config: []
+      }
+    }
+  }
+}

--- a/api/helpers/helm/get-completions.js
+++ b/api/helpers/helm/get-completions.js
@@ -1,0 +1,58 @@
+const crypto = require('node:crypto')
+
+const {
+  buildSailsCompletionSource,
+  collectSailsCompletionMetadata,
+  emptyHelmCompletions,
+  isHelmCompletionMetadata
+} = require('../../lib/helm-completions')
+
+module.exports = {
+  friendlyName: 'Get Helm completions',
+
+  description:
+    'Return secret-free Sails model, helper, and configuration metadata for Helm completion.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      description:
+        'Optional running app container. When omitted, inspect this Sails app.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName }) {
+    if (!containerName) {
+      return {
+        available: true,
+        ...collectSailsCompletionMetadata(sails)
+      }
+    }
+
+    const result = await sails.helpers.helm.executeInContainer.with({
+      containerName,
+      source: buildSailsCompletionSource(),
+      sourceStartLine: 1,
+      sourceStartColumn: 1,
+      executionId: crypto.randomUUID()
+    })
+
+    if (!result?.success || !isHelmCompletionMetadata(result.value)) {
+      return {
+        available: false,
+        ...emptyHelmCompletions()
+      }
+    }
+
+    return {
+      available: true,
+      ...result.value
+    }
+  }
+}

--- a/api/lib/helm-completions.js
+++ b/api/lib/helm-completions.js
@@ -1,0 +1,290 @@
+const EMPTY_HELM_COMPLETIONS = Object.freeze({
+  version: 1,
+  truncated: false,
+  models: [],
+  helpers: [],
+  config: []
+})
+
+function collectSailsCompletionMetadata(sailsApp) {
+  const metadata = {
+    version: 1,
+    truncated: false,
+    models: [],
+    helpers: [],
+    config: []
+  }
+
+  if (!sailsApp || typeof sailsApp !== 'object') return metadata
+
+  const MAX_CONFIG_DEPTH = 3
+  const MAX_CONFIG_ENTRIES = 500
+  const MAX_HELPER_DEPTH = 6
+  const MAX_HELPER_ENTRIES = 500
+  const MAX_MODELS = 100
+  const MAX_MODEL_ATTRIBUTES = 1000
+  const SHALLOW_CONFIG_NAMESPACES = new Set([
+    'hooks',
+    'paths',
+    'policies',
+    'routes'
+  ])
+
+  function descriptors(value) {
+    try {
+      return Object.getOwnPropertyDescriptors(value)
+    } catch {
+      return {}
+    }
+  }
+
+  function dataValue(value, propertyName) {
+    let current = value
+    let depth = 0
+
+    while (current && depth < 6) {
+      let descriptor
+      try {
+        descriptor = Object.getOwnPropertyDescriptor(current, propertyName)
+      } catch {
+        return undefined
+      }
+      if (descriptor) {
+        return 'value' in descriptor ? descriptor.value : undefined
+      }
+      try {
+        current = Object.getPrototypeOf(current)
+      } catch {
+        return undefined
+      }
+      depth++
+    }
+
+    return undefined
+  }
+
+  function stringValue(value, fallback) {
+    return typeof value === 'string' && value ? value : fallback
+  }
+
+  function publicNames(value) {
+    return Object.keys(descriptors(value)).filter(
+      (name) => name && !name.startsWith('_') && !/^\d+$/.test(name)
+    )
+  }
+
+  function valueType(value) {
+    if (value === null) return 'null'
+    if (Array.isArray(value)) return 'array'
+    try {
+      if (value instanceof Date) return 'date'
+    } catch {
+      return 'object'
+    }
+    return typeof value
+  }
+
+  function isTraversable(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return false
+    }
+    try {
+      const prototype = Object.getPrototypeOf(value)
+      return prototype === Object.prototype || prototype === null
+    } catch {
+      return false
+    }
+  }
+
+  const sailsModels = dataValue(sailsApp, 'models')
+  let modelAttributeEntries = 0
+  if (sailsModels && typeof sailsModels === 'object') {
+    for (const modelKey of publicNames(sailsModels).sort()) {
+      if (metadata.models.length >= MAX_MODELS) {
+        metadata.truncated = true
+        break
+      }
+      const model = dataValue(sailsModels, modelKey)
+      if (
+        !model ||
+        (typeof model !== 'object' && typeof model !== 'function')
+      ) {
+        continue
+      }
+
+      const attributes = dataValue(model, 'attributes')
+      const identity = stringValue(dataValue(model, 'identity'), modelKey)
+      const fallbackGlobalId = identity
+        .split(/[-_\s]+/)
+        .filter(Boolean)
+        .map((part) => part[0].toUpperCase() + part.slice(1))
+        .join('')
+      const globalId = stringValue(
+        dataValue(model, 'globalId'),
+        fallbackGlobalId
+      )
+      const modelMetadata = {
+        identity,
+        globalId,
+        attributes: []
+      }
+
+      if (attributes && typeof attributes === 'object') {
+        for (const attributeName of publicNames(attributes).sort()) {
+          if (modelAttributeEntries >= MAX_MODEL_ATTRIBUTES) {
+            metadata.truncated = true
+            break
+          }
+          const attribute = dataValue(attributes, attributeName)
+          if (!attribute || typeof attribute !== 'object') continue
+
+          const collection = dataValue(attribute, 'collection')
+          const associationModel = dataValue(attribute, 'model')
+          const type = dataValue(attribute, 'type')
+          const collectionIdentity = stringValue(collection, '')
+          const associationIdentity = stringValue(associationModel, '')
+          modelMetadata.attributes.push({
+            name: attributeName,
+            type: collectionIdentity
+              ? `collection:${collectionIdentity}`
+              : associationIdentity
+              ? `model:${associationIdentity}`
+              : stringValue(type, 'ref'),
+            association: collectionIdentity
+              ? 'collection'
+              : associationIdentity
+              ? 'model'
+              : null
+          })
+          modelAttributeEntries++
+        }
+      }
+
+      metadata.models.push(modelMetadata)
+    }
+  }
+
+  const sailsHelpers = dataValue(sailsApp, 'helpers')
+  const helperSeen = new WeakSet()
+  let helperEntries = 0
+
+  function visitHelpers(value, path, depth) {
+    if (
+      !value ||
+      (typeof value !== 'object' && typeof value !== 'function') ||
+      depth > MAX_HELPER_DEPTH ||
+      helperEntries >= MAX_HELPER_ENTRIES
+    ) {
+      return
+    }
+    if (
+      (typeof value === 'object' || typeof value === 'function') &&
+      helperSeen.has(value)
+    ) {
+      return
+    }
+    helperSeen.add(value)
+
+    for (const name of publicNames(value).sort()) {
+      if (helperEntries >= MAX_HELPER_ENTRIES) {
+        metadata.truncated = true
+        break
+      }
+      const child = dataValue(value, name)
+      const childPath = path ? `${path}.${name}` : name
+
+      if (typeof child === 'function') {
+        metadata.helpers.push({ path: childPath })
+        helperEntries++
+        continue
+      }
+
+      if (child && typeof child === 'object') {
+        visitHelpers(child, childPath, depth + 1)
+      }
+    }
+  }
+
+  visitHelpers(sailsHelpers, '', 0)
+
+  const sailsConfig = dataValue(sailsApp, 'config')
+  const configSeen = new WeakSet()
+  let configEntries = 0
+
+  function visitConfig(value, path, depth) {
+    if (
+      !isTraversable(value) ||
+      depth > MAX_CONFIG_DEPTH ||
+      configEntries >= MAX_CONFIG_ENTRIES ||
+      configSeen.has(value)
+    ) {
+      return
+    }
+    configSeen.add(value)
+
+    for (const name of publicNames(value).sort()) {
+      if (configEntries >= MAX_CONFIG_ENTRIES) {
+        metadata.truncated = true
+        break
+      }
+      const child = dataValue(value, name)
+      const childPath = path ? `${path}.${name}` : name
+
+      metadata.config.push({
+        path: childPath,
+        type: valueType(child)
+      })
+      configEntries++
+
+      const rootNamespace = childPath.split('.')[0]
+      if (
+        depth < MAX_CONFIG_DEPTH &&
+        !SHALLOW_CONFIG_NAMESPACES.has(rootNamespace) &&
+        isTraversable(child)
+      ) {
+        visitConfig(child, childPath, depth + 1)
+      }
+    }
+  }
+
+  visitConfig(sailsConfig, '', 0)
+
+  metadata.models.sort((left, right) =>
+    left.globalId.localeCompare(right.globalId)
+  )
+  metadata.helpers.sort((left, right) => left.path.localeCompare(right.path))
+  metadata.config.sort((left, right) => left.path.localeCompare(right.path))
+
+  return metadata
+}
+
+function buildSailsCompletionSource() {
+  return `return (${collectSailsCompletionMetadata.toString()})(sails)`
+}
+
+function emptyHelmCompletions() {
+  return {
+    version: EMPTY_HELM_COMPLETIONS.version,
+    truncated: EMPTY_HELM_COMPLETIONS.truncated,
+    models: [],
+    helpers: [],
+    config: []
+  }
+}
+
+function isHelmCompletionMetadata(value) {
+  return (
+    value?.version === 1 &&
+    typeof value.truncated === 'boolean' &&
+    Array.isArray(value.models) &&
+    Array.isArray(value.helpers) &&
+    Array.isArray(value.config)
+  )
+}
+
+module.exports = {
+  buildSailsCompletionSource,
+  collectSailsCompletionMetadata,
+  emptyHelmCompletions,
+  isHelmCompletionMetadata
+}

--- a/assets/js/components/CodeEditor.vue
+++ b/assets/js/components/CodeEditor.vue
@@ -6,6 +6,7 @@ import {
   historyKeymap,
   indentWithTab
 } from '@codemirror/commands'
+import { autocompletion, completionKeymap } from '@codemirror/autocomplete'
 import { javascript } from '@codemirror/lang-javascript'
 import { sql } from '@codemirror/lang-sql'
 import {
@@ -31,6 +32,7 @@ import {
   placeholder as editorPlaceholder
 } from '@codemirror/view'
 import { tags } from '@lezer/highlight'
+import { createHelmCompletionSource } from '@/lib/helmCompletions.mjs'
 
 const props = defineProps({
   modelValue: { type: String, default: '' },
@@ -43,6 +45,7 @@ const props = defineProps({
   ariaLabel: { type: String, default: 'Code editor' },
   testId: { type: String, default: '' },
   disabled: { type: Boolean, default: false },
+  completionMetadata: { type: Object, default: null },
   submitOnModEnter: { type: Boolean, default: false },
   height: {
     type: String,
@@ -64,6 +67,7 @@ const editorHost = ref(null)
 const languageCompartment = new Compartment()
 const appearanceCompartment = new Compartment()
 const editableCompartment = new Compartment()
+const completionCompartment = new Compartment()
 const setExecutedRange = StateEffect.define()
 const setInlineDiagnostic = StateEffect.define()
 const executedRangeMark = Decoration.mark({ class: 'cm-executed-range' })
@@ -195,14 +199,24 @@ function editorTheme(isDark) {
         caret: '#f5f5f5',
         placeholder: '#525252',
         selection: '#075985',
-        matchingBracket: '#404040'
+        matchingBracket: '#404040',
+        completionBackground: '#171717',
+        completionBorder: '#404040',
+        completionSelected: '#262626',
+        completionDetail: '#a3a3a3',
+        completionMuted: '#737373'
       }
     : {
         text: '#171717',
         caret: '#171717',
         placeholder: '#a3a3a3',
         selection: '#bae6fd',
-        matchingBracket: '#e5e5e5'
+        matchingBracket: '#e5e5e5',
+        completionBackground: '#ffffff',
+        completionBorder: '#e5e5e5',
+        completionSelected: '#f5f5f5',
+        completionDetail: '#737373',
+        completionMuted: '#a3a3a3'
       }
 
   return EditorView.theme(
@@ -245,6 +259,40 @@ function editorTheme(isDark) {
       '.cm-matchingBracket': {
         backgroundColor: palette.matchingBracket,
         outline: 'none'
+      },
+      '.cm-tooltip.cm-tooltip-autocomplete': {
+        overflow: 'hidden',
+        border: `1px solid ${palette.completionBorder}`,
+        borderRadius: '0.5rem',
+        backgroundColor: palette.completionBackground,
+        boxShadow:
+          '0 12px 32px -12px rgb(0 0 0 / 0.28), 0 4px 12px -6px rgb(0 0 0 / 0.18)'
+      },
+      '.cm-tooltip.cm-tooltip-autocomplete > ul': {
+        maxHeight: '18rem',
+        padding: '0.25rem'
+      },
+      '.cm-tooltip.cm-tooltip-autocomplete > ul > li': {
+        minWidth: '18rem',
+        padding: '0.375rem 0.5rem',
+        borderRadius: '0.375rem',
+        lineHeight: '1.25rem'
+      },
+      '.cm-tooltip.cm-tooltip-autocomplete > ul > li[aria-selected]': {
+        color: palette.text,
+        backgroundColor: palette.completionSelected
+      },
+      '.cm-completionLabel': {
+        fontWeight: '500'
+      },
+      '.cm-completionDetail': {
+        color: palette.completionDetail,
+        fontStyle: 'normal',
+        marginLeft: '1rem'
+      },
+      '.cm-completionIcon': {
+        color: palette.completionMuted,
+        opacity: '1'
       }
     },
     { dark: isDark }
@@ -331,6 +379,22 @@ function editableExtension() {
     EditorView.editable.of(!props.disabled),
     EditorView.contentAttributes.of(attributes)
   ]
+}
+
+function completionExtension() {
+  if (
+    props.language !== 'javascript' ||
+    !props.completionMetadata ||
+    !Array.isArray(props.completionMetadata.models)
+  ) {
+    return []
+  }
+
+  return autocompletion({
+    activateOnTyping: true,
+    maxRenderedOptions: 80,
+    override: [createHelmCompletionSource(props.completionMetadata)]
+  })
 }
 
 function submitKeymap() {
@@ -515,6 +579,7 @@ onMounted(() => {
         EditorView.lineWrapping,
         keymap.of([
           ...submitKeymap(),
+          ...completionKeymap,
           indentWithTab,
           ...defaultKeymap,
           ...historyKeymap
@@ -523,6 +588,7 @@ onMounted(() => {
         languageCompartment.of(languageExtension(props.language)),
         appearanceCompartment.of(appearanceExtension()),
         editableCompartment.of(editableExtension()),
+        completionCompartment.of(completionExtension()),
         EditorView.updateListener.of((update) => {
           if (update.docChanged && !applyingExternalValue) {
             emit('update:modelValue', update.state.doc.toString())
@@ -556,8 +622,19 @@ watch(
     view.dispatch({
       effects: [
         languageCompartment.reconfigure(languageExtension(language)),
-        appearanceCompartment.reconfigure(appearanceExtension())
+        appearanceCompartment.reconfigure(appearanceExtension()),
+        completionCompartment.reconfigure(completionExtension())
       ]
+    })
+  }
+)
+
+watch(
+  () => props.completionMetadata,
+  () => {
+    if (!view) return
+    view.dispatch({
+      effects: completionCompartment.reconfigure(completionExtension())
     })
   }
 )

--- a/assets/js/lib/helmCompletions.mjs
+++ b/assets/js/lib/helmCompletions.mjs
@@ -1,0 +1,334 @@
+const WATERLINE_MODEL_METHODS = [
+  'addToCollection',
+  'archive',
+  'archiveOne',
+  'avg',
+  'count',
+  'create',
+  'createEach',
+  'destroy',
+  'destroyOne',
+  'find',
+  'findOne',
+  'findOrCreate',
+  'native',
+  'removeFromCollection',
+  'replaceCollection',
+  'stream',
+  'sum',
+  'update',
+  'updateOne',
+  'validate'
+]
+
+const WATERLINE_QUERY_METHODS = [
+  'eachRecord',
+  'exec',
+  'fetch',
+  'intercept',
+  'limit',
+  'meta',
+  'omit',
+  'populate',
+  'select',
+  'set',
+  'skip',
+  'sort',
+  'tolerate',
+  'usingConnection',
+  'where'
+]
+
+const SAILS_ROOT_OPTIONS = [
+  {
+    label: 'config',
+    type: 'namespace',
+    detail: 'Sails configuration'
+  },
+  {
+    label: 'helpers',
+    type: 'namespace',
+    detail: 'Sails helpers'
+  },
+  {
+    label: 'models',
+    type: 'namespace',
+    detail: 'Waterline models'
+  },
+  {
+    label: 'getDatastore',
+    type: 'function',
+    detail: 'Sails datastore'
+  },
+  {
+    label: 'getRouteFor',
+    type: 'function',
+    detail: 'Sails route metadata'
+  },
+  {
+    label: 'getUrlFor',
+    type: 'function',
+    detail: 'Sails route URL'
+  },
+  {
+    label: 'hooks',
+    type: 'namespace',
+    detail: 'Loaded Sails hooks'
+  },
+  {
+    label: 'log',
+    type: 'namespace',
+    detail: 'Sails logger'
+  },
+  {
+    label: 'sendNativeQuery',
+    type: 'function',
+    detail: 'Native datastore query'
+  }
+]
+
+function normalizeMetadata(metadata) {
+  return {
+    models: Array.isArray(metadata?.models) ? metadata.models : [],
+    helpers: Array.isArray(metadata?.helpers) ? metadata.helpers : [],
+    config: Array.isArray(metadata?.config) ? metadata.config : []
+  }
+}
+
+function pathOptions(entries, typedPath, leafType, leafDetail) {
+  const pieces = typedPath.split('.')
+  const typed = pieces.pop() || ''
+  const parent = pieces.join('.')
+  const parentPrefix = parent ? `${parent}.` : ''
+  const candidates = new Map()
+
+  for (const entry of entries) {
+    const path = entry.path
+    if (typeof path !== 'string' || !path.startsWith(parentPrefix)) continue
+
+    const relativePath = path.slice(parentPrefix.length)
+    if (!relativePath) continue
+
+    const [label, ...remaining] = relativePath.split('.')
+    const existing = candidates.get(label)
+    const isNamespace = remaining.length > 0
+
+    if (!existing || isNamespace) {
+      candidates.set(label, {
+        label,
+        type: isNamespace ? 'namespace' : leafType,
+        detail: isNamespace
+          ? `${leafDetail} namespace`
+          : entry.type
+          ? `${entry.type} · ${leafDetail}`
+          : leafDetail
+      })
+    }
+  }
+
+  return {
+    typed,
+    options: [...candidates.values()].sort((left, right) =>
+      left.label.localeCompare(right.label)
+    )
+  }
+}
+
+function attributeOptions(model) {
+  return (Array.isArray(model?.attributes) ? model.attributes : []).map(
+    (attribute) => ({
+      label: attribute.name,
+      type: 'property',
+      detail: `${attribute.type || 'ref'} · model attribute`
+    })
+  )
+}
+
+function methodOptions(methods, detail) {
+  return methods.map((label) => ({
+    label,
+    type: 'function',
+    detail
+  }))
+}
+
+function findLatestModel(source, models) {
+  let latest = null
+
+  for (const model of models) {
+    if (!model?.globalId) continue
+    const index = source.lastIndexOf(`${model.globalId}.`)
+    if (index === -1 || (latest && index <= latest.index)) continue
+    latest = { model, index }
+  }
+
+  return latest
+}
+
+function completion(from, options) {
+  if (!options.length) return null
+  return {
+    from,
+    options,
+    validFor: /^[A-Za-z0-9_$]*$/
+  }
+}
+
+export function helmCompletionResult(
+  source,
+  cursor,
+  metadata,
+  { explicit = false } = {}
+) {
+  const normalized = normalizeMetadata(metadata)
+  const before = String(source || '').slice(0, cursor)
+  let match
+
+  match = before.match(/sails\.helpers\.([A-Za-z0-9_$.]*)$/)
+  if (match) {
+    const resolved = pathOptions(
+      normalized.helpers,
+      match[1],
+      'function',
+      'Sails helper'
+    )
+    return completion(cursor - resolved.typed.length, resolved.options)
+  }
+
+  match = before.match(/sails\.config\.([A-Za-z0-9_$.]*)$/)
+  if (match) {
+    const resolved = pathOptions(
+      normalized.config,
+      match[1],
+      'property',
+      'Sails config'
+    )
+    return completion(cursor - resolved.typed.length, resolved.options)
+  }
+
+  match = before.match(/sails\.models\.([A-Za-z0-9_$]*)$/)
+  if (match) {
+    return completion(
+      cursor - match[1].length,
+      normalized.models.map((model) => ({
+        label: model.identity,
+        type: 'class',
+        detail: `${model.globalId} · Waterline model`
+      }))
+    )
+  }
+
+  match = before.match(/sails\.([A-Za-z0-9_$]*)$/)
+  if (match) {
+    return completion(cursor - match[1].length, SAILS_ROOT_OPTIONS)
+  }
+
+  for (const model of normalized.models) {
+    const escapedGlobalId = model.globalId.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      '\\$&'
+    )
+    match = before.match(
+      new RegExp(`${escapedGlobalId}\\.attributes\\.([A-Za-z0-9_$]*)$`)
+    )
+    if (match) {
+      return completion(cursor - match[1].length, attributeOptions(model))
+    }
+  }
+
+  const latestModel = findLatestModel(before, normalized.models)
+  if (latestModel) {
+    const modelSource = before.slice(latestModel.index)
+    const queryStarted =
+      /\.(?:find|findOne|findOrCreate|update|updateOne|destroy|destroyOne|count|sum|avg)\s*\(/.test(
+        modelSource
+      )
+
+    if (queryStarted) {
+      match = before.match(
+        /(?:select|omit|sort|sum|avg)\s*\([^)]*['"]([A-Za-z0-9_$]*)$/
+      )
+      if (match) {
+        return completion(
+          cursor - match[1].length,
+          attributeOptions(latestModel.model)
+        )
+      }
+
+      match = before.match(/(?:\{|,)\s*([A-Za-z_$][A-Za-z0-9_$]*)?$/)
+      if (match && (explicit || match[1])) {
+        const typed = match[1] || ''
+        return completion(
+          cursor - typed.length,
+          attributeOptions(latestModel.model)
+        )
+      }
+
+      match = before.match(/\.([A-Za-z0-9_$]*)$/)
+      if (match) {
+        return completion(
+          cursor - match[1].length,
+          methodOptions(WATERLINE_QUERY_METHODS, 'Waterline query modifier')
+        )
+      }
+    }
+
+    const directModelMatch = modelSource.match(
+      new RegExp(
+        `^${latestModel.model.globalId.replace(
+          /[.*+?^${}()|[\]\\]/g,
+          '\\$&'
+        )}\\.([A-Za-z0-9_$]*)$`
+      )
+    )
+    if (directModelMatch) {
+      return completion(cursor - directModelMatch[1].length, [
+        ...methodOptions(WATERLINE_MODEL_METHODS, 'Waterline model method'),
+        {
+          label: 'attributes',
+          type: 'property',
+          detail: 'Waterline model attributes'
+        },
+        {
+          label: 'primaryKey',
+          type: 'property',
+          detail: 'Waterline model metadata'
+        }
+      ])
+    }
+  }
+
+  match = before.match(/([A-Za-z_$][A-Za-z0-9_$]*)$/)
+  if (!match) {
+    if (!explicit) return null
+    match = ['', '']
+  }
+
+  const typed = match[1] || ''
+  if (!explicit && (!typed || !/^[A-Z]/.test(typed))) return null
+
+  return completion(cursor - typed.length, [
+    ...normalized.models.map((model) => ({
+      label: model.globalId,
+      type: 'class',
+      detail: `${model.identity} · Waterline model`
+    })),
+    {
+      label: 'sails',
+      type: 'variable',
+      detail: 'Sails application'
+    }
+  ])
+}
+
+export function createHelmCompletionSource(metadata) {
+  return (context) =>
+    helmCompletionResult(
+      context.state.sliceDoc(0, context.pos),
+      context.pos,
+      metadata,
+      { explicit: context.explicit }
+    )
+}
+
+export { WATERLINE_MODEL_METHODS, WATERLINE_QUERY_METHODS }

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -122,12 +122,14 @@ const helmLoading = ref(false)
 const helmStopping = ref(false)
 const helmHistory = ref([])
 const helmEditor = ref(null)
+const helmCompletionMetadata = ref(null)
 const helmSelection = ref({
   hasSelection: false,
   hasExecutableSelection: false
 })
 let helmExecutionSequence = 0
 let activeHelmExecution = null
+let helmCompletionRequestSequence = 0
 const helmRunLabel = computed(() =>
   helmSelection.value.hasSelection ? 'Run selection' : 'Run'
 )
@@ -151,6 +153,28 @@ function showToast(message, type = 'success') {
 
 function dismissToast(id) {
   toasts.value = toasts.value.filter((t) => t.id !== id)
+}
+
+async function loadHelmCompletionMetadata() {
+  const sequence = ++helmCompletionRequestSequence
+
+  try {
+    const response = await fetch('/api/v1/bosun/helm/completions', {
+      headers: {
+        Accept: 'application/json'
+      },
+      cache: 'no-store'
+    })
+    if (!response.ok) throw new Error('Completion metadata is unavailable.')
+
+    const metadata = await response.json()
+    if (sequence !== helmCompletionRequestSequence) return
+    helmCompletionMetadata.value = metadata.available ? metadata : null
+  } catch {
+    if (sequence === helmCompletionRequestSequence) {
+      helmCompletionMetadata.value = null
+    }
+  }
 }
 
 async function executeQuery() {
@@ -746,6 +770,8 @@ function handleClickOutside(e) {
 
 onMounted(() => {
   document.addEventListener('click', handleClickOutside)
+  window.addEventListener('focus', loadHelmCompletionMetadata)
+  loadHelmCompletionMetadata()
   if (activeTab.value === 'activity') {
     fetchActivity()
   }
@@ -759,7 +785,9 @@ onBeforeUnmount(() => {
 })
 
 onUnmounted(() => {
+  helmCompletionRequestSequence++
   document.removeEventListener('click', handleClickOutside)
+  window.removeEventListener('focus', loadHelmCompletionMetadata)
 })
 </script>
 
@@ -939,6 +967,7 @@ onUnmounted(() => {
           aria-label="Bosun Helm code"
           test-id="bosun-helm-editor"
           height="fill"
+          :completion-metadata="helmCompletionMetadata"
           submit-on-mod-enter
           placeholder="// Access Slipway models and helpers&#10;await User.find()"
           @selection-change="helmSelection = $event"

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Link, Head, usePage } from '@inertiajs/vue3'
-import { inject, ref, computed, watch } from 'vue'
+import { inject, ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
@@ -30,12 +30,14 @@ const running = ref(false)
 const stopping = ref(false)
 const history = ref([])
 const editor = ref(null)
+const completionMetadata = ref(null)
 const editorSelection = ref({
   hasSelection: false,
   hasExecutableSelection: false
 })
 let executionSequence = 0
 let activeExecution = null
+let completionRequestSequence = 0
 
 const isRunning = computed(() => props.appStatus === 'running')
 const runLabel = computed(() =>
@@ -194,6 +196,41 @@ function clearExecutionOutput() {
 function clearHistory() {
   history.value = []
 }
+
+async function loadCompletionMetadata() {
+  const sequence = ++completionRequestSequence
+
+  try {
+    const response = await fetch(
+      `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/helm/completions`,
+      {
+        headers: {
+          Accept: 'application/json'
+        },
+        cache: 'no-store'
+      }
+    )
+    if (!response.ok) throw new Error('Completion metadata is unavailable.')
+
+    const metadata = await response.json()
+    if (sequence !== completionRequestSequence) return
+    completionMetadata.value = metadata.available ? metadata : null
+  } catch {
+    if (sequence === completionRequestSequence) {
+      completionMetadata.value = null
+    }
+  }
+}
+
+onMounted(() => {
+  loadCompletionMetadata()
+  window.addEventListener('focus', loadCompletionMetadata)
+})
+
+onBeforeUnmount(() => {
+  completionRequestSequence++
+  window.removeEventListener('focus', loadCompletionMetadata)
+})
 
 watch(code, () => editor.value?.clearDiagnostics())
 </script>
@@ -440,6 +477,7 @@ watch(code, () => editor.value?.clearDiagnostics())
             test-id="helm-editor"
             height="fill"
             :disabled="!isRunning"
+            :completion-metadata="completionMetadata"
             submit-on-mod-enter
             placeholder="// Enter JavaScript code..."
             @selection-change="editorSelection = $event"

--- a/config/routes.js
+++ b/config/routes.js
@@ -239,6 +239,8 @@ module.exports.routes = {
     'api/v1/app/stop-app',
   'POST /api/v1/projects/:projectSlug/environments/:environmentSlug/execute':
     'api/v1/app/execute-code',
+  'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/completions':
+    'api/v1/helm/get-project-completions',
 
   // Webhooks (public — signature-verified in controller)
   'POST /api/v1/webhooks/github/:projectSlug': {
@@ -471,6 +473,7 @@ module.exports.routes = {
   'GET /api/v1/bosun/diff': 'api/v1/bosun/get-diff',
   'POST /api/v1/bosun/migrate': 'api/v1/bosun/apply-migration',
   'POST /api/v1/bosun/eval': 'api/v1/bosun/eval',
+  'GET /api/v1/bosun/helm/completions': 'api/v1/bosun/get-helm-completions',
   'POST /api/v1/helm/executions/:executionId/cancel':
     'api/v1/helm/cancel-execution',
   'GET /api/v1/bosun/activity': 'api/v1/bosun/get-activity',

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",
         "@codemirror/lang-javascript": "^6.2.5",
         "@codemirror/lang-sql": "^6.10.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "packages/*"
   ],
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/commands": "^6.10.4",
     "@codemirror/lang-javascript": "^6.2.5",
     "@codemirror/lang-sql": "^6.10.0",

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -13,6 +13,46 @@ function helmWorld(slug) {
   }
 }
 
+const HELM_COMPLETION_METADATA = {
+  available: true,
+  version: 1,
+  models: [
+    {
+      identity: 'creator',
+      globalId: 'Creator',
+      attributes: [
+        { name: 'email', type: 'string', association: null },
+        { name: 'firstName', type: 'string', association: null },
+        {
+          name: 'invoices',
+          type: 'collection:invoice',
+          association: 'collection'
+        }
+      ]
+    },
+    {
+      identity: 'invoice',
+      globalId: 'Invoice',
+      attributes: [
+        { name: 'amount', type: 'number', association: null },
+        { name: 'status', type: 'string', association: null }
+      ]
+    }
+  ],
+  helpers: [
+    { path: 'mail.send' },
+    { path: 'mail.sendTemplate' },
+    { path: 'passwords.hashPassword' }
+  ],
+  config: [
+    { path: 'custom', type: 'object' },
+    { path: 'custom.appName', type: 'string' },
+    { path: 'custom.baseUrl', type: 'string' },
+    { path: 'models', type: 'object' },
+    { path: 'models.migrate', type: 'string' }
+  ]
+}
+
 function oversizedOutput() {
   return JSON.stringify(
     Array.from({ length: 180 }, (_, index) => ({
@@ -1193,6 +1233,143 @@ test(
       await page.raw.locator('[data-test="bosun-helm-logs"]').textContent()
     ).toContain('partial')
     await page.screenshot('.tmp/issue-271-bosun-cancelled-dark.png')
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'project Helm completes models, attributes, and Waterline without stealing run shortcuts',
+  {
+    browser: true,
+    world: helmWorld('helm-completion-project')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const projectSlug = current.projects.deploymentTarget.slug
+    const environmentSlug = current.environments.production.slug
+    let executionCount = 0
+
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'sounding-helm-completion-app'
+    })
+
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+
+    await page.raw.route('**/helm/completions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(HELM_COMPLETION_METADATA)
+      })
+    })
+    await page.raw.route('**/execute', async (route) => {
+      executionCount++
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          status: 'success',
+          value: [],
+          logs: [],
+          output: '[]',
+          error: null,
+          durationMs: 2,
+          truncated: false,
+          rowCount: 0,
+          outputBytes: 2,
+          logsPartial: false
+        })
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+    )
+
+    await page.fill('@helm-editor', 'Cre')
+    await page.raw.locator('.cm-tooltip-autocomplete').waitFor()
+    expect(
+      await page.raw.locator('.cm-tooltip-autocomplete').textContent()
+    ).toContain('Creator')
+    await page.screenshot('.tmp/issue-272-project-model-completion-light.png')
+
+    await page.key('Escape')
+    await page.fill('@helm-editor', 'Creator.find({ fir')
+    await page.raw.locator('.cm-tooltip-autocomplete').waitFor()
+    expect(
+      await page.raw.locator('.cm-tooltip-autocomplete').textContent()
+    ).toContain('firstName')
+    await page.screenshot(
+      '.tmp/issue-272-project-attribute-completion-light.png'
+    )
+
+    await page.fill('@helm-editor', 'Creator.fi')
+    await page.raw.locator('.cm-tooltip-autocomplete').waitFor()
+    await page.key('Enter')
+    expect(
+      await page.raw.locator('[data-test="helm-editor"]').textContent()
+    ).toBe('Creator.find')
+    expect(executionCount).toBe(0)
+
+    await page.key('ControlOrMeta+Enter')
+    await page.wait('@helm-output')
+    expect(executionCount).toBe(1)
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'Bosun Helm completes helper and config namespaces in dark mode',
+  {
+    browser: true,
+    world: helmWorld('helm-completion-bosun')
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route('**/api/v1/bosun/helm/completions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(HELM_COMPLETION_METADATA)
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inDarkMode()
+    await page.goto('/bosun?tab=console&mode=helm')
+
+    await page.fill('@bosun-helm-editor', 'sails.helpers.ma')
+    await page.raw.locator('.cm-tooltip-autocomplete').waitFor()
+    expect(
+      await page.raw.locator('.cm-tooltip-autocomplete').textContent()
+    ).toContain('mail')
+    await page.screenshot('.tmp/issue-272-bosun-helper-completion-dark.png')
+
+    await page.key('Escape')
+    await page.fill('@bosun-helm-editor', 'sails.config.cu')
+    await page.raw.locator('.cm-tooltip-autocomplete').waitFor()
+    expect(
+      await page.raw.locator('.cm-tooltip-autocomplete').textContent()
+    ).toContain('custom')
+    await page.screenshot('.tmp/issue-272-bosun-config-completion-dark.png')
     expect(page).toHaveNoSmoke()
   }
 )

--- a/tests/functional/api/helm.test.js
+++ b/tests/functional/api/helm.test.js
@@ -15,6 +15,20 @@ const RESULT = {
   logsPartial: false
 }
 
+const COMPLETIONS = {
+  available: true,
+  version: 1,
+  models: [
+    {
+      identity: 'creator',
+      globalId: 'Creator',
+      attributes: [{ name: 'firstName', type: 'string', association: null }]
+    }
+  ],
+  helpers: [{ path: 'mail.sendTemplate' }],
+  config: [{ path: 'custom.appName', type: 'string' }]
+}
+
 test(
   'Bosun Helm exposes the shared structured execution result',
   {
@@ -162,5 +176,131 @@ test(
     } finally {
       sails.helpers.helm.cancelExecution = originalCancel
     }
+  }
+)
+
+test(
+  'Bosun Helm introspects its live Sails app without returning config values',
+  {
+    world: {
+      name: 'configured-slipway'
+    }
+  },
+  async ({ sails, request, expect }) => {
+    const secret = 'helm-completion-value-must-stay-server-side'
+    sails.config.custom.helmCompletionTestSecret = secret
+
+    try {
+      const response = await request
+        .as('genesisUser')
+        .get('/api/v1/bosun/helm/completions')
+
+      expect(response).toHaveStatus(200)
+      expect(response.header('cache-control')).toMatch('private')
+      expect(response.header('cache-control')).toMatch('no-store')
+      expect(response).toHaveJsonPath('available', true)
+      expect(response).toHaveJsonPath('version', 1)
+      const userModel = response.data.models.find(
+        (model) => model.identity === 'user'
+      )
+      expect(userModel.globalId).toBe('User')
+      expect(
+        userModel.attributes.some((attribute) => attribute.name === 'email')
+      ).toBe(true)
+      expect(response.data.helpers.length > 0).toBe(true)
+      expect(
+        response.data.config.some(
+          (entry) => entry.path === 'custom.helmCompletionTestSecret'
+        )
+      ).toBe(true)
+      expect(JSON.stringify(response.data).includes(secret)).toBe(false)
+    } finally {
+      delete sails.config.custom.helmCompletionTestSecret
+    }
+  }
+)
+
+test(
+  'project Helm completion metadata comes from the current running app',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'helm-completion-contract',
+          name: 'Helm Completion Contract'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const originalGetCompletions = sails.helpers.helm.getCompletions
+    let inspectedContainer
+
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'helm-completion-contract-web'
+    })
+    sails.helpers.helm.getCompletions = async (containerName) => {
+      inspectedContainer = containerName
+      return COMPLETIONS
+    }
+
+    try {
+      const projectSlug = current.projects.deploymentTarget.slug
+      const environmentSlug = current.environments.production.slug
+      const response = await request
+        .as('genesisUser')
+        .get(
+          `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/helm/completions`
+        )
+
+      expect(response).toHaveStatus(200)
+      expect(response.header('cache-control')).toMatch('private')
+      expect(response.header('cache-control')).toMatch('no-store')
+      expect(inspectedContainer).toBe('helm-completion-contract-web')
+      expect(response).toHaveJsonPath('available', true)
+      expect(response).toHaveJsonPath('models.0.globalId', 'Creator')
+      expect(response).toHaveJsonPath('models.0.attributes.0.name', 'firstName')
+      expect(response).toHaveJsonPath('helpers.0.path', 'mail.sendTemplate')
+    } finally {
+      sails.helpers.helm.getCompletions = originalGetCompletions
+    }
+  }
+)
+
+test(
+  'project Helm completion degrades to an empty contract when its app is unavailable',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'helm-completion-unavailable',
+          name: 'Helm Completion Unavailable'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'stopped',
+      containerName: ''
+    })
+
+    const response = await request
+      .as('genesisUser')
+      .get(
+        `/api/v1/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/helm/completions`
+      )
+
+    expect(response).toHaveStatus(200)
+    expect(response).toHaveJsonPath('available', false)
+    expect(response).toHaveJsonPath('version', 1)
+    expect(response.data.models).toEqual([])
+    expect(response.data.helpers).toEqual([])
+    expect(response.data.config).toEqual([])
   }
 )

--- a/tests/unit/config/routes.test.js
+++ b/tests/unit/config/routes.test.js
@@ -44,4 +44,12 @@ test('browser actions and JSON transports have explicit route contracts', ({
   expect(routes['DELETE /settings/team-profile/logo']).toBe(
     'team/delete-team-logo'
   )
+  expect(
+    routes[
+      'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/completions'
+    ]
+  ).toBe('api/v1/helm/get-project-completions')
+  expect(routes['GET /api/v1/bosun/helm/completions']).toBe(
+    'api/v1/bosun/get-helm-completions'
+  )
 })

--- a/tests/unit/helpers/helm/completions.test.js
+++ b/tests/unit/helpers/helm/completions.test.js
@@ -1,0 +1,171 @@
+const { test } = require('sounding')
+
+const {
+  buildSailsCompletionSource,
+  collectSailsCompletionMetadata
+} = require('../../../../api/lib/helm-completions')
+
+function completionSailsFixture() {
+  let getterRead = false
+  const config = {
+    custom: {
+      publicName: 'Hagfish',
+      secretToken: 'never-return-this-secret'
+    },
+    models: {
+      migrate: 'safe'
+    }
+  }
+  Object.defineProperty(config.custom, 'computedSecret', {
+    enumerable: true,
+    get() {
+      getterRead = true
+      return 'never-invoke-this-getter'
+    }
+  })
+
+  const creatorModel = Object.create({
+    identity: 'creator',
+    globalId: 'Creator',
+    attributes: {
+      firstName: { type: 'string', required: true },
+      team: { model: 'team' },
+      invoices: { collection: 'invoice', via: 'creator' }
+    }
+  })
+
+  const fakeSails = {
+    models: {
+      creator: creatorModel
+    },
+    helpers: {
+      mail: {
+        sendTemplate() {}
+      },
+      formatCurrency() {}
+    },
+    config
+  }
+
+  return {
+    fakeSails,
+    getterWasRead: () => getterRead
+  }
+}
+
+test('Helm completion metadata contains names and types without reading values', ({
+  expect
+}) => {
+  const fixture = completionSailsFixture()
+  const metadata = collectSailsCompletionMetadata(fixture.fakeSails)
+  const serialized = JSON.stringify(metadata)
+
+  expect(metadata.truncated).toBe(false)
+  expect(metadata.models[0]).toEqual({
+    identity: 'creator',
+    globalId: 'Creator',
+    attributes: [
+      {
+        name: 'firstName',
+        type: 'string',
+        association: null
+      },
+      {
+        name: 'invoices',
+        type: 'collection:invoice',
+        association: 'collection'
+      },
+      {
+        name: 'team',
+        type: 'model:team',
+        association: 'model'
+      }
+    ]
+  })
+  expect(metadata.helpers).toEqual([
+    { path: 'formatCurrency' },
+    { path: 'mail.sendTemplate' }
+  ])
+  expect(
+    metadata.config.find((entry) => entry.path === 'custom.secretToken')
+  ).toEqual({
+    path: 'custom.secretToken',
+    type: 'string'
+  })
+  expect(
+    metadata.config.find((entry) => entry.path === 'custom.computedSecret')
+  ).toEqual({
+    path: 'custom.computedSecret',
+    type: 'undefined'
+  })
+  expect(fixture.getterWasRead()).toBe(false)
+  expect(serialized.includes('never-return-this-secret')).toBe(false)
+  expect(serialized.includes('never-invoke-this-getter')).toBe(false)
+  expect(serialized.includes('Hagfish')).toBe(false)
+  expect(serialized.includes('safe')).toBe(false)
+})
+
+test('container completion source uses the same secret-free collector', ({
+  expect
+}) => {
+  const fixture = completionSailsFixture()
+  const source = buildSailsCompletionSource()
+  const metadata = Function('sails', source)(fixture.fakeSails)
+
+  expect(metadata).toEqual(collectSailsCompletionMetadata(fixture.fakeSails))
+  expect(JSON.stringify(metadata).includes('never-return-this-secret')).toBe(
+    false
+  )
+})
+
+test('Helm completion metadata is bounded for unusually large apps', ({
+  expect
+}) => {
+  const models = {}
+  for (let index = 0; index < 101; index++) {
+    const identity = `model${String(index).padStart(3, '0')}`
+    models[identity] = {
+      identity,
+      globalId: `Model${String(index).padStart(3, '0')}`,
+      attributes: {}
+    }
+  }
+
+  const metadata = collectSailsCompletionMetadata({
+    models,
+    helpers: {},
+    config: {}
+  })
+
+  expect(metadata.models.length).toBe(100)
+  expect(metadata.truncated).toBe(true)
+})
+
+test('Helm completion resolves Sails and Waterline contexts', async ({
+  expect
+}) => {
+  const { helmCompletionResult } = await import(
+    '../../../../assets/js/lib/helmCompletions.mjs'
+  )
+  const metadata = collectSailsCompletionMetadata(
+    completionSailsFixture().fakeSails
+  )
+  const labelsFor = (source, explicit = false) =>
+    helmCompletionResult(source, source.length, metadata, {
+      explicit
+    })?.options.map((option) => option.label) || []
+
+  expect(labelsFor('Cre')).toContain('Creator')
+  expect(labelsFor('Creator.fi')).toContain('find')
+  expect(labelsFor('Creator.find().li')).toContain('limit')
+  expect(labelsFor('Creator.find({ fir')).toContain('firstName')
+  expect(labelsFor("Creator.find().select(['fir")).toContain('firstName')
+  expect(labelsFor('Creator.attributes.te')).toContain('team')
+  expect(labelsFor('sails.helpers.ma')).toContain('mail')
+  expect(labelsFor('sails.helpers.mail.s')).toContain('sendTemplate')
+  expect(labelsFor('sails.config.cu')).toContain('custom')
+  expect(labelsFor('sails.config.custom.se')).toContain('secretToken')
+  expect(labelsFor('sails.models.cre')).toContain('creator')
+  expect(labelsFor('ordinaryLowercase')).toEqual([])
+  expect(labelsFor('', true)).toContain('sails')
+})


### PR DESCRIPTION
## Summary

- add a bounded, secret-free completion metadata contract for live Sails models, attributes, helpers, and configuration keys
- inspect Bosun locally and the selected environment's current running app through the existing isolated Helm runtime
- add shared CodeMirror completion for Sails globals, helper/config paths, model attributes, Waterline methods, and chained query modifiers
- preserve the existing Enter and Cmd/Ctrl+Enter execution behavior while supporting completion keyboard navigation
- refresh metadata on focus and degrade quietly when the app is stopped or cannot be inspected
- theme the minimal completion popup for Slipway's light and dark modes

## Security

The browser receives names and types only. The collector does not invoke getters or return configuration values, credentials, model records, attribute defaults, or secrets. Responses are bounded and sent with `Cache-Control: private, no-store`.

## Verification

- `npx sounding test --file tests/unit/helpers/helm/completions.test.js --test-concurrency=1` — 4 passed
- `npx sounding test --file tests/functional/api/helm.test.js --test-concurrency=1` — 6 passed
- Helm completion browser trials — 2 passed across project Helm, Bosun, light mode, and dark mode
- `npm run lint`
- `git diff --check`

Closes #272