### PR TITLE
fix(dock): compact command-only SQL results

### DIFF
--- a/assets/js/components/DockResultStatusIcon.vue
+++ b/assets/js/components/DockResultStatusIcon.vue
@@ -1,0 +1,57 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  status: {
+    type: String,
+    default: 'success'
+  },
+  contained: Boolean
+})
+
+const statusClasses = computed(() => {
+  if (props.status === 'error') {
+    return props.contained
+      ? 'bg-red-100 text-red-600 dark:bg-red-950 dark:text-red-400'
+      : 'text-red-500'
+  }
+
+  return props.contained
+    ? 'bg-green-100 text-green-700 dark:bg-green-950 dark:text-green-400'
+    : 'text-green-600 dark:text-green-400'
+})
+</script>
+
+<template>
+  <span
+    :class="[
+      'flex shrink-0 items-center justify-center',
+      contained ? 'h-5 w-5 rounded-full' : 'h-3.5 w-3.5',
+      statusClasses
+    ]"
+    aria-hidden="true"
+  >
+    <svg
+      v-if="status === 'error'"
+      :class="contained ? 'h-3 w-3' : 'h-3.5 w-3.5'"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        d="M5.47 5.47a.75.75 0 011.06 0L10 8.94l3.47-3.47a.75.75 0 111.06 1.06L11.06 10l3.47 3.47a.75.75 0 11-1.06 1.06L10 11.06l-3.47 3.47a.75.75 0 01-1.06-1.06L8.94 10 5.47 6.53a.75.75 0 010-1.06z"
+      />
+    </svg>
+    <svg
+      v-else
+      :class="contained ? 'h-3 w-3' : 'h-3.5 w-3.5'"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        fill-rule="evenodd"
+        d="M16.704 4.153a.75.75 0 01.143 1.051l-7 9.5a.75.75 0 01-1.127.08l-4.5-4.5a.75.75 0 011.06-1.06l3.89 3.889 6.48-8.817a.75.75 0 011.054-.143z"
+        clip-rule="evenodd"
+      />
+    </svg>
+  </span>
+</template>

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -14,6 +14,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
+import DockResultStatusIcon from '@/components/DockResultStatusIcon.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
 import { highlightJSON } from '@/lib/highlightJSON'
 import SlippyLoader from '@/components/SlippyLoader.vue'
@@ -112,6 +113,28 @@ const activeQueryResult = computed(
   () => queryResults.value[activeQueryResultIndex.value] || null
 )
 const hasMultipleQueryResults = computed(() => queryResults.value.length > 1)
+const hasOnlyCommandResults = computed(
+  () =>
+    isSQL.value &&
+    queryResults.value.length > 0 &&
+    queryResults.value.every((result) => !result.columns?.length)
+)
+const commandBatchSummary = computed(() => {
+  const total = queryResults.value.length
+  const failed = queryResults.value.filter(
+    (result) => result.status === 'error'
+  ).length
+  const completed = total - failed
+  const statements = total === 1 ? 'statement' : 'statements'
+  const duration = formatQueryDuration(queryResult.value?.duration)
+
+  const summary =
+    failed > 0
+      ? `${completed} of ${total} ${statements} completed · ${failed} failed`
+      : `${total} ${statements} completed`
+
+  return duration ? `${summary} · ${duration}` : summary
+})
 
 // Redis console state
 const redisCommand = ref('')
@@ -850,6 +873,23 @@ function queryResultCountLabel(result) {
   return result.commandTag || 'Completed'
 }
 
+function formatQueryDuration(duration) {
+  if (duration === null || duration === undefined || duration === '') return ''
+
+  const value = Number(duration)
+  if (!Number.isFinite(value)) return ''
+
+  const rounded =
+    value >= 100 ? Math.round(value) : Math.round(value * 100) / 100
+  return `${rounded}ms`
+}
+
+function queryResultStatementLabel(result) {
+  return (
+    result.statementPreview || result.statementSql || result.commandTag || 'SQL'
+  )
+}
+
 // Export functions
 function exportAsJSON() {
   if (!activeQueryResult.value?.rows) return
@@ -1529,6 +1569,7 @@ onUnmounted(() => {
       >
         <!-- Editor -->
         <div
+          data-test="dock-query-editor-pane"
           class="flex-1 overflow-hidden border-b border-gray-200 dark:border-gray-800"
         >
           <CodeEditor
@@ -1571,7 +1612,15 @@ onUnmounted(() => {
         </div>
 
         <!-- Results -->
-        <div class="flex-1 overflow-auto">
+        <div
+          data-test="dock-query-results"
+          :class="[
+            'overflow-auto',
+            queryResult && hasOnlyCommandResults
+              ? 'max-h-[45%] shrink-0'
+              : 'min-h-0 flex-1'
+          ]"
+        >
           <!-- Error -->
           <div v-if="queryError" class="p-4">
             <div
@@ -1583,7 +1632,98 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <!-- Results -->
+          <!-- Compact command-only results -->
+          <section
+            v-else-if="queryResult && hasOnlyCommandResults"
+            aria-labelledby="dock-command-summary-heading"
+            aria-live="polite"
+            data-test="dock-command-summary"
+            class="px-4 py-4 sm:px-6"
+          >
+            <h2 id="dock-command-summary-heading" class="sr-only">
+              SQL statement results
+            </h2>
+            <ol class="space-y-1.5">
+              <li
+                v-for="(result, index) in queryResults"
+                :key="index"
+                :data-test="`dock-command-result-${index + 1}`"
+                class="rounded-lg bg-gray-50 px-3 py-2.5 dark:bg-gray-900/60"
+              >
+                <div class="flex items-start gap-3">
+                  <DockResultStatusIcon
+                    :status="result.status"
+                    contained
+                    class="mt-0.5"
+                  />
+                  <span
+                    class="mt-0.5 w-4 shrink-0 text-right text-xs font-medium tabular-nums text-gray-400 dark:text-gray-600"
+                  >
+                    {{ index + 1 }}
+                  </span>
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-start gap-3">
+                      <p
+                        class="min-w-0 flex-1 truncate font-mono text-sm text-gray-800 dark:text-gray-200"
+                        :title="
+                          result.statementSql ||
+                          queryResultStatementLabel(result)
+                        "
+                      >
+                        {{ queryResultStatementLabel(result) }}
+                      </p>
+                      <span
+                        v-if="formatQueryDuration(result.duration)"
+                        class="shrink-0 text-xs tabular-nums text-gray-400 dark:text-gray-500"
+                      >
+                        {{ formatQueryDuration(result.duration) }}
+                      </span>
+                    </div>
+                    <div
+                      class="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs"
+                    >
+                      <span
+                        :class="
+                          result.status === 'error'
+                            ? 'font-medium text-red-600 dark:text-red-400'
+                            : 'font-medium text-green-700 dark:text-green-400'
+                        "
+                      >
+                        {{ result.status === 'error' ? 'Failed' : 'Completed' }}
+                      </span>
+                      <span
+                        v-if="
+                          result.status !== 'error' &&
+                          queryResultCountLabel(result) !== 'Completed'
+                        "
+                        class="text-gray-500 dark:text-gray-400"
+                      >
+                        {{ queryResultCountLabel(result) }}
+                      </span>
+                    </div>
+                    <p
+                      v-if="result.status === 'error'"
+                      class="mt-1.5 break-words font-mono text-xs leading-5 text-red-600 dark:text-red-400"
+                    >
+                      {{
+                        result.error ||
+                        result.message ||
+                        'The statement could not be completed.'
+                      }}
+                    </p>
+                  </div>
+                </div>
+              </li>
+            </ol>
+            <p
+              data-test="dock-command-summary-total"
+              class="mt-3 text-right text-xs tabular-nums text-gray-500 dark:text-gray-400"
+            >
+              {{ commandBatchSummary }}
+            </p>
+          </section>
+
+          <!-- Row-returning and mixed results -->
           <div v-else-if="queryResult" class="flex h-full min-h-0 flex-col">
             <div
               v-if="hasMultipleQueryResults"
@@ -1611,11 +1751,7 @@ onUnmounted(() => {
                 @click="selectQueryResult(index)"
                 @keydown="handleQueryResultKeydown($event, index)"
               >
-                <span
-                  v-if="result.status === 'error'"
-                  class="h-1.5 w-1.5 shrink-0 rounded-full bg-red-500"
-                  aria-hidden="true"
-                ></span>
+                <DockResultStatusIcon :status="result.status" />
                 <span class="shrink-0 font-medium tabular-nums">{{
                   index + 1
                 }}</span>
@@ -1725,23 +1861,42 @@ onUnmounted(() => {
               </div>
 
               <!-- Command or error result -->
-              <div
-                v-else
-                class="flex flex-1 items-center justify-center p-4 text-sm"
-              >
-                <p
-                  :class="
-                    activeQueryResult.status === 'error'
-                      ? 'font-mono text-red-600 dark:text-red-400'
-                      : 'text-gray-500 dark:text-gray-400'
-                  "
-                >
-                  {{
-                    activeQueryResult.message ||
-                    activeQueryResult.error ||
-                    'Query executed successfully'
-                  }}
-                </p>
+              <div v-else class="flex flex-1 items-start p-4 text-sm sm:p-6">
+                <div class="flex min-w-0 items-start gap-3">
+                  <DockResultStatusIcon
+                    :status="activeQueryResult.status"
+                    contained
+                    class="mt-0.5"
+                  />
+                  <div class="min-w-0">
+                    <p
+                      :class="
+                        activeQueryResult.status === 'error'
+                          ? 'font-medium text-red-600 dark:text-red-400'
+                          : 'font-medium text-green-700 dark:text-green-400'
+                      "
+                    >
+                      {{
+                        activeQueryResult.status === 'error'
+                          ? 'Statement failed'
+                          : 'Statement completed'
+                      }}
+                    </p>
+                    <p
+                      v-if="
+                        activeQueryResult.message || activeQueryResult.error
+                      "
+                      :class="[
+                        'mt-1 break-words text-xs leading-5',
+                        activeQueryResult.status === 'error'
+                          ? 'font-mono text-red-600 dark:text-red-400'
+                          : 'text-gray-500 dark:text-gray-400'
+                      ]"
+                    >
+                      {{ activeQueryResult.message || activeQueryResult.error }}
+                    </p>
+                  </div>
+                </div>
               </div>
             </div>
 

--- a/tests/e2e/pages/projects/dock-multi-results.test.js
+++ b/tests/e2e/pages/projects/dock-multi-results.test.js
@@ -96,7 +96,7 @@ test(
       `/projects/${current.projects.deploymentTarget.slug}/environments/production/dock/${database.id}`
     )
 
-    await page.fill('@dock-query-editor', successfulQuery)
+    await replaceQuery(page, expect, successfulQuery)
     await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
     await page.wait('@dock-query-result-1')
 
@@ -123,7 +123,7 @@ test(
     await page.key('ArrowRight')
     expect(await tabs.nth(1).getAttribute('aria-selected')).toBe('true')
 
-    await page.fill('@dock-query-editor', commandOnlyQuery)
+    await replaceQuery(page, expect, commandOnlyQuery)
     await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
     await page.wait('@dock-command-summary')
 
@@ -144,7 +144,7 @@ test(
     await page.screenshot('.tmp/issue-293-command-summary-light.png')
 
     await page.inDarkMode()
-    await page.fill('@dock-query-editor', partiallyFailedQuery)
+    await replaceQuery(page, expect, partiallyFailedQuery)
     await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
     await page.wait('@dock-command-summary')
 
@@ -153,7 +153,7 @@ test(
     await expect(page).toSee('1 of 2 statements completed · 1 failed · 5ms')
     await page.screenshot('.tmp/issue-293-partial-failure-dark.png')
 
-    await page.fill('@dock-query-editor', mixedQuery)
+    await replaceQuery(page, expect, mixedQuery)
     await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
     await page.wait('@dock-query-result-1')
 
@@ -171,6 +171,16 @@ test(
     expect(page).toHaveNoSmoke()
   }
 )
+
+async function replaceQuery(page, expect, value) {
+  const editor = page.raw.locator('[data-test="dock-query-editor"]')
+
+  await editor.click()
+  await editor.press('ControlOrMeta+A')
+  await page.raw.keyboard.insertText(value)
+
+  expect(await editor.innerText()).toBe(value)
+}
 
 function successfulResponse() {
   const results = [

--- a/tests/e2e/pages/projects/dock-multi-results.test.js
+++ b/tests/e2e/pages/projects/dock-multi-results.test.js
@@ -4,13 +4,22 @@ const successfulQuery = [
   'SELECT count(*) AS creators FROM creators;',
   'SELECT count(*) AS teams FROM teams;'
 ].join('\n')
+const commandOnlyQuery = [
+  'ALTER TABLE invoices ADD COLUMN IF NOT EXISTS recurring_anchor_date VARCHAR(10);',
+  'UPDATE invoices SET recurring_anchor_date = next_recurring_date WHERE recurring_enabled = TRUE;',
+  'CREATE UNIQUE INDEX IF NOT EXISTS invoices_recurring_occurrence_unique ON invoices (template_invoice, recurring_occurrence_date);'
+].join('\n')
 const partiallyFailedQuery = [
   'DROP TABLE audit_events;',
   'SELECT * FROM missing_table;'
 ].join('\n')
+const mixedQuery = [
+  'SELECT count(*) AS creators FROM creators;',
+  'UPDATE missing_table SET active = TRUE;'
+].join('\n')
 
 test(
-  'Dock keeps every SQL result labeled, navigable, and independently copyable',
+  'Dock presents row, command, failure, and mixed SQL batches clearly',
   {
     browser: true,
     world: {
@@ -54,9 +63,15 @@ test(
     })
     await page.raw.route('**/dock/sql?**', async (route) => {
       const { query } = route.request().postDataJSON()
-      const response = query.includes('missing_table')
-        ? partiallyFailedResponse()
-        : successfulResponse()
+      let response = successfulResponse()
+
+      if (query.includes('ALTER TABLE invoices')) {
+        response = commandOnlyResponse()
+      } else if (query.includes('UPDATE missing_table')) {
+        response = mixedResponse()
+      } else if (query.includes('missing_table')) {
+        response = partiallyFailedResponse()
+      }
 
       await route.fulfill({
         status: 200,
@@ -108,21 +123,51 @@ test(
     await page.key('ArrowRight')
     expect(await tabs.nth(1).getAttribute('aria-selected')).toBe('true')
 
+    await page.fill('@dock-query-editor', commandOnlyQuery)
+    await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
+    await page.wait('@dock-command-summary')
+
+    expect(await tabs.count()).toBe(0)
+    expect(
+      await page.raw.locator('[data-test^="dock-command-result-"]').count()
+    ).toBe(3)
+    await expect(page).toSee('4 rows affected')
+    await expect(page).toSee('3 statements completed · 195ms')
+
+    const editorBounds = await page.raw
+      .locator('[data-test="dock-query-editor-pane"]')
+      .boundingBox()
+    const commandResultBounds = await page.raw
+      .locator('[data-test="dock-query-results"]')
+      .boundingBox()
+    expect(commandResultBounds.height < editorBounds.height).toBe(true)
+    await page.screenshot('.tmp/issue-293-command-summary-light.png')
+
     await page.inDarkMode()
     await page.fill('@dock-query-editor', partiallyFailedQuery)
     await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
-    await page.wait(100)
+    await page.wait('@dock-command-summary')
+
+    expect(await tabs.count()).toBe(0)
+    await expect(page).toSee('relation "missing_table" does not exist')
+    await expect(page).toSee('1 of 2 statements completed · 1 failed · 5ms')
+    await page.screenshot('.tmp/issue-293-partial-failure-dark.png')
+
+    await page.fill('@dock-query-editor', mixedQuery)
+    await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
+    await page.wait('@dock-query-result-1')
 
     expect(await tabs.count()).toBe(2)
     expect(await tabs.nth(1).getAttribute('aria-selected')).toBe('true')
-    await expect(page).toSee('relation "missing_table" does not exist')
-    await page.screenshot('.tmp/issue-213-partial-failure-dark.png')
+    await expect(page).toSee('Statement failed')
+    await expect(page).not.toSee('@dock-copy-query-result')
 
     await page.click('@dock-query-result-1')
-    await expect(page).toSee('DROP TABLE completed')
+    await expect(page).toSee('24873')
+    await page.wait('@dock-copy-query-result')
 
     await page.resize(390, 844)
-    await page.screenshot('.tmp/issue-213-multi-results-mobile-dark.png')
+    await page.screenshot('.tmp/issue-293-mixed-results-mobile-dark.png')
     expect(page).toHaveNoSmoke()
   }
 )
@@ -198,6 +243,110 @@ function partiallyFailedResponse() {
     results,
     error: results[1].error,
     messages: 'ERROR: relation "missing_table" does not exist'
+  }
+}
+
+function commandOnlyResponse() {
+  const results = [
+    commandResult({
+      statementIndex: 0,
+      statementSql:
+        'ALTER TABLE invoices ADD COLUMN IF NOT EXISTS recurring_anchor_date VARCHAR(10);',
+      statementPreview:
+        'ALTER TABLE invoices ADD COLUMN IF NOT EXISTS recurring_anchor_date VARCHAR(10)',
+      commandTag: 'ALTER TABLE',
+      duration: 82
+    }),
+    commandResult({
+      statementIndex: 1,
+      statementSql:
+        'UPDATE invoices SET recurring_anchor_date = next_recurring_date WHERE recurring_enabled = TRUE;',
+      statementPreview:
+        'UPDATE invoices SET recurring_anchor_date = next_recurring_date WHERE recurring_enabled = TRUE',
+      commandTag: 'UPDATE',
+      duration: 61,
+      affected: 4
+    }),
+    commandResult({
+      statementIndex: 2,
+      statementSql:
+        'CREATE UNIQUE INDEX IF NOT EXISTS invoices_recurring_occurrence_unique ON invoices (template_invoice, recurring_occurrence_date);',
+      statementPreview:
+        'CREATE UNIQUE INDEX IF NOT EXISTS invoices_recurring_occurrence_unique ON invoices (template_invoice, recurring_occurrence_date)',
+      commandTag: 'CREATE INDEX',
+      duration: 52
+    })
+  ]
+
+  return {
+    success: true,
+    ...results[0],
+    duration: 195,
+    results,
+    messages: ''
+  }
+}
+
+function mixedResponse() {
+  const results = [
+    queryResult({
+      statementIndex: 0,
+      statementSql: 'SELECT count(*) AS creators FROM creators;',
+      statementPreview: 'SELECT count(*) AS creators FROM creators',
+      duration: 2.4,
+      columns: ['creators'],
+      rows: [{ creators: 24873 }]
+    }),
+    {
+      statementIndex: 1,
+      statementSql: 'UPDATE missing_table SET active = TRUE;',
+      statementPreview: 'UPDATE missing_table SET active = TRUE',
+      commandTag: 'UPDATE',
+      status: 'error',
+      duration: 1.2,
+      rowCount: 0,
+      affected: null,
+      columns: [],
+      rows: [],
+      message: 'relation "missing_table" does not exist',
+      error: 'relation "missing_table" does not exist',
+      sqlState: '42P01',
+      raw: ''
+    }
+  ]
+
+  return {
+    success: false,
+    ...results[0],
+    duration: 4,
+    results,
+    error: results[1].error,
+    messages: 'ERROR: relation "missing_table" does not exist'
+  }
+}
+
+function commandResult({
+  statementIndex,
+  statementSql,
+  statementPreview,
+  commandTag,
+  duration,
+  affected = null
+}) {
+  return {
+    statementIndex,
+    statementSql,
+    statementPreview,
+    commandTag,
+    status: 'success',
+    duration,
+    rowCount: 0,
+    affected,
+    columns: [],
+    rows: [],
+    message: null,
+    error: null,
+    raw: commandTag
   }
 }
 


### PR DESCRIPTION
## Summary
- replace oversized command-only output panes with compact ordered execution summaries
- show statement status, affected rows, duration, and inline failures without displacing the editor
- keep mixed row/command results accessible, responsive, and independently navigable

## Verification
- `node node_modules/sounding/bin/sounding.js test --file tests/e2e/pages/projects/dock-multi-results.test.js --test-concurrency=1 --compact`
- `node node_modules/sounding/bin/sounding.js test --file tests/unit/helpers/dock/execute-sql-results.test.js --test-concurrency=1 --compact`
- `npm run lint`

Closes #293