### PR TITLE
feat(helm): add durable history and reusable snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Slipway includes integrated tools that work with your deployed Sails apps:
 
 | Tool        | What it does                                                                                                                             |
 | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| **Helm**    | Production REPL — query models, run helpers, inspect config from the browser                                                             |
+| **Helm**    | Production REPL — query models, run helpers, inspect config, and reuse private or project snippets with source-only history              |
 | **Bridge**  | Configurable data management UI from your Waterline models, with a [server-enforced resource contract](docs/bridge-resource-contract.md) |
 | **Dock**    | SQL console, schema diff, and migration tool for your databases                                                                          |
 | **Quest**   | Job scheduler dashboard for [sails-hook-quest](https://docs.sailscasts.com/quest)                                                        |

--- a/api/controllers/api/v1/app/execute-code.js
+++ b/api/controllers/api/v1/app/execute-code.js
@@ -66,32 +66,16 @@ module.exports = {
     sourceStartColumn,
     appSlug
   }) {
-    const user = await User.findOne({ id: this.req.session.userId })
-
-    const project = await Project.findOne({ slug: projectSlug }).populate(
-      'team'
-    )
-
-    if (!project) {
-      throw 'notFound'
-    }
-
-    if (project.team.id !== user.team) {
-      throw 'forbidden'
-    }
-
-    const environment = await Environment.findOne({
-      project: project.id,
-      slug: environmentSlug
-    })
-
-    if (!environment) {
-      throw 'notFound'
-    }
-
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug,
+        appSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const app = scope.app
 
     if (!app || app.status !== 'running' || !app.containerName) {
       throw { badRequest: 'App is not running.' }
@@ -102,9 +86,10 @@ module.exports = {
       this.req,
       this.res
     )
+    const startedAt = Date.now()
 
     try {
-      return await sails.helpers.helm.executeInContainer(
+      const result = await sails.helpers.helm.executeInContainer(
         app.containerName,
         code,
         sourceStartLine,
@@ -112,6 +97,25 @@ module.exports = {
         executionId,
         execution.signal
       )
+      await sails.helpers.helm.recordExecution.with({
+        scope,
+        source: code,
+        result,
+        ipAddress: this.req.ip
+      })
+      return result
+    } catch (error) {
+      await sails.helpers.helm.recordExecution.with({
+        scope,
+        source: code,
+        result: {
+          status: 'error',
+          success: false,
+          durationMs: Date.now() - startedAt
+        },
+        ipAddress: this.req.ip
+      })
+      throw error
     } finally {
       execution.release()
     }

--- a/api/controllers/api/v1/helm/clear-history.js
+++ b/api/controllers/api/v1/helm/clear-history.js
@@ -1,0 +1,61 @@
+module.exports = {
+  friendlyName: 'Clear Helm history',
+
+  description:
+    'Clear owned Helm history for an environment while preserving pinned entries by default.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    includePinned: {
+      type: 'boolean',
+      defaultsTo: false
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, includePinned }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const criteria = {
+      user: scope.user.id,
+      project: scope.project.id,
+      environment: scope.environment.id
+    }
+    if (!includePinned) criteria.pinned = false
+
+    const deleted = await HelmHistoryEntry.destroy(criteria).fetch()
+    await sails.helpers.audit.log.with({
+      action: 'helm.history.cleared',
+      resourceType: 'environment',
+      resourceId: String(scope.environment.id),
+      details: {
+        projectId: scope.project.id,
+        includePinned,
+        deletedCount: deleted.length
+      },
+      userId: String(scope.user.id),
+      teamId: String(scope.project.team.id),
+      ipAddress: this.req.ip
+    })
+
+    return { deletedCount: deleted.length }
+  }
+}

--- a/api/controllers/api/v1/helm/create-snippet.js
+++ b/api/controllers/api/v1/helm/create-snippet.js
@@ -1,0 +1,143 @@
+module.exports = {
+  friendlyName: 'Create Helm snippet',
+
+  description: 'Save source as an inert personal or project Helm snippet.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    name: {
+      type: 'string',
+      required: true,
+      maxLength: 100
+    },
+    source: {
+      type: 'string',
+      required: true
+    },
+    scope: {
+      type: 'string',
+      isIn: ['personal', 'project'],
+      defaultsTo: 'personal'
+    }
+  },
+
+  exits: {
+    success: { statusCode: 201 },
+    badRequest: { responseType: 'badRequest' },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({
+    projectSlug,
+    environmentSlug,
+    name,
+    source,
+    scope: snippetScope
+  }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const normalizedName = name.trim()
+    const normalizedSource = source.trim()
+
+    if (!normalizedName) throw { badRequest: 'Give this snippet a name.' }
+    if (!normalizedSource) throw { badRequest: 'Snippet source is required.' }
+    if (Buffer.byteLength(source) > sails.config.custom.helm.maxSourceBytes) {
+      throw { badRequest: 'Snippet source is too large.' }
+    }
+
+    const conflict = await findNameConflict({
+      projectId: scope.project.id,
+      ownerId: scope.user.id,
+      snippetScope,
+      name: normalizedName
+    })
+    if (conflict) {
+      throw {
+        badRequest:
+          snippetScope === 'project'
+            ? 'A project snippet already uses this name.'
+            : 'You already have a snippet with this name.'
+      }
+    }
+
+    let snippet
+    try {
+      snippet = await HelmSnippet.create({
+        name: normalizedName,
+        source,
+        scope: snippetScope,
+        owner: scope.user.id,
+        team: scope.project.team.id,
+        project: scope.project.id
+      }).fetch()
+    } catch (error) {
+      if (isUniqueConstraint(error)) {
+        throw {
+          badRequest:
+            snippetScope === 'project'
+              ? 'A project snippet already uses this name.'
+              : 'You already have a snippet with this name.'
+        }
+      }
+      throw error
+    }
+
+    await sails.helpers.audit.log.with({
+      action: 'helm.snippet.created',
+      resourceType: 'helmSnippet',
+      resourceId: String(snippet.id),
+      details: {
+        projectId: scope.project.id,
+        name: snippet.name,
+        scope: snippet.scope
+      },
+      userId: String(scope.user.id),
+      teamId: String(scope.project.team.id),
+      ipAddress: this.req.ip
+    })
+
+    return {
+      snippet: {
+        ...snippet,
+        owner: { id: scope.user.id, name: scope.user.fullName },
+        canManage: true
+      }
+    }
+  }
+}
+
+async function findNameConflict({ projectId, ownerId, snippetScope, name }) {
+  const criteria = {
+    project: projectId,
+    scope: snippetScope
+  }
+  if (snippetScope === 'personal') criteria.owner = ownerId
+
+  const candidates = await HelmSnippet.find(criteria)
+  const normalized = name.toLocaleLowerCase()
+  return candidates.find(
+    (snippet) => snippet.name.toLocaleLowerCase() === normalized
+  )
+}
+
+function isUniqueConstraint(error) {
+  return (
+    error?.code === 'E_UNIQUE' ||
+    error?.code === 'SQLITE_CONSTRAINT' ||
+    /unique constraint/i.test(error?.message || '')
+  )
+}

--- a/api/controllers/api/v1/helm/delete-history-entry.js
+++ b/api/controllers/api/v1/helm/delete-history-entry.js
@@ -1,0 +1,47 @@
+module.exports = {
+  friendlyName: 'Delete Helm history entry',
+
+  description:
+    'Delete one owned Helm history entry without touching audit logs.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    id: {
+      type: 'number',
+      required: true
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, id }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const deleted = await HelmHistoryEntry.destroyOne({
+      id,
+      user: scope.user.id,
+      project: scope.project.id,
+      environment: scope.environment.id
+    })
+
+    if (!deleted) throw 'notFound'
+    return { deleted: true }
+  }
+}

--- a/api/controllers/api/v1/helm/delete-snippet.js
+++ b/api/controllers/api/v1/helm/delete-snippet.js
@@ -1,0 +1,60 @@
+module.exports = {
+  friendlyName: 'Delete Helm snippet',
+
+  description: 'Delete a Helm snippet owned by the current user.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    id: {
+      type: 'number',
+      required: true
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, id }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const snippet = await HelmSnippet.findOne({
+      id,
+      project: scope.project.id
+    })
+    if (!snippet) throw 'notFound'
+    if (Number(snippet.owner) !== Number(scope.user.id)) throw 'forbidden'
+
+    await HelmSnippet.destroyOne({ id: snippet.id })
+    await sails.helpers.audit.log.with({
+      action: 'helm.snippet.deleted',
+      resourceType: 'helmSnippet',
+      resourceId: String(snippet.id),
+      details: {
+        projectId: scope.project.id,
+        name: snippet.name,
+        scope: snippet.scope
+      },
+      userId: String(scope.user.id),
+      teamId: String(scope.project.team.id),
+      ipAddress: this.req.ip
+    })
+
+    return { deleted: true }
+  }
+}

--- a/api/controllers/api/v1/helm/list-history.js
+++ b/api/controllers/api/v1/helm/list-history.js
@@ -1,0 +1,69 @@
+module.exports = {
+  friendlyName: 'List Helm history',
+
+  description:
+    'List searchable execution metadata for the current user and Helm environment.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    q: {
+      type: 'string',
+      maxLength: 200
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, q }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const search = (q || '').trim()
+    const criteria = {
+      user: scope.user.id,
+      project: scope.project.id,
+      environment: scope.environment.id
+    }
+    if (search) criteria.source = { contains: search }
+
+    const entries = await HelmHistoryEntry.find(criteria)
+      .sort(['pinned DESC', 'executedAt DESC', 'id DESC'])
+      .limit(sails.config.custom.helm.historyMaxEntriesPerScope)
+
+    this.res.set('Cache-Control', 'private, no-store')
+    return {
+      entries: entries.map(serializeEntry),
+      retentionDays: Math.round(
+        sails.config.custom.helm.historyRetentionMs / (24 * 60 * 60 * 1000)
+      )
+    }
+  }
+}
+
+function serializeEntry(entry) {
+  return {
+    id: entry.id,
+    source: entry.source,
+    status: entry.status,
+    durationMs: entry.durationMs,
+    executedAt: entry.executedAt,
+    target: entry.target,
+    pinned: entry.pinned
+  }
+}

--- a/api/controllers/api/v1/helm/list-snippets.js
+++ b/api/controllers/api/v1/helm/list-snippets.js
@@ -1,0 +1,89 @@
+module.exports = {
+  friendlyName: 'List Helm snippets',
+
+  description:
+    'List personal and project-shared snippets visible to the current user.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    q: {
+      type: 'string',
+      maxLength: 200
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, q }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const search = (q || '').trim()
+    const visibility = [
+      { scope: 'personal', owner: scope.user.id },
+      { scope: 'project' }
+    ]
+    const criteria = {
+      project: scope.project.id,
+      or: visibility
+    }
+
+    let snippets = await HelmSnippet.find(criteria)
+      .populate('owner')
+      .sort(['scope ASC', 'name ASC'])
+    if (search) {
+      const query = search.toLocaleLowerCase()
+      snippets = snippets.filter(
+        (snippet) =>
+          snippet.name.toLocaleLowerCase().includes(query) ||
+          snippet.source.toLocaleLowerCase().includes(query)
+      )
+    }
+
+    this.res.set('Cache-Control', 'private, no-store')
+    return {
+      snippets: snippets.map((snippet) =>
+        serializeSnippet(snippet, scope.user.id)
+      )
+    }
+  }
+}
+
+function serializeSnippet(snippet, userId) {
+  const ownerId =
+    snippet.owner && typeof snippet.owner === 'object'
+      ? snippet.owner.id
+      : snippet.owner
+  return {
+    id: snippet.id,
+    name: snippet.name,
+    source: snippet.source,
+    scope: snippet.scope,
+    owner: {
+      id: ownerId,
+      name:
+        snippet.owner && typeof snippet.owner === 'object'
+          ? snippet.owner.fullName
+          : 'Unknown'
+    },
+    canManage: Number(ownerId) === Number(userId),
+    createdAt: snippet.createdAt,
+    updatedAt: snippet.updatedAt
+  }
+}

--- a/api/controllers/api/v1/helm/update-history-entry.js
+++ b/api/controllers/api/v1/helm/update-history-entry.js
@@ -1,0 +1,56 @@
+module.exports = {
+  friendlyName: 'Update Helm history entry',
+
+  description: 'Pin or unpin an owned Helm history entry.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    id: {
+      type: 'number',
+      required: true
+    },
+    pinned: {
+      type: 'boolean',
+      required: true
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, id, pinned }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const entry = await HelmHistoryEntry.updateOne({
+      id,
+      user: scope.user.id,
+      project: scope.project.id,
+      environment: scope.environment.id
+    }).set({ pinned })
+
+    if (!entry) throw 'notFound'
+
+    return {
+      entry: {
+        id: entry.id,
+        pinned: entry.pinned
+      }
+    }
+  }
+}

--- a/api/controllers/api/v1/helm/update-snippet.js
+++ b/api/controllers/api/v1/helm/update-snippet.js
@@ -1,0 +1,163 @@
+module.exports = {
+  friendlyName: 'Update Helm snippet',
+
+  description: 'Update a Helm snippet owned by the current user.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    id: {
+      type: 'number',
+      required: true
+    },
+    name: {
+      type: 'string',
+      maxLength: 100
+    },
+    source: {
+      type: 'string'
+    },
+    scope: {
+      type: 'string',
+      isIn: ['personal', 'project']
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    badRequest: { responseType: 'badRequest' },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({
+    projectSlug,
+    environmentSlug,
+    id,
+    name,
+    source,
+    scope: nextScope
+  }) {
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const snippet = await HelmSnippet.findOne({
+      id,
+      project: scope.project.id
+    })
+    if (!snippet) throw 'notFound'
+    if (Number(snippet.owner) !== Number(scope.user.id)) throw 'forbidden'
+
+    const updates = {}
+    if (name !== undefined) {
+      updates.name = name.trim()
+      if (!updates.name) throw { badRequest: 'Give this snippet a name.' }
+    }
+    if (source !== undefined) {
+      if (!source.trim()) throw { badRequest: 'Snippet source is required.' }
+      if (Buffer.byteLength(source) > sails.config.custom.helm.maxSourceBytes) {
+        throw { badRequest: 'Snippet source is too large.' }
+      }
+      updates.source = source
+    }
+    if (nextScope !== undefined) updates.scope = nextScope
+    if (Object.keys(updates).length === 0) {
+      throw { badRequest: 'No snippet changes were provided.' }
+    }
+
+    const effectiveName = updates.name || snippet.name
+    const effectiveScope = updates.scope || snippet.scope
+    const conflict = await findNameConflict({
+      projectId: scope.project.id,
+      ownerId: scope.user.id,
+      snippetScope: effectiveScope,
+      name: effectiveName,
+      excludeId: snippet.id
+    })
+    if (conflict) {
+      throw {
+        badRequest:
+          effectiveScope === 'project'
+            ? 'A project snippet already uses this name.'
+            : 'You already have a snippet with this name.'
+      }
+    }
+
+    let updated
+    try {
+      updated = await HelmSnippet.updateOne({ id: snippet.id }).set(updates)
+    } catch (error) {
+      if (isUniqueConstraint(error)) {
+        throw {
+          badRequest:
+            effectiveScope === 'project'
+              ? 'A project snippet already uses this name.'
+              : 'You already have a snippet with this name.'
+        }
+      }
+      throw error
+    }
+    await sails.helpers.audit.log.with({
+      action: 'helm.snippet.updated',
+      resourceType: 'helmSnippet',
+      resourceId: String(updated.id),
+      details: {
+        projectId: scope.project.id,
+        name: updated.name,
+        scope: updated.scope
+      },
+      userId: String(scope.user.id),
+      teamId: String(scope.project.team.id),
+      ipAddress: this.req.ip
+    })
+
+    return {
+      snippet: {
+        ...updated,
+        owner: { id: scope.user.id, name: scope.user.fullName },
+        canManage: true
+      }
+    }
+  }
+}
+
+async function findNameConflict({
+  projectId,
+  ownerId,
+  snippetScope,
+  name,
+  excludeId
+}) {
+  const criteria = {
+    project: projectId,
+    scope: snippetScope
+  }
+  if (snippetScope === 'personal') criteria.owner = ownerId
+
+  const candidates = await HelmSnippet.find(criteria)
+  const normalized = name.toLocaleLowerCase()
+  return candidates.find(
+    (snippet) =>
+      Number(snippet.id) !== Number(excludeId) &&
+      snippet.name.toLocaleLowerCase() === normalized
+  )
+}
+
+function isUniqueConstraint(error) {
+  return (
+    error?.code === 'E_UNIQUE' ||
+    error?.code === 'SQLITE_CONSTRAINT' ||
+    /unique constraint/i.test(error?.message || '')
+  )
+}

--- a/api/helpers/helm/ensure-workspace-schema.js
+++ b/api/helpers/helm/ensure-workspace-schema.js
@@ -1,0 +1,78 @@
+module.exports = {
+  friendlyName: 'Ensure Helm workspace schema',
+
+  description:
+    'Create durable Helm history and snippet tables on existing production databases.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore()
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS helm_history_entries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        source TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'error',
+        duration_ms INTEGER NOT NULL DEFAULT 0,
+        executed_at INTEGER NOT NULL,
+        target TEXT NOT NULL,
+        pinned BOOLEAN NOT NULL DEFAULT 0,
+        user INTEGER NOT NULL,
+        team INTEGER NOT NULL,
+        project INTEGER NOT NULL,
+        environment INTEGER NOT NULL,
+        app INTEGER NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS helm_history_scope
+      ON helm_history_entries (
+        user,
+        project,
+        environment,
+        pinned,
+        executed_at DESC
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS helm_history_retention
+      ON helm_history_entries (pinned, executed_at, id)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS helm_snippets (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        name TEXT NOT NULL,
+        source TEXT NOT NULL,
+        scope TEXT NOT NULL DEFAULT 'personal',
+        owner INTEGER NOT NULL,
+        team INTEGER NOT NULL,
+        project INTEGER NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE UNIQUE INDEX IF NOT EXISTS helm_snippets_personal_name
+      ON helm_snippets (project, owner, lower(name))
+      WHERE scope = 'personal'
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE UNIQUE INDEX IF NOT EXISTS helm_snippets_project_name
+      ON helm_snippets (project, lower(name))
+      WHERE scope = 'project'
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS helm_snippets_visible
+      ON helm_snippets (project, scope, owner, updated_at DESC)
+    `)
+  }
+}

--- a/api/helpers/helm/record-execution.js
+++ b/api/helpers/helm/record-execution.js
@@ -1,0 +1,104 @@
+module.exports = {
+  friendlyName: 'Record Helm execution',
+
+  description:
+    'Persist bounded execution metadata and an independent source-free audit event.',
+
+  inputs: {
+    scope: {
+      type: 'ref',
+      required: true
+    },
+    source: {
+      type: 'string',
+      required: true
+    },
+    result: {
+      type: 'ref',
+      required: true
+    },
+    ipAddress: {
+      type: 'string'
+    }
+  },
+
+  fn: async function ({ scope, source, result, ipAddress }) {
+    const executedAt = Date.now()
+    const status = normalizeStatus(result)
+    const durationMs = Math.max(0, Math.round(Number(result.durationMs) || 0))
+    let historyEntry = null
+
+    try {
+      historyEntry = await HelmHistoryEntry.create({
+        source,
+        status,
+        durationMs,
+        executedAt,
+        target: scope.app.slug,
+        user: scope.user.id,
+        team: scope.project.team.id,
+        project: scope.project.id,
+        environment: scope.environment.id,
+        app: scope.app.id
+      }).fetch()
+
+      await pruneHistory(scope, executedAt)
+    } catch (error) {
+      sails.log.verbose(
+        `Could not persist Helm history: ${error.message || error}`
+      )
+    }
+
+    await sails.helpers.audit.log.with({
+      action: 'helm.executed',
+      resourceType: 'app',
+      resourceId: String(scope.app.id),
+      details: {
+        projectId: scope.project.id,
+        environmentId: scope.environment.id,
+        target: scope.app.slug,
+        status,
+        durationMs,
+        sourceBytes: Buffer.byteLength(source)
+      },
+      userId: String(scope.user.id),
+      teamId: String(scope.project.team.id),
+      ipAddress
+    })
+
+    return historyEntry
+  }
+}
+
+function normalizeStatus(result) {
+  if (['success', 'error', 'timeout', 'cancelled'].includes(result?.status)) {
+    return result.status
+  }
+  return result?.success ? 'success' : 'error'
+}
+
+async function pruneHistory(scope, now) {
+  const retentionMs = sails.config.custom.helm.historyRetentionMs
+  const maxEntries = sails.config.custom.helm.historyMaxEntriesPerScope
+  const criteria = {
+    user: scope.user.id,
+    project: scope.project.id,
+    environment: scope.environment.id,
+    pinned: false
+  }
+
+  await HelmHistoryEntry.destroy({
+    ...criteria,
+    executedAt: { '<': now - retentionMs }
+  })
+
+  const overflow = await HelmHistoryEntry.find(criteria)
+    .sort(['executedAt DESC', 'id DESC'])
+    .skip(maxEntries)
+    .limit(1000)
+  if (overflow.length > 0) {
+    await HelmHistoryEntry.destroy({
+      id: overflow.map((entry) => entry.id)
+    })
+  }
+}

--- a/api/helpers/helm/resolve-project-scope.js
+++ b/api/helpers/helm/resolve-project-scope.js
@@ -1,0 +1,63 @@
+module.exports = {
+  friendlyName: 'Resolve project Helm scope',
+
+  description:
+    'Resolve and authorize the current user, project, environment, and target app for Helm.',
+
+  inputs: {
+    userId: {
+      type: 'number',
+      required: true
+    },
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    appSlug: {
+      type: 'string'
+    }
+  },
+
+  exits: {
+    notFound: {},
+    forbidden: {}
+  },
+
+  fn: async function ({ userId, projectSlug, environmentSlug, appSlug }) {
+    const user = await User.findOne({ id: userId })
+    const project = await Project.findOne({ slug: projectSlug }).populate(
+      'team'
+    )
+
+    if (!user || !project) throw 'notFound'
+    if (Number(project.team.id) !== Number(user.team)) throw 'forbidden'
+
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug: environmentSlug
+    })
+    if (!environment) throw 'notFound'
+
+    let app
+    if (appSlug) {
+      app = await App.findOne({
+        environment: environment.id,
+        slug: appSlug
+      })
+    } else {
+      app =
+        (await App.findOne({
+          environment: environment.id,
+          isDefault: true
+        })) || (await App.findOne({ environment: environment.id }))
+    }
+
+    if (!app) throw 'notFound'
+
+    return { user, project, environment, app }
+  }
+}

--- a/api/models/HelmHistoryEntry.js
+++ b/api/models/HelmHistoryEntry.js
@@ -1,0 +1,72 @@
+/**
+ * HelmHistoryEntry.js
+ *
+ * Durable, user-scoped Helm execution metadata. Results and captured logs are
+ * deliberately never persisted here.
+ */
+
+module.exports = {
+  tableName: 'helm_history_entries',
+
+  attributes: {
+    source: {
+      type: 'string',
+      required: true,
+      columnType: 'text'
+    },
+
+    status: {
+      type: 'string',
+      isIn: ['success', 'error', 'timeout', 'cancelled'],
+      defaultsTo: 'error'
+    },
+
+    durationMs: {
+      type: 'number',
+      defaultsTo: 0,
+      columnName: 'duration_ms'
+    },
+
+    executedAt: {
+      type: 'number',
+      required: true,
+      columnName: 'executed_at'
+    },
+
+    target: {
+      type: 'string',
+      required: true,
+      maxLength: 200
+    },
+
+    pinned: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+
+    user: {
+      model: 'user',
+      required: true
+    },
+
+    team: {
+      model: 'team',
+      required: true
+    },
+
+    project: {
+      model: 'project',
+      required: true
+    },
+
+    environment: {
+      model: 'environment',
+      required: true
+    },
+
+    app: {
+      model: 'app',
+      required: true
+    }
+  }
+}

--- a/api/models/HelmSnippet.js
+++ b/api/models/HelmSnippet.js
@@ -1,0 +1,44 @@
+/**
+ * HelmSnippet.js
+ *
+ * Named Helm source that can be inserted into the editor without executing it.
+ */
+
+module.exports = {
+  tableName: 'helm_snippets',
+
+  attributes: {
+    name: {
+      type: 'string',
+      required: true,
+      maxLength: 100
+    },
+
+    source: {
+      type: 'string',
+      required: true,
+      columnType: 'text'
+    },
+
+    scope: {
+      type: 'string',
+      isIn: ['personal', 'project'],
+      defaultsTo: 'personal'
+    },
+
+    owner: {
+      model: 'user',
+      required: true
+    },
+
+    team: {
+      model: 'team',
+      required: true
+    },
+
+    project: {
+      model: 'project',
+      required: true
+    }
+  }
+}

--- a/assets/js/components/CodeEditor.vue
+++ b/assets/js/components/CodeEditor.vue
@@ -438,7 +438,8 @@ function emitSelectionChange(state) {
   emit('selection-change', {
     hasSelection: snapshot.hasSelection,
     hasExecutableSelection:
-      snapshot.hasSelection && snapshot.hasExecutableSource
+      snapshot.hasSelection && snapshot.hasExecutableSource,
+    source: snapshot.source
   })
 }
 

--- a/assets/js/components/HelmSnippetDialog.vue
+++ b/assets/js/components/HelmSnippetDialog.vue
@@ -1,0 +1,286 @@
+<script setup>
+import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import CodeEditor from '@/components/CodeEditor.vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
+
+const props = defineProps({
+  show: Boolean,
+  snippet: {
+    type: Object,
+    default: null
+  },
+  loading: Boolean,
+  error: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['cancel', 'save'])
+const dialogRoot = ref(null)
+const nameInput = ref(null)
+const name = ref('')
+const source = ref('')
+const scope = ref('personal')
+
+const editing = computed(() => Boolean(props.snippet?.id))
+const canSave = computed(
+  () =>
+    !props.loading && Boolean(name.value.trim()) && Boolean(source.value.trim())
+)
+let previouslyFocused
+let previousBodyOverflow = ''
+
+watch(
+  () => [props.show, props.snippet],
+  async ([show]) => {
+    if (!show) {
+      document.body.style.overflow = previousBodyOverflow
+      previouslyFocused?.focus?.()
+      previouslyFocused = null
+      return
+    }
+    previouslyFocused = document.activeElement
+    previousBodyOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    name.value = props.snippet?.name || ''
+    source.value = props.snippet?.source || ''
+    scope.value = props.snippet?.scope || 'personal'
+    await nextTick()
+    nameInput.value?.focus()
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => {
+  document.body.style.overflow = previousBodyOverflow
+})
+
+function close() {
+  if (!props.loading) emit('cancel')
+}
+
+function submit() {
+  if (!canSave.value) return
+  emit('save', {
+    name: name.value.trim(),
+    source: source.value,
+    scope: scope.value
+  })
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    close()
+    return
+  }
+
+  if (event.key === 'Tab') {
+    const focusable = Array.from(
+      dialogRoot.value?.querySelectorAll(
+        'button:not(:disabled), input:not(:disabled), [contenteditable="true"], [tabindex]:not([tabindex="-1"])'
+      ) || []
+    )
+    if (focusable.length === 0) return
+
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-150 ease-out"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-100 ease-in"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="show"
+        class="fixed inset-0 isolate z-[60] flex items-center justify-center p-4"
+        @keydown="handleKeydown"
+      >
+        <div class="fixed inset-0 z-0 bg-black/50" @click="close" />
+        <form
+          ref="dialogRoot"
+          data-test="helm-snippet-dialog"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="helm-snippet-dialog-title"
+          class="relative z-10 flex max-h-[calc(100vh-2rem)] w-full max-w-xl flex-col overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+          @submit.prevent="submit"
+        >
+          <div class="px-5 pb-4 pt-5">
+            <div class="flex items-start justify-between gap-4">
+              <div>
+                <h2
+                  id="helm-snippet-dialog-title"
+                  class="text-base font-semibold text-gray-900 dark:text-white"
+                >
+                  {{ editing ? 'Edit snippet' : 'Save snippet' }}
+                </h2>
+                <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+                  Snippets are inserted into Helm without running.
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Close"
+                class="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
+                @click="close"
+              >
+                <svg
+                  class="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M6 18 18 6M6 6l12 12"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <div class="mt-5 space-y-5">
+              <label class="block">
+                <span
+                  class="text-sm font-medium text-gray-700 dark:text-gray-300"
+                  >Name</span
+                >
+                <input
+                  ref="nameInput"
+                  v-model="name"
+                  data-test="helm-snippet-name"
+                  type="text"
+                  maxlength="100"
+                  autocomplete="off"
+                  placeholder="Active creators"
+                  class="mt-2 block w-full border-0 border-b border-gray-200 bg-transparent px-0 py-2 text-sm text-gray-900 outline-none placeholder:text-gray-400 focus:border-gray-900 focus:ring-0 dark:border-gray-700 dark:text-white dark:placeholder:text-gray-600 dark:focus:border-gray-300"
+                />
+              </label>
+
+              <fieldset>
+                <legend
+                  class="text-sm font-medium text-gray-700 dark:text-gray-300"
+                >
+                  Visibility
+                </legend>
+                <div class="mt-2 grid grid-cols-2 gap-2">
+                  <label
+                    v-for="option in [
+                      {
+                        value: 'personal',
+                        label: 'Personal',
+                        hint: 'Only you'
+                      },
+                      {
+                        value: 'project',
+                        label: 'Project',
+                        hint: 'Everyone on this project'
+                      }
+                    ]"
+                    :key="option.value"
+                    :class="[
+                      'cursor-pointer rounded-lg border px-3 py-2.5 transition-colors',
+                      scope === option.value
+                        ? 'border-gray-900 bg-gray-50 dark:border-gray-300 dark:bg-gray-800'
+                        : 'border-gray-200 hover:border-gray-300 dark:border-gray-700 dark:hover:border-gray-600'
+                    ]"
+                  >
+                    <input
+                      v-model="scope"
+                      type="radio"
+                      name="snippet-scope"
+                      :value="option.value"
+                      class="sr-only"
+                    />
+                    <span
+                      class="block text-sm font-medium text-gray-900 dark:text-white"
+                      >{{ option.label }}</span
+                    >
+                    <span
+                      class="mt-0.5 block text-xs text-gray-500 dark:text-gray-400"
+                      >{{ option.hint }}</span
+                    >
+                  </label>
+                </div>
+              </fieldset>
+
+              <div>
+                <p class="text-sm font-medium text-gray-700 dark:text-gray-300">
+                  Source
+                </p>
+                <div
+                  class="mt-2 overflow-hidden rounded-lg border border-gray-200 bg-white focus-within:border-gray-400 dark:border-gray-700 dark:bg-gray-950 dark:focus-within:border-gray-500"
+                >
+                  <CodeEditor
+                    v-model="source"
+                    language="javascript"
+                    aria-label="Snippet source"
+                    test-id="helm-snippet-source"
+                    min-height="8rem"
+                    max-height="14rem"
+                    padding="compact"
+                  />
+                </div>
+              </div>
+
+              <p
+                v-if="error"
+                data-test="helm-snippet-error"
+                role="alert"
+                class="text-sm text-red-600 dark:text-red-400"
+              >
+                {{ error }}
+              </p>
+            </div>
+          </div>
+
+          <div
+            class="flex shrink-0 justify-end gap-3 border-t border-gray-100 px-5 py-4 dark:border-gray-800"
+          >
+            <button
+              type="button"
+              :disabled="loading"
+              class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 disabled:opacity-50 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+              @click="close"
+            >
+              Cancel
+            </button>
+            <button
+              data-test="helm-snippet-save"
+              type="submit"
+              :disabled="!canSave"
+              class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+            >
+              <span v-if="loading" class="flex items-center gap-2">
+                <SlippyLoader size="h-3.5 w-3.5" />
+                Saving
+              </span>
+              <span v-else>{{
+                editing ? 'Save changes' : 'Save snippet'
+              }}</span>
+            </button>
+          </div>
+        </form>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/assets/js/components/HelmWorkspaceLibrary.vue
+++ b/assets/js/components/HelmWorkspaceLibrary.vue
@@ -1,0 +1,712 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import ActionMenu from '@/components/ActionMenu.vue'
+import ConfirmModal from '@/components/ConfirmModal.vue'
+import HelmSnippetDialog from '@/components/HelmSnippetDialog.vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
+import Tooltip from '@/components/Tooltip.vue'
+import ToastContainer from '@/components/ToastContainer.vue'
+
+const props = defineProps({
+  tab: {
+    type: String,
+    default: 'history',
+    validator: (value) => ['history', 'snippets'].includes(value)
+  },
+  baseUrl: {
+    type: String,
+    required: true
+  },
+  csrf: {
+    type: String,
+    default: ''
+  },
+  currentSource: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['update:tab', 'close', 'load', 'rerun', 'insert'])
+const history = ref([])
+const snippets = ref([])
+const historyQuery = ref('')
+const snippetQuery = ref('')
+const historyLoading = ref(false)
+const snippetsLoading = ref(false)
+const requestError = ref('')
+const retentionDays = ref(30)
+const snippetDialog = ref({ show: false, snippet: null })
+const snippetSaving = ref(false)
+const confirm = ref({ show: false, type: '', item: null })
+const confirmLoading = ref(false)
+const toasts = ref([])
+let historySearchTimer
+let snippetSearchTimer
+let toastId = 0
+
+const activeQuery = computed({
+  get: () =>
+    props.tab === 'history' ? historyQuery.value : snippetQuery.value,
+  set: (value) => {
+    if (props.tab === 'history') historyQuery.value = value
+    else snippetQuery.value = value
+  }
+})
+const activeLoading = computed(() =>
+  props.tab === 'history' ? historyLoading.value : snippetsLoading.value
+)
+const libraryTabs = computed(() => [
+  {
+    key: 'history',
+    label: 'History',
+    countLabel: `${history.value.length} ${
+      history.value.length === 1 ? 'run' : 'runs'
+    }`
+  },
+  {
+    key: 'snippets',
+    label: 'Snippets',
+    countLabel: `${snippets.value.length} ${
+      snippets.value.length === 1 ? 'snippet' : 'snippets'
+    }`
+  }
+])
+const hasCurrentSource = computed(() => Boolean(props.currentSource.trim()))
+const clearableHistoryCount = computed(
+  () => history.value.filter((entry) => !entry.pinned).length
+)
+const confirmDetails = computed(() => {
+  if (confirm.value.type === 'clear-history') {
+    return {
+      title: 'Clear recent Helm history?',
+      message:
+        'Unpinned runs in this environment will be removed. Pinned runs and audit records stay intact.',
+      label: 'Clear history'
+    }
+  }
+  return {
+    title: `Delete “${confirm.value.item?.name || 'snippet'}”?`,
+    message:
+      'This removes the saved snippet. It does not change anything already in the editor.',
+    label: 'Delete snippet'
+  }
+})
+
+onMounted(() => {
+  refreshHistory()
+  refreshSnippets()
+})
+
+onBeforeUnmount(() => {
+  window.clearTimeout(historySearchTimer)
+  window.clearTimeout(snippetSearchTimer)
+})
+
+watch(historyQuery, () => {
+  window.clearTimeout(historySearchTimer)
+  historySearchTimer = window.setTimeout(refreshHistory, 180)
+})
+
+watch(snippetQuery, () => {
+  window.clearTimeout(snippetSearchTimer)
+  snippetSearchTimer = window.setTimeout(refreshSnippets, 180)
+})
+
+async function api(path, options = {}) {
+  const headers = {
+    Accept: 'application/json',
+    ...(options.body ? { 'Content-Type': 'application/json' } : {}),
+    ...(options.method && options.method !== 'GET'
+      ? { 'x-csrf-token': props.csrf }
+      : {})
+  }
+  const response = await fetch(path, {
+    ...options,
+    headers: { ...headers, ...(options.headers || {}) },
+    cache: 'no-store'
+  })
+  const text = await response.text()
+  let data = {}
+  if (text) {
+    try {
+      data = JSON.parse(text)
+    } catch {
+      data = { message: text }
+    }
+  }
+  if (!response.ok) {
+    throw new Error(
+      data.message ||
+        data.error ||
+        text ||
+        'The request could not be completed.'
+    )
+  }
+  return data
+}
+
+async function refreshHistory() {
+  historyLoading.value = true
+  requestError.value = ''
+  try {
+    const query = historyQuery.value.trim()
+    const data = await api(
+      `${props.baseUrl}/history${
+        query ? `?q=${encodeURIComponent(query)}` : ''
+      }`
+    )
+    history.value = data.entries || []
+    retentionDays.value = data.retentionDays || 30
+  } catch (error) {
+    requestError.value = error.message
+  } finally {
+    historyLoading.value = false
+  }
+}
+
+async function refreshSnippets() {
+  snippetsLoading.value = true
+  requestError.value = ''
+  try {
+    const query = snippetQuery.value.trim()
+    const data = await api(
+      `${props.baseUrl}/snippets${
+        query ? `?q=${encodeURIComponent(query)}` : ''
+      }`
+    )
+    snippets.value = data.snippets || []
+  } catch (error) {
+    requestError.value = error.message
+  } finally {
+    snippetsLoading.value = false
+  }
+}
+
+function historyActions(entry) {
+  return [
+    { key: 'load', label: 'Load in editor' },
+    { key: 'rerun', label: 'Run again' },
+    {
+      key: 'pin',
+      label: entry.pinned ? 'Unpin' : 'Pin'
+    },
+    { key: 'save', label: 'Save as snippet' },
+    { key: 'delete', label: 'Delete', destructive: true }
+  ]
+}
+
+function snippetActions(snippet) {
+  const actions = [{ key: 'insert', label: 'Insert in editor' }]
+  if (snippet.canManage) {
+    actions.push(
+      { key: 'edit', label: 'Edit' },
+      { key: 'delete', label: 'Delete', destructive: true }
+    )
+  }
+  return actions
+}
+
+async function handleHistoryAction(entry, action) {
+  if (action.key === 'load') emit('load', entry.source)
+  if (action.key === 'rerun') emit('rerun', entry.source)
+  if (action.key === 'save') openSnippetDialog(entry.source)
+  if (action.key === 'pin') await setPinned(entry, !entry.pinned)
+  if (action.key === 'delete') await deleteHistoryEntry(entry)
+}
+
+function handleSnippetAction(snippet, action) {
+  if (action.key === 'insert') emit('insert', snippet.source)
+  if (action.key === 'edit') {
+    requestError.value = ''
+    snippetDialog.value = { show: true, snippet: { ...snippet } }
+  }
+  if (action.key === 'delete') {
+    confirm.value = { show: true, type: 'delete-snippet', item: snippet }
+  }
+}
+
+async function setPinned(entry, pinned) {
+  requestError.value = ''
+  try {
+    await api(`${props.baseUrl}/history/${entry.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ pinned })
+    })
+    entry.pinned = pinned
+    history.value = [...history.value].sort(
+      (left, right) =>
+        Number(right.pinned) - Number(left.pinned) ||
+        right.executedAt - left.executedAt
+    )
+  } catch (error) {
+    requestError.value = error.message
+  }
+}
+
+async function deleteHistoryEntry(entry) {
+  requestError.value = ''
+  try {
+    await api(`${props.baseUrl}/history/${entry.id}`, { method: 'DELETE' })
+    history.value = history.value.filter((item) => item.id !== entry.id)
+  } catch (error) {
+    requestError.value = error.message
+  }
+}
+
+function openSnippetDialog(source = props.currentSource) {
+  if (!source?.trim()) return
+  requestError.value = ''
+  snippetDialog.value = {
+    show: true,
+    snippet: { name: '', source, scope: 'personal' }
+  }
+}
+
+async function saveSnippet(values) {
+  snippetSaving.value = true
+  requestError.value = ''
+  const existing = snippetDialog.value.snippet
+  try {
+    await api(
+      existing?.id
+        ? `${props.baseUrl}/snippets/${existing.id}`
+        : `${props.baseUrl}/snippets`,
+      {
+        method: existing?.id ? 'PATCH' : 'POST',
+        body: JSON.stringify(values)
+      }
+    )
+    snippetDialog.value = { show: false, snippet: null }
+    await refreshSnippets()
+    notify(existing?.id ? 'Snippet updated' : 'Snippet saved')
+  } catch (error) {
+    requestError.value = error.message
+  } finally {
+    snippetSaving.value = false
+  }
+}
+
+async function confirmDestructiveAction() {
+  confirmLoading.value = true
+  requestError.value = ''
+  try {
+    if (confirm.value.type === 'clear-history') {
+      await api(`${props.baseUrl}/history`, {
+        method: 'DELETE',
+        body: JSON.stringify({ includePinned: false })
+      })
+      await refreshHistory()
+      notify('Recent history cleared')
+    } else {
+      await api(`${props.baseUrl}/snippets/${confirm.value.item.id}`, {
+        method: 'DELETE'
+      })
+      snippets.value = snippets.value.filter(
+        (snippet) => snippet.id !== confirm.value.item.id
+      )
+      notify('Snippet deleted')
+    }
+    confirm.value = { show: false, type: '', item: null }
+  } catch (error) {
+    requestError.value = error.message
+  } finally {
+    confirmLoading.value = false
+  }
+}
+
+function sourcePreview(source) {
+  return (
+    source
+      .split('\n')
+      .find((line) => line.trim() && !line.trim().startsWith('//'))
+      ?.trim() || source.trim()
+  )
+}
+
+function statusClass(status) {
+  if (status === 'success') return 'bg-green-500'
+  if (status === 'timeout') return 'bg-amber-500'
+  if (status === 'cancelled') return 'bg-gray-400'
+  return 'bg-red-500'
+}
+
+function formatDuration(durationMs) {
+  if (durationMs < 1000) return `${durationMs}ms`
+  return `${(durationMs / 1000).toFixed(durationMs < 10000 ? 1 : 0)}s`
+}
+
+function relativeTime(timestamp) {
+  const seconds = Math.round((timestamp - Date.now()) / 1000)
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  if (Math.abs(seconds) < 60) return formatter.format(seconds, 'second')
+  const minutes = Math.round(seconds / 60)
+  if (Math.abs(minutes) < 60) return formatter.format(minutes, 'minute')
+  const hours = Math.round(minutes / 60)
+  if (Math.abs(hours) < 24) return formatter.format(hours, 'hour')
+  return formatter.format(Math.round(hours / 24), 'day')
+}
+
+function notify(message, type = 'success') {
+  const id = ++toastId
+  toasts.value.push({ id, message, type })
+  window.setTimeout(() => dismissToast(id), 3500)
+}
+
+function dismissToast(id) {
+  toasts.value = toasts.value.filter((toast) => toast.id !== id)
+}
+
+function handleLibraryTabKeydown(event, index) {
+  let nextIndex = index
+  if (event.key === 'ArrowRight') {
+    nextIndex = (index + 1) % libraryTabs.value.length
+  } else if (event.key === 'ArrowLeft') {
+    nextIndex =
+      (index - 1 + libraryTabs.value.length) % libraryTabs.value.length
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = libraryTabs.value.length - 1
+  } else {
+    return
+  }
+
+  event.preventDefault()
+  const nextTab = libraryTabs.value[nextIndex]
+  emit('update:tab', nextTab.key)
+  window.requestAnimationFrame(() => {
+    document.getElementById(`helm-library-${nextTab.key}-tab`)?.focus()
+  })
+}
+
+defineExpose({ refreshHistory, openSnippetDialog })
+</script>
+
+<template>
+  <section
+    data-test="helm-library"
+    class="flex max-h-[17rem] min-h-0 shrink-0 flex-col border-t border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-950"
+  >
+    <header
+      class="flex shrink-0 items-center gap-2 border-b border-gray-100 px-3 py-2 dark:border-gray-800"
+    >
+      <div
+        class="flex shrink-0 overflow-hidden rounded-md border border-gray-300 dark:border-gray-700"
+        role="tablist"
+        aria-label="Helm library"
+      >
+        <Tooltip
+          v-for="(item, index) in libraryTabs"
+          :key="item.key"
+          :text="`${item.label} · ${item.countLabel}`"
+          position="top"
+        >
+          <button
+            :id="`helm-library-${item.key}-tab`"
+            type="button"
+            role="tab"
+            aria-controls="helm-library-panel"
+            :aria-label="`${item.label}, ${item.countLabel}`"
+            :aria-selected="tab === item.key"
+            :tabindex="tab === item.key ? 0 : -1"
+            :data-test="`helm-library-${item.key}`"
+            :class="[
+              'flex h-7 w-8 items-center justify-center outline-none transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-400 motion-reduce:transition-none dark:focus-visible:ring-gray-600',
+              index > 0 ? 'border-l border-gray-300 dark:border-gray-700' : '',
+              tab === item.key
+                ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
+                : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+            ]"
+            @click="emit('update:tab', item.key)"
+            @keydown="handleLibraryTabKeydown($event, index)"
+          >
+            <svg
+              v-if="item.key === 'history'"
+              class="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.75"
+                d="M12 8v4l2.5 1.5M3.5 12a8.5 8.5 0 1 0 2.1-5.6M3.5 4.5v4h4"
+              />
+            </svg>
+            <svg
+              v-else
+              class="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.75"
+                d="M6.5 4.5h11v15L12 16l-5.5 3.5v-15Z"
+              />
+            </svg>
+            <span class="sr-only">{{ item.label }}</span>
+          </button>
+        </Tooltip>
+      </div>
+
+      <label class="relative min-w-0 flex-1">
+        <span class="sr-only">Search {{ tab }}</span>
+        <svg
+          class="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="m21 21-4.35-4.35m2.35-5.65a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z"
+          />
+        </svg>
+        <input
+          v-model="activeQuery"
+          data-test="helm-library-search"
+          type="search"
+          :placeholder="`Search ${tab}`"
+          class="block w-full rounded-md border-0 bg-gray-50 py-1.5 pl-8 pr-3 text-xs text-gray-900 outline-none ring-1 ring-inset ring-gray-200 placeholder:text-gray-400 focus:ring-1 focus:ring-gray-400 dark:bg-gray-900 dark:text-white dark:ring-gray-800 dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
+        />
+      </label>
+
+      <button
+        v-if="tab === 'history'"
+        type="button"
+        data-test="helm-clear-history"
+        :disabled="clearableHistoryCount === 0"
+        class="disabled:opacity-35 rounded-md px-2 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+        @click="confirm = { show: true, type: 'clear-history', item: null }"
+      >
+        Clear
+      </button>
+      <button
+        v-else
+        type="button"
+        data-test="helm-new-snippet"
+        :disabled="!hasCurrentSource"
+        class="disabled:opacity-35 rounded-md bg-gray-900 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+        @click="openSnippetDialog()"
+      >
+        Save current
+      </button>
+
+      <button
+        type="button"
+        aria-label="Close Helm library"
+        class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
+        @click="emit('close')"
+      >
+        <svg
+          class="h-4 w-4"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18 18 6M6 6l12 12"
+          />
+        </svg>
+      </button>
+    </header>
+
+    <div
+      id="helm-library-panel"
+      role="tabpanel"
+      :aria-labelledby="`helm-library-${tab}-tab`"
+      class="min-h-0 flex-1 overflow-y-auto"
+    >
+      <div
+        v-if="activeLoading"
+        class="flex h-24 items-center justify-center"
+        aria-live="polite"
+      >
+        <SlippyLoader size="h-4 w-4" />
+      </div>
+
+      <template v-else-if="tab === 'history'">
+        <div
+          v-if="history.length === 0"
+          class="flex h-24 flex-col items-center justify-center px-4 text-center"
+        >
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            {{ historyQuery ? 'No matching runs' : 'No Helm history yet' }}
+          </p>
+          <p
+            v-if="!historyQuery"
+            class="mt-1 text-xs text-gray-400 dark:text-gray-600"
+          >
+            Runs appear here without their returned data.
+          </p>
+        </div>
+        <div v-else>
+          <div
+            v-for="entry in history"
+            :key="entry.id"
+            data-test="helm-history-entry"
+            class="group flex items-center gap-2 border-b border-gray-100 px-3 py-2 last:border-b-0 hover:bg-gray-50 dark:border-gray-900 dark:hover:bg-gray-900/60"
+          >
+            <button
+              type="button"
+              class="flex min-w-0 flex-1 items-center gap-2 text-left"
+              :title="entry.source"
+              @click="emit('load', entry.source)"
+            >
+              <span
+                data-test="helm-history-status"
+                :class="[
+                  'h-1.5 w-1.5 shrink-0 rounded-full',
+                  statusClass(entry.status)
+                ]"
+              />
+              <span class="min-w-0 flex-1">
+                <span
+                  class="block truncate font-mono text-xs text-gray-700 dark:text-gray-300"
+                  >{{ sourcePreview(entry.source) }}</span
+                >
+                <span
+                  class="mt-0.5 flex items-center gap-1.5 text-[11px] text-gray-400 dark:text-gray-600"
+                >
+                  <span>{{ entry.target }}</span>
+                  <span aria-hidden="true">&middot;</span>
+                  <span>{{ formatDuration(entry.durationMs) }}</span>
+                  <span aria-hidden="true">&middot;</span>
+                  <time
+                    :datetime="new Date(entry.executedAt).toISOString()"
+                    :title="new Date(entry.executedAt).toLocaleString()"
+                    >{{ relativeTime(entry.executedAt) }}</time
+                  >
+                </span>
+              </span>
+              <svg
+                v-if="entry.pinned"
+                class="h-3.5 w-3.5 shrink-0 text-gray-400 dark:text-gray-500"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                aria-label="Pinned"
+              >
+                <path
+                  d="M7.3 2.4a1 1 0 0 1 .9-.6h3.6a1 1 0 0 1 .9.6l.8 1.8a1 1 0 0 1-.2 1.1l-1 1v3l1.4 1.4a1 1 0 0 1-.7 1.7h-2v4.1a1 1 0 0 1-2 0v-4.1H7a1 1 0 0 1-.7-1.7l1.4-1.4v-3l-1-1a1 1 0 0 1-.2-1.1l.8-1.8Z"
+                />
+              </svg>
+            </button>
+            <ActionMenu
+              :items="historyActions(entry)"
+              :test-id="`helm-history-actions-${entry.id}`"
+              label="History actions"
+              placement="top"
+              @select="handleHistoryAction(entry, $event)"
+            />
+          </div>
+        </div>
+      </template>
+
+      <template v-else>
+        <div
+          v-if="snippets.length === 0"
+          class="flex h-24 flex-col items-center justify-center px-4 text-center"
+        >
+          <p class="text-sm text-gray-500 dark:text-gray-400">
+            {{ snippetQuery ? 'No matching snippets' : 'No saved snippets' }}
+          </p>
+          <p
+            v-if="!snippetQuery"
+            class="mt-1 text-xs text-gray-400 dark:text-gray-600"
+          >
+            Save repeatable work, then insert it without running.
+          </p>
+        </div>
+        <div v-else>
+          <div
+            v-for="snippet in snippets"
+            :key="snippet.id"
+            data-test="helm-snippet-entry"
+            class="group flex items-center gap-2 border-b border-gray-100 px-3 py-2 last:border-b-0 hover:bg-gray-50 dark:border-gray-900 dark:hover:bg-gray-900/60"
+          >
+            <button
+              type="button"
+              class="min-w-0 flex-1 text-left"
+              :title="snippet.source"
+              @click="emit('insert', snippet.source)"
+            >
+              <span
+                class="block truncate text-xs font-medium text-gray-800 dark:text-gray-200"
+                >{{ snippet.name }}</span
+              >
+              <span
+                class="mt-0.5 flex min-w-0 items-center gap-1.5 text-[11px] text-gray-400 dark:text-gray-600"
+              >
+                <span>{{
+                  snippet.scope === 'personal'
+                    ? 'Personal'
+                    : `Project · ${snippet.owner.name}`
+                }}</span>
+                <span aria-hidden="true">&middot;</span>
+                <code class="truncate">{{
+                  sourcePreview(snippet.source)
+                }}</code>
+              </span>
+            </button>
+            <ActionMenu
+              :items="snippetActions(snippet)"
+              :test-id="`helm-snippet-actions-${snippet.id}`"
+              label="Snippet actions"
+              placement="top"
+              @select="handleSnippetAction(snippet, $event)"
+            />
+          </div>
+        </div>
+      </template>
+    </div>
+
+    <footer
+      v-if="requestError || (tab === 'history' && history.length > 0)"
+      class="shrink-0 border-t border-gray-100 px-3 py-1.5 text-[11px] dark:border-gray-800"
+    >
+      <p v-if="requestError" class="text-red-600 dark:text-red-400">
+        {{ requestError }}
+      </p>
+      <p v-else class="text-gray-400 dark:text-gray-600">
+        Unpinned runs are kept for {{ retentionDays }} days. Results and logs
+        are never saved.
+      </p>
+    </footer>
+  </section>
+
+  <HelmSnippetDialog
+    :show="snippetDialog.show"
+    :snippet="snippetDialog.snippet"
+    :loading="snippetSaving"
+    :error="requestError"
+    @cancel="snippetDialog = { show: false, snippet: null }"
+    @save="saveSnippet"
+  />
+
+  <ConfirmModal
+    :show="confirm.show"
+    :title="confirmDetails.title"
+    :message="confirmDetails.message"
+    :confirm-label="confirmDetails.label"
+    destructive
+    :loading="confirmLoading"
+    @cancel="confirm = { show: false, type: '', item: null }"
+    @confirm="confirmDestructiveAction"
+  />
+
+  <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
+</template>

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -1,10 +1,20 @@
 <script setup>
 import { Link, Head, usePage } from '@inertiajs/vue3'
-import { inject, ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
+import {
+  inject,
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onBeforeUnmount,
+  nextTick
+} from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import HelmResultViewer from '@/components/HelmResultViewer.vue'
+import HelmWorkspaceLibrary from '@/components/HelmWorkspaceLibrary.vue'
+import Tooltip from '@/components/Tooltip.vue'
 import { helmEditorDiagnostic } from '@/lib/helmResult'
 import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
 
@@ -28,12 +38,15 @@ const executionResult = ref(null)
 const requestError = ref('')
 const running = ref(false)
 const stopping = ref(false)
-const history = ref([])
 const editor = ref(null)
+const library = ref(null)
+const libraryOpen = ref(false)
+const libraryTab = ref('history')
 const completionMetadata = ref(null)
 const editorSelection = ref({
   hasSelection: false,
-  hasExecutableSelection: false
+  hasExecutableSelection: false,
+  source: code.value
 })
 let executionSequence = 0
 let activeExecution = null
@@ -50,10 +63,29 @@ const canExecute = computed(() => {
   }
   return Boolean(code.value.trim())
 })
+const helmLibraryUrl = computed(
+  () =>
+    `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/helm`
+)
 
-async function execute() {
-  const execution = editor.value?.getExecutionSnapshot()
-  if (!execution?.hasExecutableSource || !canExecute.value) return
+async function execute(sourceOverride) {
+  let execution
+  if (typeof sourceOverride === 'string') {
+    if (!sourceOverride.trim() || !isRunning.value || running.value) return
+    code.value = sourceOverride
+    await nextTick()
+    execution = {
+      source: sourceOverride,
+      from: 0,
+      to: sourceOverride.length,
+      hasExecutableSource: true,
+      startLine: 1,
+      startColumn: 1
+    }
+  } else {
+    execution = editor.value?.getExecutionSnapshot()
+    if (!execution?.hasExecutableSource || !canExecute.value) return
+  }
 
   editor.value.highlightExecution(execution)
   editor.value.clearDiagnostics()
@@ -62,8 +94,7 @@ async function execute() {
     id: crypto.randomUUID(),
     sequence: ++executionSequence,
     startedAt: performance.now(),
-    source: execution.source,
-    historyRecorded: false
+    source: execution.source
   }
   activeExecution = currentExecution
   running.value = true
@@ -113,7 +144,7 @@ async function execute() {
     const diagnostic = helmEditorDiagnostic(result.error)
     if (diagnostic) editor.value.showDiagnostic(diagnostic)
 
-    recordHistory(currentExecution, result)
+    await revealHistory()
   } catch (err) {
     if (activeExecution?.sequence !== currentExecution.sequence) return
     requestError.value = err.message || 'Network error'
@@ -147,7 +178,6 @@ async function stopExecution() {
       Math.round(performance.now() - currentExecution.startedAt)
     )
     executionResult.value = result
-    recordHistory(currentExecution, result)
     running.value = false
   } catch (error) {
     if (activeExecution?.sequence !== currentExecution.sequence) return
@@ -164,37 +194,32 @@ function runOrStop() {
   else execute()
 }
 
-function historyStatusClass(entry) {
-  if (entry.status === 'cancelled') return 'bg-gray-400'
-  if (entry.status === 'timeout' || entry.truncated) return 'bg-amber-500'
-  return entry.success ? 'bg-green-500' : 'bg-red-500'
+async function revealHistory() {
+  libraryTab.value = 'history'
+  libraryOpen.value = true
+  await nextTick()
+  await library.value?.refreshHistory()
 }
 
-function recordHistory(execution, result) {
-  if (execution.historyRecorded) return
-  execution.historyRecorded = true
-  history.value.unshift({
-    code: execution.source,
-    success: result.success,
-    status: result.status,
-    truncated: result.truncated,
-    time: new Date()
-  })
-  history.value = history.value.slice(0, 20)
+function toggleLibrary(tab) {
+  if (libraryOpen.value && libraryTab.value === tab) {
+    libraryOpen.value = false
+    return
+  }
+  libraryTab.value = tab
+  libraryOpen.value = true
 }
 
-function loadFromHistory(entry) {
-  code.value = entry.code
+async function loadSource(source) {
+  code.value = source
+  await nextTick()
+  editor.value?.focus()
 }
 
 function clearExecutionOutput() {
   executionResult.value = null
   requestError.value = ''
   editor.value?.clearDiagnostics()
-}
-
-function clearHistory() {
-  history.value = []
 }
 
 async function loadCompletionMetadata() {
@@ -391,6 +416,69 @@ watch(code, () => editor.value?.clearDiagnostics())
           <span class="hidden sm:inline">not running</span>
         </span>
 
+        <div class="flex items-center">
+          <Tooltip text="History" position="bottom">
+            <button
+              type="button"
+              data-test="helm-history-toggle"
+              :aria-pressed="libraryOpen && libraryTab === 'history'"
+              :class="[
+                'rounded-md p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:focus-visible:ring-gray-700',
+                libraryOpen && libraryTab === 'history'
+                  ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
+                  : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200'
+              ]"
+              @click="toggleLibrary('history')"
+            >
+              <svg
+                class="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.75"
+                  d="M12 8v4l2.5 1.5M3.5 12a8.5 8.5 0 1 0 2.1-5.6M3.5 4.5v4h4"
+                />
+              </svg>
+              <span class="sr-only">History</span>
+            </button>
+          </Tooltip>
+          <Tooltip text="Snippets" position="bottom">
+            <button
+              type="button"
+              data-test="helm-snippets-toggle"
+              :aria-pressed="libraryOpen && libraryTab === 'snippets'"
+              :class="[
+                'rounded-md p-1.5 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:focus-visible:ring-gray-700',
+                libraryOpen && libraryTab === 'snippets'
+                  ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
+                  : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200'
+              ]"
+              @click="toggleLibrary('snippets')"
+            >
+              <svg
+                class="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.75"
+                  d="M6.5 4.5h11v15L12 16l-5.5 3.5v-15Z"
+                />
+              </svg>
+              <span class="sr-only">Snippets</span>
+            </button>
+          </Tooltip>
+        </div>
+
         <!-- Run button -->
         <button
           data-test="helm-run"
@@ -500,52 +588,18 @@ watch(code, () => editor.value?.clearDiagnostics())
           @clear="clearExecutionOutput"
         />
 
-        <!-- History (collapsible at bottom) -->
-        <div
-          v-if="history.length > 0"
-          data-test="helm-history"
-          class="shrink-0 border-t border-gray-100 dark:border-gray-800"
-        >
-          <div class="flex items-center justify-between px-4 py-1.5">
-            <span class="text-xs text-gray-400 dark:text-gray-500"
-              >Recent runs</span
-            >
-            <button
-              type="button"
-              data-test="helm-clear-history"
-              class="text-xs text-gray-500 outline-none hover:text-gray-900 focus-visible:rounded focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-400 dark:hover:text-white dark:focus-visible:ring-gray-700"
-              @click="clearHistory"
-            >
-              Clear
-            </button>
-          </div>
-          <div class="max-h-32 overflow-y-auto">
-            <button
-              v-for="(entry, i) in history"
-              :key="i"
-              data-test="helm-history-entry"
-              @click="loadFromHistory(entry)"
-              class="flex w-full items-center justify-between border-b border-gray-100 px-4 py-2 text-left hover:bg-gray-50 dark:border-gray-800/50 dark:hover:bg-gray-800/50"
-            >
-              <code
-                class="truncate font-mono text-xs text-gray-500 dark:text-gray-400"
-                >{{
-                  entry.code
-                    .split('\n')
-                    .filter((l) => !l.trim().startsWith('//'))
-                    .join(' ')
-                    .slice(0, 50)
-                }}</code
-              >
-              <span
-                :class="[
-                  'ml-2 h-1.5 w-1.5 shrink-0 rounded-full',
-                  historyStatusClass(entry)
-                ]"
-              ></span>
-            </button>
-          </div>
-        </div>
+        <HelmWorkspaceLibrary
+          v-if="libraryOpen"
+          ref="library"
+          v-model:tab="libraryTab"
+          :base-url="helmLibraryUrl"
+          :csrf="page.props._csrf || ''"
+          :current-source="editorSelection.source || code"
+          @close="libraryOpen = false"
+          @load="loadSource"
+          @insert="loadSource"
+          @rerun="execute"
+        />
       </div>
     </div>
 

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -17,6 +17,7 @@ module.exports.bootstrap = async function () {
   await sails.helpers.service.ensureVersionSchema()
   await sails.helpers.lookout.ensureObservabilitySchema()
   await sails.helpers.bridge.ensureSchema()
+  await sails.helpers.helm.ensureWorkspaceSchema()
 
   // Initialize CLI tokens map for Bearer token authentication
   sails.cliTokens = new Map()

--- a/config/custom.js
+++ b/config/custom.js
@@ -86,7 +86,9 @@ module.exports.custom = {
     maxResultBytes: 128 * 1024,
     maxProcessOutputBytes: 256 * 1024,
     maxProcessStderrBytes: 64 * 1024,
-    killGraceMs: 250
+    killGraceMs: 250,
+    historyRetentionMs: 30 * 24 * 60 * 60 * 1000,
+    historyMaxEntriesPerScope: 200
   },
 
   // Lookout keeps infrastructure samples for 24 hours and application

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -46,7 +46,17 @@ module.exports = {
       maxResultBytes: 128 * 1024,
       maxProcessOutputBytes: 256 * 1024,
       maxProcessStderrBytes: 64 * 1024,
-      killGraceMs: 250
+      killGraceMs: 250,
+      historyRetentionMs:
+        positiveInteger(process.env.SLIPWAY_HELM_HISTORY_RETENTION_DAYS, 30) *
+        24 *
+        60 *
+        60 *
+        1000,
+      historyMaxEntriesPerScope: positiveInteger(
+        process.env.SLIPWAY_HELM_HISTORY_MAX_ENTRIES,
+        200
+      )
     }
   },
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -241,6 +241,22 @@ module.exports.routes = {
     'api/v1/app/execute-code',
   'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/completions':
     'api/v1/helm/get-project-completions',
+  'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/history':
+    'api/v1/helm/list-history',
+  'PATCH /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/history/:id':
+    'api/v1/helm/update-history-entry',
+  'DELETE /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/history/:id':
+    'api/v1/helm/delete-history-entry',
+  'DELETE /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/history':
+    'api/v1/helm/clear-history',
+  'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/snippets':
+    'api/v1/helm/list-snippets',
+  'POST /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/snippets':
+    'api/v1/helm/create-snippet',
+  'PATCH /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/snippets/:id':
+    'api/v1/helm/update-snippet',
+  'DELETE /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/snippets/:id':
+    'api/v1/helm/delete-snippet',
 
   // Webhooks (public — signature-verified in controller)
   'POST /api/v1/webhooks/github/:projectSlug': {

--- a/docs/helm-history-and-snippets.md
+++ b/docs/helm-history-and-snippets.md
@@ -1,0 +1,52 @@
+# Helm history and snippets
+
+Helm keeps a durable workspace for each signed-in user, project, and
+environment. The workspace is designed to make repeat operations convenient
+without turning production query results into another datastore.
+
+## What history stores
+
+Each run records:
+
+- the JavaScript source that was executed;
+- the execution status and duration;
+- the target app slug; and
+- the execution timestamp.
+
+Returned values, console output, captured logs, and error details are never
+stored in Helm history. Security audit records are written separately and do
+not contain the executed source. Deleting editable history therefore does not
+delete the audit trail.
+
+History is private to the user who ran it and to the project environment where
+it ran. A user can search, reload, rerun, pin, or delete an entry. Clearing
+history removes unpinned entries and preserves pins.
+
+Unpinned history is retained for 30 days and capped at 200 entries per user,
+project, and environment by default. Production installations can change
+these bounds:
+
+```text
+SLIPWAY_HELM_HISTORY_RETENTION_DAYS=30
+SLIPWAY_HELM_HISTORY_MAX_ENTRIES=200
+```
+
+Pinned entries are exempt from both automatic retention and the default clear
+action. They remain until the user unpins or explicitly deletes them.
+
+## Reusable snippets
+
+A snippet is named JavaScript source that Helm inserts into the editor without
+executing it. A snippet can be:
+
+- **Personal** — visible only to its creator in that project.
+- **Project** — visible to every Slipway team member who can access that
+  project.
+
+The creator owns a project snippet and is the only user who can rename, edit,
+change the visibility of, or delete it. Other project members can insert the
+source but cannot overwrite it. Audit records cover snippet creation, changes,
+and deletion without copying snippet source into the audit details.
+
+Snippets share Helm's maximum source-size limit. Inserting a snippet never
+triggers a run; the user must review it and press **Run**.

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -648,11 +648,6 @@ test(
       await page.raw.locator('[data-test="helm-result-raw"]').textContent()
     ).toContain('<img data-helm-xss')
     await page.screenshot('.tmp/issue-269-project-raw-console-dark.png')
-    expect(
-      await page.raw.locator('[data-test="helm-history-entry"]').count()
-    ).toBe(2)
-    await page.click('@helm-clear-history')
-    expect(await page.raw.locator('[data-test="helm-history"]').count()).toBe(0)
     expect(page).toHaveNoSmoke()
   }
 )
@@ -789,13 +784,6 @@ test(
           document.activeElement?.matches('[data-test="helm-editor"]') === true
       )
     ).toBe(true)
-    const historyText = await page.raw
-      .locator('[data-test="helm-history-entry"]')
-      .first()
-      .textContent()
-    expect(historyText).toContain('await Creator.find()')
-    expect(historyText.includes('outsideSelection')).toBe(false)
-
     const rerun = page.raw.waitForRequest(
       (request) =>
         request.method() === 'POST' && request.url().includes(endpoint)
@@ -1136,12 +1124,6 @@ test(
     expect(
       await page.raw.locator('[data-test="helm-result-status"]').textContent()
     ).toContain('Cancelled')
-    expect(
-      await page.raw
-        .locator('[data-test="helm-history-entry"] span')
-        .last()
-        .getAttribute('class')
-    ).toContain('bg-gray-400')
     await page.screenshot('.tmp/issue-271-project-cancelled-light.png')
 
     await page.fill('@helm-editor', "'newer result'")
@@ -1155,6 +1137,209 @@ test(
       await page.raw.locator('[data-test="helm-output"]').textContent()
     ).toContain('newer result')
     expect(executionCount).toBe(2)
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'project Helm presents durable searchable history and inert reusable snippets',
+  {
+    browser: true,
+    world: helmWorld('helm-durable-workspace')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const user = current.users.genesisUser
+    const commonHistory = {
+      status: 'success',
+      target: app.slug,
+      user: user.id,
+      team: current.teams.genesisTeam.id,
+      project: project.id,
+      environment: environment.id,
+      app: app.id
+    }
+    const pinned = await sails.models.helmhistoryentry
+      .create({
+        ...commonHistory,
+        source: 'await Creator.find({ isActive: true }).limit(10)',
+        durationMs: 18,
+        executedAt: Date.now() - 60_000,
+        pinned: true
+      })
+      .fetch()
+    await sails.models.helmhistoryentry.create({
+      ...commonHistory,
+      source: 'await Course.find().populate("chapters")',
+      durationMs: 42,
+      executedAt: Date.now() - 5_000
+    })
+    await sails.models.helmsnippet.create({
+      name: 'Active creators',
+      source: 'await Creator.find({ isActive: true })',
+      scope: 'personal',
+      owner: user.id,
+      team: current.teams.genesisTeam.id,
+      project: project.id
+    })
+    await sails.models.helmsnippet.create({
+      name: 'Published courses',
+      source: 'await Course.find({ published: true })',
+      scope: 'project',
+      owner: user.id,
+      team: current.teams.genesisTeam.id,
+      project: project.id
+    })
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'running',
+      containerName: 'sounding-helm-library-app'
+    })
+
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${project.slug}/environments/${environment.slug}/helm`
+    )
+
+    await page.click('@helm-history-toggle')
+    await page.raw.locator('[data-test="helm-history-entry"]').first().waitFor()
+    expect(
+      await page.raw.locator('[data-test="helm-history-entry"]').count()
+    ).toBe(2)
+    expect(
+      await page.raw
+        .locator('[data-test="helm-library-history"]')
+        .getAttribute('aria-label')
+    ).toBe('History, 2 runs')
+    await page.screenshot('.tmp/issue-273-helm-history-light.png')
+
+    await page.raw
+      .locator('[data-test="helm-library-history"]')
+      .press('ArrowRight')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-library-snippets"]')
+        .getAttribute('aria-selected')
+    ).toBe('true')
+    await page.raw
+      .locator('[data-test="helm-library-snippets"]')
+      .press('ArrowLeft')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-library-history"]')
+        .getAttribute('aria-selected')
+    ).toBe('true')
+    expect(
+      await page.raw
+        .locator(`[data-test="helm-history-actions-${pinned.id}-trigger"]`)
+        .count()
+    ).toBe(1)
+
+    await page.fill('@helm-library-search', 'Course.find')
+    await page.wait(250)
+    expect(
+      await page.raw.locator('[data-test="helm-history-entry"]').count()
+    ).toBe(1)
+    expect(
+      await page.raw.locator('[data-test="helm-history-entry"]').textContent()
+    ).toContain('Course.find')
+    await page.fill('@helm-library-search', '')
+    await page.wait(250)
+
+    await page.click('@helm-clear-history')
+    await page.raw.locator('[data-test="confirm-modal"]').waitFor()
+    await page.raw
+      .getByRole('button', { name: 'Clear history', exact: true })
+      .click()
+    await page.raw
+      .locator('[data-test="confirm-modal"]')
+      .waitFor({ state: 'detached' })
+    await page.raw.locator('[data-test="helm-history-entry"]').first().waitFor()
+    expect(
+      await page.raw.locator('[data-test="helm-history-entry"]').count()
+    ).toBe(1)
+    expect(
+      await page.raw.locator('[data-test="helm-history-entry"]').textContent()
+    ).toContain('Creator.find')
+    await page.raw
+      .getByText('Recent history cleared', { exact: true })
+      .locator('..')
+      .getByRole('button')
+      .click()
+    await page.raw
+      .getByText('Recent history cleared', { exact: true })
+      .waitFor({ state: 'detached' })
+
+    await page.inDarkMode()
+    await page.click('@helm-library-snippets')
+    await page.raw.locator('[data-test="helm-snippet-entry"]').first().waitFor()
+    await page.wait(250)
+    expect(
+      await page.raw
+        .locator('[data-test="helm-library-snippets"]')
+        .getAttribute('aria-selected')
+    ).toBe('true')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-library-snippets"]')
+        .getAttribute('aria-label')
+    ).toBe('Snippets, 2 snippets')
+    expect(
+      await page.raw.locator('[data-test="helm-snippet-entry"]').count()
+    ).toBe(2)
+    await page.screenshot('.tmp/issue-273-helm-snippets-dark.png')
+
+    let executionRequests = 0
+    page.raw.on('request', (request) => {
+      if (
+        request.method() === 'POST' &&
+        request
+          .url()
+          .endsWith(
+            `/api/v1/projects/${project.slug}/environments/${environment.slug}/execute`
+          )
+      ) {
+        executionRequests += 1
+      }
+    })
+    await page.raw
+      .locator('[data-test="helm-snippet-entry"]')
+      .filter({ hasText: 'Published courses' })
+      .getByRole('button')
+      .first()
+      .click()
+    await page.wait(100)
+    expect(executionRequests).toBe(0)
+    expect(
+      await page.raw.locator('[data-test="helm-editor"]').textContent()
+    ).toContain('Course.find({ published: true })')
+
+    await page.click('@helm-new-snippet')
+    await page.raw.locator('[data-test="helm-snippet-dialog"]').waitFor()
+    await page.resize(390, 844)
+    await page.wait(200)
+    await page.screenshot('.tmp/issue-273-helm-snippet-dialog-mobile-dark.png')
+    await page.fill('@helm-snippet-name', 'Published course check')
+    await page.click('@helm-snippet-save')
+    await page.resize(1440, 900)
+    await page.raw
+      .locator('[data-test="helm-snippet-entry"]')
+      .filter({ hasText: 'Published course check' })
+      .waitFor()
+    expect(
+      await page.raw.locator('[data-test="helm-snippet-entry"]').count()
+    ).toBe(3)
+    expect(executionRequests).toBe(0)
     expect(page).toHaveNoSmoke()
   }
 )

--- a/tests/functional/api/helm.test.js
+++ b/tests/functional/api/helm.test.js
@@ -141,9 +141,216 @@ test(
       expect(response).toHaveJsonPath('logs.0', 'querying')
       expect(response).toHaveJsonPath('durationMs', 12)
       expect(response).toHaveJsonPath('truncated', false)
+
+      const history = await sails.models.helmhistoryentry.findOne({
+        user: current.users.genesisUser.id,
+        project: current.projects.deploymentTarget.id,
+        environment: current.environments.production.id
+      })
+      expect(history.source).toBe('await Creator.find()')
+      expect(history.status).toBe('success')
+      expect(history.durationMs).toBe(12)
+      expect(history.target).toBe(current.apps.web.slug)
+      expect(JSON.stringify(history).includes('querying')).toBe(false)
+      expect(JSON.stringify(history).includes('"value"')).toBe(false)
+
+      const audit = await sails.models.auditlog.findOne({
+        action: 'helm.executed',
+        resourceId: String(current.apps.web.id)
+      })
+      expect(audit.details.status).toBe('success')
+      expect(audit.details.sourceBytes).toBe(
+        Buffer.byteLength('await Creator.find()')
+      )
+      expect(JSON.stringify(audit).includes('await Creator.find()')).toBe(false)
+      expect(JSON.stringify(audit).includes('querying')).toBe(false)
     } finally {
       sails.helpers.helm.executeInContainer = originalExecute
     }
+  }
+)
+
+test(
+  'project Helm history is durable, searchable, scoped, and preserves pins when cleared',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'durable-helm-history',
+          name: 'Durable Helm History'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const user = current.users.genesisUser
+    const otherUser = await world.create('user').with({
+      fullName: 'Other Builder',
+      email: 'other-helm-builder@example.com',
+      team: current.teams.genesisTeam.id,
+      teamRole: 'member'
+    })
+    const common = {
+      status: 'success',
+      durationMs: 8,
+      executedAt: Date.now(),
+      target: app.slug,
+      team: current.teams.genesisTeam.id,
+      project: project.id,
+      environment: environment.id,
+      app: app.id
+    }
+    const pinned = await sails.models.helmhistoryentry
+      .create({
+        ...common,
+        source: 'await Creator.find({ pinned: true })',
+        pinned: true,
+        user: user.id
+      })
+      .fetch()
+    await sails.models.helmhistoryentry.create({
+      ...common,
+      source: 'await Creator.find({ recent: true })',
+      user: user.id
+    })
+    await sails.models.helmhistoryentry.create({
+      ...common,
+      source: 'await Creator.find({ private: true })',
+      user: otherUser.id
+    })
+
+    const helmPath = `/projects/${project.slug}/environments/${environment.slug}/helm`
+    const apiPath = `/api/v1/projects/${project.slug}/environments/${environment.slug}/helm/history`
+    const browser = await withCsrfFromPage(request, helmPath, 'genesisUser')
+
+    const search = await browser.request.get(`${apiPath}?q=pinned`)
+    expect(search).toHaveStatus(200)
+    expect(search.data.entries.length).toBe(1)
+    expect(search).toHaveJsonPath('entries.0.id', pinned.id)
+    expect(search.data.entries[0].source.includes('private')).toBe(false)
+    expect(search.header('cache-control')).toMatch('private')
+    expect(search.header('cache-control')).toMatch('no-store')
+
+    const unpin = await browser.request.patch(`${apiPath}/${pinned.id}`, {
+      pinned: false
+    })
+    expect(unpin).toHaveStatus(200)
+    expect(unpin).toHaveJsonPath('entry.pinned', false)
+    await browser.request.patch(`${apiPath}/${pinned.id}`, { pinned: true })
+
+    const cleared = await browser.request.delete(apiPath, {})
+    expect(cleared).toHaveStatus(200)
+    expect(cleared).toHaveJsonPath('deletedCount', 1)
+    expect(
+      Boolean(
+        await sails.models.helmhistoryentry.findOne({
+          id: pinned.id,
+          pinned: true
+        })
+      )
+    ).toBe(true)
+    expect(
+      Boolean(
+        await sails.models.helmhistoryentry.findOne({
+          user: otherUser.id
+        })
+      )
+    ).toBe(true)
+    expect(
+      Boolean(
+        await sails.models.auditlog.findOne({
+          action: 'helm.history.cleared',
+          user: user.id
+        })
+      )
+    ).toBe(true)
+  }
+)
+
+test(
+  'Helm snippets keep personal source private and shared source owner-managed',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'helm-snippet-permissions',
+          name: 'Helm Snippet Permissions'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const helmPath = `/projects/${project.slug}/environments/${environment.slug}/helm`
+    const apiPath = `/api/v1/projects/${project.slug}/environments/${environment.slug}/helm/snippets`
+    const ownerBrowser = await withCsrfFromPage(
+      request,
+      helmPath,
+      'genesisUser'
+    )
+    const personal = await ownerBrowser.request.post(apiPath, {
+      name: 'My creators',
+      source: 'await Creator.find().limit(10)',
+      scope: 'personal'
+    })
+    const shared = await ownerBrowser.request.post(apiPath, {
+      name: 'Active creators',
+      source: 'await Creator.find({ isActive: true })',
+      scope: 'project'
+    })
+
+    expect(personal).toHaveStatus(201)
+    expect(personal).toHaveJsonPath('snippet.scope', 'personal')
+    expect(shared).toHaveStatus(201)
+    expect(shared).toHaveJsonPath('snippet.canManage', true)
+
+    const member = await world.create('user').with({
+      fullName: 'Snippet Reader',
+      email: 'snippet-reader@example.com',
+      team: current.teams.genesisTeam.id,
+      teamRole: 'member'
+    })
+    const memberBrowser = await withCsrfFromPage(request, helmPath, member)
+    const visible = await memberBrowser.request.get(apiPath)
+    expect(visible).toHaveStatus(200)
+    expect(visible.data.snippets.length).toBe(1)
+    expect(visible).toHaveJsonPath('snippets.0.name', 'Active creators')
+    expect(visible).toHaveJsonPath('snippets.0.canManage', false)
+
+    const forbidden = await memberBrowser.request.patch(
+      `${apiPath}/${shared.data.snippet.id}`,
+      { name: 'Overwritten by somebody else' }
+    )
+    expect(forbidden).toHaveStatus(403)
+
+    const updated = await ownerBrowser.request.patch(
+      `${apiPath}/${shared.data.snippet.id}`,
+      { name: 'Current creators' }
+    )
+    expect(updated).toHaveStatus(200)
+    expect(updated).toHaveJsonPath('snippet.name', 'Current creators')
+
+    const removed = await ownerBrowser.request.delete(
+      `${apiPath}/${personal.data.snippet.id}`,
+      {}
+    )
+    expect(removed).toHaveStatus(200)
+    expect(removed).toHaveJsonPath('deleted', true)
+
+    const audit = await sails.models.auditlog.findOne({
+      action: 'helm.snippet.created',
+      resourceId: String(shared.data.snippet.id)
+    })
+    expect(audit.details.name).toBe('Active creators')
+    expect(JSON.stringify(audit).includes('await Creator.find')).toBe(false)
   }
 )
 

--- a/tests/unit/config/production.test.js
+++ b/tests/unit/config/production.test.js
@@ -64,3 +64,33 @@ test('production observability retention has documented defaults and positive ov
     }
   }
 })
+
+test('production Helm history has bounded configurable retention', ({
+  expect
+}) => {
+  const names = [
+    'SLIPWAY_HELM_HISTORY_RETENTION_DAYS',
+    'SLIPWAY_HELM_HISTORY_MAX_ENTRIES'
+  ]
+  const original = Object.fromEntries(
+    names.map((name) => [name, process.env[name]])
+  )
+
+  try {
+    process.env.SLIPWAY_HELM_HISTORY_RETENTION_DAYS = '14'
+    process.env.SLIPWAY_HELM_HISTORY_MAX_ENTRIES = '80'
+    delete require.cache[productionConfigPath]
+
+    const productionConfig = require(productionConfigPath)
+    expect(productionConfig.custom.helm.historyRetentionMs).toBe(
+      14 * 24 * 60 * 60 * 1000
+    )
+    expect(productionConfig.custom.helm.historyMaxEntriesPerScope).toBe(80)
+  } finally {
+    delete require.cache[productionConfigPath]
+    for (const name of names) {
+      if (original[name] === undefined) delete process.env[name]
+      else process.env[name] = original[name]
+    }
+  }
+})


### PR DESCRIPTION
Closes #273\n\n## Summary\n- persist source-only Helm history per user, project, and environment with configurable retention and bounds\n- add searchable personal and project snippets with explicit ownership and inert insertion\n- add compact icon-tab UI, clear/pin/rerun/save actions, light/dark/mobile states, and accessible keyboard navigation\n- document privacy, retention, permissions, and operator configuration\n\n## Verification\n- npm test (219 unit, 63 functional, 33 e2e)\n- focused Sounding browser coverage regenerates the light, dark, and mobile screenshots\n- Prettier and git diff checks pass