### PR TITLE
feat(helm): guard production execution

### DIFF
--- a/api/controllers/api/v1/app/execute-code.js
+++ b/api/controllers/api/v1/app/execute-code.js
@@ -39,6 +39,12 @@ module.exports = {
     appSlug: {
       type: 'string',
       description: 'Target app slug (defaults to default app)'
+    },
+    writeArmToken: {
+      type: 'string',
+      maxLength: 200,
+      description:
+        'Short-lived, single-use capability for an exact production mutation'
     }
   },
 
@@ -54,6 +60,9 @@ module.exports = {
     },
     badRequest: {
       responseType: 'badRequest'
+    },
+    conflict: {
+      statusCode: 409
     }
   },
 
@@ -64,7 +73,8 @@ module.exports = {
     executionId,
     sourceStartLine,
     sourceStartColumn,
-    appSlug
+    appSlug,
+    writeArmToken
   }) {
     const scope = await sails.helpers.helm
       .resolveProjectScope(
@@ -79,6 +89,47 @@ module.exports = {
 
     if (!app || app.status !== 'running' || !app.containerName) {
       throw { badRequest: 'App is not running.' }
+    }
+
+    const classification = sails.helpers.helm.classifyMutations(code)
+    const sourceHash = sails.helpers.helm.hashSource(code)
+    const target = sails.helpers.helm.describeTarget(scope)
+    let writeArmed = false
+
+    if (scope.environment.isProduction && classification.mutating) {
+      if (writeArmToken) {
+        writeArmed = Boolean(
+          await sails.helpers.helm.consumeWriteArm.with({
+            token: writeArmToken,
+            scope,
+            sourceHash,
+            targetFingerprint: target.fingerprint
+          })
+        )
+      }
+
+      if (!writeArmed) {
+        await recordBlockedExecution({
+          scope,
+          source: code,
+          sourceHash,
+          target,
+          classification,
+          ipAddress: this.req.ip,
+          reason: writeArmToken ? 'invalid-or-expired-arm' : 'not-armed'
+        })
+        throw {
+          conflict: {
+            code: 'HELM_WRITES_NOT_ARMED',
+            message: writeArmToken
+              ? 'The production write arm expired or no longer matches this source and target.'
+              : 'Production writes must be armed before they can run.',
+            sourceHash,
+            classification,
+            target: publicTarget(target)
+          }
+        }
+      }
     }
 
     const execution = sails.helpers.helm.beginExecution(
@@ -101,6 +152,11 @@ module.exports = {
         scope,
         source: code,
         result,
+        startedAt,
+        sourceHash,
+        target,
+        classification,
+        writeArmed,
         ipAddress: this.req.ip
       })
       return result
@@ -113,6 +169,11 @@ module.exports = {
           success: false,
           durationMs: Date.now() - startedAt
         },
+        startedAt,
+        sourceHash,
+        target,
+        classification,
+        writeArmed,
         ipAddress: this.req.ip
       })
       throw error
@@ -120,4 +181,50 @@ module.exports = {
       execution.release()
     }
   }
+}
+
+async function recordBlockedExecution({
+  scope,
+  source,
+  sourceHash,
+  target,
+  classification,
+  ipAddress,
+  reason
+}) {
+  await sails.helpers.audit.log.with({
+    action: 'helm.execution.blocked',
+    resourceType: 'app',
+    resourceId: String(scope.app.id),
+    details: {
+      ...publicTarget(target),
+      targetFingerprint: target.fingerprint,
+      sourceHash,
+      sourceBytes: Buffer.byteLength(source),
+      startedAt: Date.now(),
+      status: 'blocked',
+      outputBytes: 0,
+      classifierComplete: classification.complete,
+      mutationKinds: [
+        ...new Set(classification.findings.map((item) => item.kind))
+      ],
+      mutationMethods: [
+        ...new Set(classification.findings.map((item) => item.method))
+      ],
+      reason
+    },
+    userId: String(scope.user.id),
+    teamId: String(scope.project.team.id),
+    ipAddress
+  })
+  try {
+    await sails.helpers.helm.pruneAudit(scope.project.team.id)
+  } catch (error) {
+    sails.log.verbose(`Could not prune Helm audit: ${error.message || error}`)
+  }
+}
+
+function publicTarget(target) {
+  const { fingerprint, ...safeTarget } = target
+  return safeTarget
 }

--- a/api/controllers/api/v1/audit-log/list-audit-logs.js
+++ b/api/controllers/api/v1/audit-log/list-audit-logs.js
@@ -14,45 +14,38 @@ module.exports = {
       defaultsTo: 50,
       min: 1,
       max: 100
+    },
+    q: {
+      type: 'string',
+      maxLength: 200
+    },
+    group: {
+      type: 'string',
+      isIn: ['all', 'helm'],
+      defaultsTo: 'all'
     }
   },
 
   exits: {
     success: {
       statusCode: 200
+    },
+    forbidden: {
+      statusCode: 403
     }
   },
 
-  fn: async function ({ page, limit }) {
+  fn: async function ({ page, limit, q, group }) {
     const user = await User.findOne({ id: this.req.session.userId })
-    const skip = (page - 1) * limit
+    if (!['owner', 'admin'].includes(user.teamRole)) throw 'forbidden'
 
-    const [logs, totalCount] = await Promise.all([
-      AuditLog.find({ team: user.team })
-        .sort('createdAt DESC')
-        .skip(skip)
-        .limit(limit)
-        .populate('user'),
-      AuditLog.count({ team: user.team })
-    ])
-
-    return {
-      logs: logs.map((log) => ({
-        id: log.id,
-        action: log.action,
-        resourceType: log.resourceType,
-        resourceId: log.resourceId,
-        details: log.details,
-        ipAddress: log.ipAddress,
-        userName: log.user ? log.user.fullName || log.user.email : 'System',
-        createdAt: log.createdAt
-      })),
-      pagination: {
-        page,
-        perPage: limit,
-        totalCount,
-        totalPages: Math.ceil(totalCount / limit)
-      }
-    }
+    this.res.set('Cache-Control', 'private, no-store')
+    return sails.helpers.audit.listTeamEvents(
+      String(user.team),
+      page,
+      limit,
+      q,
+      group
+    )
   }
 }

--- a/api/controllers/api/v1/helm/arm-writes.js
+++ b/api/controllers/api/v1/helm/arm-writes.js
@@ -1,0 +1,147 @@
+const crypto = require('node:crypto')
+
+module.exports = {
+  friendlyName: 'Arm Helm writes',
+
+  description:
+    'Issue a short-lived, single-use capability for an exact production Helm source and target.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    appSlug: {
+      type: 'string'
+    },
+    code: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: { statusCode: 201 },
+    badRequest: { responseType: 'badRequest' },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, appSlug, code }) {
+    if (Buffer.byteLength(code) > sails.config.custom.helm.maxSourceBytes) {
+      throw { badRequest: 'Helm source exceeds the configured size limit.' }
+    }
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug,
+        appSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+
+    if (!scope.environment.isProduction) {
+      throw {
+        badRequest:
+          'Write arming is only used for production Helm environments.'
+      }
+    }
+
+    const classification = sails.helpers.helm.classifyMutations(code)
+    if (!classification.mutating) {
+      throw {
+        badRequest:
+          'No obvious mutation was detected in this source. You can run it normally.'
+      }
+    }
+
+    const sourceHash = sails.helpers.helm.hashSource(code)
+    const target = sails.helpers.helm.describeTarget(scope)
+    const token = crypto.randomBytes(32).toString('base64url')
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex')
+    const now = Date.now()
+    const expiresAt = now + sails.config.custom.helm.writeArmTtlMs
+
+    await HelmWriteArm.create({
+      tokenHash,
+      sourceHash,
+      targetFingerprint: target.fingerprint,
+      expiresAt,
+      usedAt: null,
+      user: scope.user.id,
+      team: scope.project.team.id,
+      project: scope.project.id,
+      environment: scope.environment.id,
+      app: scope.app.id
+    })
+
+    await HelmWriteArm.destroy({ expiresAt: { '<': now } })
+
+    await sails.helpers.audit.log.with({
+      action: 'helm.writes.armed',
+      resourceType: 'app',
+      resourceId: String(scope.app.id),
+      details: auditDetails({
+        target,
+        sourceHash,
+        sourceBytes: Buffer.byteLength(code),
+        classification,
+        expiresAt
+      }),
+      userId: String(scope.user.id),
+      teamId: String(scope.project.team.id),
+      ipAddress: this.req.ip
+    })
+    await safelyPruneAudit(scope.project.team.id, now)
+
+    this.res.set('Cache-Control', 'private, no-store')
+    return {
+      token,
+      sourceHash,
+      expiresAt,
+      classification,
+      target: publicTarget(target)
+    }
+  }
+}
+
+function auditDetails({
+  target,
+  sourceHash,
+  sourceBytes,
+  classification,
+  expiresAt
+}) {
+  return {
+    ...publicTarget(target),
+    targetFingerprint: target.fingerprint,
+    sourceHash,
+    sourceBytes,
+    classifierComplete: classification.complete,
+    mutationKinds: [
+      ...new Set(classification.findings.map((item) => item.kind))
+    ],
+    mutationMethods: [
+      ...new Set(classification.findings.map((item) => item.method))
+    ],
+    expiresAt
+  }
+}
+
+function publicTarget(target) {
+  const { fingerprint, ...safeTarget } = target
+  return safeTarget
+}
+
+async function safelyPruneAudit(teamId, now) {
+  try {
+    await sails.helpers.helm.pruneAudit(teamId, now)
+  } catch (error) {
+    sails.log.verbose(`Could not prune Helm audit: ${error.message || error}`)
+  }
+}

--- a/api/controllers/api/v1/helm/inspect-source.js
+++ b/api/controllers/api/v1/helm/inspect-source.js
@@ -1,0 +1,58 @@
+module.exports = {
+  friendlyName: 'Inspect Helm source',
+
+  description:
+    'Classify project Helm source against its current target before the UI attempts execution.',
+
+  inputs: {
+    projectSlug: {
+      type: 'string',
+      required: true
+    },
+    environmentSlug: {
+      type: 'string',
+      required: true
+    },
+    appSlug: {
+      type: 'string'
+    },
+    code: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    badRequest: { responseType: 'badRequest' },
+    notFound: { statusCode: 404 },
+    forbidden: { statusCode: 403 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, appSlug, code }) {
+    if (Buffer.byteLength(code) > sails.config.custom.helm.maxSourceBytes) {
+      throw { badRequest: 'Helm source exceeds the configured size limit.' }
+    }
+    const scope = await sails.helpers.helm
+      .resolveProjectScope(
+        this.req.session.userId,
+        projectSlug,
+        environmentSlug,
+        appSlug
+      )
+      .intercept('notFound', 'notFound')
+      .intercept('forbidden', 'forbidden')
+    const classification = sails.helpers.helm.classifyMutations(code)
+    const target = sails.helpers.helm.describeTarget(scope)
+    const { fingerprint, ...safeTarget } = target
+
+    this.res.set('Cache-Control', 'private, no-store')
+    return {
+      classification,
+      sourceHash: sails.helpers.helm.hashSource(code),
+      requiresWriteArm:
+        Boolean(scope.environment.isProduction) && classification.mutating,
+      target: safeTarget
+    }
+  }
+}

--- a/api/controllers/api/v1/helm/list-history.js
+++ b/api/controllers/api/v1/helm/list-history.js
@@ -64,6 +64,15 @@ function serializeEntry(entry) {
     durationMs: entry.durationMs,
     executedAt: entry.executedAt,
     target: entry.target,
+    targetContext: entry.targetContext,
+    targetLabel: formatTarget(entry),
     pinned: entry.pinned
   }
+}
+
+function formatTarget(entry) {
+  const context = entry.targetContext
+  if (!context?.environment || !context?.app) return entry.target
+  const version = context.displayVersion ? ` @ ${context.displayVersion}` : ''
+  return `${context.environment.slug} / ${context.app.slug}${version}`
 }

--- a/api/controllers/project/view-helm.js
+++ b/api/controllers/project/view-helm.js
@@ -45,9 +45,19 @@ module.exports = {
       throw { notFound: `/projects/${slug}` }
     }
 
-    const app =
+    let app =
       (await App.findOne({ environment: environment.id, isDefault: true })) ||
       (await App.findOne({ environment: environment.id }))
+    if (app)
+      app = await App.findOne({ id: app.id }).populate('currentDeployment')
+    const target = app
+      ? sails.helpers.helm.describeTarget({
+          user,
+          project,
+          environment,
+          app
+        })
+      : null
 
     return {
       page: 'projects/helm',
@@ -60,10 +70,28 @@ module.exports = {
         environment: {
           id: environment.id,
           name: environment.name,
-          slug: environment.slug
+          slug: environment.slug,
+          isProduction: environment.isProduction
         },
-        appStatus: app ? app.status : null
+        app: app
+          ? {
+              id: app.id,
+              name: app.name,
+              slug: app.slug,
+              status: app.status
+            }
+          : null,
+        appStatus: app ? app.status : null,
+        target: target ? publicTarget(target) : null,
+        writeArmTtlSeconds: Math.ceil(
+          sails.config.custom.helm.writeArmTtlMs / 1000
+        )
       }
     }
   }
+}
+
+function publicTarget(target) {
+  const { fingerprint, ...safeTarget } = target
+  return safeTarget
 }

--- a/api/controllers/setting/view-audit-log.js
+++ b/api/controllers/setting/view-audit-log.js
@@ -8,52 +8,49 @@ module.exports = {
       type: 'number',
       defaultsTo: 1,
       min: 1
+    },
+    q: {
+      type: 'string',
+      maxLength: 200
+    },
+    group: {
+      type: 'string',
+      isIn: ['all', 'helm'],
+      defaultsTo: 'all'
     }
   },
 
   exits: {
     success: {
       responseType: 'inertia'
+    },
+    forbidden: {
+      responseType: 'redirect'
     }
   },
 
-  fn: async function ({ page }) {
+  fn: async function ({ page, q, group }) {
     const perPage = 50
-    const skip = (page - 1) * perPage
-
     const user = await User.findOne({ id: this.req.session.userId })
+    if (!['owner', 'admin'].includes(user.teamRole)) {
+      throw { forbidden: '/settings' }
+    }
 
-    const [logs, totalCount] = await Promise.all([
-      AuditLog.find({ team: user.team })
-        .sort('createdAt DESC')
-        .skip(skip)
-        .limit(perPage)
-        .populate('user'),
-      AuditLog.count({ team: user.team })
-    ])
-
-    // Sanitize user data for the frontend
-    const sanitizedLogs = logs.map((log) => ({
-      id: log.id,
-      action: log.action,
-      resourceType: log.resourceType,
-      resourceId: log.resourceId,
-      details: log.details,
-      ipAddress: log.ipAddress,
-      userName: log.user ? log.user.fullName || log.user.email : 'System',
-      createdAt: log.createdAt
-    }))
+    const result = await sails.helpers.audit.listTeamEvents(
+      String(user.team),
+      page,
+      perPage,
+      q,
+      group
+    )
 
     return {
       page: 'settings/audit-log',
       props: {
-        logs: sanitizedLogs,
-        pagination: {
-          page,
-          perPage,
-          totalCount,
-          totalPages: Math.ceil(totalCount / perPage)
-        }
+        ...result,
+        helmAuditRetentionDays: Math.round(
+          sails.config.custom.helm.auditRetentionMs / (24 * 60 * 60 * 1000)
+        )
       }
     }
   }

--- a/api/helpers/audit/list-team-events.js
+++ b/api/helpers/audit/list-team-events.js
@@ -1,0 +1,122 @@
+module.exports = {
+  friendlyName: 'List team audit events',
+
+  description:
+    'Return searchable, paginated audit events for one team without exposing protected user fields.',
+
+  inputs: {
+    teamId: {
+      type: 'string',
+      required: true
+    },
+    page: {
+      type: 'number',
+      defaultsTo: 1,
+      min: 1
+    },
+    limit: {
+      type: 'number',
+      defaultsTo: 50,
+      min: 1,
+      max: 100
+    },
+    q: {
+      type: 'string',
+      maxLength: 200
+    },
+    group: {
+      type: 'string',
+      isIn: ['all', 'helm'],
+      defaultsTo: 'all'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ teamId, page, limit, q, group }) {
+    const search = (q || '').trim()
+    const criteria = { team: teamId }
+    if (group === 'helm') criteria.action = { startsWith: 'helm.' }
+
+    if (search) {
+      const [matchingUsers, matchingDetails] = await Promise.all([
+        User.find({
+          team: teamId,
+          or: [
+            { fullName: { contains: search } },
+            { email: { contains: search } }
+          ]
+        }).select(['id']),
+        findMatchingDetailIds(teamId, search)
+      ])
+      criteria.or = [
+        { action: { contains: search } },
+        { resourceType: { contains: search } },
+        { resourceId: { contains: search } },
+        { ipAddress: { contains: search } }
+      ]
+      if (matchingUsers.length > 0) {
+        criteria.or.push({ user: matchingUsers.map((user) => user.id) })
+      }
+      if (matchingDetails.length > 0) {
+        criteria.or.push({ id: matchingDetails })
+      }
+    }
+
+    const skip = (page - 1) * limit
+    const [logs, totalCount] = await Promise.all([
+      AuditLog.find(criteria)
+        .sort(['createdAt DESC', 'id DESC'])
+        .skip(skip)
+        .limit(limit)
+        .populate('user'),
+      AuditLog.count(criteria)
+    ])
+
+    return {
+      logs: logs.map(serializeLog),
+      filters: { q: search, group },
+      pagination: {
+        page,
+        perPage: limit,
+        totalCount,
+        totalPages: Math.max(1, Math.ceil(totalCount / limit))
+      }
+    }
+  }
+}
+
+function findMatchingDetailIds(teamId, search) {
+  const database = sails.getDatastore().manager
+  return database
+    .prepare(
+      `
+        SELECT id
+        FROM audit_logs
+        WHERE team = ?
+          AND details LIKE ?
+        ORDER BY created_at DESC, id DESC
+        LIMIT 1000
+      `
+    )
+    .all(teamId, `%${search}%`)
+    .map((row) => row.id)
+}
+
+function serializeLog(log) {
+  return {
+    id: log.id,
+    action: log.action,
+    resourceType: log.resourceType,
+    resourceId: log.resourceId,
+    details: log.details,
+    ipAddress: log.ipAddress,
+    userName: log.user ? log.user.fullName || log.user.email : 'System',
+    userEmail: log.user ? log.user.email : null,
+    createdAt: log.createdAt
+  }
+}

--- a/api/helpers/helm/classify-mutations.js
+++ b/api/helpers/helm/classify-mutations.js
@@ -1,0 +1,231 @@
+const acorn = require('acorn')
+
+const MODEL_MUTATIONS = new Map([
+  ['addToCollection', 'Add to collection'],
+  ['archive', 'Archive records'],
+  ['archiveOne', 'Archive one record'],
+  ['create', 'Create records'],
+  ['createEach', 'Create records'],
+  ['destroy', 'Destroy records'],
+  ['destroyOne', 'Destroy one record'],
+  ['removeFromCollection', 'Remove from collection'],
+  ['replaceCollection', 'Replace collection'],
+  ['save', 'Save a record'],
+  ['update', 'Update records'],
+  ['updateOne', 'Update one record']
+])
+
+const NATIVE_CALLS = new Map([
+  ['sendNativeQuery', 'Run a native database query'],
+  ['query', 'Run a native query']
+])
+
+const EXTERNAL_IDENTIFIERS = new Map([
+  ['fetch', 'Make an external request'],
+  ['request', 'Make an external request']
+])
+
+const EXTERNAL_METHODS = new Map([
+  ['broadcast', 'Broadcast an external event'],
+  ['emit', 'Emit an external event'],
+  ['enqueue', 'Enqueue background work'],
+  ['publish', 'Publish an external event'],
+  ['schedule', 'Schedule background work'],
+  ['sendTemplate', 'Send a message']
+])
+
+module.exports = {
+  friendlyName: 'Classify Helm mutations',
+
+  description:
+    'Use JavaScript parser data to identify obvious writes and external side effects without executing submitted source.',
+
+  inputs: {
+    source: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  sync: true,
+
+  fn: function ({ source }) {
+    const submittedSource = String(source || '')
+    const prefix = 'async function __helmMutationScan__() {\n'
+    const suffix = '\n}'
+    let program
+
+    try {
+      program = acorn.parse(`${prefix}${submittedSource}${suffix}`, {
+        ecmaVersion: 'latest',
+        sourceType: 'script',
+        locations: true
+      })
+    } catch (error) {
+      return {
+        mutating: false,
+        complete: false,
+        findings: [],
+        parserError: {
+          line: Math.max(1, (error.loc?.line || 2) - 1),
+          column: (error.loc?.column || 0) + 1
+        }
+      }
+    }
+
+    const findings = []
+    walk(program, (node) => {
+      if (node.type !== 'CallExpression') return
+
+      const callee = unwrapChain(node.callee)
+      const property = memberPropertyName(callee)
+      const identifier = callee?.type === 'Identifier' ? callee.name : null
+      const path = memberPath(callee)
+
+      if (property && MODEL_MUTATIONS.has(property)) {
+        addFinding(findings, node, {
+          kind: 'database-write',
+          method: property,
+          label: MODEL_MUTATIONS.get(property)
+        })
+        return
+      }
+
+      if (property && NATIVE_CALLS.has(property)) {
+        addFinding(findings, node, {
+          kind: 'native-query',
+          method: property,
+          label: NATIVE_CALLS.get(property)
+        })
+        return
+      }
+
+      if (identifier && EXTERNAL_IDENTIFIERS.has(identifier)) {
+        addFinding(findings, node, {
+          kind: 'external-side-effect',
+          method: identifier,
+          label: EXTERNAL_IDENTIFIERS.get(identifier)
+        })
+        return
+      }
+
+      if (
+        (identifier === 'axios' || path.startsWith('axios.')) &&
+        !path.endsWith('.get')
+      ) {
+        addFinding(findings, node, {
+          kind: 'external-side-effect',
+          method: property || identifier,
+          label: 'Make an external request'
+        })
+        return
+      }
+
+      const helperExternalMethod = [...EXTERNAL_METHODS.keys()].find(
+        (method) =>
+          path.includes(`.${method}.`) && isRecognizedExternalPath(path)
+      )
+      if (helperExternalMethod) {
+        addFinding(findings, node, {
+          kind: 'external-side-effect',
+          method: helperExternalMethod,
+          label: EXTERNAL_METHODS.get(helperExternalMethod)
+        })
+        return
+      }
+
+      if (
+        property &&
+        EXTERNAL_METHODS.has(property) &&
+        isRecognizedExternalPath(path)
+      ) {
+        addFinding(findings, node, {
+          kind: 'external-side-effect',
+          method: property,
+          label: EXTERNAL_METHODS.get(property)
+        })
+      }
+    })
+
+    return {
+      mutating: findings.length > 0,
+      complete: true,
+      findings: findings.slice(0, 20).map(({ key, ...finding }) => finding)
+    }
+  }
+}
+
+function addFinding(findings, node, finding) {
+  const line = Math.max(1, (node.loc?.start.line || 2) - 1)
+  const column = (node.loc?.start.column || 0) + 1
+  const key = `${finding.kind}:${finding.method}:${line}:${column}`
+  if (findings.some((candidate) => candidate.key === key)) return
+  findings.push({ ...finding, line, column, key })
+}
+
+function unwrapChain(node) {
+  return node?.type === 'ChainExpression' ? node.expression : node
+}
+
+function memberPropertyName(node) {
+  const unwrapped = unwrapChain(node)
+  if (unwrapped?.type !== 'MemberExpression') return null
+  if (!unwrapped.computed && unwrapped.property.type === 'Identifier') {
+    return unwrapped.property.name
+  }
+  if (
+    unwrapped.computed &&
+    unwrapped.property.type === 'Literal' &&
+    typeof unwrapped.property.value === 'string'
+  ) {
+    return unwrapped.property.value
+  }
+  return null
+}
+
+function memberPath(node) {
+  const unwrapped = unwrapChain(node)
+  if (!unwrapped) return ''
+  if (unwrapped.type === 'Identifier') return unwrapped.name
+  if (unwrapped.type === 'CallExpression') return memberPath(unwrapped.callee)
+  if (unwrapped.type !== 'MemberExpression') return ''
+
+  const object = memberPath(unwrapped.object)
+  const property = memberPropertyName(unwrapped)
+  return [object, property].filter(Boolean).join('.')
+}
+
+function isRecognizedExternalPath(path) {
+  return [
+    'sails.helpers.mail.',
+    'sails.helpers.quest.',
+    'sails.helpers.request.',
+    'sails.helpers.webhook.',
+    'sails.sockets.',
+    'Mail.',
+    'Quest.',
+    'Webhook.'
+  ].some((prefix) => path.startsWith(prefix))
+}
+
+function walk(value, visit, seen = new Set()) {
+  if (!value || typeof value !== 'object' || seen.has(value)) return
+  seen.add(value)
+
+  if (typeof value.type === 'string') visit(value)
+
+  for (const [key, child] of Object.entries(value)) {
+    if (['loc', 'start', 'end'].includes(key)) continue
+    if (Array.isArray(child)) {
+      for (const entry of child) walk(entry, visit, seen)
+    } else {
+      walk(child, visit, seen)
+    }
+  }
+}

--- a/api/helpers/helm/consume-write-arm.js
+++ b/api/helpers/helm/consume-write-arm.js
@@ -1,0 +1,66 @@
+const crypto = require('node:crypto')
+
+module.exports = {
+  friendlyName: 'Consume Helm write arm',
+
+  description:
+    'Atomically consume one unexpired write arm bound to the exact actor, source, and production target.',
+
+  inputs: {
+    token: {
+      type: 'string',
+      required: true
+    },
+    scope: {
+      type: 'ref',
+      required: true
+    },
+    sourceHash: {
+      type: 'string',
+      required: true
+    },
+    targetFingerprint: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  fn: async function ({ token, scope, sourceHash, targetFingerprint }) {
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex')
+    const now = Date.now()
+    const database = sails.getDatastore().manager
+    const result = database
+      .prepare(
+        `
+          UPDATE helm_write_arms
+          SET used_at = ?, updated_at = ?
+          WHERE token_hash = ?
+            AND source_hash = ?
+            AND target_fingerprint = ?
+            AND user = ?
+            AND team = ?
+            AND project = ?
+            AND environment = ?
+            AND app = ?
+            AND used_at IS NULL
+            AND expires_at > ?
+        `
+      )
+      .run(
+        now,
+        now,
+        tokenHash,
+        sourceHash,
+        targetFingerprint,
+        scope.user.id,
+        scope.project.team.id,
+        scope.project.id,
+        scope.environment.id,
+        scope.app.id,
+        now
+      )
+
+    if (result.changes !== 1) return null
+    return HelmWriteArm.findOne({ tokenHash })
+  }
+}

--- a/api/helpers/helm/describe-target.js
+++ b/api/helpers/helm/describe-target.js
@@ -1,0 +1,87 @@
+const crypto = require('node:crypto')
+
+module.exports = {
+  friendlyName: 'Describe Helm target',
+
+  description:
+    'Build the stable, non-secret project, environment, app, container, and deployment context for a Helm execution.',
+
+  inputs: {
+    scope: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  sync: true,
+
+  fn: function ({ scope }) {
+    const deployment =
+      scope.app.currentDeployment &&
+      typeof scope.app.currentDeployment === 'object'
+        ? scope.app.currentDeployment
+        : null
+    const version =
+      deployment?.gitCommit ||
+      deployment?.imageName ||
+      deployment?.imageId ||
+      scope.app.imageName ||
+      scope.app.imageId ||
+      null
+    const target = {
+      project: {
+        id: scope.project.id,
+        name: scope.project.name,
+        slug: scope.project.slug
+      },
+      environment: {
+        id: scope.environment.id,
+        name: scope.environment.name,
+        slug: scope.environment.slug,
+        isProduction: Boolean(scope.environment.isProduction)
+      },
+      app: {
+        id: scope.app.id,
+        name: scope.app.name,
+        slug: scope.app.slug
+      },
+      container: scope.app.containerName || null,
+      deployment: deployment
+        ? {
+            id: deployment.id,
+            gitCommit: deployment.gitCommit || null,
+            gitBranch: deployment.gitBranch || null,
+            imageId: deployment.imageId || null,
+            imageName: deployment.imageName || null
+          }
+        : null,
+      version,
+      displayVersion: shortVersion(version)
+    }
+
+    target.fingerprint = crypto
+      .createHash('sha256')
+      .update(
+        JSON.stringify([
+          target.project.id,
+          target.environment.id,
+          target.app.id,
+          target.container,
+          target.deployment?.id || null,
+          target.version
+        ])
+      )
+      .digest('hex')
+
+    return target
+  }
+}
+
+function shortVersion(version) {
+  if (!version) return null
+  const value = String(version)
+  const sha = value.match(/(?:sha256:)?([0-9a-f]{7,64})/i)
+  if (sha) return sha[1].slice(0, 7)
+  const tag = value.split(':').at(-1)
+  return tag.length > 18 ? `${tag.slice(0, 15)}…` : tag
+}

--- a/api/helpers/helm/ensure-workspace-schema.js
+++ b/api/helpers/helm/ensure-workspace-schema.js
@@ -17,6 +17,7 @@ module.exports = {
         duration_ms INTEGER NOT NULL DEFAULT 0,
         executed_at INTEGER NOT NULL,
         target TEXT NOT NULL,
+        target_context TEXT,
         pinned BOOLEAN NOT NULL DEFAULT 0,
         user INTEGER NOT NULL,
         team INTEGER NOT NULL,
@@ -27,6 +28,20 @@ module.exports = {
         updated_at INTEGER
       )
     `)
+
+    const historyColumnsResult = await datastore.sendNativeQuery(
+      'PRAGMA table_info(helm_history_entries)'
+    )
+    const historyColumns = new Set(
+      (historyColumnsResult.rows || historyColumnsResult || []).map(
+        (column) => column.name
+      )
+    )
+    if (!historyColumns.has('target_context')) {
+      await datastore.sendNativeQuery(
+        'ALTER TABLE helm_history_entries ADD COLUMN target_context TEXT'
+      )
+    }
 
     await datastore.sendNativeQuery(`
       CREATE INDEX IF NOT EXISTS helm_history_scope
@@ -73,6 +88,40 @@ module.exports = {
     await datastore.sendNativeQuery(`
       CREATE INDEX IF NOT EXISTS helm_snippets_visible
       ON helm_snippets (project, scope, owner, updated_at DESC)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS helm_write_arms (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        token_hash TEXT NOT NULL UNIQUE,
+        source_hash TEXT NOT NULL,
+        target_fingerprint TEXT NOT NULL,
+        expires_at INTEGER NOT NULL,
+        used_at INTEGER,
+        user INTEGER NOT NULL,
+        team INTEGER NOT NULL,
+        project INTEGER NOT NULL,
+        environment INTEGER NOT NULL,
+        app INTEGER NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS helm_write_arms_lookup
+      ON helm_write_arms (
+        token_hash,
+        source_hash,
+        target_fingerprint,
+        expires_at,
+        used_at
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS helm_write_arms_retention
+      ON helm_write_arms (expires_at, used_at)
     `)
   }
 }

--- a/api/helpers/helm/hash-source.js
+++ b/api/helpers/helm/hash-source.js
@@ -1,0 +1,21 @@
+const crypto = require('node:crypto')
+
+module.exports = {
+  friendlyName: 'Hash Helm source',
+
+  description:
+    'Return the SHA-256 digest used to bind write arms and identify protected Helm source in audit events.',
+
+  inputs: {
+    source: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  sync: true,
+
+  fn: function ({ source }) {
+    return crypto.createHash('sha256').update(source).digest('hex')
+  }
+}

--- a/api/helpers/helm/prune-audit.js
+++ b/api/helpers/helm/prune-audit.js
@@ -1,0 +1,39 @@
+module.exports = {
+  friendlyName: 'Prune Helm audit',
+
+  description:
+    'Apply the configured age and per-team bounds to Helm audit events.',
+
+  inputs: {
+    teamId: {
+      type: 'string',
+      required: true
+    },
+    now: {
+      type: 'number'
+    }
+  },
+
+  fn: async function ({ teamId, now }) {
+    now = now || Date.now()
+    const retentionMs = sails.config.custom.helm.auditRetentionMs
+    const maxEntries = sails.config.custom.helm.auditMaxEntriesPerTeam
+    const criteria = {
+      team: teamId,
+      action: { startsWith: 'helm.' }
+    }
+
+    await AuditLog.destroy({
+      ...criteria,
+      createdAt: { '<': now - retentionMs }
+    })
+
+    const overflow = await AuditLog.find(criteria)
+      .sort(['createdAt DESC', 'id DESC'])
+      .skip(maxEntries)
+      .limit(1000)
+    if (overflow.length > 0) {
+      await AuditLog.destroy({ id: overflow.map((event) => event.id) })
+    }
+  }
+}

--- a/api/helpers/helm/record-execution.js
+++ b/api/helpers/helm/record-execution.js
@@ -17,15 +17,52 @@ module.exports = {
       type: 'ref',
       required: true
     },
+    startedAt: {
+      type: 'number',
+      required: true
+    },
+    sourceHash: {
+      type: 'string',
+      required: true
+    },
+    target: {
+      type: 'ref',
+      required: true
+    },
+    classification: {
+      type: 'ref',
+      required: true
+    },
+    writeArmed: {
+      type: 'boolean',
+      defaultsTo: false
+    },
     ipAddress: {
       type: 'string'
     }
   },
 
-  fn: async function ({ scope, source, result, ipAddress }) {
-    const executedAt = Date.now()
+  fn: async function ({
+    scope,
+    source,
+    result,
+    startedAt,
+    sourceHash,
+    target,
+    classification,
+    writeArmed,
+    ipAddress
+  }) {
+    const executedAt = startedAt
     const status = normalizeStatus(result)
     const durationMs = Math.max(0, Math.round(Number(result.durationMs) || 0))
+    const outputBytes = Math.max(
+      0,
+      Math.round(
+        Number(result.outputBytes) ||
+          Buffer.byteLength(String(result.output || ''))
+      )
+    )
     let historyEntry = null
 
     try {
@@ -35,6 +72,7 @@ module.exports = {
         durationMs,
         executedAt,
         target: scope.app.slug,
+        targetContext: publicTarget(target),
         user: scope.user.id,
         team: scope.project.team.id,
         project: scope.project.id,
@@ -56,18 +94,41 @@ module.exports = {
       details: {
         projectId: scope.project.id,
         environmentId: scope.environment.id,
-        target: scope.app.slug,
+        ...publicTarget(target),
+        targetFingerprint: target.fingerprint,
+        sourceHash,
+        startedAt,
         status,
         durationMs,
-        sourceBytes: Buffer.byteLength(source)
+        outputBytes,
+        sourceBytes: Buffer.byteLength(source),
+        classifierComplete: classification.complete,
+        mutationDetected: classification.mutating,
+        mutationKinds: [
+          ...new Set(classification.findings.map((item) => item.kind))
+        ],
+        mutationMethods: [
+          ...new Set(classification.findings.map((item) => item.method))
+        ],
+        writeArmed
       },
       userId: String(scope.user.id),
       teamId: String(scope.project.team.id),
       ipAddress
     })
+    try {
+      await sails.helpers.helm.pruneAudit(scope.project.team.id)
+    } catch (error) {
+      sails.log.verbose(`Could not prune Helm audit: ${error.message || error}`)
+    }
 
     return historyEntry
   }
+}
+
+function publicTarget(target) {
+  const { fingerprint, ...safeTarget } = target
+  return safeTarget
 }
 
 function normalizeStatus(result) {

--- a/api/helpers/helm/resolve-project-scope.js
+++ b/api/helpers/helm/resolve-project-scope.js
@@ -58,6 +58,8 @@ module.exports = {
 
     if (!app) throw 'notFound'
 
+    app = await App.findOne({ id: app.id }).populate('currentDeployment')
+
     return { user, project, environment, app }
   }
 }

--- a/api/hooks/custom/index.js
+++ b/api/hooks/custom/index.js
@@ -35,7 +35,13 @@ module.exports = function defineCustomHook(sails) {
                   const user = await User.findOne({
                     id: userId
                   })
-                    .select(['email', 'fullName', 'initials', 'team'])
+                    .select([
+                      'email',
+                      'fullName',
+                      'initials',
+                      'team',
+                      'teamRole'
+                    ])
                     .populate('team')
 
                   if (!user) {

--- a/api/models/HelmHistoryEntry.js
+++ b/api/models/HelmHistoryEntry.js
@@ -39,6 +39,11 @@ module.exports = {
       maxLength: 200
     },
 
+    targetContext: {
+      type: 'json',
+      columnName: 'target_context'
+    },
+
     pinned: {
       type: 'boolean',
       defaultsTo: false

--- a/api/models/HelmWriteArm.js
+++ b/api/models/HelmWriteArm.js
@@ -1,0 +1,68 @@
+/**
+ * HelmWriteArm.js
+ *
+ * A short-lived, single-use server capability for an exact production Helm
+ * source and execution target. Only a SHA-256 token digest is persisted.
+ */
+
+module.exports = {
+  tableName: 'helm_write_arms',
+
+  attributes: {
+    tokenHash: {
+      type: 'string',
+      required: true,
+      unique: true,
+      columnName: 'token_hash'
+    },
+
+    sourceHash: {
+      type: 'string',
+      required: true,
+      columnName: 'source_hash'
+    },
+
+    targetFingerprint: {
+      type: 'string',
+      required: true,
+      columnName: 'target_fingerprint'
+    },
+
+    expiresAt: {
+      type: 'number',
+      required: true,
+      columnName: 'expires_at'
+    },
+
+    usedAt: {
+      type: 'number',
+      allowNull: true,
+      columnName: 'used_at'
+    },
+
+    user: {
+      model: 'user',
+      required: true
+    },
+
+    team: {
+      model: 'team',
+      required: true
+    },
+
+    project: {
+      model: 'project',
+      required: true
+    },
+
+    environment: {
+      model: 'environment',
+      required: true
+    },
+
+    app: {
+      model: 'app',
+      required: true
+    }
+  }
+}

--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -34,6 +34,10 @@ const props = defineProps({
   testId: {
     type: String,
     default: 'helm'
+  },
+  target: {
+    type: Object,
+    default: null
   }
 })
 
@@ -186,6 +190,9 @@ const actionItems = computed(() => {
       items.push({ key: 'export-csv', label: 'Export CSV' })
     }
   }
+  if (props.result) {
+    items.push({ key: 'copy-diagnostics', label: 'Copy diagnostics' })
+  }
   if (props.clearable && (props.result || props.error)) {
     items.push({ key: 'clear', label: 'Clear result' })
   }
@@ -270,7 +277,42 @@ async function handleAction(item) {
     notify('Exported helm-result.csv')
     return
   }
+  if (item.key === 'copy-diagnostics') {
+    await navigator.clipboard.writeText(
+      JSON.stringify(buildDiagnostics(), null, 2)
+    )
+    notify('Copied diagnostics to clipboard')
+    return
+  }
   if (item.key === 'clear') emit('clear')
+}
+
+function buildDiagnostics() {
+  return {
+    target: props.target,
+    execution: {
+      status:
+        props.result?.status || (props.result?.success ? 'success' : 'error'),
+      durationMs: props.result?.durationMs ?? null,
+      outputBytes: Number.isFinite(props.result?.outputBytes)
+        ? props.result.outputBytes
+        : new TextEncoder().encode(String(props.result?.output || '')).length,
+      rowCount: Number.isSafeInteger(props.result?.rowCount)
+        ? props.result.rowCount
+        : null,
+      truncated: Boolean(props.result?.truncated),
+      logsPartial: Boolean(props.result?.logsPartial),
+      error: props.result?.error
+        ? {
+            name: props.result.error.name || 'Error',
+            message: props.result.error.message || 'Execution failed',
+            line: props.result.error.line || null,
+            column: props.result.error.column || null,
+            code: props.result.error.code || null
+          }
+        : null
+    }
+  }
 }
 
 function downloadCsv() {

--- a/assets/js/components/HelmWorkspaceLibrary.vue
+++ b/assets/js/components/HelmWorkspaceLibrary.vue
@@ -582,7 +582,9 @@ defineExpose({ refreshHistory, openSnippetDialog })
                 <span
                   class="mt-0.5 flex items-center gap-1.5 text-[11px] text-gray-400 dark:text-gray-600"
                 >
-                  <span>{{ entry.target }}</span>
+                  <span :title="entry.targetLabel || entry.target">{{
+                    entry.targetLabel || entry.target
+                  }}</span>
                   <span aria-hidden="true">&middot;</span>
                   <span>{{ formatDuration(entry.durationMs) }}</span>
                   <span aria-hidden="true">&middot;</span>

--- a/assets/js/components/HelmWriteGuardDialog.vue
+++ b/assets/js/components/HelmWriteGuardDialog.vue
@@ -1,0 +1,203 @@
+<script setup>
+import { nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import SlippyLoader from '@/components/SlippyLoader.vue'
+
+const props = defineProps({
+  show: Boolean,
+  findings: {
+    type: Array,
+    default: () => []
+  },
+  target: {
+    type: Object,
+    default: null
+  },
+  ttlSeconds: {
+    type: Number,
+    default: 60
+  },
+  loading: Boolean,
+  error: {
+    type: String,
+    default: ''
+  }
+})
+
+const emit = defineEmits(['arm', 'cancel'])
+const dialog = ref(null)
+const cancelButton = ref(null)
+
+watch(
+  () => props.show,
+  async (show) => {
+    if (show) {
+      document.addEventListener('keydown', handleKeydown)
+      await nextTick()
+      cancelButton.value?.focus()
+    } else {
+      document.removeEventListener('keydown', handleKeydown)
+    }
+  },
+  { immediate: true }
+)
+
+onBeforeUnmount(() => document.removeEventListener('keydown', handleKeydown))
+
+function handleKeydown(event) {
+  if (event.key === 'Escape' && !props.loading) {
+    emit('cancel')
+    return
+  }
+  if (event.key !== 'Tab' || !dialog.value) return
+
+  const focusable = [
+    ...dialog.value.querySelectorAll(
+      'button:not([disabled]), [href], input:not([disabled])'
+    )
+  ]
+  if (focusable.length === 0) return
+  const first = focusable[0]
+  const last = focusable.at(-1)
+  if (event.shiftKey && document.activeElement === first) {
+    event.preventDefault()
+    last.focus()
+  } else if (!event.shiftKey && document.activeElement === last) {
+    event.preventDefault()
+    first.focus()
+  }
+}
+</script>
+
+<template>
+  <Teleport to="body">
+    <Transition
+      enter-active-class="transition duration-150 ease-out motion-reduce:transition-none"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition duration-100 ease-in motion-reduce:transition-none"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <div
+        v-if="show"
+        class="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <button
+          type="button"
+          aria-label="Close production write warning"
+          class="bg-black/45 absolute inset-0 cursor-default"
+          :disabled="loading"
+          @click="emit('cancel')"
+        />
+
+        <section
+          ref="dialog"
+          data-test="helm-write-guard"
+          role="alertdialog"
+          aria-modal="true"
+          aria-labelledby="helm-write-guard-title"
+          aria-describedby="helm-write-guard-description"
+          class="relative w-full max-w-md rounded-xl bg-white p-5 shadow-2xl ring-1 ring-black/10 dark:bg-gray-900 dark:ring-white/10"
+        >
+          <div class="flex items-start gap-3">
+            <span
+              class="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-red-50 text-red-600 dark:bg-red-950/50 dark:text-red-400"
+              aria-hidden="true"
+            >
+              <svg
+                class="h-4 w-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                stroke-width="1.8"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M12 9v4m0 3.25h.01M10.3 4.55 2.9 17.4a2 2 0 0 0 1.73 3h14.74a2 2 0 0 0 1.73-3L13.7 4.55a1.96 1.96 0 0 0-3.4 0Z"
+                />
+              </svg>
+            </span>
+            <div class="min-w-0 flex-1">
+              <h2
+                id="helm-write-guard-title"
+                class="text-base font-semibold text-gray-950 dark:text-white"
+              >
+                Arm production writes?
+              </h2>
+              <p
+                id="helm-write-guard-description"
+                class="mt-1 text-sm leading-5 text-gray-500 dark:text-gray-400"
+              >
+                Helm found an obvious side effect in code targeting
+                <span class="font-medium text-gray-700 dark:text-gray-200">{{
+                  target?.app?.name || 'this app'
+                }}</span
+                >.
+              </p>
+            </div>
+          </div>
+
+          <ul
+            v-if="findings.length"
+            class="mt-4 space-y-1.5 rounded-lg bg-gray-50 px-3 py-2.5 dark:bg-gray-950/70"
+          >
+            <li
+              v-for="(finding, index) in findings"
+              :key="`${finding.kind}-${finding.line}-${index}`"
+              class="flex items-baseline justify-between gap-3 text-xs"
+            >
+              <span class="text-gray-700 dark:text-gray-300">{{
+                finding.label
+              }}</span>
+              <code
+                class="shrink-0 text-[11px] text-gray-400 dark:text-gray-600"
+                >line {{ finding.line }}</code
+              >
+            </li>
+          </ul>
+
+          <p class="mt-3 text-xs leading-5 text-gray-500 dark:text-gray-400">
+            Arming lasts {{ ttlSeconds }} seconds, applies only to this exact
+            source and deployment, and is consumed after one attempt. Detection
+            is a safety heuristic—not a security sandbox.
+          </p>
+
+          <p
+            v-if="error"
+            data-test="helm-write-guard-error"
+            role="alert"
+            class="mt-3 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ error }}
+          </p>
+
+          <div class="mt-5 flex items-center justify-end gap-2">
+            <button
+              ref="cancelButton"
+              type="button"
+              :disabled="loading"
+              class="rounded-md px-3 py-1.5 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-900 disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white"
+              @click="emit('cancel')"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              data-test="helm-arm-writes"
+              :disabled="loading"
+              class="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 disabled:cursor-wait disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+              @click="emit('arm')"
+            >
+              <span v-if="loading" class="flex items-center gap-2">
+                <SlippyLoader size="h-3.5 w-3.5" />
+                Arming
+              </span>
+              <span v-else>Arm writes for {{ ttlSeconds }}s</span>
+            </button>
+          </div>
+        </section>
+      </div>
+    </Transition>
+  </Teleport>
+</template>

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -14,6 +14,7 @@ import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import HelmResultViewer from '@/components/HelmResultViewer.vue'
 import HelmWorkspaceLibrary from '@/components/HelmWorkspaceLibrary.vue'
+import HelmWriteGuardDialog from '@/components/HelmWriteGuardDialog.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { helmEditorDiagnostic } from '@/lib/helmResult'
 import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
@@ -25,6 +26,12 @@ defineOptions({
 const props = defineProps({
   project: Object,
   environment: Object,
+  app: Object,
+  target: Object,
+  writeArmTtlSeconds: {
+    type: Number,
+    default: 60
+  },
   appStatus: String
 })
 
@@ -43,6 +50,17 @@ const library = ref(null)
 const libraryOpen = ref(false)
 const libraryTab = ref('history')
 const completionMetadata = ref(null)
+const writeGuard = ref({
+  show: false,
+  execution: null,
+  findings: [],
+  target: null,
+  error: ''
+})
+const writeArm = ref(null)
+const writeArmRemaining = ref(0)
+const armingWrites = ref(false)
+const inspectingSource = ref(false)
 const editorSelection = ref({
   hasSelection: false,
   hasExecutableSelection: false,
@@ -51,13 +69,21 @@ const editorSelection = ref({
 let executionSequence = 0
 let activeExecution = null
 let completionRequestSequence = 0
+let writeArmTimer = null
 
 const isRunning = computed(() => props.appStatus === 'running')
+const isProduction = computed(() => Boolean(props.environment.isProduction))
+const writeArmActive = computed(
+  () =>
+    Boolean(writeArm.value) &&
+    writeArmRemaining.value > 0 &&
+    writeArm.value.expiresAt > Date.now()
+)
 const runLabel = computed(() =>
   editorSelection.value.hasSelection ? 'Run selection' : 'Run'
 )
 const canExecute = computed(() => {
-  if (!isRunning.value || running.value) return false
+  if (!isRunning.value || running.value || inspectingSource.value) return false
   if (editorSelection.value.hasSelection) {
     return editorSelection.value.hasExecutableSelection
   }
@@ -71,7 +97,13 @@ const helmLibraryUrl = computed(
 async function execute(sourceOverride) {
   let execution
   if (typeof sourceOverride === 'string') {
-    if (!sourceOverride.trim() || !isRunning.value || running.value) return
+    if (
+      !sourceOverride.trim() ||
+      !isRunning.value ||
+      running.value ||
+      inspectingSource.value
+    )
+      return
     code.value = sourceOverride
     await nextTick()
     execution = {
@@ -85,6 +117,36 @@ async function execute(sourceOverride) {
   } else {
     execution = editor.value?.getExecutionSnapshot()
     if (!execution?.hasExecutableSource || !canExecute.value) return
+  }
+
+  const candidateArm =
+    writeArmActive.value && writeArm.value.source === execution.source
+      ? writeArm.value
+      : null
+  if (writeArm.value && !candidateArm) clearWriteArm()
+
+  if (isProduction.value && !candidateArm) {
+    inspectingSource.value = true
+    requestError.value = ''
+    try {
+      const inspection = await inspectSource(execution.source)
+      if (inspection.requiresWriteArm) {
+        writeGuard.value = {
+          show: true,
+          execution,
+          findings: inspection.classification?.findings || [],
+          target: inspection.target || props.target,
+          error: ''
+        }
+        return
+      }
+    } catch (error) {
+      requestError.value =
+        error.message || 'Could not inspect this production source.'
+      return
+    } finally {
+      inspectingSource.value = false
+    }
   }
 
   editor.value.highlightExecution(execution)
@@ -101,6 +163,8 @@ async function execute(sourceOverride) {
   stopping.value = false
   executionResult.value = null
   requestError.value = ''
+  const activeArm = candidateArm
+  if (activeArm) clearWriteArm()
 
   try {
     const response = await fetch(
@@ -115,11 +179,12 @@ async function execute(sourceOverride) {
           executionId: currentExecution.id,
           code: execution.source,
           sourceStartLine: execution.startLine,
-          sourceStartColumn: execution.startColumn
+          sourceStartColumn: execution.startColumn,
+          appSlug: props.app?.slug,
+          writeArmToken: activeArm?.token
         })
       }
     )
-
     const responseText = await response.text()
     let result
     try {
@@ -129,6 +194,16 @@ async function execute(sourceOverride) {
     }
 
     if (!response.ok) {
+      if (response.status === 409 && result.code === 'HELM_WRITES_NOT_ARMED') {
+        writeGuard.value = {
+          show: true,
+          execution,
+          findings: result.classification?.findings || [],
+          target: result.target || props.target,
+          error: ''
+        }
+        return
+      }
       const diagnostic = helmEditorDiagnostic(result.error)
       if (diagnostic) editor.value.showDiagnostic(diagnostic)
       throw new Error(
@@ -154,6 +229,131 @@ async function execute(sourceOverride) {
       stopping.value = false
     }
   }
+}
+
+async function inspectSource(source) {
+  const response = await fetch(`${helmLibraryUrl.value}/inspect-source`, {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      'x-csrf-token': page.props._csrf || ''
+    },
+    cache: 'no-store',
+    body: JSON.stringify({
+      code: source,
+      appSlug: props.app?.slug
+    })
+  })
+  const text = await response.text()
+  let result
+  try {
+    result = JSON.parse(text)
+  } catch {
+    throw new Error(text || 'Could not inspect this production source.')
+  }
+  if (!response.ok) {
+    throw new Error(
+      result.message ||
+        result.error ||
+        'Could not inspect this production source.'
+    )
+  }
+  return result
+}
+
+async function armWrites() {
+  const execution = writeGuard.value.execution
+  if (!execution || armingWrites.value) return
+
+  armingWrites.value = true
+  writeGuard.value.error = ''
+  try {
+    const response = await fetch(`${helmLibraryUrl.value}/arm-writes`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        'x-csrf-token': page.props._csrf || ''
+      },
+      cache: 'no-store',
+      body: JSON.stringify({
+        code: execution.source,
+        appSlug: props.app?.slug
+      })
+    })
+    const text = await response.text()
+    let result
+    try {
+      result = JSON.parse(text)
+    } catch {
+      throw new Error(text || 'Could not arm production writes.')
+    }
+    if (!response.ok) {
+      throw new Error(
+        result.message || result.error || 'Could not arm production writes.'
+      )
+    }
+
+    writeArm.value = {
+      token: result.token,
+      sourceHash: result.sourceHash,
+      source: execution.source,
+      expiresAt: result.expiresAt,
+      target: result.target
+    }
+    writeGuard.value = {
+      show: false,
+      execution: null,
+      findings: [],
+      target: null,
+      error: ''
+    }
+    startWriteArmTimer()
+    await nextTick()
+    editor.value?.focus()
+  } catch (error) {
+    writeGuard.value.error = error.message || 'Could not arm production writes.'
+  } finally {
+    armingWrites.value = false
+  }
+}
+
+function cancelWriteGuard() {
+  if (armingWrites.value) return
+  writeGuard.value = {
+    show: false,
+    execution: null,
+    findings: [],
+    target: null,
+    error: ''
+  }
+  nextTick(() => editor.value?.focus())
+}
+
+function startWriteArmTimer() {
+  window.clearInterval(writeArmTimer)
+  updateWriteArmRemaining()
+  writeArmTimer = window.setInterval(updateWriteArmRemaining, 250)
+}
+
+function updateWriteArmRemaining() {
+  if (!writeArm.value) {
+    writeArmRemaining.value = 0
+    return
+  }
+  writeArmRemaining.value = Math.max(
+    0,
+    Math.ceil((writeArm.value.expiresAt - Date.now()) / 1000)
+  )
+  if (writeArmRemaining.value === 0) clearWriteArm()
+}
+
+function clearWriteArm() {
+  writeArm.value = null
+  writeArmRemaining.value = 0
+  window.clearInterval(writeArmTimer)
+  writeArmTimer = null
 }
 
 async function stopExecution() {
@@ -254,10 +454,14 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   completionRequestSequence++
+  clearWriteArm()
   window.removeEventListener('focus', loadCompletionMetadata)
 })
 
-watch(code, () => editor.value?.clearDiagnostics())
+watch(code, () => {
+  editor.value?.clearDiagnostics()
+  if (writeArm.value && writeArm.value.source !== code.value) clearWriteArm()
+})
 </script>
 <template>
   <Head
@@ -371,6 +575,13 @@ watch(code, () => editor.value?.clearDiagnostics())
             {{ project.name.toLowerCase() }}
           </Link>
           <span class="text-gray-400 dark:text-gray-600">/</span>
+          <span
+            v-if="app"
+            class="max-w-28 truncate text-gray-500 dark:text-gray-400"
+            :title="app.name"
+            >{{ app.name.toLowerCase() }}</span
+          >
+          <span v-if="app" class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white">helm</span>
         </nav>
         <!-- Desktop: full breadcrumb -->
@@ -396,6 +607,13 @@ watch(code, () => editor.value?.clearDiagnostics())
             {{ environment.name.toLowerCase() }}
           </Link>
           <span class="text-gray-400 dark:text-gray-600">/</span>
+          <span
+            v-if="app"
+            class="max-w-32 truncate text-gray-500 dark:text-gray-400"
+            :title="app.name"
+            >{{ app.name.toLowerCase() }}</span
+          >
+          <span v-if="app" class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white">helm</span>
         </nav>
       </div>
@@ -486,19 +704,21 @@ watch(code, () => editor.value?.clearDiagnostics())
           :disabled="running ? stopping : !canExecute"
           :class="[
             'flex items-center space-x-1.5 rounded-md px-2.5 py-1.5 text-xs font-medium text-white disabled:opacity-50 sm:px-3',
-            running
+            running || writeArmActive
               ? 'bg-red-600 hover:bg-red-700 dark:bg-red-600 dark:hover:bg-red-500'
               : 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
           ]"
           :title="
             running
               ? 'Stop execution'
+              : writeArmActive
+              ? `Run armed production write within ${writeArmRemaining} seconds`
               : `${runLabel} · ${
                   navigator?.platform?.includes('Mac') ? '⌘' : 'Ctrl'
                 }+Enter`
           "
         >
-          <SlippyLoader v-if="stopping" size="h-3 w-3" />
+          <SlippyLoader v-if="stopping || inspectingSource" size="h-3 w-3" />
           <svg
             v-else-if="running"
             class="h-3 w-3"
@@ -514,8 +734,24 @@ watch(code, () => editor.value?.clearDiagnostics())
             />
           </svg>
           <span class="hidden sm:inline">{{
-            stopping ? 'Stopping' : running ? 'Stop' : runLabel
+            stopping
+              ? 'Stopping'
+              : running
+              ? 'Stop'
+              : inspectingSource
+              ? 'Checking'
+              : writeArmActive
+              ? `Run write · ${writeArmRemaining}s`
+              : runLabel
           }}</span>
+          <span
+            v-if="writeArmActive"
+            data-test="helm-writes-armed"
+            class="sr-only"
+            role="status"
+          >
+            Production writes armed for {{ writeArmRemaining }} seconds
+          </span>
         </button>
 
         <!-- Docs link -->
@@ -583,6 +819,7 @@ watch(code, () => editor.value?.clearDiagnostics())
           :result="executionResult"
           :error="requestError"
           :loading="running"
+          :target="target"
           clearable
           test-id="helm"
           @clear="clearExecutionOutput"
@@ -602,6 +839,17 @@ watch(code, () => editor.value?.clearDiagnostics())
         />
       </div>
     </div>
+
+    <HelmWriteGuardDialog
+      :show="writeGuard.show"
+      :findings="writeGuard.findings"
+      :target="writeGuard.target"
+      :ttl-seconds="writeArmTtlSeconds"
+      :loading="armingWrites"
+      :error="writeGuard.error"
+      @arm="armWrites"
+      @cancel="cancelWriteGuard"
+    />
 
     <!-- Not running warning -->
     <div

--- a/assets/js/pages/settings/audit-log.vue
+++ b/assets/js/pages/settings/audit-log.vue
@@ -1,6 +1,6 @@
 <script setup>
-import { Link, Head, router } from '@inertiajs/vue3'
-import { inject, computed } from 'vue'
+import { Head, Link, router } from '@inertiajs/vue3'
+import { computed, inject, onBeforeUnmount, ref, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 
 defineOptions({
@@ -8,13 +8,27 @@ defineOptions({
 })
 
 const props = defineProps({
-  logs: Array,
-  pagination: Object
+  logs: {
+    type: Array,
+    default: () => []
+  },
+  pagination: Object,
+  filters: {
+    type: Object,
+    default: () => ({ q: '', group: 'all' })
+  },
+  helmAuditRetentionDays: {
+    type: Number,
+    default: 90
+  }
 })
 
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
+const query = ref(props.filters.q || '')
+const group = ref(props.filters.group || 'all')
+let searchTimer
 
 const actionLabels = {
   'deployment.triggered': 'Triggered deployment',
@@ -27,125 +41,178 @@ const actionLabels = {
   'cleanup.stage.completed': 'Completed cleanup stage',
   'cleanup.stage.failed': 'Cleanup stage failed',
   'cleanup.completed': 'Completed cleanup',
-  'settings.updated': 'Updated settings'
+  'settings.updated': 'Updated settings',
+  'helm.executed': 'Ran Helm',
+  'helm.execution.blocked': 'Blocked Helm write',
+  'helm.writes.armed': 'Armed Helm writes',
+  'helm.history.cleared': 'Cleared Helm history',
+  'helm.snippet.created': 'Created Helm snippet'
+}
+
+const resultRange = computed(() => {
+  if (!props.pagination.totalCount) return null
+  return {
+    first: (props.pagination.page - 1) * props.pagination.perPage + 1,
+    last: Math.min(
+      props.pagination.page * props.pagination.perPage,
+      props.pagination.totalCount
+    )
+  }
+})
+
+watch([query, group], ([, nextGroup], [, previousGroup]) => {
+  window.clearTimeout(searchTimer)
+  searchTimer = window.setTimeout(
+    () => fetchLogs(1),
+    nextGroup !== previousGroup ? 0 : 220
+  )
+})
+
+onBeforeUnmount(() => window.clearTimeout(searchTimer))
+
+function fetchLogs(page) {
+  router.get(
+    '/settings/audit-log',
+    {
+      page,
+      q: query.value.trim() || undefined,
+      group: group.value === 'all' ? undefined : group.value
+    },
+    {
+      preserveState: true,
+      preserveScroll: true,
+      replace: true,
+      only: ['logs', 'pagination', 'filters', 'helmAuditRetentionDays']
+    }
+  )
 }
 
 function actionLabel(action) {
   return actionLabels[action] || action
 }
 
-function actionColor(action) {
-  if (action.includes('destroy') || action.includes('failed'))
-    return 'text-red-600 dark:text-red-400'
-  if (
-    action.includes('created') ||
-    action.includes('triggered') ||
-    action.includes('completed')
-  )
-    return 'text-green-600 dark:text-green-400'
-  return 'text-blue-600 dark:text-blue-400'
+function eventTone(action) {
+  if (action.includes('blocked') || action.includes('failed')) return 'danger'
+  if (action === 'helm.writes.armed') return 'warning'
+  if (action.includes('completed') || action === 'helm.executed')
+    return 'success'
+  return 'neutral'
+}
+
+function dotClass(action) {
+  return {
+    danger: 'bg-red-500',
+    warning: 'bg-amber-500',
+    success: 'bg-green-500',
+    neutral: 'bg-gray-400'
+  }[eventTone(action)]
 }
 
 function formatTime(date) {
-  return new Date(date).toLocaleString()
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(new Date(date))
 }
 
-function goToPage(page) {
-  router.get('/settings/audit-log', { page }, { preserveState: true })
+function relativeTime(timestamp) {
+  const seconds = Math.round((timestamp - Date.now()) / 1000)
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: 'auto' })
+  if (Math.abs(seconds) < 60) return formatter.format(seconds, 'second')
+  const minutes = Math.round(seconds / 60)
+  if (Math.abs(minutes) < 60) return formatter.format(minutes, 'minute')
+  const hours = Math.round(minutes / 60)
+  if (Math.abs(hours) < 24) return formatter.format(hours, 'hour')
+  return formatter.format(Math.round(hours / 24), 'day')
+}
+
+function targetLabel(log) {
+  const details = log.details || {}
+  if (details.project && details.environment && details.app) {
+    return `${details.project.slug} / ${details.environment.slug} / ${details.app.slug}`
+  }
+  if (details.name) return details.name
+  return `${log.resourceType}${log.resourceId ? ` · ${log.resourceId}` : ''}`
+}
+
+function formatDuration(durationMs) {
+  if (!Number.isFinite(durationMs)) return null
+  if (durationMs < 1000) return `${Math.max(0, durationMs)}ms`
+  return `${(durationMs / 1000).toFixed(durationMs < 10000 ? 1 : 0)}s`
+}
+
+function formatBytes(bytes) {
+  if (!Number.isFinite(bytes)) return null
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function shortHash(hash) {
+  return hash ? `${hash.slice(0, 12)}…` : null
 }
 </script>
+
 <template>
-  <Head title="Audit Log | Slipway"></Head>
+  <Head title="Audit Log | Slipway" />
   <div class="flex h-full flex-col">
-    <!-- Header -->
-    <div
+    <header
       class="flex items-center justify-between border-b border-gray-200 py-4 pl-4 pr-4 dark:border-gray-800 sm:pl-4 sm:pr-8"
     >
       <div class="flex items-center space-x-3">
         <button
-          @click="toggleMobileMenu"
+          type="button"
+          aria-label="Open navigation"
           class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
+          @click="toggleMobileMenu"
         >
           <svg
             class="h-5 w-5"
             viewBox="-0.5 -0.5 16 16"
             fill="none"
             stroke="currentColor"
+            aria-hidden="true"
           >
             <path
               d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
               stroke-linecap="round"
               stroke-linejoin="round"
-              stroke-width="1"
             />
-            <path
-              d="M5.615 14.285V.715"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
+            <path d="M5.615 14.285V.715" stroke-linecap="round" />
             <path
               d="M2.6 5.992 3.919 7.5 2.6 9.008"
               stroke-linecap="round"
               stroke-linejoin="round"
-              stroke-width="1"
             />
           </svg>
         </button>
         <button
-          @click="toggleSidebar"
+          type="button"
+          aria-label="Toggle sidebar"
           class="hidden text-gray-400 dark:text-gray-500 md:block"
+          @click="toggleSidebar"
         >
           <svg
-            v-if="sidebarCollapsed"
             class="h-5 w-5"
             viewBox="-0.5 -0.5 16 16"
             fill="none"
             stroke="currentColor"
+            aria-hidden="true"
           >
             <path
               d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
               stroke-linecap="round"
               stroke-linejoin="round"
-              stroke-width="1"
             />
+            <path d="M5.615 14.285V.715" stroke-linecap="round" />
             <path
-              d="M5.615 14.285V.715"
+              :d="
+                sidebarCollapsed
+                  ? 'M2.6 5.992 3.919 7.5 2.6 9.008'
+                  : 'M3.919 5.992 2.6 7.5l1.319 1.508'
+              "
               stroke-linecap="round"
               stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M2.6 5.992 3.919 7.5 2.6 9.008"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-          </svg>
-          <svg
-            v-else
-            class="h-5 w-5"
-            viewBox="-0.5 -0.5 16 16"
-            fill="none"
-            stroke="currentColor"
-          >
-            <path
-              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M5.615 14.285V.715"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M3.919 5.992 2.6 7.5l1.319 1.508"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
             />
           </svg>
         </button>
@@ -153,144 +220,227 @@ function goToPage(page) {
           <Link
             href="/settings"
             class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >settings</Link
           >
-            settings
-          </Link>
           <span class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white"
             >audit log</span
           >
         </nav>
       </div>
-    </div>
+    </header>
 
-    <!-- Content -->
-    <div class="flex-1 overflow-y-auto px-4 py-6 sm:px-8 sm:py-8">
-      <div class="mx-auto max-w-6xl">
-        <div class="mb-6">
-          <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
-            Audit Log
-          </h1>
-          <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
-            A chronological record of important actions performed in your team.
-          </p>
+    <main class="flex-1 overflow-y-auto px-4 py-6 sm:px-8 sm:py-8">
+      <div class="mx-auto max-w-5xl">
+        <div
+          class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between"
+        >
+          <div>
+            <h1 class="text-xl font-semibold text-gray-950 dark:text-white">
+              Audit log
+            </h1>
+            <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Operational events visible to team owners and admins.
+            </p>
+          </div>
+
+          <div class="flex items-center gap-2">
+            <label class="relative min-w-0 flex-1 sm:w-64">
+              <span class="sr-only">Search audit events</span>
+              <svg
+                class="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.75"
+                  d="m21 21-4.35-4.35m2.35-5.65a8 8 0 1 1-16 0 8 8 0 0 1 16 0Z"
+                />
+              </svg>
+              <input
+                v-model="query"
+                data-test="audit-search"
+                type="search"
+                autocomplete="off"
+                placeholder="Search events or people"
+                class="w-full rounded-md border-0 bg-gray-50 py-2 pl-9 pr-3 text-sm text-gray-900 outline-none ring-1 ring-inset ring-gray-200 placeholder:text-gray-400 focus:ring-gray-400 dark:bg-gray-900 dark:text-white dark:ring-gray-800 dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
+              />
+            </label>
+            <label>
+              <span class="sr-only">Filter audit events</span>
+              <select
+                v-model="group"
+                data-test="audit-group"
+                class="rounded-md border-0 bg-gray-50 py-2 pl-3 pr-8 text-sm text-gray-700 outline-none ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-900 dark:text-gray-300 dark:ring-gray-800 dark:focus:ring-gray-600"
+              >
+                <option value="all">All events</option>
+                <option value="helm">Helm</option>
+              </select>
+            </label>
+          </div>
         </div>
 
-        <!-- Empty state -->
         <div
           v-if="logs.length === 0"
-          class="rounded-lg border border-gray-200 px-4 py-12 text-center dark:border-gray-800"
+          data-test="audit-empty"
+          class="min-h-56 flex flex-col items-center justify-center text-center"
         >
-          <p class="text-sm text-gray-500 dark:text-gray-400">
-            No audit events recorded yet.
+          <p class="text-sm font-medium text-gray-700 dark:text-gray-300">
+            {{ query ? 'No matching events' : 'No audit events yet' }}
           </p>
-        </div>
-
-        <!-- Log table -->
-        <div
-          v-else
-          class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
-        >
-          <table class="w-full text-left text-sm">
-            <thead
-              class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50"
-            >
-              <tr>
-                <th
-                  class="px-4 py-2.5 font-medium text-gray-500 dark:text-gray-400"
-                >
-                  Action
-                </th>
-                <th
-                  class="px-4 py-2.5 font-medium text-gray-500 dark:text-gray-400"
-                >
-                  Resource
-                </th>
-                <th
-                  class="px-4 py-2.5 font-medium text-gray-500 dark:text-gray-400"
-                >
-                  User
-                </th>
-                <th
-                  class="px-4 py-2.5 font-medium text-gray-500 dark:text-gray-400"
-                >
-                  IP
-                </th>
-                <th
-                  class="px-4 py-2.5 font-medium text-gray-500 dark:text-gray-400"
-                >
-                  Time
-                </th>
-              </tr>
-            </thead>
-            <tbody class="divide-y divide-gray-200 dark:divide-gray-800">
-              <tr
-                v-for="log in logs"
-                :key="log.id"
-                class="hover:bg-gray-50 dark:hover:bg-gray-900/30"
-              >
-                <td class="px-4 py-2.5">
-                  <span :class="actionColor(log.action)" class="font-medium">
-                    {{ actionLabel(log.action) }}
-                  </span>
-                </td>
-                <td class="px-4 py-2.5 text-gray-600 dark:text-gray-300">
-                  <span class="font-mono text-xs">{{ log.resourceType }}</span>
-                  <span
-                    v-if="log.details && log.details.name"
-                    class="ml-1 text-gray-400"
-                  >
-                    ({{ log.details.name }})
-                  </span>
-                </td>
-                <td class="px-4 py-2.5 text-gray-600 dark:text-gray-300">
-                  {{ log.userName }}
-                </td>
-                <td
-                  class="px-4 py-2.5 font-mono text-xs text-gray-400 dark:text-gray-500"
-                >
-                  {{ log.ipAddress || '-' }}
-                </td>
-                <td class="px-4 py-2.5 text-gray-400 dark:text-gray-500">
-                  {{ formatTime(log.createdAt) }}
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-
-        <!-- Pagination -->
-        <div
-          v-if="pagination.totalPages > 1"
-          class="mt-4 flex items-center justify-between"
-        >
-          <p class="text-sm text-gray-500 dark:text-gray-400">
-            Showing {{ (pagination.page - 1) * pagination.perPage + 1 }}–{{
-              Math.min(
-                pagination.page * pagination.perPage,
-                pagination.totalCount
-              )
+          <p class="mt-1 text-xs text-gray-400 dark:text-gray-600">
+            {{
+              query
+                ? 'Try a person, action, resource, or IP address.'
+                : 'Important team activity will appear here.'
             }}
-            of {{ pagination.totalCount }}
           </p>
-          <div class="flex space-x-2">
+        </div>
+
+        <ol v-else data-test="audit-events" class="mt-6">
+          <li
+            v-for="log in logs"
+            :key="log.id"
+            data-test="audit-event"
+            class="group border-b border-gray-100 py-3.5 last:border-b-0 dark:border-gray-900"
+          >
+            <details>
+              <summary
+                class="flex cursor-pointer list-none items-start gap-3 rounded-md outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:focus-visible:ring-gray-700 [&::-webkit-details-marker]:hidden"
+              >
+                <span
+                  :class="[
+                    'mt-2 h-1.5 w-1.5 shrink-0 rounded-full',
+                    dotClass(log.action)
+                  ]"
+                  aria-hidden="true"
+                />
+                <span class="min-w-0 flex-1">
+                  <span class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
+                    <span
+                      class="text-sm font-medium text-gray-800 dark:text-gray-200"
+                      >{{ actionLabel(log.action) }}</span
+                    >
+                    <span
+                      class="truncate font-mono text-xs text-gray-400 dark:text-gray-600"
+                      >{{ targetLabel(log) }}</span
+                    >
+                  </span>
+                  <span
+                    class="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-gray-400 dark:text-gray-600"
+                  >
+                    <span>{{ log.userName }}</span>
+                    <span aria-hidden="true">&middot;</span>
+                    <time
+                      :datetime="new Date(log.createdAt).toISOString()"
+                      :title="formatTime(log.createdAt)"
+                      >{{ relativeTime(log.createdAt) }}</time
+                    >
+                    <template v-if="log.details?.status">
+                      <span aria-hidden="true">&middot;</span>
+                      <span>{{ log.details.status }}</span>
+                    </template>
+                    <template v-if="formatDuration(log.details?.durationMs)">
+                      <span aria-hidden="true">&middot;</span>
+                      <span>{{ formatDuration(log.details.durationMs) }}</span>
+                    </template>
+                  </span>
+                </span>
+                <svg
+                  class="mt-1.5 h-4 w-4 shrink-0 text-gray-300 transition-transform group-open:rotate-180 motion-reduce:transition-none dark:text-gray-700"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  stroke-width="1.75"
+                  aria-hidden="true"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    d="m8 10 4 4 4-4"
+                  />
+                </svg>
+              </summary>
+
+              <dl
+                class="ml-4 mt-3 grid grid-cols-[6.5rem_1fr] gap-x-3 gap-y-2 rounded-lg bg-gray-50 px-3 py-3 text-xs dark:bg-gray-950/70 sm:ml-5 sm:max-w-2xl"
+              >
+                <dt class="text-gray-400 dark:text-gray-600">Actor</dt>
+                <dd class="truncate text-gray-700 dark:text-gray-300">
+                  {{ log.userName
+                  }}<span v-if="log.userEmail" class="text-gray-400">
+                    · {{ log.userEmail }}</span
+                  >
+                </dd>
+                <dt class="text-gray-400 dark:text-gray-600">Time</dt>
+                <dd class="text-gray-700 dark:text-gray-300">
+                  {{ formatTime(log.createdAt) }}
+                </dd>
+                <dt class="text-gray-400 dark:text-gray-600">IP address</dt>
+                <dd class="font-mono text-gray-700 dark:text-gray-300">
+                  {{ log.ipAddress || 'Unavailable' }}
+                </dd>
+                <template v-if="log.details?.sourceHash">
+                  <dt class="text-gray-400 dark:text-gray-600">Source hash</dt>
+                  <dd
+                    class="font-mono text-gray-700 dark:text-gray-300"
+                    :title="log.details.sourceHash"
+                  >
+                    {{ shortHash(log.details.sourceHash) }}
+                  </dd>
+                </template>
+                <template v-if="formatBytes(log.details?.outputBytes)">
+                  <dt class="text-gray-400 dark:text-gray-600">Output size</dt>
+                  <dd class="text-gray-700 dark:text-gray-300">
+                    {{ formatBytes(log.details.outputBytes) }}
+                  </dd>
+                </template>
+                <template v-if="log.details?.mutationMethods?.length">
+                  <dt class="text-gray-400 dark:text-gray-600">Detected</dt>
+                  <dd class="text-gray-700 dark:text-gray-300">
+                    {{ log.details.mutationMethods.join(', ') }}
+                  </dd>
+                </template>
+              </dl>
+            </details>
+          </li>
+        </ol>
+
+        <footer
+          class="mt-5 flex flex-col gap-3 border-t border-gray-100 pt-4 text-xs text-gray-400 dark:border-gray-900 dark:text-gray-600 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <p>
+            <template v-if="resultRange">
+              {{ resultRange.first }}–{{ resultRange.last }} of
+              {{ pagination.totalCount }} events.
+            </template>
+            Helm audit events are retained for
+            {{ helmAuditRetentionDays }} days.
+          </p>
+          <div v-if="pagination.totalPages > 1" class="flex items-center gap-1">
             <button
-              @click="goToPage(pagination.page - 1)"
+              type="button"
               :disabled="pagination.page <= 1"
-              class="rounded-md border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+              class="disabled:opacity-35 rounded-md px-2.5 py-1.5 font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+              @click="fetchLogs(pagination.page - 1)"
             >
               Previous
             </button>
             <button
-              @click="goToPage(pagination.page + 1)"
+              type="button"
               :disabled="pagination.page >= pagination.totalPages"
-              class="rounded-md border border-gray-200 px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-700 dark:text-gray-400 dark:hover:bg-gray-800"
+              class="disabled:opacity-35 rounded-md px-2.5 py-1.5 font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
+              @click="fetchLogs(pagination.page + 1)"
             >
               Next
             </button>
           </div>
-        </div>
+        </footer>
       </div>
-    </div>
+    </main>
   </div>
 </template>

--- a/assets/js/pages/settings/index.vue
+++ b/assets/js/pages/settings/index.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Link, Head } from '@inertiajs/vue3'
+import { Link, Head, usePage } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 
@@ -10,10 +10,14 @@ defineOptions({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
+const page = usePage()
 
 const search = ref('')
+const canManage = computed(() =>
+  ['owner', 'admin'].includes(page.props.loggedInUser?.teamRole)
+)
 
-const categories = [
+const rawCategories = [
   {
     name: 'Instance',
     items: [
@@ -89,6 +93,14 @@ const categories = [
           'Check for Slipway updates and view installation instructions.',
         href: '/settings/update',
         icon: 'update'
+      },
+      {
+        title: 'Audit Log',
+        description:
+          'Search operational events, production Helm runs, and write arms.',
+        href: '/settings/audit-log',
+        icon: 'audit',
+        adminOnly: true
       }
     ]
   }
@@ -96,6 +108,12 @@ const categories = [
 
 const filteredCategories = computed(() => {
   const q = search.value.toLowerCase().trim()
+  const categories = rawCategories
+    .map((category) => ({
+      ...category,
+      items: category.items.filter((item) => !item.adminOnly || canManage.value)
+    }))
+    .filter((category) => category.items.length > 0)
   if (!q) return categories
 
   return categories
@@ -398,6 +416,21 @@ const filteredCategories = computed(() => {
                       stroke-linejoin="round"
                       stroke-width="1.5"
                       d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+                    />
+                  </svg>
+                  <!-- Audit icon -->
+                  <svg
+                    v-if="item.icon === 'audit'"
+                    class="h-4 w-4 text-gray-400 dark:text-gray-500"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                      stroke-width="1.5"
+                      d="M9 12.75 11.25 15 15 9.75M12 3.75l7.5 3.75v4.8c0 4.35-3.08 7.25-7.5 8.7-4.42-1.45-7.5-4.35-7.5-8.7V7.5L12 3.75Z"
                     />
                   </svg>
                   <div>

--- a/config/custom.js
+++ b/config/custom.js
@@ -87,8 +87,11 @@ module.exports.custom = {
     maxProcessOutputBytes: 256 * 1024,
     maxProcessStderrBytes: 64 * 1024,
     killGraceMs: 250,
+    writeArmTtlMs: 60 * 1000,
     historyRetentionMs: 30 * 24 * 60 * 60 * 1000,
-    historyMaxEntriesPerScope: 200
+    historyMaxEntriesPerScope: 200,
+    auditRetentionMs: 90 * 24 * 60 * 60 * 1000,
+    auditMaxEntriesPerTeam: 5000
   },
 
   // Lookout keeps infrastructure samples for 24 hours and application

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -47,6 +47,9 @@ module.exports = {
       maxProcessOutputBytes: 256 * 1024,
       maxProcessStderrBytes: 64 * 1024,
       killGraceMs: 250,
+      writeArmTtlMs:
+        positiveInteger(process.env.SLIPWAY_HELM_WRITE_ARM_TTL_SECONDS, 60) *
+        1000,
       historyRetentionMs:
         positiveInteger(process.env.SLIPWAY_HELM_HISTORY_RETENTION_DAYS, 30) *
         24 *
@@ -56,6 +59,16 @@ module.exports = {
       historyMaxEntriesPerScope: positiveInteger(
         process.env.SLIPWAY_HELM_HISTORY_MAX_ENTRIES,
         200
+      ),
+      auditRetentionMs:
+        positiveInteger(process.env.SLIPWAY_HELM_AUDIT_RETENTION_DAYS, 90) *
+        24 *
+        60 *
+        60 *
+        1000,
+      auditMaxEntriesPerTeam: positiveInteger(
+        process.env.SLIPWAY_HELM_AUDIT_MAX_ENTRIES,
+        5000
       )
     }
   },

--- a/config/routes.js
+++ b/config/routes.js
@@ -239,6 +239,10 @@ module.exports.routes = {
     'api/v1/app/stop-app',
   'POST /api/v1/projects/:projectSlug/environments/:environmentSlug/execute':
     'api/v1/app/execute-code',
+  'POST /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/arm-writes':
+    'api/v1/helm/arm-writes',
+  'POST /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/inspect-source':
+    'api/v1/helm/inspect-source',
   'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/completions':
     'api/v1/helm/get-project-completions',
   'GET /api/v1/projects/:projectSlug/environments/:environmentSlug/helm/history':

--- a/docs/helm-history-and-snippets.md
+++ b/docs/helm-history-and-snippets.md
@@ -10,7 +10,7 @@ Each run records:
 
 - the JavaScript source that was executed;
 - the execution status and duration;
-- the target app slug; and
+- the project, environment, app, container, and deployment version target; and
 - the execution timestamp.
 
 Returned values, console output, captured logs, and error details are never
@@ -33,6 +33,64 @@ SLIPWAY_HELM_HISTORY_MAX_ENTRIES=200
 
 Pinned entries are exempt from both automatic retention and the default clear
 action. They remain until the user unpins or explicitly deletes them.
+
+## Production context and write arming
+
+Helm's breadcrumb identifies the active project, environment, and app. Slipway
+resolves the container and deployment again on the server for every execution,
+then includes that complete target in history rows and **Copy diagnostics**
+output. Production mutation confirmations also show the resolved target before
+writes can be armed.
+
+Before every project Helm execution, Slipway parses the submitted JavaScript
+and looks for obvious database mutations, native queries, and recognizable
+external side effects. A matching production run is blocked until the
+operator explicitly arms writes.
+
+A write arm:
+
+- expires after 60 seconds by default;
+- belongs to the current signed-in user and team;
+- is bound to the exact source hash, project, environment, app, container, and
+  deployment version;
+- is stored by Slipway only as a token hash; and
+- is consumed after one execution attempt.
+
+Changing the source or deploying a new version invalidates the arm. Production
+installations can shorten the window:
+
+```text
+SLIPWAY_HELM_WRITE_ARM_TTL_SECONDS=60
+```
+
+Mutation detection is safety friction, not a security sandbox. Arbitrary
+JavaScript can hide or construct side effects in ways static analysis cannot
+prove. Teams that require strong read-only enforcement must give the
+application or Helm runtime read-only database credentials and restrict any
+other runtime capabilities at the infrastructure boundary.
+
+## Audit access, privacy, and retention
+
+Team owners and admins can open **Settings → Audit Log**, search by action,
+resource, person, or IP address, and filter to Helm events. Team members cannot
+open either the audit page or its JSON endpoint.
+
+Helm execution audit events contain the actor, request IP, target, SHA-256
+source hash, source and output byte counts, start time, duration, status,
+classifier metadata, and whether writes were armed. Blocked runs and write-arm
+actions are recorded separately.
+
+Audit events never contain submitted source, returned values, captured logs,
+credentials, or full production records. The editable, user-private history
+described above is therefore separate from the administrative audit trail.
+
+Helm audit events are retained for 90 days and capped at 5,000 events per team
+by default. Both limits are configurable:
+
+```text
+SLIPWAY_HELM_AUDIT_RETENTION_DAYS=90
+SLIPWAY_HELM_AUDIT_MAX_ENTRIES=5000
+```
 
 ## Reusable snippets
 

--- a/tests/e2e/pages/projects/helm-production-guard.test.js
+++ b/tests/e2e/pages/projects/helm-production-guard.test.js
@@ -1,0 +1,138 @@
+const { test } = require('sounding')
+
+const RESULT = {
+  success: true,
+  value: { updated: true },
+  logs: [],
+  output: '{\n  "updated": true\n}',
+  error: null,
+  durationMs: 18,
+  truncated: false,
+  status: 'success',
+  outputBytes: 21,
+  logsPartial: false
+}
+
+test(
+  'Helm makes its production target obvious and requires a short-lived write arm',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'helm-production-guard',
+          name: 'Helm Production Guard'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const originalExecute = sails.helpers.helm.executeInContainer
+    const deployment = await sails.models.deployment
+      .create({
+        status: 'running',
+        gitCommit: '274acbd91324beef',
+        gitBranch: 'main',
+        imageName: 'slipway/helm-production-guard:274acbd',
+        environment: environment.id,
+        app: app.id,
+        triggeredBy: current.users.genesisUser.id
+      })
+      .fetch()
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'running',
+      containerName: 'helm-production-guard-web',
+      currentDeployment: deployment.id
+    })
+    sails.helpers.helm.executeInContainer = async () => RESULT
+
+    try {
+      const updateCheckFinished = page.raw.waitForResponse(
+        '**/api/v1/system/check-update'
+      )
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await updateCheckFinished
+      await page.raw
+        .context()
+        .grantPermissions(['clipboard-read', 'clipboard-write'])
+      await page.resize(1440, 900)
+      await page.inLightMode()
+      await page.goto(
+        `/projects/${project.slug}/environments/${environment.slug}/helm`
+      )
+
+      expect(page).toSee('production')
+      expect(page).toSee('web')
+      expect(await page.raw.locator('[data-test="helm-target"]').count()).toBe(
+        0
+      )
+
+      await page.fill(
+        '@helm-editor',
+        "await Creator.updateOne({ id: 1 }).set({ email: 'grace@example.com' })"
+      )
+      await page.click('@helm-run')
+      await page.wait('@helm-write-guard')
+      expect(page).toSee('Arm production writes?')
+      expect(page).toSee('Update one record')
+      expect(page).toSee('safety heuristic')
+      await page.wait(200)
+      await page.screenshot('.tmp/issue-274-write-warning-light.png')
+
+      await page.inDarkMode()
+      await page.click('@helm-arm-writes')
+      await page.wait('@helm-writes-armed')
+      await page.raw
+        .locator('[data-test="helm-write-guard"]')
+        .waitFor({ state: 'hidden' })
+      await page.wait(150)
+      expect(page).toSee('Run write')
+      await page.screenshot('.tmp/issue-274-writes-armed-dark.png')
+
+      await page.click('@helm-run')
+      await page.wait('@helm-output')
+      expect(page).toSee('updated')
+      expect(
+        await page.raw.locator('[data-test="helm-writes-armed"]').count()
+      ).toBe(0)
+
+      await page.click('@helm-result-actions-trigger')
+      await page.click('@helm-result-actions-copy-diagnostics')
+      const diagnostics = JSON.parse(
+        await page.script(() => navigator.clipboard.readText())
+      )
+      expect(diagnostics.target.environment.isProduction).toBe(true)
+      expect(diagnostics.target.app.slug).toBe(app.slug)
+      expect(diagnostics.target.container).toBe('helm-production-guard-web')
+      expect(diagnostics.execution.status).toBe('success')
+      expect(JSON.stringify(diagnostics).includes('grace@example.com')).toBe(
+        false
+      )
+
+      await page.inLightMode()
+      await page.goto('/settings/audit-log?group=helm')
+      await page.wait('@audit-events')
+      expect(page).toSee('Ran Helm')
+      expect(page).toSee('Armed Helm writes')
+      await page.screenshot('.tmp/issue-274-audit-light.png')
+
+      await page.fill('@audit-search', 'armed')
+      await page.wait(350)
+      await page.wait('@audit-events')
+      expect(page).toSee('Armed Helm writes')
+      await page.inDarkMode()
+      await page.screenshot('.tmp/issue-274-audit-search-dark.png')
+      expect(page).toHaveNoSmoke()
+    } finally {
+      sails.helpers.helm.executeInContainer = originalExecute
+    }
+  }
+)

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -765,9 +765,7 @@ test(
     await page.screenshot('.tmp/issue-268-project-helm-selection-light.png')
 
     await page.click('@helm-run')
-    expect((await page.raw.locator('.cm-executed-range').count()) > 0).toBe(
-      true
-    )
+    await page.wait('.cm-executed-range')
     await page.wait('@helm-output')
 
     expectHelmSubmission(expect, submitted[0], {

--- a/tests/functional/api/helm.test.js
+++ b/tests/functional/api/helm.test.js
@@ -171,6 +171,109 @@ test(
 )
 
 test(
+  'production Helm requires a source-and-deployment-bound single-use write arm',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'production-helm-write-arm',
+          name: 'Production Helm Write Arm'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const originalExecute = sails.helpers.helm.executeInContainer
+    let executions = 0
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'running',
+      containerName: 'production-helm-write-arm-web'
+    })
+    sails.helpers.helm.executeInContainer = async () => {
+      executions += 1
+      return RESULT
+    }
+
+    try {
+      const helmPath = `/projects/${project.slug}/environments/${environment.slug}/helm`
+      const executePath = `/api/v1/projects/${project.slug}/environments/${environment.slug}/execute`
+      const armPath = `/api/v1/projects/${project.slug}/environments/${environment.slug}/helm/arm-writes`
+      const inspectPath = `/api/v1/projects/${project.slug}/environments/${environment.slug}/helm/inspect-source`
+      const browser = await withCsrfFromPage(request, helmPath, 'genesisUser')
+      const source =
+        "await Creator.updateOne({ id: 1 }).set({ email: 'new@example.com' })"
+
+      const inspection = await browser.request.post(inspectPath, {
+        code: source
+      })
+      expect(inspection).toHaveStatus(200)
+      expect(inspection).toHaveJsonPath('requiresWriteArm', true)
+      expect(inspection).toHaveJsonPath('classification.mutating', true)
+
+      const blocked = await browser.request.post(executePath, {
+        code: source,
+        executionId: '2667db5d-46af-4762-80aa-7c3f89704c9f'
+      })
+      expect(blocked).toHaveStatus(409)
+      expect(blocked).toHaveJsonPath('code', 'HELM_WRITES_NOT_ARMED')
+      expect(blocked).toHaveJsonPath('classification.mutating', true)
+      expect(executions).toBe(0)
+
+      const armed = await browser.request.post(armPath, { code: source })
+      expect(armed).toHaveStatus(201)
+      expect(armed.data.token.length > 30).toBe(true)
+      expect(armed.data.sourceHash.length).toBe(64)
+      expect(armed).toHaveJsonPath('target.environment.isProduction', true)
+
+      const executed = await browser.request.post(executePath, {
+        code: source,
+        writeArmToken: armed.data.token,
+        executionId: '47c4b4fe-d30d-4649-8a86-d12a63c716f7'
+      })
+      expect(executed).toHaveStatus(200)
+      expect(executions).toBe(1)
+
+      const reused = await browser.request.post(executePath, {
+        code: source,
+        writeArmToken: armed.data.token,
+        executionId: '873cb28a-a1bb-45f7-a73c-9090283d6992'
+      })
+      expect(reused).toHaveStatus(409)
+      expect(executions).toBe(1)
+
+      const executionAudit = await sails.models.auditlog.findOne({
+        action: 'helm.executed',
+        resourceId: String(app.id)
+      })
+      expect(executionAudit.details.sourceHash).toBe(armed.data.sourceHash)
+      expect(executionAudit.details.writeArmed).toBe(true)
+      expect(executionAudit.details.outputBytes).toBe(RESULT.outputBytes)
+      expect(executionAudit.details.environment.isProduction).toBe(true)
+      expect(JSON.stringify(executionAudit).includes(source)).toBe(false)
+      expect(JSON.stringify(executionAudit).includes('querying')).toBe(false)
+
+      const [blockedAudit] = await sails.models.auditlog
+        .find({
+          action: 'helm.execution.blocked',
+          resourceId: String(app.id)
+        })
+        .sort('createdAt ASC')
+        .limit(1)
+      expect(blockedAudit.details.outputBytes).toBe(0)
+      expect(JSON.stringify(blockedAudit).includes(source)).toBe(false)
+    } finally {
+      sails.helpers.helm.executeInContainer = originalExecute
+    }
+  }
+)
+
+test(
   'project Helm history is durable, searchable, scoped, and preserves pins when cleared',
   {
     world: {

--- a/tests/functional/pages/audit-log.test.js
+++ b/tests/functional/pages/audit-log.test.js
@@ -1,0 +1,60 @@
+const { test } = require('sounding')
+
+test(
+  'owners can search Helm audit events while members cannot open the audit log',
+  { world: 'configured-slipway' },
+  async ({ sails, world, visit, request, expect }) => {
+    const current = world.current
+    const team = current.teams.genesisTeam
+    const owner = current.users.genesisUser
+    const member = await world.create('user').with({
+      fullName: 'Audit Reader',
+      email: 'audit-reader@example.com',
+      team: team.id,
+      teamRole: 'member'
+    })
+
+    await sails.models.auditlog.createEach([
+      {
+        action: 'helm.executed',
+        resourceType: 'app',
+        resourceId: '7',
+        details: {
+          sourceHash: 'a'.repeat(64),
+          status: 'success',
+          project: { slug: 'hagfish' },
+          environment: { slug: 'production' },
+          app: { slug: 'web' }
+        },
+        user: owner.id,
+        team: team.id
+      },
+      {
+        action: 'settings.updated',
+        resourceType: 'setting',
+        resourceId: 'instance',
+        details: {},
+        user: owner.id,
+        team: team.id
+      }
+    ])
+
+    const ownerPage = await visit.as('genesisUser')(
+      '/settings/audit-log?group=helm&q=hagfish'
+    )
+    expect(ownerPage).toHaveStatus(200)
+    expect(ownerPage).toBeInertiaPage('settings/audit-log')
+    expect(ownerPage).toHaveInertiaPropCount('logs', 1)
+    expect(ownerPage).toHaveInertiaProp('logs.0.action', 'helm.executed')
+    expect(ownerPage).toHaveInertiaProp('filters.group', 'helm')
+    expect(ownerPage).toHaveInertiaProp('filters.q', 'hagfish')
+    expect(ownerPage).toHaveInertiaProp('helmAuditRetentionDays', 90)
+
+    const memberPage = await visit.as(member)('/settings/audit-log')
+    expect(memberPage).toHaveStatus(302)
+    expect(memberPage).toRedirectTo('/settings')
+
+    const memberApi = await request.as(member).get('/api/v1/audit-logs')
+    expect(memberApi).toHaveStatus(403)
+  }
+)

--- a/tests/unit/config/production.test.js
+++ b/tests/unit/config/production.test.js
@@ -70,7 +70,10 @@ test('production Helm history has bounded configurable retention', ({
 }) => {
   const names = [
     'SLIPWAY_HELM_HISTORY_RETENTION_DAYS',
-    'SLIPWAY_HELM_HISTORY_MAX_ENTRIES'
+    'SLIPWAY_HELM_HISTORY_MAX_ENTRIES',
+    'SLIPWAY_HELM_WRITE_ARM_TTL_SECONDS',
+    'SLIPWAY_HELM_AUDIT_RETENTION_DAYS',
+    'SLIPWAY_HELM_AUDIT_MAX_ENTRIES'
   ]
   const original = Object.fromEntries(
     names.map((name) => [name, process.env[name]])
@@ -79,6 +82,9 @@ test('production Helm history has bounded configurable retention', ({
   try {
     process.env.SLIPWAY_HELM_HISTORY_RETENTION_DAYS = '14'
     process.env.SLIPWAY_HELM_HISTORY_MAX_ENTRIES = '80'
+    process.env.SLIPWAY_HELM_WRITE_ARM_TTL_SECONDS = '45'
+    process.env.SLIPWAY_HELM_AUDIT_RETENTION_DAYS = '120'
+    process.env.SLIPWAY_HELM_AUDIT_MAX_ENTRIES = '2400'
     delete require.cache[productionConfigPath]
 
     const productionConfig = require(productionConfigPath)
@@ -86,6 +92,11 @@ test('production Helm history has bounded configurable retention', ({
       14 * 24 * 60 * 60 * 1000
     )
     expect(productionConfig.custom.helm.historyMaxEntriesPerScope).toBe(80)
+    expect(productionConfig.custom.helm.writeArmTtlMs).toBe(45 * 1000)
+    expect(productionConfig.custom.helm.auditRetentionMs).toBe(
+      120 * 24 * 60 * 60 * 1000
+    )
+    expect(productionConfig.custom.helm.auditMaxEntriesPerTeam).toBe(2400)
   } finally {
     delete require.cache[productionConfigPath]
     for (const name of names) {

--- a/tests/unit/helpers/helm/mutation-guard.test.js
+++ b/tests/unit/helpers/helm/mutation-guard.test.js
@@ -1,0 +1,88 @@
+const { test } = require('sounding')
+
+test('Helm mutation classification ignores reads, strings, and comments', ({
+  sails,
+  expect
+}) => {
+  const result = sails.helpers.helm.classifyMutations(`
+// Creator.destroy() is documentation, not a call.
+const example = "await Creator.updateOne({ id: 1 })"
+await Creator.find({ isActive: true })
+`)
+
+  expect(result.complete).toBe(true)
+  expect(result.mutating).toBe(false)
+  expect(result.findings).toEqual([])
+})
+
+test('Helm mutation classification reports obvious model writes with source locations', ({
+  sails,
+  expect
+}) => {
+  const result = sails.helpers.helm.classifyMutations(`
+await Creator.create({ email: 'grace@example.com' })
+await Creator.updateOne({ id: 1 }).set({ isActive: false })
+await Creator.destroy({ isActive: false })
+`)
+
+  expect(result.complete).toBe(true)
+  expect(result.mutating).toBe(true)
+  expect(result.findings.map((finding) => finding.method)).toEqual([
+    'create',
+    'updateOne',
+    'destroy'
+  ])
+  expect(result.findings[0].line).toBe(2)
+  expect(result.findings[0].kind).toBe('database-write')
+})
+
+test('Helm mutation classification catches native queries and recognizable external side effects', ({
+  sails,
+  expect
+}) => {
+  const result = sails.helpers.helm.classifyMutations(`
+await sails.getDatastore().sendNativeQuery('DELETE FROM creators')
+await fetch('https://example.com/webhook', { method: 'POST' })
+await sails.helpers.mail.sendTemplate.with({ to: 'builder@example.com' })
+`)
+
+  expect(result.mutating).toBe(true)
+  expect(result.findings.map((finding) => finding.kind)).toEqual([
+    'native-query',
+    'external-side-effect',
+    'external-side-effect'
+  ])
+  expect(result.findings.map((finding) => finding.method)).toEqual([
+    'sendNativeQuery',
+    'fetch',
+    'sendTemplate'
+  ])
+})
+
+test('Helm mutation classification remains explicitly incomplete when source cannot be parsed', ({
+  sails,
+  expect
+}) => {
+  const result = sails.helpers.helm.classifyMutations(
+    'await Creator.updateOne({'
+  )
+
+  expect(result.complete).toBe(false)
+  expect(result.mutating).toBe(false)
+  expect(result.findings).toEqual([])
+  expect(result.parserError.line >= 1).toBe(true)
+})
+
+test('Helm source hashing is stable without storing submitted source', ({
+  sails,
+  expect
+}) => {
+  const source = 'await Creator.find()'
+  const first = sails.helpers.helm.hashSource(source)
+  const second = sails.helpers.helm.hashSource(source)
+
+  expect(first).toBe(second)
+  expect(first.length).toBe(64)
+  expect(first.includes(source)).toBe(false)
+  expect(sails.helpers.helm.hashSource(`${source}\n`) === first).toBe(false)
+})


### PR DESCRIPTION
## Summary
- detect likely production mutations before execution and require a short-lived single-use write arm
- bind authorization and diagnostics to the exact actor, source, app, container, and deployment
- add privacy-safe Helm audit events, retention controls, and admin audit browsing
- keep the existing Helm header minimal while surfacing the armed state on the Run action

## Verification
- npm run test:unit
- npm run test:functional
- npx sounding test tests/e2e/pages/projects/helm-production-guard.test.js --test-concurrency=1
- npm run lint

Fixes #274