### PR TITLE
feat(helm): add inline inspection and query tracing

### DIFF
--- a/api/helpers/helm/prepare-source.js
+++ b/api/helpers/helm/prepare-source.js
@@ -4,7 +4,7 @@ module.exports = {
   friendlyName: 'Prepare Helm source',
 
   description:
-    'Parse Helm JavaScript and return its complete final top-level expression.',
+    'Parse Helm JavaScript, instrument opted-in diagnostics, and return its complete final expression.',
 
   inputs: {
     source: {

--- a/api/helpers/helm/run.js
+++ b/api/helpers/helm/run.js
@@ -86,12 +86,17 @@ module.exports = {
     const runnerSource = helmRuntime.buildRunnerSource({
       preparedSource: prepared.source,
       finalExpression: prepared.finalExpression,
+      inspections: prepared.inspections,
+      sourceMappings: prepared.sourceMappings,
+      traceQueries: prepared.traceQueries,
       sourceStartLine,
       sourceStartColumn,
       bootstrapSails,
       timeoutMs: executionTimeoutMs,
       maxLogBytes: limits.maxLogBytes,
       maxResultBytes: limits.maxResultBytes,
+      maxInspectionValuesPerMarker: limits.maxInspectionValuesPerMarker,
+      maxQueryTraceEntries: limits.maxQueryTraceEntries,
       executionId
     })
 

--- a/api/lib/helm-query-tracer.js
+++ b/api/lib/helm-query-tracer.js
@@ -1,0 +1,350 @@
+module.exports = function createHelmQueryTracer({
+  sailsApp,
+  queryTrace,
+  queryTraceContext,
+  maxEntries
+}) {
+  const tracedMethods = [
+    'addToCollection',
+    'archive',
+    'archiveOne',
+    'avg',
+    'count',
+    'create',
+    'createEach',
+    'destroy',
+    'destroyOne',
+    'find',
+    'findOne',
+    'findOrCreate',
+    'removeFromCollection',
+    'replaceCollection',
+    'stream',
+    'sum',
+    'update',
+    'updateOne'
+  ]
+
+  for (const identity of Object.keys(sailsApp.models || {})) {
+    const model = sailsApp.models[identity]
+
+    for (const method of tracedMethods) {
+      const original = model[method]
+      if (typeof original !== 'function') continue
+
+      model[method] = function (...originalArgs) {
+        const args = [...originalArgs]
+        const callbackIndex = args.findIndex(
+          (argument) => typeof argument === 'function'
+        )
+
+        if (callbackIndex !== -1) {
+          const started = Date.now()
+          const callback = args[callbackIndex]
+          args[callbackIndex] = function (error, ...values) {
+            recordWaterlineTrace({
+              model,
+              method,
+              queryInfo: initialQueryInfo(method, originalArgs),
+              started,
+              error
+            })
+            return Reflect.apply(callback, this, [error, ...values])
+          }
+
+          try {
+            return Reflect.apply(original, this, args)
+          } catch (error) {
+            recordWaterlineTrace({
+              model,
+              method,
+              queryInfo: initialQueryInfo(method, originalArgs),
+              started,
+              error
+            })
+            throw error
+          }
+        }
+
+        const deferred = Reflect.apply(original, this, args)
+        return instrumentWaterlineDeferred(deferred, model, method)
+      }
+    }
+  }
+
+  instrumentNativeDatastores()
+
+  function instrumentWaterlineDeferred(deferred, model, fallbackMethod) {
+    if (!deferred || typeof deferred._handleExec !== 'function') {
+      return deferred
+    }
+
+    const originalHandleExec = deferred._handleExec
+    deferred._handleExec = function (done) {
+      const started = Date.now()
+      const criteria = deferred._wlQueryInfo?.criteria
+        ? redactQueryStructure(deferred._wlQueryInfo.criteria)
+        : null
+      return Reflect.apply(originalHandleExec, this, [
+        function (error, ...values) {
+          recordWaterlineTrace({
+            model,
+            method: deferred._wlQueryInfo?.method || fallbackMethod,
+            criteria,
+            started,
+            error
+          })
+          return done(error, ...values)
+        }
+      ])
+    }
+    return deferred
+  }
+
+  function instrumentNativeDatastores() {
+    const originalGetDatastore = sailsApp.getDatastore
+    const instrumentedDatastores = new WeakSet()
+    sailsApp.getDatastore = function (name) {
+      const datastore = Reflect.apply(originalGetDatastore, this, arguments)
+      return instrumentDatastore(datastore, name || 'default')
+    }
+
+    for (const datastoreName of Object.keys(
+      sailsApp.config.datastores || { default: {} }
+    )) {
+      try {
+        instrumentDatastore(
+          Reflect.apply(originalGetDatastore, sailsApp, [datastoreName]),
+          datastoreName
+        )
+      } catch {
+        // An unavailable datastore is unrelated to tracing another datastore.
+      }
+    }
+
+    function instrumentDatastore(datastore, datastoreName) {
+      if (
+        !datastore ||
+        instrumentedDatastores.has(datastore) ||
+        typeof datastore.sendNativeQuery !== 'function'
+      ) {
+        return datastore
+      }
+
+      instrumentedDatastores.add(datastore)
+      const originalSendNativeQuery = datastore.sendNativeQuery
+      datastore.sendNativeQuery = function (statement, ...originalArgs) {
+        const args = [...originalArgs]
+        const callbackIndex = args.findIndex(
+          (argument) => typeof argument === 'function'
+        )
+        const started = Date.now()
+
+        if (callbackIndex !== -1) {
+          const callback = args[callbackIndex]
+          args[callbackIndex] = function (error, ...values) {
+            recordNativeTrace({
+              datastoreName,
+              statement,
+              started,
+              error
+            })
+            return Reflect.apply(callback, this, [error, ...values])
+          }
+        }
+
+        let operation
+        try {
+          operation = Reflect.apply(originalSendNativeQuery, this, [
+            statement,
+            ...args
+          ])
+        } catch (error) {
+          recordNativeTrace({
+            datastoreName,
+            statement,
+            started,
+            error
+          })
+          throw error
+        }
+
+        if (
+          callbackIndex === -1 &&
+          operation &&
+          typeof operation.then === 'function'
+        ) {
+          return Promise.resolve(operation).then(
+            (value) => {
+              recordNativeTrace({
+                datastoreName,
+                statement,
+                started,
+                error: null
+              })
+              return value
+            },
+            (error) => {
+              recordNativeTrace({
+                datastoreName,
+                statement,
+                started,
+                error
+              })
+              throw error
+            }
+          )
+        }
+
+        return operation
+      }
+
+      return datastore
+    }
+  }
+
+  function recordWaterlineTrace({
+    model,
+    method,
+    queryInfo,
+    criteria,
+    started,
+    error
+  }) {
+    record({
+      kind: 'waterline',
+      model: safeIdentifier(model?.identity || queryInfo?.using, 'unknown'),
+      datastore: safeIdentifier(model?.datastore, 'default'),
+      method: safeIdentifier(method, 'query'),
+      durationMs: Math.max(0, Date.now() - started),
+      status: error ? 'error' : 'success',
+      criteria:
+        criteria ||
+        (queryInfo?.criteria ? redactQueryStructure(queryInfo.criteria) : null)
+    })
+  }
+
+  function recordNativeTrace({ datastoreName, statement, started, error }) {
+    record({
+      kind: 'native',
+      model: null,
+      datastore: safeIdentifier(datastoreName, 'default'),
+      method: 'sendNativeQuery',
+      durationMs: Math.max(0, Date.now() - started),
+      status: error ? 'error' : 'success',
+      statement: sanitizeSql(statement)
+    })
+  }
+
+  function record(entry) {
+    if (queryTraceContext.getStore() !== true) return
+    if (queryTrace.entries.length >= maxEntries) {
+      queryTrace.omittedCount++
+      return
+    }
+    queryTrace.entries.push(entry)
+  }
+
+  function initialQueryInfo(method, args) {
+    if (
+      [
+        'archive',
+        'archiveOne',
+        'avg',
+        'count',
+        'destroy',
+        'destroyOne',
+        'find',
+        'findOne',
+        'findOrCreate',
+        'sum',
+        'update',
+        'updateOne'
+      ].includes(method)
+    ) {
+      return { criteria: args[0] }
+    }
+    return null
+  }
+
+  function redactQueryStructure(value, depth = 0) {
+    if (value === null || value === undefined) return '[value]'
+    if (depth >= 6) return '[nested]'
+    if (Array.isArray(value)) {
+      const redacted = value
+        .slice(0, 12)
+        .map((entry) => redactQueryStructure(entry, depth + 1))
+      if (value.length > redacted.length) redacted.push('[more]')
+      return redacted
+    }
+    if (typeof value !== 'object') return '[value]'
+
+    const output = {}
+    const descriptors = safeDescriptors(value)
+    const entries = Object.entries(descriptors).slice(0, 40)
+    for (const [unsafeKey, descriptor] of entries) {
+      if (!descriptor.enumerable) continue
+      const key = /^[A-Za-z0-9_.$:<>!=-]{1,80}$/.test(unsafeKey)
+        ? unsafeKey
+        : '[key]'
+      output[key] =
+        'value' in descriptor
+          ? redactQueryStructure(descriptor.value, depth + 1)
+          : '[value]'
+    }
+    if (Object.keys(descriptors).length > entries.length) {
+      output['[more]'] = '[nested]'
+    }
+    return output
+  }
+
+  function sanitizeSql(value) {
+    let statement = safeString(value, '')
+      .slice(0, 32 * 1024)
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')
+      .replace(/--[^\r\n]*/g, ' ')
+      .replace(
+        /\$[A-Za-z_][A-Za-z0-9_]*\$[\s\S]*?\$[A-Za-z_][A-Za-z0-9_]*\$/g,
+        '?'
+      )
+      .replace(/\$\$[\s\S]*?\$\$/g, '?')
+      .replace(/'(?:''|\\.|[^'])*'/g, '?')
+      .replace(/"(?:\"\"|\\.|[^"])*"/g, '?')
+      .replace(/`(?:``|\\.|[^`])*`/g, '?')
+      .replace(/\b(?:0x[0-9a-f]+|\d+(?:\.\d+)?)\b/gi, '?')
+      .replace(/\s+/g, ' ')
+      .trim()
+
+    if (!statement) statement = '[redacted statement]'
+    return truncateUtf8(statement, 512)
+  }
+
+  function safeIdentifier(value, fallback) {
+    const identifier = safeString(value, fallback)
+    return /^[A-Za-z0-9_.:-]{1,120}$/.test(identifier) ? identifier : fallback
+  }
+
+  function safeDescriptors(value) {
+    try {
+      return Object.getOwnPropertyDescriptors(value)
+    } catch {
+      return {}
+    }
+  }
+
+  function safeString(value, fallback) {
+    try {
+      return value === undefined || value === null ? fallback : String(value)
+    } catch {
+      return fallback
+    }
+  }
+
+  function truncateUtf8(value, maxBytes) {
+    const string = String(value)
+    const buffer = Buffer.from(string)
+    return buffer.length <= maxBytes
+      ? string
+      : `${buffer.subarray(0, Math.max(0, maxBytes - 1)).toString('utf8')}…`
+  }
+}

--- a/api/lib/helm-runtime.js
+++ b/api/lib/helm-runtime.js
@@ -1,10 +1,14 @@
 const acorn = require('acorn')
+const createHelmQueryTracer = require('./helm-query-tracer')
 
 const START_MARKER = '___SLIPWAY_HELM_RESULT_START___'
 const END_MARKER = '___SLIPWAY_HELM_RESULT_END___'
 const LOG_MARKER = '___SLIPWAY_HELM_LOG___'
 const VIRTUAL_FILENAME = 'helm-input.js'
 const MAX_SOURCE_COORDINATE = 1_000_000
+const INSPECTION_MARKER = '@inspect'
+const QUERY_TRACE_MARKER = '@trace queries'
+const INSPECTION_RUNTIME_IDENTIFIER = 'globalThis.__slipwayHelmInspectValue__'
 
 function prepareSource(
   source,
@@ -43,12 +47,14 @@ function prepareSource(
   const prefix = 'async function __helmInput__() {\n'
   const suffix = '\n}'
   let program
+  const comments = []
 
   try {
     program = acorn.parse(`${prefix}${submittedSource}${suffix}`, {
       ecmaVersion: 'latest',
       sourceType: 'script',
-      locations: true
+      locations: true,
+      onComment: comments
     })
   } catch (error) {
     const submittedLineCount = submittedSource.split('\n').length
@@ -68,11 +74,48 @@ function prepareSource(
 
   const statements = program.body[0].body.body
   const finalStatement = statements.at(-1)
+  const submittedComments = comments.filter(
+    (comment) =>
+      comment.type === 'Line' &&
+      comment.start >= prefix.length &&
+      comment.end <= prefix.length + submittedSource.length
+  )
+  const inspectionComments = submittedComments.filter(
+    (comment) => comment.value.trim() === INSPECTION_MARKER
+  )
+  const traceQueries = submittedComments.some(
+    (comment) => comment.value.trim() === QUERY_TRACE_MARKER
+  )
+  const inspectionTargets = collectInspectionTargets(
+    program.body[0].body,
+    inspectionComments,
+    submittedSource,
+    prefix.length,
+    origin
+  )
+  const sourceMappings = []
+  const replacements = inspectionTargets.map((target) => {
+    const expression = submittedSource.slice(target.start, target.end)
+    const prefixText = `${INSPECTION_RUNTIME_IDENTIFIER}(${target.id}, (`
+    sourceMappings.push({
+      line: target.line,
+      column: target.expressionColumn,
+      addedColumns: prefixText.length
+    })
+    return {
+      start: target.start,
+      end: target.end,
+      value: `${prefixText}${expression}))`
+    }
+  })
 
   if (!finalStatement || finalStatement.type !== 'ExpressionStatement') {
     return {
-      source: submittedSource,
-      finalExpression: null
+      source: applySourceReplacements(submittedSource, replacements),
+      finalExpression: null,
+      inspections: inspectionTargets.map(publicInspectionTarget),
+      sourceMappings,
+      traceQueries
     }
   }
 
@@ -80,51 +123,191 @@ function prepareSource(
   const statementEnd = finalStatement.end - prefix.length
   const expressionStart = finalStatement.expression.start - prefix.length
   const expressionEnd = finalStatement.expression.end - prefix.length
+  const inspectionTarget = inspectionTargets.find(
+    (target) => target.start === expressionStart && target.end === expressionEnd
+  )
   const expression = submittedSource.slice(expressionStart, expressionEnd)
-  const replacement = `return (${expression});`
+  const inspectedExpression = inspectionTarget
+    ? `${INSPECTION_RUNTIME_IDENTIFIER}(${inspectionTarget.id}, (${expression}))`
+    : expression
+  const replacement = `return (${inspectedExpression});`
+  const finalLocation = mapSourceLocation(
+    finalStatement.loc.start.line - 1,
+    finalStatement.loc.start.column + 1,
+    origin
+  )
+  sourceMappings.push({
+    ...finalLocation,
+    addedColumns: 'return ('.length
+  })
 
   return {
-    source:
-      submittedSource.slice(0, statementStart) +
-      replacement +
-      submittedSource.slice(statementEnd),
-    finalExpression: {
-      ...mapSourceLocation(
-        finalStatement.loc.start.line - 1,
-        finalStatement.loc.start.column + 1,
-        origin
+    source: applySourceReplacements(submittedSource, [
+      ...replacements.filter(
+        ({ start, end }) => start !== expressionStart || end !== expressionEnd
       ),
+      {
+        start: statementStart,
+        end: statementEnd,
+        value: replacement
+      }
+    ]),
+    finalExpression: {
+      ...finalLocation,
       addedColumns: 'return ('.length
+    },
+    inspections: inspectionTargets.map(publicInspectionTarget),
+    sourceMappings,
+    traceQueries
+  }
+}
+
+function collectInspectionTargets(
+  root,
+  comments,
+  source,
+  prefixLength,
+  origin
+) {
+  const statements = []
+  visitSyntaxTree(root, (node) => {
+    const expression = inspectableExpression(node)
+    if (expression) statements.push({ node, expression })
+  })
+
+  return comments.flatMap((comment, index) => {
+    const commentStart = comment.start - prefixLength
+    const target = statements
+      .filter(
+        ({ node }) =>
+          node.end <= comment.start &&
+          node.loc.end.line === comment.loc.start.line &&
+          /^\s*$/.test(source.slice(node.end - prefixLength, commentStart))
+      )
+      .sort((left, right) => right.node.end - left.node.end)[0]
+
+    if (!target) {
+      const location = mapSourceLocation(
+        comment.loc.start.line - 1,
+        comment.loc.start.column + 1,
+        origin
+      )
+      throw sourceError(
+        'The // @inspect marker must follow a complete expression.',
+        {
+          name: 'HelmSourceError',
+          line: location.line,
+          column: location.column
+        }
+      )
+    }
+
+    const expressionLocation = mapSourceLocation(
+      target.expression.loc.start.line - 1,
+      target.expression.loc.start.column + 1,
+      origin
+    )
+    const markerLocation = mapSourceLocation(
+      comment.loc.start.line - 1,
+      comment.loc.start.column + 1,
+      origin
+    )
+
+    return [
+      {
+        id: index,
+        start: target.expression.start - prefixLength,
+        end: target.expression.end - prefixLength,
+        line: markerLocation.line,
+        column: markerLocation.column,
+        expressionColumn: expressionLocation.column
+      }
+    ]
+  })
+}
+
+function inspectableExpression(node) {
+  if (node.type === 'ExpressionStatement') return node.expression
+  if (node.type === 'ReturnStatement') return node.argument
+  if (node.type === 'VariableDeclaration' && node.declarations.length === 1) {
+    return node.declarations[0].init
+  }
+  return null
+}
+
+function visitSyntaxTree(node, visitor) {
+  if (!node || typeof node !== 'object') return
+  if (typeof node.type === 'string') visitor(node)
+
+  for (const [key, value] of Object.entries(node)) {
+    if (['start', 'end', 'loc'].includes(key)) continue
+    if (Array.isArray(value)) {
+      for (const child of value) visitSyntaxTree(child, visitor)
+    } else {
+      visitSyntaxTree(value, visitor)
     }
   }
+}
+
+function publicInspectionTarget({ id, line, column }) {
+  return { id, line, column }
+}
+
+function applySourceReplacements(source, replacements) {
+  let output = source
+  const ordered = [...replacements].sort(
+    (left, right) => right.start - left.start
+  )
+
+  for (const replacement of ordered) {
+    output =
+      output.slice(0, replacement.start) +
+      replacement.value +
+      output.slice(replacement.end)
+  }
+
+  return output
 }
 
 function buildRunnerSource({
   preparedSource,
   finalExpression,
+  inspections = [],
+  sourceMappings = [],
+  traceQueries = false,
   sourceStartLine = 1,
   sourceStartColumn = 1,
   bootstrapSails = true,
   timeoutMs = 30000,
   maxLogBytes = 64 * 1024,
   maxResultBytes = 128 * 1024,
+  maxInspectionValuesPerMarker = 20,
+  maxQueryTraceEntries = 100,
   executionId
 }) {
+  const queryTracerSource = traceQueries
+    ? `(${createHelmQueryTracer.toString()})`
+    : 'null'
   return `(${helmSubprocessMain.toString()})(${JSON.stringify({
     preparedSource,
     finalExpression,
+    inspections,
+    sourceMappings,
+    traceQueries,
     sourceStartLine,
     sourceStartColumn,
     bootstrapSails,
     timeoutMs,
     maxLogBytes,
     maxResultBytes,
+    maxInspectionValuesPerMarker,
+    maxQueryTraceEntries,
     executionId,
     startMarker: START_MARKER,
     endMarker: END_MARKER,
     logMarker: LOG_MARKER,
     filename: VIRTUAL_FILENAME
-  })})`
+  })}, ${queryTracerSource})`
 }
 
 function parseRunnerOutput(stdout) {
@@ -271,9 +454,12 @@ function formatBytes(bytes) {
   return `${Math.round(bytes / 1024)} KB`
 }
 
-async function helmSubprocessMain(options) {
+async function helmSubprocessMain(options, createQueryTracer) {
   const fs = require('node:fs')
   const vm = require('node:vm')
+  const AsyncLocalStorage = options.traceQueries
+    ? require('node:async_hooks').AsyncLocalStorage
+    : null
   const startedAt = Date.now()
   let sailsApp
   let resultSent = false
@@ -282,6 +468,19 @@ async function helmSubprocessMain(options) {
   const logs = []
   let logBytes = 0
   let logsTruncated = false
+  const inspections = (options.inspections || []).map((inspection) => ({
+    ...inspection,
+    values: [],
+    omittedCount: 0
+  }))
+  const queryTrace = options.traceQueries
+    ? {
+        enabled: true,
+        entries: [],
+        omittedCount: 0
+      }
+    : null
+  const queryTraceContext = queryTrace ? new AsyncLocalStorage() : null
   const pidFile = options.executionId
     ? `/tmp/slipway-helm-${options.executionId}.pid`
     : null
@@ -336,6 +535,15 @@ async function helmSubprocessMain(options) {
             else resolve()
           }
         )
+      })
+    }
+
+    if (queryTrace && sailsApp) {
+      createQueryTracer({
+        sailsApp,
+        queryTrace,
+        queryTraceContext,
+        maxEntries: options.maxQueryTraceEntries
       })
     }
 
@@ -407,7 +615,8 @@ async function helmSubprocessMain(options) {
       isNaN,
       isFinite,
       encodeURIComponent,
-      decodeURIComponent
+      decodeURIComponent,
+      __slipwayHelmInspectValue__: recordInspection
     }
 
     for (const identity of Object.keys(sailsApp?.models || {})) {
@@ -427,10 +636,14 @@ async function helmSubprocessMain(options) {
       1,
       options.timeoutMs - (Date.now() - startedAt)
     )
-    const value = await script.runInContext(sandbox, {
-      timeout: remainingMs,
-      displayErrors: true
-    })
+    const runScript = () =>
+      script.runInContext(sandbox, {
+        timeout: remainingMs,
+        displayErrors: true
+      })
+    const value = await (queryTraceContext
+      ? queryTraceContext.run(true, runScript)
+      : runScript())
     const valueResult = formatResultValue(value, options.maxResultBytes)
     const outputParts = [...logs]
 
@@ -445,7 +658,9 @@ async function helmSubprocessMain(options) {
         error: null,
         durationMs: Date.now() - startedAt,
         truncated: logsTruncated || valueResult.truncated,
-        logsPartial: false
+        logsPartial: false,
+        inspections: completedInspections(),
+        queryTrace
       })
     )
   } catch (error) {
@@ -464,8 +679,69 @@ async function helmSubprocessMain(options) {
       error: normalizeRuntimeError(error, options),
       durationMs: Date.now() - startedAt,
       truncated: logsTruncated,
-      logsPartial: false
+      logsPartial: false,
+      inspections: completedInspections(),
+      queryTrace
     })
+  }
+
+  function recordInspection(id, value) {
+    const inspection = inspections[id]
+    if (!inspection) return value
+
+    if (inspection.values.length >= options.maxInspectionValuesPerMarker) {
+      inspection.omittedCount++
+      return value
+    }
+
+    inspection.values.push(formatInspectionValue(value))
+    return value
+  }
+
+  function completedInspections() {
+    return inspections.filter(
+      (inspection) =>
+        inspection.values.length > 0 || inspection.omittedCount > 0
+    )
+  }
+
+  function formatInspectionValue(value) {
+    if (value === undefined) {
+      return {
+        value: { type: 'undefined' },
+        preview: 'undefined',
+        truncated: false
+      }
+    }
+
+    if (typeof value === 'string') {
+      const bounded = truncateUtf8(value, 2048)
+      const preview = truncateUtf8(JSON.stringify(bounded.value), 320)
+      return {
+        value: bounded.value,
+        preview: preview.value,
+        truncated: bounded.truncated || preview.truncated
+      }
+    }
+
+    const state = {
+      seen: new WeakMap(),
+      nextReference: 1,
+      entries: 0,
+      maxEntries: 50,
+      maxDepth: 4,
+      maxStringBytes: 2048,
+      truncated: false
+    }
+    const snapshot = snapshotValue(value, state, 0)
+    const serialized = safeJson(snapshot, '[Uninspectable]')
+    const preview = truncateUtf8(serialized.replace(/\s+/g, ' '), 320)
+
+    return {
+      value: snapshot,
+      preview: preview.value,
+      truncated: state.truncated || preview.truncated
+    }
   }
 
   function completeResult(result) {
@@ -798,16 +1074,24 @@ async function helmSubprocessMain(options) {
     if (location) {
       line = Number(location[1])
       column = Number(location[2])
+      const mappings =
+        runtimeOptions.sourceMappings?.length > 0
+          ? runtimeOptions.sourceMappings
+          : runtimeOptions.finalExpression
+          ? [runtimeOptions.finalExpression]
+          : []
+      let mappedColumn = column
 
-      if (
-        runtimeOptions.finalExpression &&
-        line === runtimeOptions.finalExpression.line &&
-        column >=
-          runtimeOptions.finalExpression.column +
-            runtimeOptions.finalExpression.addedColumns
-      ) {
-        const mappedColumn =
-          column - runtimeOptions.finalExpression.addedColumns
+      for (const mapping of mappings) {
+        if (
+          line === mapping.line &&
+          mappedColumn >= mapping.column + mapping.addedColumns
+        ) {
+          mappedColumn -= mapping.addedColumns
+        }
+      }
+
+      if (mappedColumn !== column) {
         stack = stack.replace(
           `${runtimeOptions.filename}:${line}:${column}`,
           `${runtimeOptions.filename}:${line}:${mappedColumn}`
@@ -836,6 +1120,25 @@ async function helmSubprocessMain(options) {
       ...result,
       value: { type: 'truncated' },
       logs: [],
+      inspections: (result.inspections || []).map((inspection) => ({
+        id: inspection.id,
+        line: inspection.line,
+        column: inspection.column,
+        values: [],
+        omittedCount:
+          (inspection.omittedCount || 0) + (inspection.values?.length || 0),
+        truncated: true
+      })),
+      queryTrace: result.queryTrace
+        ? {
+            enabled: true,
+            entries: [],
+            omittedCount:
+              (result.queryTrace.omittedCount || 0) +
+              (result.queryTrace.entries?.length || 0),
+            truncated: true
+          }
+        : null,
       output: truncateUtf8(result.output || '', Math.floor(maxBytes / 8)).value,
       truncated: true
     }
@@ -877,7 +1180,18 @@ async function helmSubprocessMain(options) {
         status: result.status,
         rowCount: result.rowCount,
         outputBytes: result.outputBytes,
-        logsPartial: result.logsPartial
+        logsPartial: result.logsPartial,
+        inspections: [],
+        queryTrace: result.queryTrace
+          ? {
+              enabled: true,
+              entries: [],
+              omittedCount:
+                (result.queryTrace.omittedCount || 0) +
+                (result.queryTrace.entries?.length || 0),
+              truncated: true
+            }
+          : null
       }),
       truncated: true
     }
@@ -951,6 +1265,14 @@ async function helmSubprocessMain(options) {
   function safeString(value, fallback) {
     try {
       return value === undefined || value === null ? fallback : String(value)
+    } catch {
+      return fallback
+    }
+  }
+
+  function safeJson(value, fallback) {
+    try {
+      return JSON.stringify(value)
     } catch {
       return fallback
     }

--- a/assets/js/components/CodeEditor.vue
+++ b/assets/js/components/CodeEditor.vue
@@ -70,6 +70,7 @@ const editableCompartment = new Compartment()
 const completionCompartment = new Compartment()
 const setExecutedRange = StateEffect.define()
 const setInlineDiagnostic = StateEffect.define()
+const setInlineInspections = StateEffect.define()
 const executedRangeMark = Decoration.mark({ class: 'cm-executed-range' })
 
 class InlineDiagnosticWidget extends WidgetType {
@@ -94,6 +95,61 @@ class InlineDiagnosticWidget extends WidgetType {
   ignoreEvent() {
     return true
   }
+}
+
+class InlineInspectionWidget extends WidgetType {
+  constructor(inspection) {
+    super()
+    this.inspection = inspection
+  }
+
+  eq(other) {
+    return (
+      inspectionSignature(other.inspection) ===
+      inspectionSignature(this.inspection)
+    )
+  }
+
+  toDOM() {
+    const values = this.inspection.values || []
+    const latest = values.at(-1)
+    const count = values.length + (this.inspection.omittedCount || 0)
+    const label = document.createElement('span')
+    const preview = latest?.preview || 'not reached'
+    label.className = 'cm-inline-inspection'
+    label.textContent = `→ ${preview}${count > 1 ? ` · ${count}×` : ''}`
+    label.title = [
+      ...values.map(
+        (value, index) => `${index + 1}. ${value.preview || 'undefined'}`
+      ),
+      this.inspection.omittedCount
+        ? `… ${this.inspection.omittedCount} more value${
+            this.inspection.omittedCount === 1 ? '' : 's'
+          }`
+        : ''
+    ]
+      .filter(Boolean)
+      .join('\n')
+    label.setAttribute(
+      'aria-label',
+      `Inspected value: ${preview}${
+        count > 1 ? `, captured ${count} times` : ''
+      }`
+    )
+    return label
+  }
+
+  ignoreEvent() {
+    return true
+  }
+}
+
+function inspectionSignature(inspection) {
+  return JSON.stringify({
+    line: inspection?.line,
+    omittedCount: inspection?.omittedCount,
+    previews: inspection?.values?.map((value) => value.preview)
+  })
 }
 
 const executedRangeField = StateField.define({
@@ -138,6 +194,45 @@ const inlineDiagnosticField = StateField.define({
             }).range(diagnostic.position)
           ])
         : Decoration.none
+    }
+
+    return nextDecorations
+  },
+  provide(field) {
+    return EditorView.decorations.from(field)
+  }
+})
+const inlineInspectionField = StateField.define({
+  create() {
+    return Decoration.none
+  },
+  update(decorations, transaction) {
+    let nextDecorations = transaction.docChanged
+      ? Decoration.none
+      : decorations.map(transaction.changes)
+
+    for (const effect of transaction.effects) {
+      if (!effect.is(setInlineInspections)) continue
+      const inspectionDecorations = (effect.value || []).flatMap(
+        (inspection) => {
+          const lineNumber = Number(inspection.line)
+          if (
+            !Number.isSafeInteger(lineNumber) ||
+            lineNumber < 1 ||
+            lineNumber > transaction.state.doc.lines
+          ) {
+            return []
+          }
+
+          return [
+            Decoration.widget({
+              widget: new InlineInspectionWidget(inspection),
+              side: 1
+            }).range(transaction.state.doc.line(lineNumber).to)
+          ]
+        }
+      )
+      nextDecorations = Decoration.set(inspectionDecorations, true)
     }
 
     return nextDecorations
@@ -498,6 +593,19 @@ function clearDiagnostics() {
   })
 }
 
+function showInspections(inspections) {
+  if (!view) return
+  view.dispatch({
+    effects: setInlineInspections.of(
+      Array.isArray(inspections) ? inspections : []
+    )
+  })
+}
+
+function clearInspections() {
+  showInspections([])
+}
+
 function resolveDiagnosticRange(state, diagnostic) {
   const lineNumber = Number(diagnostic?.line)
   const columnNumber = Number(diagnostic?.column)
@@ -575,6 +683,7 @@ onMounted(() => {
         drawSelection(),
         executedRangeField,
         inlineDiagnosticField,
+        inlineInspectionField,
         indentOnInput(),
         bracketMatching(),
         EditorView.lineWrapping,
@@ -658,9 +767,11 @@ onBeforeUnmount(() => {
 
 defineExpose({
   clearDiagnostics,
+  clearInspections,
   focus,
   getExecutionSnapshot,
   highlightExecution,
+  showInspections,
   showDiagnostic
 })
 </script>
@@ -732,6 +843,22 @@ defineExpose({
   white-space: nowrap;
 }
 
+.code-editor :deep(.cm-inline-inspection) {
+  display: inline-block;
+  max-width: min(28rem, 50vw);
+  margin-left: 0.75rem;
+  overflow: hidden;
+  color: var(--color-gray-500);
+  font-family: ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
+    'Segoe UI Emoji';
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1rem;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
 @media (prefers-color-scheme: dark) {
   .code-editor :deep(.cm-editor.cm-focused) {
     outline-color: var(--color-brand-800);
@@ -739,6 +866,10 @@ defineExpose({
 
   .code-editor :deep(.cm-inline-diagnostic) {
     color: var(--color-red-400);
+  }
+
+  .code-editor :deep(.cm-inline-inspection) {
+    color: var(--color-gray-400);
   }
 }
 </style>

--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -44,6 +44,7 @@ const props = defineProps({
 const emit = defineEmits(['clear'])
 const activeView = ref('raw')
 const logsOpen = ref(false)
+const queriesOpen = ref(false)
 const toasts = ref([])
 const runningDurationMs = ref(0)
 let runningStartedAt = 0
@@ -123,6 +124,19 @@ const errorStack = computed(() =>
 )
 const logs = computed(() =>
   Array.isArray(props.result?.logs) ? props.result.logs : []
+)
+const queryTrace = computed(() =>
+  props.result?.queryTrace?.enabled ? props.result.queryTrace : null
+)
+const queryEntries = computed(() =>
+  Array.isArray(queryTrace.value?.entries) ? queryTrace.value.entries : []
+)
+const queryDurationMs = computed(() =>
+  queryEntries.value.reduce(
+    (total, entry) =>
+      total + (Number.isFinite(entry.durationMs) ? entry.durationMs : 0),
+    0
+  )
 )
 const metadata = computed(() => {
   if (!props.result) return []
@@ -210,6 +224,7 @@ watch(
     logsOpen.value = Boolean(
       logs.value.length && props.result?.success === false
     )
+    queriesOpen.value = Boolean(queryTrace.value)
   },
   { immediate: true }
 )
@@ -302,6 +317,13 @@ function buildDiagnostics() {
         : null,
       truncated: Boolean(props.result?.truncated),
       logsPartial: Boolean(props.result?.logsPartial),
+      queryTrace: queryTrace.value
+        ? {
+            count: queryEntries.value.length,
+            omittedCount: queryTrace.value.omittedCount || 0,
+            truncated: Boolean(queryTrace.value.truncated)
+          }
+        : null,
       error: props.result?.error
         ? {
             name: props.result.error.name || 'Error',
@@ -336,6 +358,17 @@ function notify(message) {
 
 function dismissToast(id) {
   toasts.value = toasts.value.filter((toast) => toast.id !== id)
+}
+
+function queryLabel(entry) {
+  return entry.kind === 'native'
+    ? `${entry.datastore}.sendNativeQuery`
+    : `${entry.model}.${entry.method}`
+}
+
+function queryDetail(entry) {
+  if (entry.kind === 'native') return entry.statement
+  return entry.criteria ? JSON.stringify(entry.criteria) : 'No criteria'
 }
 </script>
 
@@ -500,6 +533,101 @@ function dismissToast(id) {
         {{ emptyText }}
       </div>
     </div>
+
+    <details
+      v-if="queryTrace"
+      :open="queriesOpen"
+      :data-test="`${testId}-queries`"
+      class="group shrink-0 border-t border-gray-200 bg-gray-50/70 dark:border-gray-800 dark:bg-gray-900/40"
+      @toggle="queriesOpen = $event.currentTarget.open"
+    >
+      <summary
+        class="flex cursor-pointer list-none items-center gap-2 px-4 py-2 text-xs font-medium text-gray-500 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-300 dark:text-gray-400 dark:focus-visible:ring-gray-700"
+      >
+        <svg
+          class="h-3.5 w-3.5"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.5"
+          aria-hidden="true"
+        >
+          <ellipse cx="12" cy="5" rx="7.5" ry="2.75" />
+          <path
+            stroke-linecap="round"
+            d="M4.5 5v7c0 1.52 3.36 2.75 7.5 2.75s7.5-1.23 7.5-2.75V5m-15 7v7c0 1.52 3.36 2.75 7.5 2.75s7.5-1.23 7.5-2.75v-7"
+          />
+        </svg>
+        <span>Queries</span>
+        <span class="font-normal text-gray-400 dark:text-gray-600">
+          {{ queryEntries.length
+          }}{{
+            queryTrace.omittedCount
+              ? ` + ${queryTrace.omittedCount} omitted`
+              : ''
+          }}
+          &middot; {{ formatDuration(queryDurationMs) }}
+          {{ queryTrace.truncated ? ' · truncated' : '' }}
+        </span>
+        <svg
+          class="ml-auto h-3.5 w-3.5 shrink-0 transition-transform group-open:rotate-180 motion-reduce:transition-none"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.5"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m6 9 6 6 6-6"
+          />
+        </svg>
+      </summary>
+      <ol
+        v-if="queryEntries.length"
+        :data-test="`${testId}-query-list`"
+        class="max-h-56 space-y-3 overflow-auto px-4 pb-3"
+      >
+        <li
+          v-for="(entry, index) in queryEntries"
+          :key="`${entry.kind}-${entry.model || entry.datastore}-${
+            entry.method
+          }-${index}`"
+          class="min-w-0"
+        >
+          <div class="flex min-w-0 items-center justify-between gap-4">
+            <code
+              class="truncate font-mono text-xs font-medium text-gray-700 dark:text-gray-300"
+              >{{ queryLabel(entry) }}</code
+            >
+            <span
+              :class="[
+                'shrink-0 text-xs tabular-nums',
+                entry.status === 'error'
+                  ? 'text-red-600 dark:text-red-400'
+                  : 'text-gray-400 dark:text-gray-600'
+              ]"
+            >
+              {{ entry.status === 'error' ? 'Error · ' : ''
+              }}{{ formatDuration(entry.durationMs) }}
+            </span>
+          </div>
+          <code
+            :title="queryDetail(entry)"
+            class="mt-0.5 block truncate font-mono text-[0.6875rem] leading-4 text-gray-400 dark:text-gray-600"
+            >{{ queryDetail(entry) }}</code
+          >
+        </li>
+      </ol>
+      <p
+        v-else
+        :data-test="`${testId}-query-empty`"
+        class="px-4 pb-3 text-xs text-gray-400 dark:text-gray-600"
+      >
+        No Waterline or native queries ran.
+      </p>
+    </details>
 
     <details
       v-if="logs.length"

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -233,6 +233,7 @@ async function executeHelm() {
 
   helmEditor.value.highlightExecution(execution)
   helmEditor.value.clearDiagnostics()
+  helmEditor.value.clearInspections()
   helmEditor.value.focus()
   const currentExecution = {
     id: crypto.randomUUID(),
@@ -283,6 +284,7 @@ async function executeHelm() {
     if (activeHelmExecution?.sequence !== currentExecution.sequence) return
 
     helmResults.value = data
+    helmEditor.value.showInspections(data.inspections)
     const diagnostic = helmEditorDiagnostic(data.error)
     if (diagnostic) helmEditor.value.showDiagnostic(diagnostic)
 
@@ -335,7 +337,10 @@ async function stopHelmExecution() {
   }
 }
 
-watch(helmCode, () => helmEditor.value?.clearDiagnostics())
+watch(helmCode, () => {
+  helmEditor.value?.clearDiagnostics()
+  helmEditor.value?.clearInspections()
+})
 
 function executeCurrentMode() {
   if (consoleMode.value === 'helm') {

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -151,6 +151,7 @@ async function execute(sourceOverride) {
 
   editor.value.highlightExecution(execution)
   editor.value.clearDiagnostics()
+  editor.value.clearInspections()
   editor.value.focus()
   const currentExecution = {
     id: crypto.randomUUID(),
@@ -216,6 +217,7 @@ async function execute(sourceOverride) {
     if (activeExecution?.sequence !== currentExecution.sequence) return
 
     executionResult.value = result
+    editor.value.showInspections(result.inspections)
     const diagnostic = helmEditorDiagnostic(result.error)
     if (diagnostic) editor.value.showDiagnostic(diagnostic)
 
@@ -420,6 +422,7 @@ function clearExecutionOutput() {
   executionResult.value = null
   requestError.value = ''
   editor.value?.clearDiagnostics()
+  editor.value?.clearInspections()
 }
 
 async function loadCompletionMetadata() {
@@ -460,6 +463,7 @@ onBeforeUnmount(() => {
 
 watch(code, () => {
   editor.value?.clearDiagnostics()
+  editor.value?.clearInspections()
   if (writeArm.value && writeArm.value.source !== code.value) clearWriteArm()
 })
 </script>

--- a/config/custom.js
+++ b/config/custom.js
@@ -86,6 +86,8 @@ module.exports.custom = {
     maxResultBytes: 128 * 1024,
     maxProcessOutputBytes: 256 * 1024,
     maxProcessStderrBytes: 64 * 1024,
+    maxInspectionValuesPerMarker: 20,
+    maxQueryTraceEntries: 100,
     killGraceMs: 250,
     writeArmTtlMs: 60 * 1000,
     historyRetentionMs: 30 * 24 * 60 * 60 * 1000,

--- a/docs/helm-history-and-snippets.md
+++ b/docs/helm-history-and-snippets.md
@@ -18,6 +18,10 @@ stored in Helm history. Security audit records are written separately and do
 not contain the executed source. Deleting editable history therefore does not
 delete the audit trail.
 
+Inline values captured with `// @inspect` and the redacted database trace
+enabled by `// @trace queries` belong only to the current execution response.
+Slipway does not copy either diagnostic into history or audit records.
+
 History is private to the user who ran it and to the project environment where
 it ran. A user can search, reload, rerun, pin, or delete an entry. Clearing
 history removes unpinned entries and preserves pins.

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -511,6 +511,150 @@ test(
 )
 
 test(
+  'Helm shows transient inline values and redacted query traces in both executors',
+  {
+    browser: true,
+    world: helmWorld('helm-inspection-and-query-trace')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const projectSlug = current.projects.deploymentTarget.slug
+    const environmentSlug = current.environments.production.slug
+    const projectEndpoint = `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`
+    let projectExecution = 0
+
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'sounding-helm-inspection-app'
+    })
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route(`**${projectEndpoint}`, async (route) => {
+      projectExecution += 1
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          projectExecution === 1
+            ? inspectedHelmResult({
+                inspectionLine: 2,
+                query: {
+                  kind: 'waterline',
+                  model: 'creator',
+                  datastore: 'default',
+                  method: 'find',
+                  durationMs: 4,
+                  status: 'success',
+                  criteria: {
+                    where: {
+                      subscriptionStatus: '[value]'
+                    }
+                  }
+                }
+              })
+            : {
+                success: true,
+                value: 2,
+                logs: [],
+                output: '2',
+                error: null,
+                durationMs: 1,
+                truncated: false,
+                inspections: [],
+                queryTrace: null
+              }
+        )
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+    )
+    await page.fill(
+      '@helm-editor',
+      [
+        '// @trace queries',
+        "const creators = await Creator.find({ subscriptionStatus: 'active' }) // @inspect",
+        'creators'
+      ].join('\n')
+    )
+    await page.click('@helm-run')
+    await page.raw.locator('.cm-inline-inspection').waitFor()
+    await page.wait('@helm-queries')
+
+    expect(
+      await page.raw.locator('.cm-inline-inspection').textContent()
+    ).toContain('Ada')
+    expect(
+      await page.raw.locator('[data-test="helm-query-list"]').textContent()
+    ).toContain('creator.find')
+    expect(
+      await page.raw.locator('[data-test="helm-query-list"]').textContent()
+    ).toContain('"subscriptionStatus":"[value]"')
+    await page.screenshot(
+      '.tmp/issue-275-project-inspection-query-trace-light.png'
+    )
+
+    await page.fill('@helm-editor', '1 + 1')
+    expect(await page.raw.locator('.cm-inline-inspection').count()).toBe(0)
+    await page.click('@helm-run')
+    await page.wait('@helm-output')
+    expect(await page.raw.locator('[data-test="helm-queries"]').count()).toBe(0)
+
+    await page.raw.route('**/api/v1/bosun/eval', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(
+          inspectedHelmResult({
+            inspectionLine: 2,
+            query: {
+              kind: 'native',
+              model: null,
+              datastore: 'default',
+              method: 'sendNativeQuery',
+              durationMs: 2,
+              status: 'success',
+              statement: 'SELECT ? AS active_creators'
+            }
+          })
+        )
+      })
+    })
+    await page.inDarkMode()
+    await page.goto('/bosun?tab=console&mode=helm')
+    await page.fill(
+      '@bosun-helm-editor',
+      [
+        '// @trace queries',
+        "const creators = [{ firstName: 'Ada', lastName: 'Lovelace' }] // @inspect",
+        'creators'
+      ].join('\n')
+    )
+    await page.click('@bosun-console-run')
+    await page.raw.locator('.cm-inline-inspection').waitFor()
+    await page.wait('@bosun-helm-queries')
+
+    expect(
+      await page.raw
+        .locator('[data-test="bosun-helm-query-list"]')
+        .textContent()
+    ).toContain('default.sendNativeQuery')
+    await page.screenshot(
+      '.tmp/issue-275-bosun-inspection-query-trace-dark.png'
+    )
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
   'Helm presents structured values as minimal table, tree, and raw views',
   {
     browser: true,
@@ -651,6 +795,46 @@ test(
     expect(page).toHaveNoSmoke()
   }
 )
+
+function inspectedHelmResult({ inspectionLine, query }) {
+  const creators = [
+    {
+      firstName: 'Ada',
+      lastName: 'Lovelace',
+      subscriptionStatus: 'active'
+    }
+  ]
+
+  return {
+    success: true,
+    value: creators,
+    logs: [],
+    output: JSON.stringify(creators, null, 2),
+    error: null,
+    durationMs: 7,
+    truncated: false,
+    inspections: [
+      {
+        id: 0,
+        line: inspectionLine,
+        column: 73,
+        values: [
+          {
+            value: creators,
+            preview: JSON.stringify(creators),
+            truncated: false
+          }
+        ],
+        omittedCount: 0
+      }
+    ],
+    queryTrace: {
+      enabled: true,
+      entries: [query],
+      omittedCount: 0
+    }
+  }
+}
 
 test(
   'Bosun Helm uses the same structured result viewer in dark mode',

--- a/tests/functional/api/helm.test.js
+++ b/tests/functional/api/helm.test.js
@@ -12,7 +12,31 @@ const RESULT = {
   status: 'success',
   rowCount: 1,
   outputBytes: 36,
-  logsPartial: false
+  logsPartial: false,
+  inspections: [
+    {
+      id: 0,
+      line: 7,
+      column: 25,
+      values: [{ value: 1, preview: '1', truncated: false }],
+      omittedCount: 0
+    }
+  ],
+  queryTrace: {
+    enabled: true,
+    entries: [
+      {
+        kind: 'waterline',
+        model: 'creator',
+        datastore: 'default',
+        method: 'find',
+        durationMs: 2,
+        status: 'success',
+        criteria: { where: { id: '[value]' } }
+      }
+    ],
+    omittedCount: 0
+  }
 }
 
 const COMPLETIONS = {
@@ -68,6 +92,11 @@ test(
       expect(response).toHaveJsonPath('logs.0', 'querying')
       expect(response).toHaveJsonPath('durationMs', 12)
       expect(response).toHaveJsonPath('truncated', false)
+      expect(response).toHaveJsonPath('inspections.0.line', 7)
+      expect(response).toHaveJsonPath(
+        'queryTrace.entries.0.criteria.where.id',
+        '[value]'
+      )
     } finally {
       sails.helpers.helm.evaluate = originalEvaluate
     }
@@ -141,6 +170,8 @@ test(
       expect(response).toHaveJsonPath('logs.0', 'querying')
       expect(response).toHaveJsonPath('durationMs', 12)
       expect(response).toHaveJsonPath('truncated', false)
+      expect(response).toHaveJsonPath('inspections.0.values.0.preview', '1')
+      expect(response).toHaveJsonPath('queryTrace.entries.0.method', 'find')
 
       const history = await sails.models.helmhistoryentry.findOne({
         user: current.users.genesisUser.id,

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -135,14 +135,8 @@ test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', as
   const project = {
     identity: 'project',
     datastore: 'default',
-    find(criteria) {
-      return deferredQuery({
-        method: 'find',
-        criteria: {
-          where: criteria,
-          limit: 1
-        }
-      })
+    find(criteria, done) {
+      done(null, [])
     }
   }
   const sailsApp = {
@@ -160,9 +154,9 @@ test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', as
     maxEntries: 3
   })
 
-  await project.find({ slug: 'outside-trace-secret' })
+  project.find({ slug: 'outside-trace-secret' }, () => {})
   await queryTraceContext.run(true, async () => {
-    await project.find({ slug: 'waterline-secret' })
+    project.find({ slug: 'waterline-secret' }, () => {})
     for (let index = 0; index < 5; index++) {
       await sailsApp
         .getDatastore()
@@ -186,10 +180,7 @@ test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', as
     method: 'find',
     status: 'success',
     criteria: {
-      where: {
-        slug: '[value]'
-      },
-      limit: '[value]'
+      slug: '[value]'
     }
   })
   expect({
@@ -644,25 +635,6 @@ async function runHelm(sails, source, options = {}) {
     bootstrapSails: false,
     ...options
   })
-}
-
-function deferredQuery(queryInfo) {
-  const deferred = {
-    _wlQueryInfo: queryInfo,
-    _handleExec(done) {
-      queueMicrotask(() => done(null, []))
-    },
-    then(onFulfilled, onRejected) {
-      return new Promise((resolve, reject) => {
-        deferred._handleExec((error, value) => {
-          if (error) reject(error)
-          else resolve(value)
-        })
-      }).then(onFulfilled, onRejected)
-    }
-  }
-
-  return deferred
 }
 
 async function captureError(operation) {

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -1,5 +1,7 @@
 const { test } = require('sounding')
+const { AsyncLocalStorage } = require('node:async_hooks')
 const helmRuntime = require('../../../../api/lib/helm-runtime')
+const createHelmQueryTracer = require('../../../../api/lib/helm-query-tracer')
 
 test('Helm returns complete final expressions instead of physical lines', async ({
   sails,
@@ -117,42 +119,66 @@ test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', as
   sails,
   expect
 }) => {
-  const defaultMaxEntries = sails.config.custom.helm.maxQueryTraceEntries
-  expect(defaultMaxEntries).toBe(100)
-  sails.config.custom.helm.maxQueryTraceEntries = 3
+  expect(sails.config.custom.helm.maxQueryTraceEntries).toBe(100)
 
-  let result
-  try {
-    result = await runHelm(
-      sails,
-      [
-        '// @trace queries',
-        "await Project.find({ slug: 'waterline-secret' }).limit(1)",
-        'for (let index = 0; index < 5; index++) {',
-        '  await sails.getDatastore().sendNativeQuery(',
-        '    "SELECT \'native-secret\' AS value, 99 AS count"',
-        '  )',
-        '}',
-        "'done'"
-      ].join('\n'),
-      { bootstrapSails: true }
-    )
-  } finally {
-    sails.config.custom.helm.maxQueryTraceEntries = defaultMaxEntries
+  const queryTrace = {
+    enabled: true,
+    entries: [],
+    omittedCount: 0
+  }
+  const queryTraceContext = new AsyncLocalStorage()
+  const datastore = {
+    sendNativeQuery() {
+      return Promise.resolve({ rows: [] })
+    }
+  }
+  const project = {
+    identity: 'project',
+    datastore: 'default',
+    find(criteria) {
+      return deferredQuery({
+        method: 'find',
+        criteria: {
+          where: criteria,
+          limit: 1
+        }
+      })
+    }
+  }
+  const sailsApp = {
+    models: { project },
+    config: { datastores: { default: {} } },
+    getDatastore() {
+      return datastore
+    }
   }
 
-  expect(result.success).toBe(true)
-  expect(result.value).toBe('done')
-  expect(result.queryTrace.enabled).toBe(true)
-  expect(result.queryTrace.entries.length).toBe(3)
-  expect(result.queryTrace.omittedCount).toBe(3)
+  createHelmQueryTracer({
+    sailsApp,
+    queryTrace,
+    queryTraceContext,
+    maxEntries: 3
+  })
+
+  await project.find({ slug: 'outside-trace-secret' })
+  await queryTraceContext.run(true, async () => {
+    await project.find({ slug: 'waterline-secret' })
+    for (let index = 0; index < 5; index++) {
+      await sailsApp
+        .getDatastore()
+        .sendNativeQuery("SELECT 'native-secret' AS value, 99 AS count")
+    }
+  })
+
+  expect(queryTrace.entries.length).toBe(3)
+  expect(queryTrace.omittedCount).toBe(3)
   expect({
-    kind: result.queryTrace.entries[0].kind,
-    model: result.queryTrace.entries[0].model,
-    datastore: result.queryTrace.entries[0].datastore,
-    method: result.queryTrace.entries[0].method,
-    status: result.queryTrace.entries[0].status,
-    criteria: result.queryTrace.entries[0].criteria
+    kind: queryTrace.entries[0].kind,
+    model: queryTrace.entries[0].model,
+    datastore: queryTrace.entries[0].datastore,
+    method: queryTrace.entries[0].method,
+    status: queryTrace.entries[0].status,
+    criteria: queryTrace.entries[0].criteria
   }).toEqual({
     kind: 'waterline',
     model: 'project',
@@ -167,11 +193,11 @@ test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', as
     }
   })
   expect({
-    kind: result.queryTrace.entries[1].kind,
-    datastore: result.queryTrace.entries[1].datastore,
-    method: result.queryTrace.entries[1].method,
-    status: result.queryTrace.entries[1].status,
-    statement: result.queryTrace.entries[1].statement
+    kind: queryTrace.entries[1].kind,
+    datastore: queryTrace.entries[1].datastore,
+    method: queryTrace.entries[1].method,
+    status: queryTrace.entries[1].status,
+    statement: queryTrace.entries[1].statement
   }).toEqual({
     kind: 'native',
     datastore: 'default',
@@ -179,12 +205,11 @@ test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', as
     status: 'success',
     statement: 'SELECT ? AS value, ? AS count'
   })
-  expect(JSON.stringify(result.queryTrace).includes('waterline-secret')).toBe(
+  expect(JSON.stringify(queryTrace).includes('outside-trace-secret')).toBe(
     false
   )
-  expect(JSON.stringify(result.queryTrace).includes('native-secret')).toBe(
-    false
-  )
+  expect(JSON.stringify(queryTrace).includes('waterline-secret')).toBe(false)
+  expect(JSON.stringify(queryTrace).includes('native-secret')).toBe(false)
 })
 
 test('Helm understands normal JavaScript syntax around return words', async ({
@@ -619,6 +644,25 @@ async function runHelm(sails, source, options = {}) {
     bootstrapSails: false,
     ...options
   })
+}
+
+function deferredQuery(queryInfo) {
+  const deferred = {
+    _wlQueryInfo: queryInfo,
+    _handleExec(done) {
+      queueMicrotask(() => done(null, []))
+    },
+    then(onFulfilled, onRejected) {
+      return new Promise((resolve, reject) => {
+        deferred._handleExec((error, value) => {
+          if (error) reject(error)
+          else resolve(value)
+        })
+      }).then(onFulfilled, onRejected)
+    }
+  }
+
+  return deferred
 }
 
 async function captureError(operation) {

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -1,4 +1,5 @@
 const { test } = require('sounding')
+const helmRuntime = require('../../../../api/lib/helm-runtime')
 
 test('Helm returns complete final expressions instead of physical lines', async ({
   sails,
@@ -39,6 +40,142 @@ await Creator.find({
   expect(result.status).toBe('success')
   expect(result.rowCount).toBe(1)
   expect(result.outputBytes).toBe(Buffer.byteLength(result.output))
+})
+
+test('Helm captures parser-backed inline inspections without changing expression values', async ({
+  sails,
+  expect
+}) => {
+  const result = await runHelm(
+    sails,
+    [
+      'const values = []',
+      'for (const number of [1, 2, 3]) {',
+      '  const doubled = number * 2 // @inspect',
+      '  values.push(doubled)',
+      '}',
+      'values // @inspect'
+    ].join('\n')
+  )
+
+  expect(result.success).toBe(true)
+  expect(result.value).toEqual([2, 4, 6])
+  expect(result.inspections.length).toBe(2)
+  expect(result.inspections[0].line).toBe(3)
+  expect(result.inspections[0].values.map(({ value }) => value)).toEqual([
+    2, 4, 6
+  ])
+  expect(result.inspections[1].line).toBe(6)
+  expect(result.inspections[1].values[0].value).toEqual([2, 4, 6])
+
+  const capped = await runHelm(
+    sails,
+    [
+      'for (let index = 0; index < 25; index++) {',
+      '  index // @inspect',
+      '}'
+    ].join('\n')
+  )
+  expect(capped.success).toBe(true)
+  expect(capped.inspections[0].values.length).toBe(20)
+  expect(capped.inspections[0].omittedCount).toBe(5)
+
+  const lookalike = await runHelm(
+    sails,
+    'const marker = "// @inspect and // @trace queries"\nmarker'
+  )
+  expect(lookalike.inspections).toEqual([])
+  expect(lookalike.queryTrace).toBe(null)
+  const ordinarySource = helmRuntime.prepareSource('1 + 1')
+  const tracedSource = helmRuntime.prepareSource('// @trace queries\n1 + 1')
+  expect(
+    helmRuntime
+      .buildRunnerSource({
+        preparedSource: ordinarySource.source,
+        finalExpression: ordinarySource.finalExpression,
+        traceQueries: ordinarySource.traceQueries
+      })
+      .includes('sendNativeQuery')
+  ).toBe(false)
+  expect(
+    helmRuntime
+      .buildRunnerSource({
+        preparedSource: tracedSource.source,
+        finalExpression: tracedSource.finalExpression,
+        traceQueries: tracedSource.traceQueries
+      })
+      .includes('sendNativeQuery')
+  ).toBe(true)
+
+  const invalid = await runHelm(sails, 'const value = 1\n// @inspect\nvalue')
+  expect(invalid.success).toBe(false)
+  expect(invalid.error.code).toBe('HELM_SOURCE_INVALID')
+  expect(invalid.error.message).toContain('complete expression')
+})
+
+test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', async ({
+  sails,
+  expect
+}) => {
+  const result = await runHelm(
+    sails,
+    [
+      '// @trace queries',
+      "await Project.find({ slug: 'waterline-secret' }).limit(1)",
+      'for (let index = 0; index < 105; index++) {',
+      '  await sails.getDatastore().sendNativeQuery(',
+      '    "SELECT \'native-secret\' AS value, 99 AS count"',
+      '  )',
+      '}',
+      "'done'"
+    ].join('\n'),
+    { bootstrapSails: true }
+  )
+
+  expect(result.success).toBe(true)
+  expect(result.value).toBe('done')
+  expect(result.queryTrace.enabled).toBe(true)
+  expect(result.queryTrace.entries.length).toBe(100)
+  expect(result.queryTrace.omittedCount).toBe(6)
+  expect({
+    kind: result.queryTrace.entries[0].kind,
+    model: result.queryTrace.entries[0].model,
+    datastore: result.queryTrace.entries[0].datastore,
+    method: result.queryTrace.entries[0].method,
+    status: result.queryTrace.entries[0].status,
+    criteria: result.queryTrace.entries[0].criteria
+  }).toEqual({
+    kind: 'waterline',
+    model: 'project',
+    datastore: 'default',
+    method: 'find',
+    status: 'success',
+    criteria: {
+      where: {
+        slug: '[value]'
+      },
+      limit: '[value]'
+    }
+  })
+  expect({
+    kind: result.queryTrace.entries[1].kind,
+    datastore: result.queryTrace.entries[1].datastore,
+    method: result.queryTrace.entries[1].method,
+    status: result.queryTrace.entries[1].status,
+    statement: result.queryTrace.entries[1].statement
+  }).toEqual({
+    kind: 'native',
+    datastore: 'default',
+    method: 'sendNativeQuery',
+    status: 'success',
+    statement: 'SELECT ? AS value, ? AS count'
+  })
+  expect(JSON.stringify(result.queryTrace).includes('waterline-secret')).toBe(
+    false
+  )
+  expect(JSON.stringify(result.queryTrace).includes('native-secret')).toBe(
+    false
+  )
 })
 
 test('Helm understands normal JavaScript syntax around return words', async ({
@@ -224,6 +361,15 @@ test('Helm maps syntax and runtime failures to helm-input.js', async ({
   expect(runtimeFailure.error.line).toBe(2)
   expect(runtimeFailure.error.column).toBe(9)
   expect(runtimeFailure.error.stack).toContain('helm-input.js:2:9')
+
+  const inspectedFailure = await runHelm(
+    sails,
+    'const creator = null\ncreator.publicId // @inspect'
+  )
+  expect(inspectedFailure.success).toBe(false)
+  expect(inspectedFailure.error.line).toBe(2)
+  expect(inspectedFailure.error.column).toBe(9)
+  expect(inspectedFailure.error.stack).toContain('helm-input.js:2:9')
 
   const rejectedPromise = await runHelm(
     sails,

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -117,26 +117,35 @@ test('Helm query tracing is opt-in, execution-scoped, bounded, and redacted', as
   sails,
   expect
 }) => {
-  const result = await runHelm(
-    sails,
-    [
-      '// @trace queries',
-      "await Project.find({ slug: 'waterline-secret' }).limit(1)",
-      'for (let index = 0; index < 105; index++) {',
-      '  await sails.getDatastore().sendNativeQuery(',
-      '    "SELECT \'native-secret\' AS value, 99 AS count"',
-      '  )',
-      '}',
-      "'done'"
-    ].join('\n'),
-    { bootstrapSails: true }
-  )
+  const defaultMaxEntries = sails.config.custom.helm.maxQueryTraceEntries
+  expect(defaultMaxEntries).toBe(100)
+  sails.config.custom.helm.maxQueryTraceEntries = 3
+
+  let result
+  try {
+    result = await runHelm(
+      sails,
+      [
+        '// @trace queries',
+        "await Project.find({ slug: 'waterline-secret' }).limit(1)",
+        'for (let index = 0; index < 5; index++) {',
+        '  await sails.getDatastore().sendNativeQuery(',
+        '    "SELECT \'native-secret\' AS value, 99 AS count"',
+        '  )',
+        '}',
+        "'done'"
+      ].join('\n'),
+      { bootstrapSails: true }
+    )
+  } finally {
+    sails.config.custom.helm.maxQueryTraceEntries = defaultMaxEntries
+  }
 
   expect(result.success).toBe(true)
   expect(result.value).toBe('done')
   expect(result.queryTrace.enabled).toBe(true)
-  expect(result.queryTrace.entries.length).toBe(100)
-  expect(result.queryTrace.omittedCount).toBe(6)
+  expect(result.queryTrace.entries.length).toBe(3)
+  expect(result.queryTrace.omittedCount).toBe(3)
   expect({
     kind: result.queryTrace.entries[0].kind,
     model: result.queryTrace.entries[0].model,


### PR DESCRIPTION
## What changed

- add parser-backed `// @inspect` markers with bounded inline CodeMirror values
- add opt-in `// @trace queries` instrumentation for Waterline and native queries
- scope tracing to the Helm execution and redact criteria, SQL literals, bindings,
  and query errors
- keep inspection and trace diagnostics transient and separate from Helm history
- support project Helm and Bosun consistently in light and dark modes
- document limits, privacy behavior, and production write-guard interaction

## Why

Helm could previously show only the final result and explicit console output.
Developers had to rewrite snippets or add temporary logging to understand
intermediate state and database activity.

## Validation

- `npm run test:unit` — 226 passed
- `npm run test:functional` — 65 passed
- complete Helm browser file — 14 passed
- focused Helm runtime file — 12 passed
- `npm run lint`
- `npm run check:consistency`

Closes #275
