### PR TITLE
feat(helm): add durable named scratchpads

### DIFF
--- a/api/controllers/project/view-helm.js
+++ b/api/controllers/project/view-helm.js
@@ -13,6 +13,10 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'Environment slug'
+    },
+    appSlug: {
+      type: 'string',
+      description: 'App slug'
     }
   },
 
@@ -25,7 +29,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ slug, envSlug }) {
+  fn: async function ({ slug, envSlug, appSlug }) {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
@@ -45,9 +49,17 @@ module.exports = {
       throw { notFound: `/projects/${slug}` }
     }
 
-    let app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
+    let app = appSlug
+      ? await App.findOne({ environment: environment.id, slug: appSlug })
+      : (await App.findOne({
+          environment: environment.id,
+          isDefault: true
+        })) || (await App.findOne({ environment: environment.id }))
+    if (appSlug && !app) {
+      throw {
+        notFound: `/projects/${slug}/environments/${envSlug}`
+      }
+    }
     if (app)
       app = await App.findOne({ id: app.id }).populate('currentDeployment')
     const target = app

--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -38,11 +38,16 @@ const props = defineProps({
   target: {
     type: Object,
     default: null
+  },
+  view: {
+    type: String,
+    default: 'auto',
+    validator: (value) => ['auto', 'raw', 'tree', 'table'].includes(value)
   }
 })
 
-const emit = defineEmits(['clear'])
-const activeView = ref('raw')
+const emit = defineEmits(['clear', 'update:view'])
+const activeView = ref(props.view === 'auto' ? 'raw' : props.view)
 const logsOpen = ref(false)
 const queriesOpen = ref(false)
 const toasts = ref([])
@@ -216,17 +221,20 @@ const actionItems = computed(() => {
 watch(
   () => props.result,
   () => {
-    activeView.value = tableCompatible.value
-      ? 'table'
-      : structured.value
-      ? 'tree'
-      : 'raw'
+    activeView.value = preferredView()
     logsOpen.value = Boolean(
       logs.value.length && props.result?.success === false
     )
     queriesOpen.value = Boolean(queryTrace.value)
   },
   { immediate: true }
+)
+
+watch(
+  () => props.view,
+  () => {
+    activeView.value = preferredView()
+  }
 )
 
 watch(
@@ -250,6 +258,18 @@ onBeforeUnmount(() => clearInterval(runningTimer))
 function formatDuration(durationMs) {
   if (durationMs < 1000) return `${Math.max(0, Math.round(durationMs))}ms`
   return `${(durationMs / 1000).toFixed(durationMs < 10000 ? 1 : 0)}s`
+}
+
+function selectView(view) {
+  activeView.value = view
+  emit('update:view', view)
+}
+
+function preferredView() {
+  if (views.value.includes(props.view)) return props.view
+  if (tableCompatible.value) return 'table'
+  if (structured.value) return 'tree'
+  return 'raw'
 }
 
 function formatBytes(bytes) {
@@ -538,7 +558,7 @@ function queryDetail(entry) {
       v-if="queryTrace"
       :open="queriesOpen"
       :data-test="`${testId}-queries`"
-      class="group shrink-0 border-t border-gray-200 bg-gray-50/70 dark:border-gray-800 dark:bg-gray-900/40"
+      class="group shrink-0 bg-gray-50/70 dark:bg-gray-900/40"
       @toggle="queriesOpen = $event.currentTarget.open"
     >
       <summary
@@ -633,13 +653,27 @@ function queryDetail(entry) {
       v-if="logs.length"
       :open="logsOpen"
       :data-test="`${testId}-logs`"
-      class="shrink-0 border-t border-gray-200 bg-gray-50/70 dark:border-gray-800 dark:bg-gray-900/40"
+      class="group shrink-0 bg-gray-50/70 dark:bg-gray-900/40"
       @toggle="logsOpen = $event.currentTarget.open"
     >
       <summary
-        class="cursor-pointer px-4 py-2 text-xs font-medium text-gray-500 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-300 dark:text-gray-400 dark:focus-visible:ring-gray-700"
+        class="flex cursor-pointer list-none items-center gap-2 px-3 py-2 text-xs font-medium text-gray-500 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-300 dark:text-gray-400 dark:focus-visible:ring-gray-700"
       >
-        Console
+        <svg
+          class="h-3 w-3 shrink-0 -rotate-90 transition-transform group-open:rotate-0 motion-reduce:transition-none"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          stroke-width="1.75"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="m6 9 6 6 6-6"
+          />
+        </svg>
+        <span>Console</span>
         <span class="font-normal text-gray-400 dark:text-gray-600"
           >{{ logs.length }} line{{ logs.length === 1 ? '' : 's'
           }}{{ result?.logsPartial ? ' · partial' : '' }}</span
@@ -654,12 +688,12 @@ function queryDetail(entry) {
     <footer
       v-if="result"
       :data-test="`${testId}-result-status`"
-      class="min-h-10 flex shrink-0 items-center justify-between gap-3 border-t border-gray-200 bg-gray-50 px-3 py-1.5 dark:border-gray-800 dark:bg-gray-900/50"
+      class="min-h-10 flex shrink-0 items-center justify-between gap-3 bg-gray-50/70 px-3 py-1.5 dark:bg-gray-900/40"
     >
-      <div class="flex min-w-0 items-center gap-3">
+      <div class="flex min-w-0 items-center gap-2">
         <div
           v-if="views.length > 1"
-          class="flex shrink-0 overflow-hidden rounded-md border border-gray-300 dark:border-gray-700"
+          class="flex shrink-0 items-center gap-0.5"
           role="group"
           aria-label="Result view"
         >
@@ -675,15 +709,12 @@ function queryDetail(entry) {
               :aria-label="`${view[0].toUpperCase()}${view.slice(1)} view`"
               :aria-pressed="activeView === view"
               :class="[
-                'flex h-7 w-8 items-center justify-center outline-none transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-400 motion-reduce:transition-none dark:focus-visible:ring-gray-600',
-                view !== views[0]
-                  ? 'border-l border-gray-300 dark:border-gray-700'
-                  : '',
+                'flex h-7 w-7 items-center justify-center rounded-md outline-none transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-400 motion-reduce:transition-none dark:focus-visible:ring-gray-600',
                 activeView === view
-                  ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+                  ? 'bg-gray-200/80 text-gray-900 dark:bg-gray-800 dark:text-white'
+                  : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300'
               ]"
-              @click="activeView = view"
+              @click="selectView(view)"
             >
               <svg
                 v-if="view === 'table'"

--- a/assets/js/components/HelmScratchpadTabs.vue
+++ b/assets/js/components/HelmScratchpadTabs.vue
@@ -1,0 +1,212 @@
+<script setup>
+import { computed, nextTick, ref } from 'vue'
+import ActionMenu from '@/components/ActionMenu.vue'
+import Tooltip from '@/components/Tooltip.vue'
+import {
+  helmScratchpadIsModified,
+  helmScratchpadTargetLabel,
+  helmScratchpadTargetTitle
+} from '@/lib/helmScratchpads.mjs'
+
+const props = defineProps({
+  tabs: { type: Array, default: () => [] },
+  activeId: { type: String, default: '' },
+  currentTargetKey: { type: String, default: '' },
+  disabled: Boolean,
+  canCreate: Boolean
+})
+
+const emit = defineEmits([
+  'activate',
+  'close',
+  'create',
+  'duplicate',
+  'move',
+  'rename',
+  'save'
+])
+
+const tabRefs = ref([])
+const renamingId = ref('')
+const renameValue = ref('')
+const renameInput = ref(null)
+const activeIndex = computed(() =>
+  props.tabs.findIndex((tab) => tab.id === props.activeId)
+)
+const activeTab = computed(() => props.tabs[activeIndex.value] || null)
+const actions = computed(() => {
+  if (!activeTab.value) return []
+  return [
+    { key: 'rename', label: 'Rename' },
+    { key: 'duplicate', label: 'Duplicate', disabled: !props.canCreate },
+    {
+      key: 'move-left',
+      label: 'Move left',
+      disabled: activeIndex.value <= 0
+    },
+    {
+      key: 'move-right',
+      label: 'Move right',
+      disabled: activeIndex.value >= props.tabs.length - 1
+    },
+    { key: 'save', label: 'Save as snippet' },
+    { key: 'close', label: 'Close scratchpad', destructive: true }
+  ]
+})
+
+async function beginRename(tab = activeTab.value) {
+  if (!tab || props.disabled) return
+  renamingId.value = tab.id
+  renameValue.value = tab.name
+  await nextTick()
+  renameInput.value?.select()
+}
+
+function commitRename() {
+  if (!renamingId.value) return
+  emit('rename', renamingId.value, renameValue.value)
+  renamingId.value = ''
+}
+
+function cancelRename() {
+  renamingId.value = ''
+}
+
+function setRenameInput(element) {
+  renameInput.value = element
+}
+
+function handleAction(action) {
+  const tab = activeTab.value
+  if (!tab) return
+  if (action.key === 'rename') beginRename(tab)
+  if (action.key === 'duplicate') emit('duplicate', tab)
+  if (action.key === 'move-left') emit('move', tab, -1)
+  if (action.key === 'move-right') emit('move', tab, 1)
+  if (action.key === 'save') emit('save', tab)
+  if (action.key === 'close') emit('close', tab)
+}
+
+function handleTabKeydown(event, index) {
+  let nextIndex = index
+  if (event.key === 'ArrowRight') {
+    nextIndex = (index + 1) % props.tabs.length
+  } else if (event.key === 'ArrowLeft') {
+    nextIndex = (index - 1 + props.tabs.length) % props.tabs.length
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = props.tabs.length - 1
+  } else {
+    return
+  }
+
+  event.preventDefault()
+  const tab = props.tabs[nextIndex]
+  emit('activate', tab)
+  nextTick(() => tabRefs.value[nextIndex]?.focus())
+}
+</script>
+
+<template>
+  <div
+    data-test="helm-scratchpads"
+    class="min-h-9 flex shrink-0 items-center gap-2 bg-white px-3 py-0.5 dark:bg-gray-950"
+  >
+    <div
+      role="tablist"
+      aria-label="Helm scratchpads"
+      class="flex min-w-0 flex-1 items-center gap-3 overflow-x-auto"
+    >
+      <template v-for="(tab, index) in tabs" :key="tab.id">
+        <input
+          v-if="renamingId === tab.id"
+          :ref="setRenameInput"
+          v-model="renameValue"
+          data-test="helm-scratchpad-rename"
+          maxlength="64"
+          aria-label="Scratchpad name"
+          class="h-8 w-40 shrink-0 rounded-md bg-white px-2 text-xs font-medium text-gray-900 shadow-sm outline-none ring-1 ring-gray-300 focus:ring-2 focus:ring-gray-400 dark:bg-gray-900 dark:text-white dark:ring-gray-700 dark:focus:ring-gray-600"
+          @blur="commitRename"
+          @keydown.enter.prevent="commitRename"
+          @keydown.escape.prevent="cancelRename"
+        />
+        <button
+          v-else
+          :id="`helm-scratchpad-${tab.id}-tab`"
+          :ref="(element) => (tabRefs[index] = element)"
+          type="button"
+          role="tab"
+          :data-test="`helm-scratchpad-${index}`"
+          :aria-selected="tab.id === activeId"
+          aria-controls="helm-scratchpad-panel"
+          :tabindex="tab.id === activeId ? 0 : -1"
+          :disabled="disabled"
+          :title="helmScratchpadTargetTitle(tab.target)"
+          :class="[
+            'max-w-64 flex h-8 shrink-0 items-center gap-1.5 rounded-sm px-0.5 text-left text-xs outline-none transition-colors focus-visible:ring-2 focus-visible:ring-gray-300 disabled:cursor-not-allowed disabled:opacity-50 motion-reduce:transition-none dark:focus-visible:ring-gray-700',
+            tab.id === activeId
+              ? 'font-medium text-gray-900 dark:text-white'
+              : 'text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300'
+          ]"
+          @click="emit('activate', tab)"
+          @dblclick="beginRename(tab)"
+          @keydown="handleTabKeydown($event, index)"
+        >
+          <span class="truncate">{{ tab.name }}</span>
+          <span
+            v-if="tab.target.key !== currentTargetKey"
+            class="max-w-28 truncate font-normal text-gray-400 dark:text-gray-500"
+            >{{ helmScratchpadTargetLabel(tab.target) }}</span
+          >
+          <span
+            v-if="helmScratchpadIsModified(tab)"
+            class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+            aria-hidden="true"
+          ></span>
+          <span v-if="helmScratchpadIsModified(tab)" class="sr-only">
+            Modified
+          </span>
+        </button>
+      </template>
+    </div>
+
+    <div class="flex shrink-0 items-center gap-0.5">
+      <Tooltip
+        :text="canCreate ? 'New scratchpad' : 'Scratchpad limit reached'"
+        position="bottom"
+      >
+        <button
+          type="button"
+          data-test="helm-scratchpad-create"
+          :disabled="disabled || !canCreate"
+          aria-label="New scratchpad"
+          class="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-500 dark:hover:bg-gray-900 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
+          @click="emit('create')"
+        >
+          <svg
+            class="h-4 w-4"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            stroke-width="1.75"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M12 5v14M5 12h14"
+            />
+          </svg>
+        </button>
+      </Tooltip>
+      <ActionMenu
+        :items="actions"
+        label="Scratchpad actions"
+        test-id="helm-scratchpad-actions"
+        :disabled="disabled || !activeTab"
+        @select="handleAction"
+      />
+    </div>
+  </div>
+</template>

--- a/assets/js/components/HelmWorkspaceLibrary.vue
+++ b/assets/js/components/HelmWorkspaceLibrary.vue
@@ -27,7 +27,14 @@ const props = defineProps({
   }
 })
 
-const emit = defineEmits(['update:tab', 'close', 'load', 'rerun', 'insert'])
+const emit = defineEmits([
+  'update:tab',
+  'close',
+  'load',
+  'rerun',
+  'insert',
+  'snippet-saved'
+])
 const history = ref([])
 const snippets = ref([])
 const historyQuery = ref('')
@@ -279,6 +286,7 @@ async function saveSnippet(values) {
     )
     snippetDialog.value = { show: false, snippet: null }
     await refreshSnippets()
+    emit('snippet-saved', values.source)
     notify(existing?.id ? 'Snippet updated' : 'Snippet saved')
   } catch (error) {
     requestError.value = error.message
@@ -388,11 +396,9 @@ defineExpose({ refreshHistory, openSnippetDialog })
     data-test="helm-library"
     class="flex max-h-[17rem] min-h-0 shrink-0 flex-col border-t border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-950"
   >
-    <header
-      class="flex shrink-0 items-center gap-2 border-b border-gray-100 px-3 py-2 dark:border-gray-800"
-    >
+    <header class="flex shrink-0 items-center gap-2 px-3 py-2">
       <div
-        class="flex shrink-0 overflow-hidden rounded-md border border-gray-300 dark:border-gray-700"
+        class="flex shrink-0 items-center gap-0.5"
         role="tablist"
         aria-label="Helm library"
       >
@@ -412,11 +418,10 @@ defineExpose({ refreshHistory, openSnippetDialog })
             :tabindex="tab === item.key ? 0 : -1"
             :data-test="`helm-library-${item.key}`"
             :class="[
-              'flex h-7 w-8 items-center justify-center outline-none transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-400 motion-reduce:transition-none dark:focus-visible:ring-gray-600',
-              index > 0 ? 'border-l border-gray-300 dark:border-gray-700' : '',
+              'flex h-7 w-7 items-center justify-center rounded-md outline-none transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-400 motion-reduce:transition-none dark:focus-visible:ring-gray-600',
               tab === item.key
-                ? 'bg-gray-200 text-gray-900 dark:bg-gray-700 dark:text-white'
-                : 'text-gray-500 hover:bg-gray-100 dark:text-gray-400 dark:hover:bg-gray-800'
+                ? 'bg-gray-200/80 text-gray-900 dark:bg-gray-800 dark:text-white'
+                : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300'
             ]"
             @click="emit('update:tab', item.key)"
             @keydown="handleLibraryTabKeydown($event, index)"
@@ -477,22 +482,40 @@ defineExpose({ refreshHistory, openSnippetDialog })
           data-test="helm-library-search"
           type="search"
           :placeholder="`Search ${tab}`"
-          class="block w-full rounded-md border-0 bg-gray-50 py-1.5 pl-8 pr-3 text-xs text-gray-900 outline-none ring-1 ring-inset ring-gray-200 placeholder:text-gray-400 focus:ring-1 focus:ring-gray-400 dark:bg-gray-900 dark:text-white dark:ring-gray-800 dark:placeholder:text-gray-600 dark:focus:ring-gray-600"
+          class="block w-full rounded-md border-0 bg-gray-100/70 py-1.5 pl-8 pr-3 text-xs text-gray-900 outline-none placeholder:text-gray-400 focus:ring-1 focus:ring-gray-300 dark:bg-gray-900 dark:text-white dark:placeholder:text-gray-600 dark:focus:ring-gray-700"
         />
       </label>
 
-      <button
-        v-if="tab === 'history'"
-        type="button"
-        data-test="helm-clear-history"
-        :disabled="clearableHistoryCount === 0"
-        class="disabled:opacity-35 rounded-md px-2 py-1.5 text-xs font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
-        @click="confirm = { show: true, type: 'clear-history', item: null }"
+      <Tooltip
+        v-if="tab === 'history' && clearableHistoryCount > 0"
+        text="Clear recent history"
+        position="top"
       >
-        Clear
-      </button>
+        <button
+          type="button"
+          data-test="helm-clear-history"
+          aria-label="Clear recent history"
+          class="rounded-md p-1.5 text-gray-400 hover:bg-red-50 hover:text-red-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-500 dark:hover:bg-red-950/40 dark:hover:text-red-400 dark:focus-visible:ring-gray-700"
+          @click="confirm = { show: true, type: 'clear-history', item: null }"
+        >
+          <svg
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            stroke-width="1.75"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              d="M4.5 7.5h15M9 7.5V5.25h6V7.5m-8.25 0 .75 11.25h9l.75-11.25M10 11v4.5m4-4.5v4.5"
+            />
+          </svg>
+        </button>
+      </Tooltip>
       <button
-        v-else
+        v-if="tab !== 'history'"
         type="button"
         data-test="helm-new-snippet"
         :disabled="!hasCurrentSource"
@@ -554,12 +577,12 @@ defineExpose({ refreshHistory, openSnippetDialog })
             Runs appear here without their returned data.
           </p>
         </div>
-        <div v-else>
+        <div v-else class="space-y-0.5 p-1">
           <div
             v-for="entry in history"
             :key="entry.id"
             data-test="helm-history-entry"
-            class="group flex items-center gap-2 border-b border-gray-100 px-3 py-2 last:border-b-0 hover:bg-gray-50 dark:border-gray-900 dark:hover:bg-gray-900/60"
+            class="group flex items-center gap-2 rounded-md px-2 py-2 hover:bg-gray-50 dark:hover:bg-gray-900/60"
           >
             <button
               type="button"
@@ -633,12 +656,12 @@ defineExpose({ refreshHistory, openSnippetDialog })
             Save repeatable work, then insert it without running.
           </p>
         </div>
-        <div v-else>
+        <div v-else class="space-y-0.5 p-1">
           <div
             v-for="snippet in snippets"
             :key="snippet.id"
             data-test="helm-snippet-entry"
-            class="group flex items-center gap-2 border-b border-gray-100 px-3 py-2 last:border-b-0 hover:bg-gray-50 dark:border-gray-900 dark:hover:bg-gray-900/60"
+            class="group flex items-center gap-2 rounded-md px-2 py-2 hover:bg-gray-50 dark:hover:bg-gray-900/60"
           >
             <button
               type="button"
@@ -678,7 +701,7 @@ defineExpose({ refreshHistory, openSnippetDialog })
 
     <footer
       v-if="requestError || (tab === 'history' && history.length > 0)"
-      class="shrink-0 border-t border-gray-100 px-3 py-1.5 text-[11px] dark:border-gray-800"
+      class="shrink-0 px-3 py-1.5 text-[11px]"
     >
       <p v-if="requestError" class="text-red-600 dark:text-red-400">
         {{ requestError }}

--- a/assets/js/composables/useHelmScratchpads.js
+++ b/assets/js/composables/useHelmScratchpads.js
@@ -1,0 +1,277 @@
+import { computed, ref, watch } from 'vue'
+import { LOCAL_STORAGE_KEYS } from '@/lib/localStorageKeys'
+import {
+  HELM_SCRATCHPAD_DEFAULT_SOURCE,
+  HELM_SCRATCHPAD_LIMIT,
+  createHelmScratchpad,
+  duplicateHelmScratchpadName,
+  nextHelmScratchpadName,
+  parseHelmScratchpadState,
+  serializeHelmScratchpadState,
+  snapshotHelmTarget
+} from '@/lib/helmScratchpads.mjs'
+
+export function useHelmScratchpads(targetSource) {
+  const tabs = ref([])
+  const activeByTarget = ref({})
+  const runtime = ref({})
+  const ready = ref(false)
+  const currentTarget = computed(() =>
+    snapshotHelmTarget(
+      typeof targetSource === 'function' ? targetSource() : targetSource
+    )
+  )
+  const currentTargetKey = computed(() => currentTarget.value?.key || '')
+  const activeId = computed(
+    () => activeByTarget.value[currentTargetKey.value] || ''
+  )
+  const activeTab = computed(
+    () => tabs.value.find((tab) => tab.id === activeId.value) || null
+  )
+  const canCreate = computed(() => tabs.value.length < HELM_SCRATCHPAD_LIMIT)
+
+  const code = computed({
+    get: () => activeTab.value?.source || HELM_SCRATCHPAD_DEFAULT_SOURCE,
+    set: (source) => {
+      update(activeId.value, { source: String(source), updatedAt: Date.now() })
+    }
+  })
+  const view = computed({
+    get: () => activeTab.value?.view || 'auto',
+    set: (selectedView) => {
+      update(activeId.value, {
+        view: selectedView,
+        updatedAt: Date.now()
+      })
+    }
+  })
+  const result = computed({
+    get: () => runtime.value[activeId.value]?.result || null,
+    set: (value) => setRuntime(activeId.value, { result: value })
+  })
+  const error = computed({
+    get: () => runtime.value[activeId.value]?.error || '',
+    set: (value) => setRuntime(activeId.value, { error: String(value || '') })
+  })
+
+  initialize()
+
+  watch(
+    [tabs, activeByTarget],
+    () => {
+      if (!ready.value || typeof window === 'undefined') return
+      try {
+        window.localStorage.setItem(
+          LOCAL_STORAGE_KEYS.helmScratchpads,
+          serializeHelmScratchpadState({
+            tabs: tabs.value,
+            activeByTarget: activeByTarget.value
+          })
+        )
+      } catch (error) {
+        console.warn('Could not save Helm scratchpads:', error)
+      }
+    },
+    { deep: true }
+  )
+
+  function initialize() {
+    const state = readState()
+    const target = currentTarget.value
+    tabs.value = state.tabs
+    activeByTarget.value = state.activeByTarget
+
+    if (!target) {
+      ready.value = true
+      return
+    }
+
+    tabs.value = tabs.value.map((tab) =>
+      tab.target.key === target.key ? { ...tab, target } : tab
+    )
+    let targetTabs = tabs.value.filter((tab) => tab.target.key === target.key)
+    if (targetTabs.length === 0) {
+      const tab = createHelmScratchpad({
+        name: nextHelmScratchpadName(tabs.value, target.key),
+        target
+      })
+      tabs.value.push(tab)
+      targetTabs = [tab]
+    }
+
+    const remembered = activeByTarget.value[target.key]
+    if (!targetTabs.some((tab) => tab.id === remembered)) {
+      activeByTarget.value = {
+        ...activeByTarget.value,
+        [target.key]: targetTabs[0].id
+      }
+    }
+    ready.value = true
+  }
+
+  function create({ source = HELM_SCRATCHPAD_DEFAULT_SOURCE } = {}) {
+    if (!canCreate.value || !currentTarget.value) return null
+    const tab = createHelmScratchpad({
+      name: nextHelmScratchpadName(tabs.value, currentTargetKey.value),
+      source,
+      baselineSource: source,
+      target: currentTarget.value
+    })
+    tabs.value = [...tabs.value, tab]
+    activate(tab.id)
+    return tab
+  }
+
+  function activate(id) {
+    const tab = tabs.value.find((item) => item.id === id)
+    if (!tab) return null
+    activeByTarget.value = {
+      ...activeByTarget.value,
+      [tab.target.key]: tab.id
+    }
+    return tab
+  }
+
+  function rename(id, name) {
+    update(id, { name, updatedAt: Date.now() })
+  }
+
+  function duplicate(id) {
+    if (!canCreate.value) return null
+    const index = tabs.value.findIndex((tab) => tab.id === id)
+    const original = tabs.value[index]
+    if (!original) return null
+
+    const copy = createHelmScratchpad({
+      name: duplicateHelmScratchpadName(tabs.value, original),
+      source: original.source,
+      baselineSource: '',
+      view: original.view,
+      target: original.target
+    })
+    const nextTabs = [...tabs.value]
+    nextTabs.splice(index + 1, 0, copy)
+    tabs.value = nextTabs
+    activate(copy.id)
+    return copy
+  }
+
+  function move(id, offset) {
+    const index = tabs.value.findIndex((tab) => tab.id === id)
+    const nextIndex = index + offset
+    if (index < 0 || nextIndex < 0 || nextIndex >= tabs.value.length) return
+    const nextTabs = [...tabs.value]
+    const [tab] = nextTabs.splice(index, 1)
+    nextTabs.splice(nextIndex, 0, tab)
+    tabs.value = nextTabs
+  }
+
+  function close(id) {
+    const index = tabs.value.findIndex((tab) => tab.id === id)
+    const closing = tabs.value[index]
+    if (!closing) return
+
+    tabs.value = tabs.value.filter((tab) => tab.id !== id)
+    const nextForTarget = tabs.value.filter(
+      (tab) => tab.target.key === closing.target.key
+    )
+    delete runtime.value[id]
+
+    if (
+      nextForTarget.length === 0 &&
+      closing.target.key === currentTargetKey.value
+    ) {
+      create()
+      return
+    }
+
+    if (activeByTarget.value[closing.target.key] === id) {
+      const next =
+        tabs.value[Math.min(index, tabs.value.length - 1)] || nextForTarget[0]
+      activeByTarget.value = {
+        ...activeByTarget.value,
+        [closing.target.key]:
+          next?.target.key === closing.target.key
+            ? next.id
+            : nextForTarget[0]?.id || ''
+      }
+    }
+  }
+
+  function markCurrentSourceSaved(source = code.value) {
+    const tab = activeTab.value
+    if (!tab || tab.source !== source) return
+    update(tab.id, { baselineSource: source, updatedAt: Date.now() })
+  }
+
+  function clearRuntime() {
+    setRuntime(activeId.value, { result: null, error: '' })
+  }
+
+  function update(id, changes) {
+    if (!id) return
+    tabs.value = tabs.value.map((tab) =>
+      tab.id === id ? normalizeUpdate(tab, changes) : tab
+    )
+  }
+
+  function setRuntime(id, changes) {
+    if (!id) return
+    runtime.value = {
+      ...runtime.value,
+      [id]: {
+        result: null,
+        error: '',
+        ...(runtime.value[id] || {}),
+        ...changes
+      }
+    }
+  }
+
+  function readState() {
+    if (typeof window === 'undefined') {
+      return { tabs: [], activeByTarget: {} }
+    }
+    try {
+      return parseHelmScratchpadState(
+        window.localStorage.getItem(LOCAL_STORAGE_KEYS.helmScratchpads)
+      )
+    } catch {
+      return { tabs: [], activeByTarget: {} }
+    }
+  }
+
+  return {
+    tabs,
+    activeId,
+    activeTab,
+    currentTarget,
+    currentTargetKey,
+    code,
+    view,
+    result,
+    error,
+    canCreate,
+    limit: HELM_SCRATCHPAD_LIMIT,
+    activate,
+    clearRuntime,
+    close,
+    create,
+    duplicate,
+    markCurrentSourceSaved,
+    move,
+    rename
+  }
+}
+
+function normalizeUpdate(tab, changes) {
+  const next = { ...tab, ...changes }
+  next.name =
+    typeof next.name === 'string' && next.name.trim()
+      ? next.name.trim().slice(0, 64)
+      : tab.name
+  next.view = ['auto', 'raw', 'tree', 'table'].includes(next.view)
+    ? next.view
+    : tab.view
+  return next
+}

--- a/assets/js/lib/helmScratchpads.mjs
+++ b/assets/js/lib/helmScratchpads.mjs
@@ -1,0 +1,220 @@
+export const HELM_SCRATCHPAD_STORAGE_VERSION = 1
+export const HELM_SCRATCHPAD_LIMIT = 20
+export const HELM_SCRATCHPAD_DEFAULT_SOURCE =
+  '// Access your Sails models, helpers, and config\n'
+
+const RESULT_VIEWS = new Set(['auto', 'raw', 'tree', 'table'])
+
+export function snapshotHelmTarget(target) {
+  const project = cleanIdentity(target?.project)
+  const environment = cleanIdentity(target?.environment)
+  const app = cleanIdentity(target?.app)
+  if (!project || !environment || !app) return null
+
+  const key = [project.id, environment.id, app.id].join(':')
+  return {
+    key,
+    project,
+    environment: {
+      ...environment,
+      isProduction: Boolean(target.environment.isProduction)
+    },
+    app,
+    href: `/projects/${encodeURIComponent(
+      project.slug
+    )}/environments/${encodeURIComponent(
+      environment.slug
+    )}/helm?appSlug=${encodeURIComponent(app.slug)}`
+  }
+}
+
+export function createHelmScratchpad({
+  id = createId(),
+  name = 'Scratchpad',
+  source = HELM_SCRATCHPAD_DEFAULT_SOURCE,
+  baselineSource = source,
+  view = 'auto',
+  target,
+  now = Date.now()
+}) {
+  const safeTarget = snapshotHelmTarget(target)
+  if (!safeTarget) return null
+
+  return {
+    id: String(id),
+    name: cleanName(name),
+    source: String(source),
+    baselineSource: String(baselineSource),
+    view: RESULT_VIEWS.has(view) ? view : 'auto',
+    target: safeTarget,
+    createdAt: finiteTimestamp(now),
+    updatedAt: finiteTimestamp(now)
+  }
+}
+
+export function parseHelmScratchpadState(value) {
+  let parsed
+  try {
+    parsed = typeof value === 'string' ? JSON.parse(value) : value
+  } catch {
+    return emptyState()
+  }
+
+  if (
+    !parsed ||
+    parsed.version !== HELM_SCRATCHPAD_STORAGE_VERSION ||
+    !Array.isArray(parsed.tabs)
+  ) {
+    return emptyState()
+  }
+
+  const ids = new Set()
+  const tabs = []
+  for (const candidate of parsed.tabs.slice(0, HELM_SCRATCHPAD_LIMIT)) {
+    const tab = normalizeStoredTab(candidate)
+    if (!tab || ids.has(tab.id)) continue
+    ids.add(tab.id)
+    tabs.push(tab)
+  }
+
+  const activeByTarget = {}
+  if (isPlainObject(parsed.activeByTarget)) {
+    for (const [targetKey, tabId] of Object.entries(parsed.activeByTarget)) {
+      if (
+        typeof targetKey === 'string' &&
+        typeof tabId === 'string' &&
+        tabs.some((tab) => tab.id === tabId && tab.target.key === targetKey)
+      ) {
+        activeByTarget[targetKey] = tabId
+      }
+    }
+  }
+
+  return { tabs, activeByTarget }
+}
+
+export function serializeHelmScratchpadState({ tabs, activeByTarget }) {
+  return JSON.stringify({
+    version: HELM_SCRATCHPAD_STORAGE_VERSION,
+    tabs: (tabs || []).slice(0, HELM_SCRATCHPAD_LIMIT).map((tab) => ({
+      id: tab.id,
+      name: tab.name,
+      source: tab.source,
+      baselineSource: tab.baselineSource,
+      view: tab.view,
+      target: tab.target,
+      createdAt: tab.createdAt,
+      updatedAt: tab.updatedAt
+    })),
+    activeByTarget: activeByTarget || {}
+  })
+}
+
+export function helmScratchpadTargetLabel(target) {
+  if (!target) return ''
+  return `${target.app.name} · ${target.environment.name}`
+}
+
+export function helmScratchpadTargetTitle(target) {
+  if (!target) return ''
+  return `${target.project.name} / ${target.environment.name} / ${target.app.name}`
+}
+
+export function helmScratchpadIsModified(tab) {
+  return Boolean(tab) && tab.source !== tab.baselineSource
+}
+
+export function nextHelmScratchpadName(tabs, targetKey) {
+  const used = new Set(
+    (tabs || [])
+      .filter((tab) => tab.target.key === targetKey)
+      .map((tab) => tab.name)
+  )
+  let number = 1
+  while (used.has(`Scratchpad ${number}`)) number += 1
+  return `Scratchpad ${number}`
+}
+
+export function duplicateHelmScratchpadName(tabs, tab) {
+  const base = `Copy of ${tab.name}`.slice(0, 64)
+  const used = new Set(
+    (tabs || [])
+      .filter((item) => item.target.key === tab.target.key)
+      .map((item) => item.name)
+  )
+  if (!used.has(base)) return base
+
+  let number = 2
+  while (used.has(`${base} ${number}`.slice(0, 64))) number += 1
+  return `${base} ${number}`.slice(0, 64)
+}
+
+function normalizeStoredTab(candidate) {
+  if (
+    !isPlainObject(candidate) ||
+    typeof candidate.id !== 'string' ||
+    !candidate.id ||
+    typeof candidate.source !== 'string'
+  ) {
+    return null
+  }
+
+  const tab = createHelmScratchpad({
+    id: candidate.id,
+    name: candidate.name,
+    source: candidate.source,
+    baselineSource:
+      typeof candidate.baselineSource === 'string'
+        ? candidate.baselineSource
+        : candidate.source,
+    view: candidate.view,
+    target: candidate.target,
+    now: candidate.createdAt
+  })
+  if (!tab) return null
+
+  return {
+    ...tab,
+    updatedAt: finiteTimestamp(candidate.updatedAt)
+  }
+}
+
+function cleanIdentity(value) {
+  if (!isPlainObject(value)) return null
+  const id = cleanIdentifier(value.id)
+  const slug = cleanIdentifier(value.slug)
+  const name =
+    typeof value.name === 'string' && value.name.trim()
+      ? value.name.trim().slice(0, 120)
+      : slug
+  if (!id || !slug || !name) return null
+  return { id, slug, name }
+}
+
+function cleanIdentifier(value) {
+  if (!['string', 'number'].includes(typeof value)) return ''
+  return String(value).trim().slice(0, 180)
+}
+
+function cleanName(value) {
+  if (typeof value !== 'string' || !value.trim()) return 'Scratchpad'
+  return value.trim().slice(0, 64)
+}
+
+function finiteTimestamp(value) {
+  const number = Number(value)
+  return Number.isFinite(number) && number > 0 ? number : Date.now()
+}
+
+function createId() {
+  if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID()
+  return `scratchpad-${Date.now()}-${Math.random().toString(16).slice(2)}`
+}
+
+function emptyState() {
+  return { tabs: [], activeByTarget: {} }
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}

--- a/assets/js/lib/localStorageKeys.js
+++ b/assets/js/lib/localStorageKeys.js
@@ -1,6 +1,7 @@
 export const LOCAL_STORAGE_KEYS = Object.freeze({
   sidebarCollapsed: 'slipway:sidebar-collapsed',
   commandHistory: 'slipway:command-history',
+  helmScratchpads: 'slipway:helm-scratchpads',
   updateDismissed: 'slipway:update-dismissed'
 })
 

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -927,7 +927,7 @@ onBeforeUnmount(() => {
                     class="border-b border-gray-100 pb-1 dark:border-gray-800"
                   >
                     <Link
-                      :href="`/projects/${project.slug}/environments/${environment.slug}/helm`"
+                      :href="`/projects/${project.slug}/environments/${environment.slug}/helm?appSlug=${app.slug}`"
                       class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
                     >
                       <svg

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Link, Head, usePage } from '@inertiajs/vue3'
+import { Link, Head, router, usePage } from '@inertiajs/vue3'
 import {
   inject,
   ref,
@@ -12,12 +12,19 @@ import {
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
+import ConfirmModal from '@/components/ConfirmModal.vue'
 import HelmResultViewer from '@/components/HelmResultViewer.vue'
+import HelmScratchpadTabs from '@/components/HelmScratchpadTabs.vue'
 import HelmWorkspaceLibrary from '@/components/HelmWorkspaceLibrary.vue'
 import HelmWriteGuardDialog from '@/components/HelmWriteGuardDialog.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import { useHelmScratchpads } from '@/composables/useHelmScratchpads'
 import { helmEditorDiagnostic } from '@/lib/helmResult'
 import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
+import {
+  helmScratchpadIsModified,
+  helmScratchpadTargetTitle
+} from '@/lib/helmScratchpads.mjs'
 
 defineOptions({
   layout: AppLayout
@@ -40,9 +47,18 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 
-const code = ref('// Access your Sails models, helpers, and config\n')
-const executionResult = ref(null)
-const requestError = ref('')
+const scratchpads = useHelmScratchpads(() => props.target)
+const {
+  tabs: scratchpadTabs,
+  activeId: activeScratchpadId,
+  activeTab: activeScratchpad,
+  currentTargetKey,
+  code,
+  view: resultView,
+  result: executionResult,
+  error: requestError,
+  canCreate: canCreateScratchpad
+} = scratchpads
 const running = ref(false)
 const stopping = ref(false)
 const editor = ref(null)
@@ -61,6 +77,8 @@ const writeArm = ref(null)
 const writeArmRemaining = ref(0)
 const armingWrites = ref(false)
 const inspectingSource = ref(false)
+const targetSwitch = ref({ show: false, tab: null })
+const closeScratchpadGuard = ref({ show: false, tab: null })
 const editorSelection = ref({
   hasSelection: false,
   hasExecutableSelection: false,
@@ -93,6 +111,20 @@ const helmLibraryUrl = computed(
   () =>
     `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/helm`
 )
+const targetSwitchMessage = computed(() => {
+  const target = targetSwitch.value.tab?.target
+  return target
+    ? `This scratchpad runs against ${helmScratchpadTargetTitle(
+        target
+      )}. Confirm the production target before continuing.`
+    : ''
+})
+const closeScratchpadMessage = computed(() => {
+  const tab = closeScratchpadGuard.value.tab
+  return tab
+    ? `“${tab.name}” has changes that have not been executed or saved as a snippet.`
+    : ''
+})
 
 async function execute(sourceOverride) {
   let execution
@@ -220,6 +252,9 @@ async function execute(sourceOverride) {
     editor.value.showInspections(result.inspections)
     const diagnostic = helmEditorDiagnostic(result.error)
     if (diagnostic) editor.value.showDiagnostic(diagnostic)
+    if (!execution.hasSelection) {
+      scratchpads.markCurrentSourceSaved(code.value)
+    }
 
     await revealHistory()
   } catch (err) {
@@ -419,10 +454,77 @@ async function loadSource(source) {
 }
 
 function clearExecutionOutput() {
-  executionResult.value = null
-  requestError.value = ''
+  scratchpads.clearRuntime()
   editor.value?.clearDiagnostics()
   editor.value?.clearInspections()
+}
+
+async function activateScratchpad(tab) {
+  if (!tab || running.value || inspectingSource.value) return
+  if (tab.target.key === currentTargetKey.value) {
+    scratchpads.activate(tab.id)
+    clearWriteArm()
+    await nextTick()
+    editor.value?.clearDiagnostics()
+    editor.value?.clearInspections()
+    editor.value?.focus()
+    return
+  }
+
+  if (tab.target.environment.isProduction) {
+    targetSwitch.value = { show: true, tab }
+    return
+  }
+  openScratchpadTarget(tab)
+}
+
+function openScratchpadTarget(tab = targetSwitch.value.tab) {
+  if (!tab) return
+  targetSwitch.value = { show: false, tab: null }
+  scratchpads.activate(tab.id)
+  router.visit(tab.target.href)
+}
+
+async function createScratchpad() {
+  if (running.value || inspectingSource.value) return
+  const tab = scratchpads.create()
+  if (!tab) return
+  clearWriteArm()
+  await nextTick()
+  editor.value?.focus()
+}
+
+async function duplicateScratchpad(tab) {
+  if (running.value || inspectingSource.value) return
+  const copy = scratchpads.duplicate(tab.id)
+  if (!copy) return
+  clearWriteArm()
+  await nextTick()
+  editor.value?.focus()
+}
+
+function requestCloseScratchpad(tab) {
+  if (!tab || running.value || inspectingSource.value) return
+  if (helmScratchpadIsModified(tab)) {
+    closeScratchpadGuard.value = { show: true, tab }
+    return
+  }
+  closeScratchpad(tab)
+}
+
+function closeScratchpad(tab = closeScratchpadGuard.value.tab) {
+  if (!tab) return
+  closeScratchpadGuard.value = { show: false, tab: null }
+  scratchpads.close(tab.id)
+  clearWriteArm()
+  nextTick(() => editor.value?.focus())
+}
+
+async function saveScratchpadAsSnippet() {
+  libraryTab.value = 'snippets'
+  libraryOpen.value = true
+  await nextTick()
+  library.value?.openSnippetDialog(code.value)
 }
 
 async function loadCompletionMetadata() {
@@ -782,8 +884,30 @@ watch(code, () => {
       </div>
     </div>
 
+    <HelmScratchpadTabs
+      :tabs="scratchpadTabs"
+      :active-id="activeScratchpadId"
+      :current-target-key="currentTargetKey"
+      :disabled="running || inspectingSource"
+      :can-create="canCreateScratchpad"
+      @activate="activateScratchpad"
+      @create="createScratchpad"
+      @rename="scratchpads.rename"
+      @duplicate="duplicateScratchpad"
+      @move="(tab, offset) => scratchpads.move(tab.id, offset)"
+      @save="saveScratchpadAsSnippet"
+      @close="requestCloseScratchpad"
+    />
+
     <!-- Main content - Tinkerwell style -->
     <div
+      id="helm-scratchpad-panel"
+      role="tabpanel"
+      :aria-labelledby="
+        activeScratchpad
+          ? `helm-scratchpad-${activeScratchpad.id}-tab`
+          : undefined
+      "
       data-test="helm-workspace"
       class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden lg:flex-row"
     >
@@ -820,6 +944,7 @@ watch(code, () => {
         class="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-white dark:bg-gray-950"
       >
         <HelmResultViewer
+          v-model:view="resultView"
           :result="executionResult"
           :error="requestError"
           :loading="running"
@@ -840,6 +965,7 @@ watch(code, () => {
           @load="loadSource"
           @insert="loadSource"
           @rerun="execute"
+          @snippet-saved="scratchpads.markCurrentSourceSaved"
         />
       </div>
     </div>
@@ -853,6 +979,25 @@ watch(code, () => {
       :error="writeGuard.error"
       @arm="armWrites"
       @cancel="cancelWriteGuard"
+    />
+
+    <ConfirmModal
+      :show="targetSwitch.show"
+      title="Open production scratchpad?"
+      :message="targetSwitchMessage"
+      confirm-label="Open production"
+      @cancel="targetSwitch = { show: false, tab: null }"
+      @confirm="openScratchpadTarget"
+    />
+
+    <ConfirmModal
+      :show="closeScratchpadGuard.show"
+      title="Close modified scratchpad?"
+      :message="closeScratchpadMessage"
+      confirm-label="Close scratchpad"
+      destructive
+      @cancel="closeScratchpadGuard = { show: false, tab: null }"
+      @confirm="closeScratchpad"
     />
 
     <!-- Not running warning -->

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -197,6 +197,208 @@ async function selectFromSecondLine(page, { toDocumentEnd = true } = {}) {
 }
 
 test(
+  'project Helm keeps named scratchpads durable without storing returned values',
+  {
+    browser: true,
+    world: helmWorld('helm-named-scratchpads')
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const projectSlug = current.projects.deploymentTarget.slug
+    const environmentSlug = current.environments.production.slug
+    const endpoint = `/api/v1/projects/${projectSlug}/environments/${environmentSlug}/execute`
+    const returnedValue = 'server-only-result'
+
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'sounding-helm-scratchpads-app'
+    })
+    const updateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheckFinished
+    await page.raw.route(`**${endpoint}`, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          success: true,
+          value: [{ id: 1, name: returnedValue }],
+          logs: [`loaded ${returnedValue}`],
+          output: JSON.stringify([{ id: 1, name: returnedValue }], null, 2),
+          error: null,
+          durationMs: 5,
+          truncated: false
+        })
+      })
+    })
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${projectSlug}/environments/${environmentSlug}/helm`
+    )
+
+    const tabs = page.raw.locator('[data-test="helm-scratchpads"] [role="tab"]')
+    expect(await tabs.count()).toBe(1)
+    expect((await tabs.first().textContent()).includes('Production')).toBe(
+      false
+    )
+
+    await page.fill('@helm-editor', 'await Creator.find()')
+    expect((await tabs.first().textContent()).includes('Modified')).toBe(true)
+
+    await page.click('@helm-scratchpad-create')
+    expect(await tabs.count()).toBe(2)
+    await page.fill('@helm-editor', 'await Creator.find().limit(1)')
+
+    await page.click('@helm-scratchpad-actions-trigger')
+    await page.click('@helm-scratchpad-actions-rename')
+    await page.fill('@helm-scratchpad-rename', 'Creator audit')
+    await page.key('Enter')
+    expect((await tabs.nth(1).textContent()).includes('Creator audit')).toBe(
+      true
+    )
+
+    await page.click('@helm-run')
+    await page.wait('@helm-result-table')
+    await page.click('@helm-view-raw')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-view-raw"]')
+        .getAttribute('aria-pressed')
+    ).toBe('true')
+
+    await tabs.first().click()
+    expect(
+      (
+        await page.raw.locator('[data-test="helm-editor"]').textContent()
+      ).includes('await Creator.find()')
+    ).toBe(true)
+    expect(page).toSee('Run JavaScript to see results')
+
+    await tabs.first().focus()
+    await page.key('ArrowRight')
+    expect(await tabs.nth(1).getAttribute('aria-selected')).toBe('true')
+    expect(
+      (
+        await page.raw.locator('[data-test="helm-output"]').textContent()
+      ).includes(returnedValue)
+    ).toBe(true)
+
+    await page.click('@helm-scratchpad-actions-trigger')
+    await page.click('@helm-scratchpad-actions-save')
+    await page.wait('@helm-snippet-dialog')
+    expect(
+      (
+        await page.raw
+          .locator('[data-test="helm-snippet-source"]')
+          .textContent()
+      ).includes('await Creator.find().limit(1)')
+    ).toBe(true)
+    await page.raw
+      .locator('[data-test="helm-snippet-dialog"]')
+      .getByRole('button', { name: 'Cancel', exact: true })
+      .click()
+
+    await page.click('@helm-scratchpad-actions-trigger')
+    await page.click('@helm-scratchpad-actions-duplicate')
+    expect(await tabs.count()).toBe(3)
+    await page.click('@helm-scratchpad-actions-trigger')
+    await page.click('@helm-scratchpad-actions-move-left')
+    expect(
+      (await tabs.nth(1).textContent()).includes('Copy of Creator audit')
+    ).toBe(true)
+
+    await page.click('@helm-scratchpad-actions-trigger')
+    await page.click('@helm-scratchpad-actions-close')
+    await page.wait('@confirm-modal')
+    await page.raw
+      .locator('[data-test="confirm-modal"]')
+      .getByRole('button', { name: 'Close scratchpad', exact: true })
+      .click()
+    expect(await tabs.count()).toBe(2)
+
+    const storedBeforeReload = await page.raw.evaluate(() =>
+      window.localStorage.getItem('slipway:helm-scratchpads')
+    )
+    expect(storedBeforeReload.includes(returnedValue)).toBe(false)
+
+    await page.reload()
+    expect(await tabs.count()).toBe(2)
+    expect(page).toSee('Run JavaScript to see results')
+    expect(
+      (
+        await page.raw.locator('[data-test="helm-editor"]').textContent()
+      ).includes('await Creator.find().limit(1)')
+    ).toBe(true)
+
+    await page.click('@helm-run')
+    await page.wait('@helm-result-raw')
+    expect(
+      await page.raw
+        .locator('[data-test="helm-view-raw"]')
+        .getAttribute('aria-pressed')
+    ).toBe('true')
+    await page.screenshot('.tmp/issue-276-helm-scratchpads-light.png')
+
+    await page.raw.evaluate(() => {
+      const key = 'slipway:helm-scratchpads'
+      const state = JSON.parse(window.localStorage.getItem(key))
+      const sourceTab = state.tabs[0]
+      state.tabs.push({
+        ...sourceTab,
+        id: 'remote-production-tab',
+        name: 'Billing repair',
+        source: 'await Invoice.find()',
+        baselineSource: 'await Invoice.find()',
+        target: {
+          key: 'billing-project:billing-production:billing-app',
+          project: {
+            id: 'billing-project',
+            name: 'Billing',
+            slug: 'billing'
+          },
+          environment: {
+            id: 'billing-production',
+            name: 'Production',
+            slug: 'production',
+            isProduction: true
+          },
+          app: {
+            id: 'billing-app',
+            name: 'billing.app',
+            slug: 'billing-app'
+          },
+          href: '/projects/billing/environments/production/helm?appSlug=billing-app'
+        }
+      })
+      state.activeByTarget['billing-project:billing-production:billing-app'] =
+        'remote-production-tab'
+      window.localStorage.setItem(key, JSON.stringify(state))
+    })
+    await page.inDarkMode()
+    await page.reload()
+    const foreignTab = page.raw.getByRole('tab', { name: /Billing repair/ })
+    expect((await foreignTab.textContent()).includes('Production')).toBe(true)
+    await foreignTab.click()
+    await page.raw
+      .locator('[data-test="confirm-modal"]')
+      .waitFor({ state: 'visible' })
+    expect(page).toSee('Open production scratchpad?')
+    expect(page).toSee('Billing / Production / billing.app')
+    await page.raw.waitForTimeout(250)
+    await page.screenshot(
+      '.tmp/issue-276-helm-production-switch-warning-dark.png'
+    )
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
   'Helm keeps its editor visible while oversized output scrolls on desktop',
   { browser: true, world: helmWorld('helm-layout-desktop') },
   async ({ sails, world, login, page, expect }) => {

--- a/tests/functional/api/helm.test.js
+++ b/tests/functional/api/helm.test.js
@@ -104,6 +104,40 @@ test(
 )
 
 test(
+  'project Helm opens the app named in its page URL',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'helm-explicit-app',
+          name: 'Helm Explicit App'
+        }
+      }
+    }
+  },
+  async ({ sails, world, visit, expect }) => {
+    const current = world.current
+    const worker = await sails.models.app
+      .create({
+        name: 'Worker',
+        slug: 'worker',
+        environment: current.environments.production.id,
+        isDefault: false
+      })
+      .fetch()
+    const path = `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/helm?appSlug=${worker.slug}`
+
+    const page = await visit.as('genesisUser')(path)
+
+    expect(page).toHaveStatus(200)
+    expect(page).toBeInertiaPage('projects/helm')
+    expect(page).toHaveInertiaProp('app.slug', 'worker')
+    expect(page).toHaveInertiaProp('target.app.slug', 'worker')
+  }
+)
+
+test(
   'project Helm exposes the same structured execution result',
   {
     world: {

--- a/tests/unit/assets/helm-scratchpads.test.js
+++ b/tests/unit/assets/helm-scratchpads.test.js
@@ -1,0 +1,136 @@
+const { test } = require('sounding')
+
+test('Helm scratchpads persist source, target, and view without result data', async ({
+  expect
+}) => {
+  const {
+    createHelmScratchpad,
+    parseHelmScratchpadState,
+    serializeHelmScratchpadState
+  } = await import('../../../assets/js/lib/helmScratchpads.mjs')
+  const target = targetFixture()
+  const tab = {
+    ...createHelmScratchpad({
+      id: 'tab-1',
+      name: 'Find creators',
+      source: 'await Creator.find()',
+      baselineSource: '',
+      view: 'table',
+      target,
+      now: 100
+    }),
+    updatedAt: 200,
+    result: { rows: [{ email: 'private@example.com' }] },
+    logs: ['private log'],
+    error: 'private error'
+  }
+
+  const serialized = serializeHelmScratchpadState({
+    tabs: [tab],
+    activeByTarget: { [tab.target.key]: tab.id }
+  })
+  const restored = parseHelmScratchpadState(serialized)
+
+  expect(serialized.includes('private@example.com')).toBe(false)
+  expect(serialized.includes('private log')).toBe(false)
+  expect(serialized.includes('private error')).toBe(false)
+  expect(restored.tabs[0]).toEqual({
+    id: 'tab-1',
+    name: 'Find creators',
+    source: 'await Creator.find()',
+    baselineSource: '',
+    view: 'table',
+    target: tab.target,
+    createdAt: 100,
+    updatedAt: 200
+  })
+  expect(restored.activeByTarget[tab.target.key]).toBe('tab-1')
+})
+
+test('Helm scratchpads accept numeric or UUID identities and reject unsafe stored state', async ({
+  expect
+}) => {
+  const { createHelmScratchpad, parseHelmScratchpadState, snapshotHelmTarget } =
+    await import('../../../assets/js/lib/helmScratchpads.mjs')
+  const target = snapshotHelmTarget({
+    project: {
+      id: 'ca5b09ad-4778-4e07-a576-93d7c93defad',
+      name: 'Hagfish',
+      slug: 'hagfish'
+    },
+    environment: {
+      id: 42,
+      name: 'Production',
+      slug: 'production',
+      isProduction: true
+    },
+    app: {
+      id: 'web-app',
+      name: 'hagfish.app',
+      slug: 'hagfish-app'
+    }
+  })
+
+  expect(target.key).toBe('ca5b09ad-4778-4e07-a576-93d7c93defad:42:web-app')
+  expect(target.href).toBe(
+    '/projects/hagfish/environments/production/helm?appSlug=hagfish-app'
+  )
+  expect(target.environment.isProduction).toBe(true)
+  expect(Boolean(createHelmScratchpad({ target }))).toBe(true)
+  expect(parseHelmScratchpadState('{broken')).toEqual({
+    tabs: [],
+    activeByTarget: {}
+  })
+  expect(
+    parseHelmScratchpadState({
+      version: 1,
+      tabs: [{ id: 'unsafe', source: '1 + 1', target: null }],
+      activeByTarget: { unsafe: 'unsafe' }
+    })
+  ).toEqual({ tabs: [], activeByTarget: {} })
+})
+
+test('Helm scratchpad names remain distinct and modified state is derived', async ({
+  expect
+}) => {
+  const {
+    createHelmScratchpad,
+    duplicateHelmScratchpadName,
+    helmScratchpadIsModified,
+    nextHelmScratchpadName
+  } = await import('../../../assets/js/lib/helmScratchpads.mjs')
+  const first = createHelmScratchpad({
+    id: 'first',
+    name: 'Scratchpad 1',
+    source: '1 + 1',
+    target: targetFixture()
+  })
+  const copy = createHelmScratchpad({
+    id: 'copy',
+    name: 'Copy of Scratchpad 1',
+    source: '1 + 1',
+    target: targetFixture()
+  })
+
+  expect(nextHelmScratchpadName([first, copy], first.target.key)).toBe(
+    'Scratchpad 2'
+  )
+  expect(duplicateHelmScratchpadName([first, copy], first)).toBe(
+    'Copy of Scratchpad 1 2'
+  )
+  expect(helmScratchpadIsModified(first)).toBe(false)
+  expect(helmScratchpadIsModified({ ...first, source: '2 + 2' })).toBe(true)
+})
+
+function targetFixture() {
+  return {
+    project: { id: 1, name: 'Hagfish', slug: 'hagfish' },
+    environment: {
+      id: 2,
+      name: 'Production',
+      slug: 'production',
+      isProduction: true
+    },
+    app: { id: 3, name: 'hagfish.app', slug: 'hagfish-app' }
+  }
+}


### PR DESCRIPTION
## Summary

- add named Helm scratchpads with create, rename, duplicate, reorder, close, and keyboard navigation
- retain source and result-view preference per target without persisting returned production values
- bind scratchpads to the exact project, environment, and app, including confirmation before production switches
- reuse Helm snippets and keep the tab, result, console, and history controls minimal in light and dark mode

## Impact

Operators can keep independent investigations open without replacing editor contents or risking execution against a visually mismatched app target.

## Validation

- `npm run test:unit` — 229 passed
- `node --test --test-concurrency=1 tests/e2e/pages/projects/helm.test.js` — 15 passed
- `node --test --test-concurrency=1 tests/functional/api/helm.test.js` — 10 passed
- `npm run lint`
- `git diff --check`

Closes #276
