### PR TITLE
fix(deploy): accept nullable git metadata

### DIFF
--- a/api/helpers/deploy/ensure-build-context.js
+++ b/api/helpers/deploy/ensure-build-context.js
@@ -24,10 +24,12 @@ module.exports = {
       type: 'string'
     },
     gitBranch: {
-      type: 'string'
+      type: 'string',
+      allowNull: true
     },
     gitCommit: {
       type: 'string',
+      allowNull: true,
       description: 'Exact repository commit to build when one was recorded.'
     },
     refreshRepository: {

--- a/tests/unit/helpers/deploy/ensure-build-context.test.js
+++ b/tests/unit/helpers/deploy/ensure-build-context.test.js
@@ -6,6 +6,41 @@ const { test } = require('sounding')
 
 const ensureBuildContext = require('../../../../api/helpers/deploy/ensure-build-context')
 
+test('pushed source accepts deployment records without git metadata', async ({
+  sails,
+  expect
+}) => {
+  const tempRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'slipway-ensure-build-context-')
+  )
+  const project = { slug: 'cli-pushed-source' }
+  const contextPath = path.join(tempRoot, project.slug)
+  const originalAppsDir = sails.config.custom.slipwayAppsDir
+  sails.config.custom.slipwayAppsDir = tempRoot
+  fs.mkdirSync(contextPath)
+  fs.writeFileSync(path.join(contextPath, 'Dockerfile'), 'FROM node:22\n')
+
+  try {
+    const result = await sails.helpers.deploy.ensureBuildContext.with({
+      project,
+      environment: { id: 303, slug: 'production' },
+      deploymentId: '303',
+      gitBranch: null,
+      gitCommit: null,
+      refreshRepository: true
+    })
+
+    expect(result).toEqual({
+      contextPath,
+      hydrated: false,
+      sourceMode: 'pushed'
+    })
+  } finally {
+    sails.config.custom.slipwayAppsDir = originalAppsDir
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
 test('missing build context is hydrated from a connected repository', async ({
   expect
 }) => {


### PR DESCRIPTION
## Summary

- accept the nullable branch and commit metadata stored by pushed-source deployments
- let CLI deployments reach their uploaded build context instead of failing at Sails helper input validation
- preserve existing branch and exact-commit behavior for repository deployments
- cover the production failure through the public Sounding/Sails helper surface

## Root cause

`slipway slide` correctly creates deployments without repository metadata.
`executePipeline` passes those persisted `null` values to
`deploy.ensureBuildContext`, but its optional string inputs rejected explicit
nulls before the helper could use the already-uploaded source.

## Verification

- focused build-context trials: 4 passed
- `npm run test:unit` — 231 passed
- `npm run test:functional` — 67 passed
- `npm run lint`
- `npm run check:consistency`

Fixes #303
