### PR TITLE
feat(auth): add Precognition form validation

### DIFF
--- a/api/controllers/auth/forgot-password.js
+++ b/api/controllers/auth/forgot-password.js
@@ -20,10 +20,17 @@ module.exports = {
       description:
         'The email address might have matched a user in the database.  (If so, a recovery email was sent.)',
       responseType: 'redirect'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
   fn: async function ({ email }) {
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     const normalizedEmail = email.toLowerCase()
     const token = await sails.helpers.strings.random('url-friendly')
     const now = Date.now()

--- a/api/controllers/auth/login.js
+++ b/api/controllers/auth/login.js
@@ -54,10 +54,17 @@ and exposed as a shared data via loggedInUser prop.)`,
     },
     badCombo: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
   fn: async function ({ email, password, rememberMe, redirect, returnUrl }) {
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     const user = await User.findOne({
       email: email.toLowerCase()
     })

--- a/api/controllers/auth/reset-password.js
+++ b/api/controllers/auth/reset-password.js
@@ -1,3 +1,6 @@
+const hasSpecialCharacter = (value) =>
+  /[`!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/.test(value)
+
 module.exports = {
   friendlyName: 'Reset password',
 
@@ -12,6 +15,10 @@ module.exports = {
       type: 'string',
       required: true,
       minLength: 8
+    },
+    confirmPassword: {
+      type: 'string',
+      required: true
     }
   },
 
@@ -30,10 +37,45 @@ module.exports = {
       extendedDescription:
         'If this request was sent from a graphical user interface, the request ' +
         'parameters should have been validated/coerced _before_ they were sent.'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
-  fn: async function ({ token, password }) {
+  fn: async function ({ token, password, confirmPassword }) {
+    if (
+      sails.inertia.shouldValidate('password', this.req) &&
+      !hasSpecialCharacter(password)
+    ) {
+      throw {
+        badSignupRequest: {
+          problems: [
+            {
+              password: 'Password must include at least one special character.'
+            }
+          ]
+        }
+      }
+    }
+
+    if (
+      sails.inertia.shouldValidate('confirmPassword', this.req) &&
+      password !== confirmPassword
+    ) {
+      throw {
+        badSignupRequest: {
+          problems: [
+            { confirmPassword: 'Password confirmation does not match.' }
+          ]
+        }
+      }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     if (!token) {
       throw 'invalidOrExpiredToken'
     }

--- a/api/controllers/setup/complete-setup.js
+++ b/api/controllers/setup/complete-setup.js
@@ -1,3 +1,6 @@
+const hasSpecialCharacter = (value) =>
+  /[`!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/.test(value)
+
 module.exports = {
   friendlyName: 'Complete setup',
 
@@ -16,6 +19,11 @@ module.exports = {
       required: true,
       minLength: 8,
       description: 'Password for the genesis user'
+    },
+    confirmPassword: {
+      type: 'string',
+      required: true,
+      description: 'Password confirmation for the genesis user'
     }
   },
 
@@ -26,10 +34,45 @@ module.exports = {
     },
     success: {
       responseType: 'redirect'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
-  fn: async function ({ email: userEmail, password }) {
+  fn: async function ({ email: userEmail, password, confirmPassword }) {
+    if (
+      sails.inertia.shouldValidate('password', this.req) &&
+      !hasSpecialCharacter(password)
+    ) {
+      throw {
+        badRequest: {
+          problems: [
+            {
+              password: 'Password must include at least one special character.'
+            }
+          ]
+        }
+      }
+    }
+
+    if (
+      sails.inertia.shouldValidate('confirmPassword', this.req) &&
+      password !== confirmPassword
+    ) {
+      throw {
+        badRequest: {
+          problems: [
+            { confirmPassword: 'Password confirmation does not match.' }
+          ]
+        }
+      }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     const email = userEmail.toLowerCase()
 
     // Derive display name from email (part before @)

--- a/api/controllers/user/update-profile.js
+++ b/api/controllers/user/update-profile.js
@@ -1,3 +1,6 @@
+const hasSpecialCharacter = (value) =>
+  /[`!@#$%^&*()_+\-=[\]{};':"\\|,.<>/?~]/.test(value)
+
 module.exports = {
   friendlyName: 'Update profile',
 
@@ -23,6 +26,7 @@ module.exports = {
     password: {
       type: 'string',
       allowNull: true,
+      minLength: 8,
       description: 'The new password of the user.'
     },
     confirmPassword: {
@@ -44,6 +48,9 @@ module.exports = {
     unauthorized: {
       responseType: 'inertiaRedirect',
       description: 'The provided current password is incorrect.'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -54,6 +61,52 @@ module.exports = {
     password,
     confirmPassword
   }) {
+    if (
+      password &&
+      sails.inertia.shouldValidate('password', this.req) &&
+      !hasSpecialCharacter(password)
+    ) {
+      throw {
+        invalid: {
+          problems: [
+            {
+              password: 'Password must include at least one special character.'
+            }
+          ]
+        }
+      }
+    }
+
+    if (
+      password &&
+      sails.inertia.shouldValidate('currentPassword', this.req) &&
+      !currentPassword
+    ) {
+      throw {
+        invalid: {
+          problems: [{ currentPassword: 'Current password is required.' }]
+        }
+      }
+    }
+
+    if (
+      password &&
+      sails.inertia.shouldValidate('confirmPassword', this.req) &&
+      password !== confirmPassword
+    ) {
+      throw {
+        invalid: {
+          problems: [
+            { confirmPassword: 'Password confirmation does not match.' }
+          ]
+        }
+      }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     const userId = this.req.session.userId
     const user = await User.findOne({ id: userId }).select([
       'password',
@@ -92,13 +145,6 @@ module.exports = {
     }
 
     if (password) {
-      if (password !== confirmPassword) {
-        throw {
-          invalid: {
-            problems: [{ password: 'Password confirmation does not match.' }]
-          }
-        }
-      }
       updatedData.password = password
     }
 

--- a/api/policies/rate-limit-auth.js
+++ b/api/policies/rate-limit-auth.js
@@ -36,6 +36,12 @@ function rateLimitHandler(req, res) {
 }
 
 module.exports = function (req, res, next) {
+  // Validation-only requests never attempt authentication, send mail, or
+  // consume reset tokens, so they should not spend a real auth attempt.
+  if (sails.inertia.isPrecognitive(req)) {
+    return next()
+  }
+
   if (sails.config.environment === 'test') {
     return next()
   }

--- a/api/responses/precognitionSuccess.js
+++ b/api/responses/precognitionSuccess.js
@@ -1,0 +1,3 @@
+module.exports = function precognitionSuccess() {
+  return this.req._sails.inertia.handlePrecognitionSuccess(this.req, this.res)
+}

--- a/assets/js/composables/precognition.js
+++ b/assets/js/composables/precognition.js
@@ -1,5 +1,9 @@
 export function usePrecognitionValidation(form) {
-  function validateOnBlur(field) {
+  function validateOnBlur(field, event) {
+    if (event?.relatedTarget?.closest?.('button[type="submit"], a[href]')) {
+      return
+    }
+
     if (String(form[field] ?? '').trim()) {
       form.validate(field)
     }

--- a/assets/js/composables/precognition.js
+++ b/assets/js/composables/precognition.js
@@ -1,0 +1,18 @@
+export function usePrecognitionValidation(form) {
+  function validateOnBlur(field) {
+    if (String(form[field] ?? '').trim()) {
+      form.validate(field)
+    }
+  }
+
+  function revalidateWhenInvalid(field) {
+    if (form.invalid(field)) {
+      form.validate(field)
+    }
+  }
+
+  return {
+    revalidateWhenInvalid,
+    validateOnBlur
+  }
+}

--- a/assets/js/pages/auth/forgot-password.vue
+++ b/assets/js/pages/auth/forgot-password.vue
@@ -1,17 +1,17 @@
 <script setup>
 import { Link, Head, useForm } from '@inertiajs/vue3'
-import { computed } from 'vue'
 import SlipwayLogo from '@/components/SlipwayLogo.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 const form = useForm({
   email: ''
 })
+  .withPrecognition('post', '/forgot-password')
+  .setValidationTimeout(350)
 
-const isFormValid = computed(() => {
-  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/
-  return emailRegex.test(form.email) && !form.processing
-})
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 </script>
 
 <template>
@@ -37,14 +37,6 @@ const isFormValid = computed(() => {
         <p class="text-sm text-gray-500">Reset your password</p>
       </div>
 
-      <!-- Error message -->
-      <div
-        v-if="form.errors.email"
-        class="mb-6 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400"
-      >
-        {{ form.errors.email }}
-      </div>
-
       <form @submit.prevent="form.post('/forgot-password')" class="space-y-4">
         <div>
           <input
@@ -53,16 +45,35 @@ const isFormValid = computed(() => {
             type="email"
             placeholder="Enter your email address..."
             autocomplete="email"
+            :aria-invalid="form.invalid('email') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('email')
+                ? 'forgot-password-email-error'
+                : 'forgot-password-email-description'
+            "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('email')"
+            @input="revalidateWhenInvalid('email')"
           />
-          <p class="mt-2 text-xs text-gray-500">
+          <p
+            v-if="form.errors.email"
+            id="forgot-password-email-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.email }}
+          </p>
+          <p
+            v-else
+            id="forgot-password-email-description"
+            class="mt-2 text-xs text-gray-500"
+          >
             We'll send reset instructions to this email
           </p>
         </div>
 
         <button
           type="submit"
-          :disabled="!isFormValid"
+          :disabled="!form.email || form.processing || form.hasErrors"
           class="flex h-12 w-full items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-900 font-medium text-white transition-colors hover:bg-gray-800 disabled:bg-gray-100 disabled:text-gray-400 dark:border-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-100 dark:disabled:bg-gray-900 dark:disabled:text-gray-600"
         >
           <SlippyLoader v-if="form.processing" size="h-4 w-4" />

--- a/assets/js/pages/auth/forgot-password.vue
+++ b/assets/js/pages/auth/forgot-password.vue
@@ -52,7 +52,7 @@ const { revalidateWhenInvalid, validateOnBlur } =
                 : 'forgot-password-email-description'
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('email')"
+            @blur="validateOnBlur('email', $event)"
             @input="revalidateWhenInvalid('email')"
           />
           <p

--- a/assets/js/pages/auth/login.vue
+++ b/assets/js/pages/auth/login.vue
@@ -3,6 +3,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { computed } from 'vue'
 import SlipwayLogo from '@/components/SlipwayLogo.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 const props = defineProps({
   redirect: String,
@@ -15,6 +16,11 @@ const form = useForm({
   rememberMe: false,
   redirect: props.redirect || null
 })
+  .withPrecognition('post', '/login')
+  .setValidationTimeout(350)
+
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const isFormValid = computed(() => {
   return form.email && form.password
@@ -45,34 +51,64 @@ const isFormValid = computed(() => {
 
       <!-- Error message -->
       <div
-        v-if="form.errors.login || form.errors.email || props.error"
+        v-if="form.errors.login || props.error"
         class="mb-6 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400"
       >
-        {{ form.errors.login || form.errors.email || props.error }}
+        {{ form.errors.login || props.error }}
       </div>
 
       <form @submit.prevent="form.post('/login')" class="space-y-4">
-        <input
-          id="email"
-          v-model="form.email"
-          type="email"
-          placeholder="Enter your email address..."
-          autocomplete="email"
-          class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-        />
+        <div>
+          <input
+            id="email"
+            v-model="form.email"
+            type="email"
+            placeholder="Enter your email address..."
+            autocomplete="email"
+            :aria-invalid="form.invalid('email') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('email') ? 'login-email-error' : undefined
+            "
+            class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('email')"
+            @input="revalidateWhenInvalid('email')"
+          />
+          <p
+            v-if="form.errors.email"
+            id="login-email-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.email }}
+          </p>
+        </div>
 
-        <input
-          id="password"
-          v-model="form.password"
-          type="password"
-          placeholder="Enter password"
-          autocomplete="current-password"
-          class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-        />
+        <div>
+          <input
+            id="password"
+            v-model="form.password"
+            type="password"
+            placeholder="Enter password"
+            autocomplete="current-password"
+            :aria-invalid="form.invalid('password') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('password') ? 'login-password-error' : undefined
+            "
+            class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('password')"
+            @input="revalidateWhenInvalid('password')"
+          />
+          <p
+            v-if="form.errors.password"
+            id="login-password-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.password }}
+          </p>
+        </div>
 
         <button
           type="submit"
-          :disabled="!isFormValid || form.processing"
+          :disabled="!isFormValid || form.processing || form.hasErrors"
           class="flex h-12 w-full items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-900 font-medium text-white transition-colors hover:bg-gray-800 disabled:bg-gray-100 disabled:text-gray-400 dark:border-gray-800 dark:bg-white dark:text-black dark:hover:bg-gray-100 dark:disabled:bg-gray-900 dark:disabled:text-gray-600"
         >
           <SlippyLoader v-if="form.processing" size="h-4 w-4" />

--- a/assets/js/pages/auth/login.vue
+++ b/assets/js/pages/auth/login.vue
@@ -70,7 +70,7 @@ const isFormValid = computed(() => {
               form.invalid('email') ? 'login-email-error' : undefined
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('email')"
+            @blur="validateOnBlur('email', $event)"
             @input="revalidateWhenInvalid('email')"
           />
           <p
@@ -94,7 +94,7 @@ const isFormValid = computed(() => {
               form.invalid('password') ? 'login-password-error' : undefined
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('password')"
+            @blur="validateOnBlur('password', $event)"
             @input="revalidateWhenInvalid('password')"
           />
           <p

--- a/assets/js/pages/auth/reset-password.vue
+++ b/assets/js/pages/auth/reset-password.vue
@@ -90,7 +90,7 @@ const isFormValid = computed(() => {
                 : 'reset-password-requirements'
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('password')"
+            @blur="validateOnBlur('password', $event)"
             @input="revalidateWhenInvalid('password')"
           />
           <p
@@ -116,7 +116,7 @@ const isFormValid = computed(() => {
                 : undefined
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('confirmPassword')"
+            @blur="validateOnBlur('confirmPassword', $event)"
             @input="revalidateWhenInvalid('confirmPassword')"
           />
           <p

--- a/assets/js/pages/auth/reset-password.vue
+++ b/assets/js/pages/auth/reset-password.vue
@@ -3,6 +3,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { computed } from 'vue'
 import SlipwayLogo from '@/components/SlipwayLogo.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 const { token } = defineProps({
   token: String
@@ -13,6 +14,11 @@ const form = useForm({
   password: '',
   confirmPassword: ''
 })
+  .withPrecognition('post', '/reset-password')
+  .setValidationTimeout(350)
+
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const containsSpecialChars = computed(() => {
   const specialChars = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]/
@@ -32,6 +38,7 @@ const isFormValid = computed(() => {
     passwordIsValid.value &&
     containsSpecialChars.value &&
     passwordsMatch.value &&
+    !form.hasErrors &&
     !form.processing
   )
 })
@@ -62,33 +69,67 @@ const isFormValid = computed(() => {
 
       <!-- Error message -->
       <div
-        v-if="form.errors.password || form.errors.token"
+        v-if="form.errors.token"
         class="mb-6 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400"
       >
-        {{ form.errors.password || form.errors.token }}
+        {{ form.errors.token }}
       </div>
 
       <form @submit.prevent="form.post('/reset-password')" class="space-y-4">
-        <input
-          id="password"
-          v-model="form.password"
-          type="password"
-          placeholder="Enter new password"
-          autocomplete="new-password"
-          class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-        />
+        <div>
+          <input
+            id="password"
+            v-model="form.password"
+            type="password"
+            placeholder="Enter new password"
+            autocomplete="new-password"
+            :aria-invalid="form.invalid('password') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('password')
+                ? 'reset-password-error'
+                : 'reset-password-requirements'
+            "
+            class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('password')"
+            @input="revalidateWhenInvalid('password')"
+          />
+          <p
+            v-if="form.errors.password"
+            id="reset-password-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.password }}
+          </p>
+        </div>
 
-        <input
-          id="confirmPassword"
-          v-model="form.confirmPassword"
-          type="password"
-          placeholder="Confirm new password"
-          autocomplete="new-password"
-          class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-        />
+        <div>
+          <input
+            id="confirmPassword"
+            v-model="form.confirmPassword"
+            type="password"
+            placeholder="Confirm new password"
+            autocomplete="new-password"
+            :aria-invalid="form.invalid('confirmPassword') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('confirmPassword')
+                ? 'reset-confirm-password-error'
+                : undefined
+            "
+            class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('confirmPassword')"
+            @input="revalidateWhenInvalid('confirmPassword')"
+          />
+          <p
+            v-if="form.errors.confirmPassword"
+            id="reset-confirm-password-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.confirmPassword }}
+          </p>
+        </div>
 
         <!-- Password Requirements -->
-        <p class="text-xs text-gray-400">
+        <p id="reset-password-requirements" class="text-xs text-gray-400">
           <span
             :class="passwordIsValid ? 'text-green-600 dark:text-green-500' : ''"
             >8+ chars</span

--- a/assets/js/pages/dashboard/profile.vue
+++ b/assets/js/pages/dashboard/profile.vue
@@ -4,6 +4,7 @@ import { inject, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import { useToast } from '@/composables/toast'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -23,6 +24,11 @@ const form = useForm({
   password: '',
   confirmPassword: ''
 })
+  .withPrecognition('patch', '/profile')
+  .setValidationTimeout(350)
+
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const deleteAccountForm = useForm({
   password: ''
@@ -210,28 +216,66 @@ function logout() {
                 >Full Name</label
               >
               <input
+                id="profile-full-name"
                 v-model="form.fullName"
                 type="text"
+                autocomplete="name"
+                :aria-invalid="form.invalid('fullName') ? 'true' : undefined"
+                :aria-describedby="
+                  form.invalid('fullName')
+                    ? 'profile-full-name-error'
+                    : undefined
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                @blur="validateOnBlur('fullName')"
+                @input="revalidateWhenInvalid('fullName')"
               />
+              <p
+                v-if="form.errors.fullName"
+                id="profile-full-name-error"
+                class="mt-1 text-xs text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.fullName }}
+              </p>
             </div>
             <div class="px-4 py-3">
               <label class="mb-1 block text-sm text-gray-700 dark:text-gray-300"
                 >Email</label
               >
               <input
+                id="profile-email"
                 v-model="form.email"
                 type="email"
+                autocomplete="email"
+                :aria-invalid="form.invalid('email') ? 'true' : undefined"
+                :aria-describedby="
+                  form.invalid('email')
+                    ? 'profile-email-error'
+                    : 'profile-email-description'
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                @blur="validateOnBlur('email')"
+                @input="revalidateWhenInvalid('email')"
               />
-              <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              <p
+                v-if="form.errors.email"
+                id="profile-email-error"
+                class="mt-1 text-xs text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.email }}
+              </p>
+              <p
+                v-else
+                id="profile-email-description"
+                class="mt-1 text-xs text-gray-400 dark:text-gray-500"
+              >
                 Changing your email requires verification
               </p>
             </div>
             <div class="flex items-center justify-end px-4 py-3">
               <button
                 type="submit"
-                :disabled="form.processing || !form.isDirty"
+                :disabled="form.processing || !form.isDirty || form.hasErrors"
                 class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ form.processing ? 'Saving...' : 'Save changes' }}
@@ -261,35 +305,84 @@ function logout() {
                 >Current Password</label
               >
               <input
+                id="profile-current-password"
                 v-model="form.currentPassword"
                 type="password"
                 autocomplete="current-password"
+                :aria-invalid="
+                  form.invalid('currentPassword') ? 'true' : undefined
+                "
+                :aria-describedby="
+                  form.invalid('currentPassword')
+                    ? 'profile-current-password-error'
+                    : undefined
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                @blur="validateOnBlur('currentPassword')"
+                @input="revalidateWhenInvalid('currentPassword')"
               />
+              <p
+                v-if="form.errors.currentPassword"
+                id="profile-current-password-error"
+                class="mt-1 text-xs text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.currentPassword }}
+              </p>
             </div>
             <div class="px-4 py-3">
               <label class="mb-1 block text-sm text-gray-700 dark:text-gray-300"
                 >New Password</label
               >
               <input
+                id="profile-new-password"
                 v-model="form.password"
                 type="password"
                 autocomplete="new-password"
+                :aria-invalid="form.invalid('password') ? 'true' : undefined"
+                :aria-describedby="
+                  form.invalid('password')
+                    ? 'profile-new-password-error'
+                    : undefined
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                @blur="validateOnBlur('password')"
+                @input="revalidateWhenInvalid('password')"
               />
+              <p
+                v-if="form.errors.password"
+                id="profile-new-password-error"
+                class="mt-1 text-xs text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.password }}
+              </p>
             </div>
             <div class="px-4 py-3">
               <label class="mb-1 block text-sm text-gray-700 dark:text-gray-300"
                 >Confirm Password</label
               >
               <input
+                id="profile-confirm-password"
                 v-model="form.confirmPassword"
                 type="password"
                 autocomplete="new-password"
+                :aria-invalid="
+                  form.invalid('confirmPassword') ? 'true' : undefined
+                "
+                :aria-describedby="
+                  form.invalid('confirmPassword')
+                    ? 'profile-confirm-password-error'
+                    : undefined
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                @blur="validateOnBlur('confirmPassword')"
+                @input="revalidateWhenInvalid('confirmPassword')"
               />
-              <p v-if="form.errors.password" class="mt-1 text-xs text-red-500">
-                {{ form.errors.password }}
+              <p
+                v-if="form.errors.confirmPassword"
+                id="profile-confirm-password-error"
+                class="mt-1 text-xs text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.confirmPassword }}
               </p>
             </div>
             <div class="flex items-center justify-end px-4 py-3">
@@ -299,7 +392,8 @@ function logout() {
                   form.processing ||
                   !form.isDirty ||
                   !form.currentPassword ||
-                  !form.password
+                  !form.password ||
+                  form.hasErrors
                 "
                 class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >

--- a/assets/js/pages/dashboard/profile.vue
+++ b/assets/js/pages/dashboard/profile.vue
@@ -227,7 +227,7 @@ function logout() {
                     : undefined
                 "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
-                @blur="validateOnBlur('fullName')"
+                @blur="validateOnBlur('fullName', $event)"
                 @input="revalidateWhenInvalid('fullName')"
               />
               <p
@@ -254,7 +254,7 @@ function logout() {
                     : 'profile-email-description'
                 "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
-                @blur="validateOnBlur('email')"
+                @blur="validateOnBlur('email', $event)"
                 @input="revalidateWhenInvalid('email')"
               />
               <p
@@ -318,7 +318,7 @@ function logout() {
                     : undefined
                 "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
-                @blur="validateOnBlur('currentPassword')"
+                @blur="validateOnBlur('currentPassword', $event)"
                 @input="revalidateWhenInvalid('currentPassword')"
               />
               <p
@@ -345,7 +345,7 @@ function logout() {
                     : undefined
                 "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
-                @blur="validateOnBlur('password')"
+                @blur="validateOnBlur('password', $event)"
                 @input="revalidateWhenInvalid('password')"
               />
               <p
@@ -374,7 +374,7 @@ function logout() {
                     : undefined
                 "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
-                @blur="validateOnBlur('confirmPassword')"
+                @blur="validateOnBlur('confirmPassword', $event)"
                 @input="revalidateWhenInvalid('confirmPassword')"
               />
               <p

--- a/assets/js/pages/setup/setup.vue
+++ b/assets/js/pages/setup/setup.vue
@@ -3,12 +3,18 @@ import { Head, useForm } from '@inertiajs/vue3'
 import { computed } from 'vue'
 import SlipwayLogo from '@/components/SlipwayLogo.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 const form = useForm({
   email: '',
   password: '',
   confirmPassword: ''
 })
+  .withPrecognition('post', '/setup')
+  .setValidationTimeout(350)
+
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const containsSpecialChars = computed(() => {
   const specialChars = /[`!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?~]/
@@ -23,17 +29,13 @@ const passwordsMatch = computed(() => {
   return form.password && form.password === form.confirmPassword
 })
 
-const emailIsValid = computed(() => {
-  const emailRegex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/
-  return emailRegex.test(form.email)
-})
-
 const isFormValid = computed(() => {
   return (
-    emailIsValid.value &&
+    form.email &&
     passwordIsValid.value &&
     containsSpecialChars.value &&
     passwordsMatch.value &&
+    !form.hasErrors &&
     !form.processing
   )
 })
@@ -66,39 +68,86 @@ const isFormValid = computed(() => {
 
       <!-- Error message -->
       <div
-        v-if="form.errors.email || form.errors.password || form.errors.setup"
+        v-if="form.errors.setup"
         class="mb-6 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400"
       >
-        {{ form.errors.email || form.errors.password || form.errors.setup }}
+        {{ form.errors.setup }}
       </div>
 
       <form @submit.prevent="form.post('/setup')" class="space-y-4">
-        <input
-          id="email"
-          v-model="form.email"
-          type="email"
-          placeholder="Enter your email address..."
-          autocomplete="email"
-          class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-        />
+        <div>
+          <input
+            id="email"
+            v-model="form.email"
+            type="email"
+            placeholder="Enter your email address..."
+            autocomplete="email"
+            :aria-invalid="form.invalid('email') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('email') ? 'setup-email-error' : undefined
+            "
+            class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('email')"
+            @input="revalidateWhenInvalid('email')"
+          />
+          <p
+            v-if="form.errors.email"
+            id="setup-email-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.email }}
+          </p>
+        </div>
 
-        <input
-          id="password"
-          v-model="form.password"
-          type="password"
-          placeholder="Create a password"
-          autocomplete="new-password"
-          class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-        />
+        <div>
+          <input
+            id="password"
+            v-model="form.password"
+            type="password"
+            placeholder="Create a password"
+            autocomplete="new-password"
+            :aria-invalid="form.invalid('password') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('password') ? 'setup-password-error' : undefined
+            "
+            class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('password')"
+            @input="revalidateWhenInvalid('password')"
+          />
+          <p
+            v-if="form.errors.password"
+            id="setup-password-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.password }}
+          </p>
+        </div>
 
-        <input
-          id="confirmPassword"
-          v-model="form.confirmPassword"
-          type="password"
-          placeholder="Confirm password"
-          autocomplete="new-password"
-          class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-        />
+        <div>
+          <input
+            id="confirmPassword"
+            v-model="form.confirmPassword"
+            type="password"
+            placeholder="Confirm password"
+            autocomplete="new-password"
+            :aria-invalid="form.invalid('confirmPassword') ? 'true' : undefined"
+            :aria-describedby="
+              form.invalid('confirmPassword')
+                ? 'setup-confirm-password-error'
+                : undefined
+            "
+            class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+            @blur="validateOnBlur('confirmPassword')"
+            @input="revalidateWhenInvalid('confirmPassword')"
+          />
+          <p
+            v-if="form.errors.confirmPassword"
+            id="setup-confirm-password-error"
+            class="mt-1.5 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ form.errors.confirmPassword }}
+          </p>
+        </div>
 
         <!-- Password Requirements -->
         <p class="text-xs text-gray-400">

--- a/assets/js/pages/setup/setup.vue
+++ b/assets/js/pages/setup/setup.vue
@@ -87,7 +87,7 @@ const isFormValid = computed(() => {
               form.invalid('email') ? 'setup-email-error' : undefined
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('email')"
+            @blur="validateOnBlur('email', $event)"
             @input="revalidateWhenInvalid('email')"
           />
           <p
@@ -111,7 +111,7 @@ const isFormValid = computed(() => {
               form.invalid('password') ? 'setup-password-error' : undefined
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('password')"
+            @blur="validateOnBlur('password', $event)"
             @input="revalidateWhenInvalid('password')"
           />
           <p
@@ -137,7 +137,7 @@ const isFormValid = computed(() => {
                 : undefined
             "
             class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
-            @blur="validateOnBlur('confirmPassword')"
+            @blur="validateOnBlur('confirmPassword', $event)"
             @input="revalidateWhenInvalid('confirmPassword')"
           />
           <p

--- a/tests/e2e/pages/auth/precognition-validation.test.js
+++ b/tests/e2e/pages/auth/precognition-validation.test.js
@@ -1,0 +1,65 @@
+const { test } = require('sounding')
+
+test(
+  'auth and account forms validate quietly against the server',
+  { browser: true, world: 'configured-slipway' },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const resetToken = 'browser-precognition-reset-token'
+
+    await page.resize(1440, 900)
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+    await page.goto('/login')
+    await showEmailValidation(page, '#email', '#login-email-error')
+    await page.screenshot('.tmp/issue-205-login-validation-light.png', {
+      fullPage: true
+    })
+
+    await page.goto('/forgot-password')
+    await showEmailValidation(page, '#email', '#forgot-password-email-error')
+    await page.screenshot(
+      '.tmp/issue-205-forgot-password-validation-light.png',
+      { fullPage: true }
+    )
+
+    await sails.models.user
+      .updateOne({ id: current.users.genesisUser.id })
+      .set({
+        passwordResetToken: resetToken,
+        passwordResetTokenExpiresAt: Date.now() + 60_000
+      })
+
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await page.goto(`/reset-password?token=${resetToken}`)
+    await page.fill('#password', 'short!')
+    await page.raw.locator('#password').blur()
+    await page.raw
+      .locator('#reset-password-error')
+      .waitFor({ state: 'visible' })
+    await expect(page).toSee('Password must be at least 8 characters')
+    await page.screenshot('.tmp/issue-205-reset-validation-dark.png', {
+      fullPage: true
+    })
+
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.goto('/profile')
+    await page.fill('#profile-email', 'not-an-email')
+    await page.raw.locator('#profile-email').blur()
+    await page.raw.locator('#profile-email-error').waitFor({ state: 'visible' })
+    await expect(page).toSee('Please enter a valid email address')
+    await page.screenshot('.tmp/issue-205-profile-validation-light.png', {
+      fullPage: true
+    })
+
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)
+
+async function showEmailValidation(page, input, error) {
+  await page.fill(input, 'not-an-email')
+  await page.raw.locator(input).blur()
+  await page.raw.locator(error).waitFor({ state: 'visible' })
+}

--- a/tests/e2e/pages/setup/index.test.js
+++ b/tests/e2e/pages/setup/index.test.js
@@ -6,7 +6,16 @@ test(
   async ({ page, expect }) => {
     await page.goto('/setup')
 
+    await page.fill('#email', 'not-an-email')
+    await page.raw.locator('#email').blur()
+    await page.raw.locator('#setup-email-error').waitFor({ state: 'visible' })
+    await expect(page).toSee('Please enter a valid email address')
+    await page.screenshot('.tmp/issue-205-setup-validation-light.png', {
+      fullPage: true
+    })
+
     await page.fill('#email', 'founder@example.com')
+    await page.raw.locator('#setup-email-error').waitFor({ state: 'detached' })
     await page.fill('#password', 'secret123!')
     await page.fill('#confirmPassword', 'secret123!')
     await page.click('Create account')
@@ -15,6 +24,6 @@ test(
     await expect(page).toHavePath('/')
     await expect(page).toHaveTitle(/Slipway/i)
     await expect(page).toSee('Get started by creating your first project')
-    expect(page).toHaveNoSmoke()
+    expect(page).toHaveNoJavascriptErrors()
   }
 )

--- a/tests/functional/pages/auth.test.js
+++ b/tests/functional/pages/auth.test.js
@@ -29,6 +29,32 @@ test(
 )
 
 test(
+  'login Precognition validates shape without revealing an account',
+  { world: 'configured-slipway' },
+  async ({ request, world, expect }) => {
+    const guest = await withCsrfFromPage(request, '/login')
+    const precognitive = guest.request.withHeaders({
+      Precognition: 'true',
+      'Precognition-Validate-Only': 'email'
+    })
+
+    const existingAccount = await precognitive.post('/login', {
+      email: world.current.users.genesisUser.email,
+      password: 'not-the-password'
+    })
+    const unknownAccount = await precognitive.post('/login', {
+      email: 'nobody@example.com',
+      password: 'not-the-password'
+    })
+
+    expect(existingAccount).toHaveStatus(204)
+    expect(existingAccount).toHaveHeader('precognition-success', 'true')
+    expect(unknownAccount).toHaveStatus(204)
+    expect(unknownAccount).toHaveHeader('precognition-success', 'true')
+  }
+)
+
+test(
   'forgot password sends a reset email through the real mail helper',
   { world: 'configured-slipway' },
   async ({ request, world, expect, mailbox, sails }) => {
@@ -60,6 +86,198 @@ test(
     } finally {
       sails.config.sounding.mail = previousMailConfig
     }
+  }
+)
+
+test(
+  'forgot-password Precognition sends no mail and creates no token',
+  { world: 'configured-slipway' },
+  async ({ request, world, expect, mailbox, sails }) => {
+    const current = world.current
+    const guest = await withCsrfFromPage(request, '/forgot-password')
+    const before = await sails.models.user.findOne({
+      id: current.users.genesisUser.id
+    })
+    const response = await guest.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'email'
+      })
+      .post('/forgot-password', {
+        email: current.users.genesisUser.email
+      })
+    const after = await sails.models.user.findOne({
+      id: current.users.genesisUser.id
+    })
+
+    expect(response).toHaveStatus(204)
+    expect(response).toHaveHeader('precognition-success', 'true')
+    expect(after.passwordResetToken).toBe(before.passwordResetToken)
+    expect(mailbox.all().length).toBe(0)
+  }
+)
+
+test(
+  'reset-password Precognition does not inspect or consume the token',
+  { world: 'configured-slipway' },
+  async ({ request, world, expect, sails }) => {
+    const current = world.current
+    const guest = await withCsrfFromPage(request, '/forgot-password')
+    const before = await sails.models.user.findOne({
+      id: current.users.genesisUser.id
+    })
+    const response = await guest.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'password'
+      })
+      .post('/reset-password', {
+        token: 'token-that-does-not-exist',
+        password: 'new-secret123!',
+        confirmPassword: 'new-secret123!'
+      })
+    const after = await sails.models.user.findOne({
+      id: current.users.genesisUser.id
+    })
+
+    expect(response).toHaveStatus(204)
+    expect(response).toHaveHeader('precognition-success', 'true')
+    expect(after.password).toBe(before.password)
+  }
+)
+
+test(
+  'reset-password validates confirmation without inspecting the token',
+  { world: 'configured-slipway' },
+  async ({ request, expect }) => {
+    const guest = await withCsrfFromPage(request, '/forgot-password')
+    const response = await guest.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'confirmPassword'
+      })
+      .post('/reset-password', {
+        token: 'token-that-does-not-exist',
+        password: 'new-secret123!',
+        confirmPassword: 'different123!'
+      })
+
+    expect(response).toHaveStatus(422)
+    expect(response.data.errors.confirmPassword).toContain(
+      'Password confirmation does not match'
+    )
+  }
+)
+
+test(
+  'password reset still updates the password on a normal submit',
+  { world: 'configured-slipway' },
+  async ({ request, world, expect, sails }) => {
+    const current = world.current
+    const token = 'valid-password-reset-token'
+    await sails.models.user
+      .updateOne({ id: current.users.genesisUser.id })
+      .set({
+        passwordResetToken: token,
+        passwordResetTokenExpiresAt: Date.now() + 60_000
+      })
+
+    const guest = await withCsrfFromPage(
+      request,
+      `/reset-password?token=${token}`
+    )
+    const response = await guest.request.post('/reset-password', {
+      token,
+      password: 'new-secret123!',
+      confirmPassword: 'new-secret123!'
+    })
+    const updated = await sails.models.user.findOne({
+      id: current.users.genesisUser.id
+    })
+
+    expect(response).toHaveStatus(302)
+    expect(response).toRedirectTo('/reset-password/success')
+    expect(updated.passwordResetToken).toBe('')
+    expect(updated.passwordResetTokenExpiresAt).toBe(0)
+  }
+)
+
+test(
+  'profile Precognition validates without changing the account',
+  { world: 'configured-slipway' },
+  async ({ request, world, expect, mailbox, sails }) => {
+    const current = world.current
+    const browser = await withCsrfFromPage(request, '/profile', 'genesisUser')
+    const response = await browser.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'email'
+      })
+      .patch('/profile', {
+        fullName: current.users.genesisUser.fullName,
+        email: 'next-address@example.com',
+        currentPassword: '',
+        password: '',
+        confirmPassword: ''
+      })
+    const unchanged = await sails.models.user.findOne({
+      id: current.users.genesisUser.id
+    })
+
+    expect(response).toHaveStatus(204)
+    expect(response).toHaveHeader('precognition-success', 'true')
+    expect(unchanged.email).toBe(current.users.genesisUser.email)
+    expect(unchanged.emailChangeCandidate || '').toBe('')
+    expect(mailbox.all().length).toBe(0)
+  }
+)
+
+test(
+  'profile requires the current password before accepting a new one',
+  { world: 'configured-slipway' },
+  async ({ request, world, expect }) => {
+    const current = world.current
+    const browser = await withCsrfFromPage(request, '/profile', 'genesisUser')
+    const response = await browser.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'currentPassword'
+      })
+      .patch('/profile', {
+        fullName: current.users.genesisUser.fullName,
+        email: current.users.genesisUser.email,
+        currentPassword: '',
+        password: 'new-secret123!',
+        confirmPassword: 'new-secret123!'
+      })
+
+    expect(response).toHaveStatus(422)
+    expect(response.data.errors.currentPassword).toContain(
+      'Current password is required'
+    )
+  }
+)
+
+test(
+  'profile changes still persist on a normal submit',
+  { world: 'configured-slipway' },
+  async ({ request, world, expect, sails }) => {
+    const current = world.current
+    const browser = await withCsrfFromPage(request, '/profile', 'genesisUser')
+    const response = await browser.request.patch('/profile', {
+      fullName: 'Updated Slipway Owner',
+      email: current.users.genesisUser.email,
+      currentPassword: '',
+      password: '',
+      confirmPassword: ''
+    })
+    const updated = await sails.models.user.findOne({
+      id: current.users.genesisUser.id
+    })
+
+    expect(response).toHaveStatus(409)
+    expect(response).toHaveHeader('x-inertia-location', 'back')
+    expect(updated.fullName).toBe('Updated Slipway Owner')
   }
 )
 

--- a/tests/functional/pages/setup.test.js
+++ b/tests/functional/pages/setup.test.js
@@ -11,6 +11,76 @@ test('the genesis user gets the setup path before Slipway is configured', async 
   expect(response).toRedirectTo('/setup')
 })
 
+test('setup validates with Precognition without creating anything', async ({
+  expect,
+  sails,
+  request
+}) => {
+  const guest = await withCsrfFromPage(request, '/setup')
+  const response = await guest.request
+    .withHeaders({
+      Precognition: 'true',
+      'Precognition-Validate-Only': 'email'
+    })
+    .post('/setup', {
+      email: 'founder@example.com',
+      password: 'secret123!',
+      confirmPassword: 'secret123!'
+    })
+
+  expect(response).toHaveStatus(204)
+  expect(response).toHaveHeader('precognition', 'true')
+  expect(response).toHaveHeader('precognition-success', 'true')
+  expect(await sails.models.user.count()).toBe(0)
+  expect(await sails.models.team.count()).toBe(0)
+  expect(Boolean(sails.config.custom.slipwayIsSetup)).toBe(false)
+})
+
+test('setup returns a field error for invalid Precognition input', async ({
+  expect,
+  request
+}) => {
+  const guest = await withCsrfFromPage(request, '/setup')
+  const response = await guest.request
+    .withHeaders({
+      Precognition: 'true',
+      'Precognition-Validate-Only': 'email'
+    })
+    .post('/setup', {
+      email: 'not-an-email',
+      password: 'secret123!',
+      confirmPassword: 'secret123!'
+    })
+
+  expect(response).toHaveStatus(422)
+  expect(response.data.errors.email).toContain(
+    'Please enter a valid email address'
+  )
+  expect(response.data.errors.password).toBe(undefined)
+})
+
+test('setup validates password confirmation before submit', async ({
+  expect,
+  request
+}) => {
+  const guest = await withCsrfFromPage(request, '/setup')
+  const response = await guest.request
+    .withHeaders({
+      Precognition: 'true',
+      'Precognition-Validate-Only': 'confirmPassword'
+    })
+    .post('/setup', {
+      email: 'founder@example.com',
+      password: 'secret123!',
+      confirmPassword: 'different123!'
+    })
+
+  expect(response).toHaveStatus(422)
+  expect(response.data.errors.confirmPassword).toContain(
+    'Password confirmation does not match'
+  )
+})
+
 test('setup creates the genesis owner and default team', async ({
   expect,
   sails,
@@ -20,7 +90,8 @@ test('setup creates the genesis owner and default team', async ({
 
   const response = await guest.request.post('/setup', {
     email: 'founder@example.com',
-    password: 'secret123'
+    password: 'secret123!',
+    confirmPassword: 'secret123!'
   })
 
   expect(response).toHaveStatus(302)


### PR DESCRIPTION
## Summary

- add server-owned Precognition validation to setup, login, password recovery, password reset, and profile forms
- stop validation-only requests before authentication lookups, email delivery, token consumption, and account mutations
- add minimal accessible inline feedback while preserving normal submit and redirect flows
- keep validation requests from consuming authentication rate limits

## Impact

Users get immediate field-level feedback without noisy UI, while the server remains the source of truth. Precognition requests are side-effect free and do not reveal whether an account exists.

## Verification

- `npm run lint`
- `npm run check:consistency`
- `npm run test:unit` — 231 passed
- `npm run test:functional` — 80 passed
- focused Sounding browser trials for setup/auth validation and desktop/mobile login

Closes #205
