### PR TITLE
feat: add precognitive configuration validation

### DIFF
--- a/api/controllers/api/v1/app/update-app.js
+++ b/api/controllers/api/v1/app/update-app.js
@@ -45,7 +45,9 @@ module.exports = {
   exits: {
     success: { statusCode: 200 },
     notFound: { statusCode: 404 },
-    forbidden: { statusCode: 403 }
+    forbidden: { statusCode: 403 },
+    badRequest: { responseType: 'badRequest' },
+    precognitionSuccess: { responseType: 'precognitionSuccess' }
   },
 
   fn: async function ({
@@ -77,6 +79,20 @@ module.exports = {
       slug: appSlug
     })
     if (!app) throw 'notFound'
+
+    const problems = sails.helpers.configuration.validate({
+      name,
+      dockerfilePath,
+      routePath,
+      healthPath,
+      resourceLimits
+    })
+    if (problems.length) {
+      throw { badRequest: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
 
     const updates = {}
     if (name !== undefined) updates.name = name

--- a/api/controllers/api/v1/environment/update-environment.js
+++ b/api/controllers/api/v1/environment/update-environment.js
@@ -49,6 +49,9 @@ module.exports = {
     },
     badRequest: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -79,6 +82,18 @@ module.exports = {
 
     if (!environment) {
       throw 'notFound'
+    }
+
+    const problems = sails.helpers.configuration.validate({
+      name,
+      domain,
+      resourceLimits
+    })
+    if (problems.length) {
+      throw { badRequest: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     // Build update object

--- a/api/controllers/api/v1/service/update-service.js
+++ b/api/controllers/api/v1/service/update-service.js
@@ -31,7 +31,10 @@ module.exports = {
       statusCode: 404
     },
     badRequest: {
-      statusCode: 400
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -55,17 +58,26 @@ module.exports = {
 
     const updates = {}
 
-    // Update name if provided
-    if (name !== undefined) {
-      const trimmedName = name.trim()
-      if (!trimmedName) {
-        throw { badRequest: { message: 'Name cannot be empty' } }
-      }
-      if (trimmedName.length > 50) {
-        throw { badRequest: { message: 'Name must be 50 characters or less' } }
-      }
-      updates.name = trimmedName
+    const problems = sails.helpers.configuration.validate({
+      name,
+      resourceLimits
+    })
+    if (
+      name !== undefined &&
+      name.trim().length > 50 &&
+      !problems.some((problem) => problem.name)
+    ) {
+      problems.push({ name: 'Name must be 50 characters or less.' })
     }
+    if (problems.length) {
+      throw { badRequest: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
+    // Update name if provided
+    if (name !== undefined) updates.name = name.trim()
 
     // Update resource limits if provided
     if (resourceLimits !== undefined) {
@@ -98,7 +110,11 @@ module.exports = {
     }
 
     if (Object.keys(updates).length === 0) {
-      throw { badRequest: { message: 'No fields to update' } }
+      throw {
+        badRequest: {
+          problems: [{ settings: 'Choose a setting to update.' }]
+        }
+      }
     }
 
     const updated = await Service.updateOne({ id: service.id }).set(updates)

--- a/api/controllers/project/create-app.js
+++ b/api/controllers/project/create-app.js
@@ -51,6 +51,12 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -74,6 +80,29 @@ module.exports = {
       slug: envSlug
     })
     if (!environment) throw { notFound: `/projects/${slug}` }
+
+    const problems = sails.helpers.configuration.validate(
+      { name, dockerfilePath, routePath, healthPath },
+      ['name', 'dockerfilePath', 'healthPath']
+    )
+    const appSlug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+    if (
+      !problems.length &&
+      (await App.findOne({ environment: environment.id, slug: appSlug }))
+    ) {
+      problems.push({
+        name: 'An app with this name already exists in this environment.'
+      })
+    }
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
 
     let app
     try {

--- a/api/controllers/project/create-environment.js
+++ b/api/controllers/project/create-environment.js
@@ -22,6 +22,12 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -34,6 +40,29 @@ module.exports = {
 
     if (!project) {
       throw { notFound: '/' }
+    }
+
+    const problems = sails.helpers.configuration.validate({ name }, ['name'])
+    const environmentSlug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+    if (
+      !problems.length &&
+      (await Environment.findOne({
+        project: project.id,
+        slug: environmentSlug
+      }))
+    ) {
+      problems.push({
+        name: 'An environment with this name already exists in this project.'
+      })
+    }
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     const { telemetryToken, telemetryTokenHash } =

--- a/api/controllers/project/create-project.js
+++ b/api/controllers/project/create-project.js
@@ -22,6 +22,9 @@ module.exports = {
     },
     invalid: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -33,6 +36,24 @@ module.exports = {
 
     if (!user || !user.team) {
       throw 'invalid'
+    }
+
+    const problems = sails.helpers.configuration.validate(
+      { name, description },
+      ['name']
+    )
+    const slug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+    if (!problems.length && (await Project.findOne({ slug }))) {
+      problems.push({ name: 'A project with this name already exists.' })
+    }
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     // Create the project

--- a/api/controllers/project/update-project.js
+++ b/api/controllers/project/update-project.js
@@ -43,6 +43,12 @@ module.exports = {
     },
     notFound: {
       responseType: 'inertiaRedirect'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -63,6 +69,20 @@ module.exports = {
 
     if (!project) {
       throw { notFound: '/' }
+    }
+
+    const problems = sails.helpers.configuration.validate({
+      name,
+      description,
+      repositoryUrl,
+      autoDeploy,
+      autoDeployBranch
+    })
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     const updates = {}

--- a/api/helpers/configuration/validate.js
+++ b/api/helpers/configuration/validate.js
@@ -1,0 +1,220 @@
+const path = require('path')
+
+const MEMORY_UNITS = {
+  b: 1,
+  k: 1024,
+  m: 1024 ** 2,
+  g: 1024 ** 3,
+  t: 1024 ** 4
+}
+
+module.exports = {
+  friendlyName: 'Validate configuration',
+
+  description:
+    'Validate project, environment, app, and service configuration values.',
+
+  inputs: {
+    values: {
+      type: 'ref',
+      required: true
+    },
+    requiredFields: {
+      type: 'json',
+      defaultsTo: []
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  sync: true,
+
+  fn: function ({ values, requiredFields }) {
+    const problems = []
+    const required = new Set(requiredFields)
+
+    function add(field, message) {
+      problems.push({ [field]: message })
+    }
+
+    function isMissing(value) {
+      return (
+        value === undefined || value === null || String(value).trim() === ''
+      )
+    }
+
+    if (required.has('name') && isMissing(values.name)) {
+      add('name', 'Name is required.')
+    } else if (values.name !== undefined) {
+      const name = String(values.name).trim()
+      if (!name) {
+        add('name', 'Name cannot be empty.')
+      } else if (name.length > 120) {
+        add('name', 'Name must be 120 characters or less.')
+      } else if (!/[a-z0-9]/i.test(name)) {
+        add('name', 'Name must include at least one letter or number.')
+      }
+    }
+
+    if (
+      values.description !== undefined &&
+      String(values.description || '').length > 500
+    ) {
+      add('description', 'Description must be 500 characters or less.')
+    }
+
+    if (!isMissing(values.repositoryUrl)) {
+      try {
+        const repositoryUrl = new URL(String(values.repositoryUrl).trim())
+        if (
+          !['http:', 'https:'].includes(repositoryUrl.protocol) ||
+          !repositoryUrl.hostname ||
+          repositoryUrl.username ||
+          repositoryUrl.password
+        ) {
+          throw new Error('invalid repository URL')
+        }
+      } catch {
+        add(
+          'repositoryUrl',
+          'Enter a valid HTTP or HTTPS repository URL without credentials.'
+        )
+      }
+    }
+
+    if (values.autoDeploy === true || !isMissing(values.autoDeployBranch)) {
+      const branch = String(values.autoDeployBranch || '').trim()
+      const invalidBranch =
+        !branch ||
+        branch.length > 255 ||
+        branch.startsWith('-') ||
+        branch.startsWith('/') ||
+        branch.endsWith('/') ||
+        branch.endsWith('.') ||
+        branch.includes('..') ||
+        branch.includes('//') ||
+        branch.includes('@{') ||
+        /[\s~^:?*\[\]\\\u0000-\u001f\u007f]/.test(branch)
+
+      if (invalidBranch) {
+        add('autoDeployBranch', 'Enter a valid Git branch name.')
+      }
+    }
+
+    if (required.has('dockerfilePath') && isMissing(values.dockerfilePath)) {
+      add('dockerfilePath', 'Dockerfile path is required.')
+    } else if (values.dockerfilePath !== undefined) {
+      const dockerfilePath = String(values.dockerfilePath || '').trim()
+      const segments = dockerfilePath.split('/')
+      const invalidDockerfilePath =
+        !dockerfilePath ||
+        dockerfilePath.length > 255 ||
+        path.posix.isAbsolute(dockerfilePath) ||
+        /^[a-z]:/i.test(dockerfilePath) ||
+        dockerfilePath.includes('\\') ||
+        dockerfilePath.includes('\u0000') ||
+        segments.includes('..') ||
+        segments.some((segment) => !segment)
+
+      if (invalidDockerfilePath) {
+        add(
+          'dockerfilePath',
+          'Use a relative Dockerfile path inside the project.'
+        )
+      }
+    }
+
+    for (const field of ['healthPath', 'routePath']) {
+      const value = values[field]
+      if (field === 'routePath' && value === null) continue
+
+      if (required.has(field) && isMissing(value)) {
+        add(
+          field,
+          `${field === 'healthPath' ? 'Health' : 'Route'} path is required.`
+        )
+        continue
+      }
+
+      if (value === undefined) continue
+
+      const route = String(value || '').trim()
+      const invalidRoute =
+        !route ||
+        route.length > 256 ||
+        !route.startsWith('/') ||
+        route.startsWith('//') ||
+        (route.length > 1 && route.endsWith('/')) ||
+        /[\s?#*<>"\\\u0000-\u001f\u007f]/.test(route)
+
+      if (invalidRoute) {
+        add(
+          field,
+          `Enter a valid ${
+            field === 'healthPath' ? 'health' : 'route'
+          } path beginning with /.`
+        )
+      }
+    }
+
+    if (!isMissing(values.domain)) {
+      const domain = String(values.domain).trim().toLowerCase()
+      const labels = domain.split('.')
+      const invalidDomain =
+        domain.length > 253 ||
+        labels.some(
+          (label) =>
+            !label ||
+            label.length > 63 ||
+            !/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+        )
+
+      if (invalidDomain) {
+        add('domain', 'Enter a valid hostname without a scheme or path.')
+      }
+    }
+
+    if (values.resourceLimits !== undefined) {
+      const resourceLimits = values.resourceLimits || {}
+      const cpus = String(resourceLimits.cpus || '').trim()
+      const cpuCount = Number(cpus)
+
+      if (
+        !cpus ||
+        !Number.isFinite(cpuCount) ||
+        cpuCount <= 0 ||
+        cpuCount > 256
+      ) {
+        add(
+          'resourceLimits.cpus',
+          'CPU limit must be greater than 0 and no more than 256.'
+        )
+      }
+
+      const memory = String(resourceLimits.memory || '')
+        .trim()
+        .toLowerCase()
+      const memoryMatch = memory.match(/^(\d+(?:\.\d+)?)([bkmgt])$/)
+      const memoryBytes = memoryMatch
+        ? Number(memoryMatch[1]) * MEMORY_UNITS[memoryMatch[2]]
+        : 0
+
+      if (
+        !memoryMatch ||
+        memoryBytes < 6 * MEMORY_UNITS.m ||
+        memoryBytes > MEMORY_UNITS.t
+      ) {
+        add(
+          'resourceLimits.memory',
+          'Memory limit must be between 6m and 1t, for example 512m or 1g.'
+        )
+      }
+    }
+
+    return problems
+  }
+}

--- a/assets/js/composables/precognition.js
+++ b/assets/js/composables/precognition.js
@@ -1,10 +1,14 @@
 export function usePrecognitionValidation(form) {
+  function valueFor(field) {
+    return field.split('.').reduce((value, segment) => value?.[segment], form)
+  }
+
   function validateOnBlur(field, event) {
-    if (event?.relatedTarget?.closest?.('button[type="submit"], a[href]')) {
+    if (event?.relatedTarget?.closest?.('button, a[href]')) {
       return
     }
 
-    if (String(form[field] ?? '').trim()) {
+    if (String(valueFor(field) ?? '').trim()) {
       form.validate(field)
     }
   }
@@ -15,7 +19,25 @@ export function usePrecognitionValidation(form) {
     }
   }
 
+  function applyResponseProblems(problems = []) {
+    const errors = Object.assign(
+      {},
+      ...problems.filter(
+        (problem) =>
+          problem && typeof problem === 'object' && !Array.isArray(problem)
+      )
+    )
+
+    if (Object.keys(errors).length) {
+      form.setError(errors)
+      return true
+    }
+
+    return false
+  }
+
   return {
+    applyResponseProblems,
     revalidateWhenInvalid,
     validateOnBlur
   }

--- a/assets/js/pages/projects/app-settings.vue
+++ b/assets/js/pages/projects/app-settings.vue
@@ -6,6 +6,7 @@ import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { useToast } from '@/composables/toast'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -32,26 +33,39 @@ const basePath = computed(
 )
 
 // --- Form state ---
-const name = ref(props.app.name)
-const dockerfilePath = ref(props.app.dockerfilePath || 'Dockerfile')
-const healthPath = ref(props.app.healthPath || '/health')
-const routePath = ref(
-  props.app.routePath === null ? 'none' : props.app.routePath || '/'
-)
-const cpus = ref(props.app.resourceLimits?.cpus || '1')
-const memory = ref(props.app.resourceLimits?.memory || '512m')
+const settingsUrl = `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}`
+const form = useForm({
+  name: props.app.name,
+  dockerfilePath: props.app.dockerfilePath || 'Dockerfile',
+  healthPath: props.app.healthPath || '/health',
+  routePath: props.app.routePath === null ? null : props.app.routePath || '/',
+  resourceLimits: {
+    cpus: props.app.resourceLimits?.cpus || '1',
+    memory: props.app.resourceLimits?.memory || '512m'
+  }
+})
+  .withPrecognition('patch', settingsUrl)
+  .setValidationTimeout(350)
+const { applyResponseProblems, revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
+const routePathChoice = computed({
+  get: () => form.routePath ?? 'none',
+  set: (value) => {
+    form.routePath = value === 'none' ? null : value
+  }
+})
 const saving = ref(false)
 const savingAndRestarting = ref(false)
 
 const isDirty = computed(
   () =>
-    name.value !== props.app.name ||
-    dockerfilePath.value !== (props.app.dockerfilePath || 'Dockerfile') ||
-    healthPath.value !== (props.app.healthPath || '/health') ||
-    routePath.value !==
-      (props.app.routePath === null ? 'none' : props.app.routePath || '/') ||
-    cpus.value !== (props.app.resourceLimits?.cpus || '1') ||
-    memory.value !== (props.app.resourceLimits?.memory || '512m')
+    form.name !== props.app.name ||
+    form.dockerfilePath !== (props.app.dockerfilePath || 'Dockerfile') ||
+    form.healthPath !== (props.app.healthPath || '/health') ||
+    form.routePath !==
+      (props.app.routePath === null ? null : props.app.routePath || '/') ||
+    form.resourceLimits.cpus !== (props.app.resourceLimits?.cpus || '1') ||
+    form.resourceLimits.memory !== (props.app.resourceLimits?.memory || '512m')
 )
 
 async function saveSettings({ restart = false } = {}) {
@@ -61,25 +75,32 @@ async function saveSettings({ restart = false } = {}) {
     saving.value = true
   }
   try {
-    const res = await fetch(
-      `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}`,
-      {
-        method: 'PATCH',
-        headers: {
-          'Content-Type': 'application/json',
-          'x-csrf-token': page.props._csrf || ''
-        },
-        body: JSON.stringify({
-          name: name.value,
-          dockerfilePath: dockerfilePath.value,
-          healthPath: healthPath.value,
-          routePath: routePath.value === 'none' ? null : routePath.value,
-          resourceLimits: { cpus: cpus.value, memory: memory.value }
-        })
-      }
-    )
+    const res = await fetch(settingsUrl, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-csrf-token': page.props._csrf || ''
+      },
+      body: JSON.stringify({
+        name: form.name,
+        dockerfilePath: form.dockerfilePath,
+        healthPath: form.healthPath,
+        routePath: form.routePath,
+        resourceLimits: form.resourceLimits
+      })
+    })
 
-    if (res.ok && restart) {
+    if (!res.ok) {
+      const data = await res.json().catch(() => null)
+      applyResponseProblems(data?.problems)
+      toast({
+        message: data?.message || 'Failed to save app settings',
+        type: 'error'
+      })
+      return
+    }
+
+    if (restart) {
       await fetch(
         `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/restart`,
         {
@@ -414,10 +435,21 @@ async function deleteApp() {
             </label>
             <input
               id="appName"
-              v-model="name"
+              v-model="form.name"
               type="text"
+              :aria-invalid="form.invalid('name')"
+              :aria-describedby="form.errors.name ? 'app-name-error' : null"
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('name', $event)"
+              @input="revalidateWhenInvalid('name')"
             />
+            <p
+              v-if="form.errors.name"
+              id="app-name-error"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.name }}
+            </p>
           </div>
 
           <div>
@@ -429,11 +461,24 @@ async function deleteApp() {
             </label>
             <input
               id="healthPath"
-              v-model="healthPath"
+              v-model="form.healthPath"
               type="text"
               placeholder="/health"
+              :aria-invalid="form.invalid('healthPath')"
+              :aria-describedby="
+                form.errors.healthPath ? 'health-path-error' : null
+              "
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('healthPath', $event)"
+              @input="revalidateWhenInvalid('healthPath')"
             />
+            <p
+              v-if="form.errors.healthPath"
+              id="health-path-error"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.healthPath }}
+            </p>
             <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
               Deployment waits for this path to return a 2xx response.
             </p>
@@ -448,11 +493,24 @@ async function deleteApp() {
             </label>
             <input
               id="dockerfilePath"
-              v-model="dockerfilePath"
+              v-model="form.dockerfilePath"
               type="text"
               placeholder="Dockerfile"
+              :aria-invalid="form.invalid('dockerfilePath')"
+              :aria-describedby="
+                form.errors.dockerfilePath ? 'dockerfile-path-error' : null
+              "
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('dockerfilePath', $event)"
+              @input="revalidateWhenInvalid('dockerfilePath')"
             />
+            <p
+              v-if="form.errors.dockerfilePath"
+              id="dockerfile-path-error"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.dockerfilePath }}
+            </p>
             <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
               Relative to your project root, e.g.
               <code class="text-gray-500 dark:text-gray-400"
@@ -470,7 +528,7 @@ async function deleteApp() {
             </label>
             <select
               id="routePath"
-              v-model="routePath"
+              v-model="routePathChoice"
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:text-white"
             >
               <option value="/">/ (root)</option>
@@ -493,11 +551,24 @@ async function deleteApp() {
               </label>
               <input
                 id="cpuLimit"
-                v-model="cpus"
+                v-model="form.resourceLimits.cpus"
                 type="text"
                 placeholder="1"
+                :aria-invalid="form.invalid('resourceLimits.cpus')"
+                :aria-describedby="
+                  form.errors['resourceLimits.cpus'] ? 'cpu-limit-error' : null
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                @blur="validateOnBlur('resourceLimits.cpus', $event)"
+                @input="revalidateWhenInvalid('resourceLimits.cpus')"
               />
+              <p
+                v-if="form.errors['resourceLimits.cpus']"
+                id="cpu-limit-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors['resourceLimits.cpus'] }}
+              </p>
             </div>
             <div>
               <label
@@ -508,11 +579,26 @@ async function deleteApp() {
               </label>
               <input
                 id="memoryLimit"
-                v-model="memory"
+                v-model="form.resourceLimits.memory"
                 type="text"
                 placeholder="512m"
+                :aria-invalid="form.invalid('resourceLimits.memory')"
+                :aria-describedby="
+                  form.errors['resourceLimits.memory']
+                    ? 'memory-limit-error'
+                    : null
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                @blur="validateOnBlur('resourceLimits.memory', $event)"
+                @input="revalidateWhenInvalid('resourceLimits.memory')"
               />
+              <p
+                v-if="form.errors['resourceLimits.memory']"
+                id="memory-limit-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors['resourceLimits.memory'] }}
+              </p>
             </div>
           </div>
 
@@ -520,7 +606,9 @@ async function deleteApp() {
             <div class="inline-flex rounded-md shadow-sm">
               <button
                 type="submit"
-                :disabled="!isDirty || saving || savingAndRestarting"
+                :disabled="
+                  !isDirty || form.hasErrors || saving || savingAndRestarting
+                "
                 class="rounded-l-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ saving ? 'Saving...' : 'Save changes' }}
@@ -529,7 +617,9 @@ async function deleteApp() {
                 <button
                   type="button"
                   @click="saveSettings({ restart: true })"
-                  :disabled="!isDirty || saving || savingAndRestarting"
+                  :disabled="
+                    !isDirty || form.hasErrors || saving || savingAndRestarting
+                  "
                   class="rounded-r-md border-l border-gray-700 bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:border-gray-200 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                 >
                   <template v-if="savingAndRestarting">

--- a/assets/js/pages/projects/environment-settings.vue
+++ b/assets/js/pages/projects/environment-settings.vue
@@ -1,10 +1,11 @@
 <script setup>
-import { Link, Head, router } from '@inertiajs/vue3'
+import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import { useToast } from '@/composables/toast'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -21,14 +22,21 @@ const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const toast = useToast()
 
-const name = ref(props.environment.name)
-const isProduction = ref(props.environment.isProduction)
+const settingsUrl = `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}`
+const form = useForm({
+  name: props.environment.name,
+  isProduction: props.environment.isProduction
+})
+  .withPrecognition('patch', settingsUrl)
+  .setValidationTimeout(350)
+const { applyResponseProblems, revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 const saving = ref(false)
 
 const isDirty = computed(
   () =>
-    name.value !== props.environment.name ||
-    isProduction.value !== props.environment.isProduction
+    form.name !== props.environment.name ||
+    form.isProduction !== props.environment.isProduction
 )
 const showDeleteConfirm = ref(false)
 const deleting = ref(false)
@@ -39,34 +47,21 @@ async function save() {
   saving.value = true
 
   try {
-    const res = await fetch(
-      `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}`,
-      {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: name.value,
-          isProduction: isProduction.value
-        })
-      }
-    )
+    const res = await fetch(settingsUrl, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: form.name,
+        isProduction: form.isProduction
+      })
+    })
 
     if (res.ok) {
       toast({ message: 'Environment updated', type: 'success' })
-      // If name changed, redirect to new slug
-      if (name.value !== props.environment.name) {
-        const newSlug = name.value
-          .toLowerCase()
-          .replace(/[^a-z0-9]+/g, '-')
-          .replace(/^-|-$/g, '')
-        router.visit(
-          `/projects/${props.project.slug}/environments/${newSlug}/settings`
-        )
-      } else {
-        router.reload()
-      }
+      router.reload()
     } else {
       const err = await res.json().catch(() => null)
+      applyResponseProblems(err?.problems)
       toast({
         message: err?.message || 'Failed to update environment',
         type: 'error'
@@ -271,10 +266,23 @@ function openDeleteEnvironment() {
             </label>
             <input
               id="name"
-              v-model="name"
+              v-model="form.name"
               type="text"
+              :aria-invalid="form.invalid('name')"
+              :aria-describedby="
+                form.errors.name ? 'environment-name-error' : null
+              "
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('name', $event)"
+              @input="revalidateWhenInvalid('name')"
             />
+            <p
+              v-if="form.errors.name"
+              id="environment-name-error"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.name }}
+            </p>
           </div>
 
           <div
@@ -293,16 +301,16 @@ function openDeleteEnvironment() {
             </div>
             <button
               type="button"
-              @click="isProduction = !isProduction"
+              @click="form.isProduction = !form.isProduction"
               :class="[
                 'relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none',
-                isProduction ? 'bg-brand' : 'bg-gray-200 dark:bg-gray-700'
+                form.isProduction ? 'bg-brand' : 'bg-gray-200 dark:bg-gray-700'
               ]"
             >
               <span
                 :class="[
                   'pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out',
-                  isProduction ? 'translate-x-5' : 'translate-x-0'
+                  form.isProduction ? 'translate-x-5' : 'translate-x-0'
                 ]"
               />
             </button>
@@ -311,7 +319,7 @@ function openDeleteEnvironment() {
           <div class="flex justify-end">
             <button
               type="submit"
-              :disabled="saving || !isDirty"
+              :disabled="saving || form.hasErrors || !isDirty"
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ saving ? 'Saving...' : 'Save changes' }}

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -19,6 +19,7 @@ import DeploymentHistory from '@/components/DeploymentHistory.vue'
 import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
 import { useEventSource } from '@/composables/sse'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -65,6 +66,21 @@ const createAppForm = useForm({
   routePath: '/',
   repoId: null,
   branch: null
+})
+  .withPrecognition(
+    'post',
+    `/projects/${props.project.slug}/environments/${props.environment.slug}/apps`
+  )
+  .setValidationTimeout(350)
+const {
+  revalidateWhenInvalid: revalidateAppWhenInvalid,
+  validateOnBlur: validateAppOnBlur
+} = usePrecognitionValidation(createAppForm)
+const createAppRoutePath = computed({
+  get: () => createAppForm.routePath ?? 'none',
+  set: (value) => {
+    createAppForm.routePath = value === 'none' ? null : value
+  }
 })
 
 // --- Repo picker state ---
@@ -147,8 +163,6 @@ watch(addAppOpen, (open) => {
 
 function createApp() {
   if (!createAppForm.name.trim()) return
-  createAppForm.routePath =
-    createAppForm.routePath === 'none' ? null : createAppForm.routePath
   createAppForm.post(
     `/projects/${props.project.slug}/environments/${props.environment.slug}/apps`,
     {
@@ -1569,26 +1583,77 @@ onBeforeUnmount(() => {
               <div class="px-4 pb-3">
                 <div v-if="addAppOpen" class="space-y-3">
                   <div class="flex flex-col gap-2 sm:flex-row sm:items-center">
-                    <input
-                      v-model="createAppForm.name"
-                      placeholder="app name"
-                      class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:flex-1"
-                      @keydown.enter="createApp"
-                    />
-                    <input
-                      v-model="createAppForm.dockerfilePath"
-                      placeholder="Dockerfile"
-                      class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:w-32"
-                      @keydown.enter="createApp"
-                    />
-                    <input
-                      v-model="createAppForm.healthPath"
-                      placeholder="/health"
-                      class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:w-28"
-                      @keydown.enter="createApp"
-                    />
+                    <div class="w-full sm:flex-1">
+                      <input
+                        v-model="createAppForm.name"
+                        placeholder="app name"
+                        :aria-invalid="createAppForm.invalid('name')"
+                        :aria-describedby="
+                          createAppForm.errors.name
+                            ? 'create-app-name-error'
+                            : null
+                        "
+                        class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                        @blur="validateAppOnBlur('name', $event)"
+                        @input="revalidateAppWhenInvalid('name')"
+                        @keydown.enter="createApp"
+                      />
+                      <p
+                        v-if="createAppForm.errors.name"
+                        id="create-app-name-error"
+                        class="mt-1 text-xs text-red-600 dark:text-red-400"
+                      >
+                        {{ createAppForm.errors.name }}
+                      </p>
+                    </div>
+                    <div class="w-full sm:w-32">
+                      <input
+                        v-model="createAppForm.dockerfilePath"
+                        placeholder="Dockerfile"
+                        :aria-invalid="createAppForm.invalid('dockerfilePath')"
+                        :aria-describedby="
+                          createAppForm.errors.dockerfilePath
+                            ? 'create-app-dockerfile-error'
+                            : null
+                        "
+                        class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                        @blur="validateAppOnBlur('dockerfilePath', $event)"
+                        @input="revalidateAppWhenInvalid('dockerfilePath')"
+                        @keydown.enter="createApp"
+                      />
+                      <p
+                        v-if="createAppForm.errors.dockerfilePath"
+                        id="create-app-dockerfile-error"
+                        class="mt-1 text-xs text-red-600 dark:text-red-400"
+                      >
+                        {{ createAppForm.errors.dockerfilePath }}
+                      </p>
+                    </div>
+                    <div class="w-full sm:w-28">
+                      <input
+                        v-model="createAppForm.healthPath"
+                        placeholder="/health"
+                        :aria-invalid="createAppForm.invalid('healthPath')"
+                        :aria-describedby="
+                          createAppForm.errors.healthPath
+                            ? 'create-app-health-error'
+                            : null
+                        "
+                        class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                        @blur="validateAppOnBlur('healthPath', $event)"
+                        @input="revalidateAppWhenInvalid('healthPath')"
+                        @keydown.enter="createApp"
+                      />
+                      <p
+                        v-if="createAppForm.errors.healthPath"
+                        id="create-app-health-error"
+                        class="mt-1 text-xs text-red-600 dark:text-red-400"
+                      >
+                        {{ createAppForm.errors.healthPath }}
+                      </p>
+                    </div>
                     <select
-                      v-model="createAppForm.routePath"
+                      v-model="createAppRoutePath"
                       class="focus:border-brand rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
                     >
                       <option value="/">/ (root)</option>
@@ -1832,7 +1897,9 @@ onBeforeUnmount(() => {
                     <button
                       @click="createApp"
                       :disabled="
-                        !createAppForm.name.trim() || createAppForm.processing
+                        !createAppForm.name.trim() ||
+                        createAppForm.hasErrors ||
+                        createAppForm.processing
                       "
                       class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                     >

--- a/assets/js/pages/projects/new-environment.vue
+++ b/assets/js/pages/projects/new-environment.vue
@@ -2,6 +2,7 @@
 import { useForm, Head, Link } from '@inertiajs/vue3'
 import { inject } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -14,6 +15,10 @@ const props = defineProps({
 const form = useForm({
   name: ''
 })
+  .withPrecognition('post', `/projects/${props.project.slug}/environments`)
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const submit = () => {
   form.post(`/projects/${props.project.slug}/environments`)
@@ -170,14 +175,6 @@ const sidebarCollapsed = inject('sidebarCollapsed')
     >
       <div class="flex justify-center">
         <div class="w-full max-w-md">
-          <!-- Error message -->
-          <div
-            v-if="form.errors.name"
-            class="mb-6 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400"
-          >
-            {{ form.errors.name }}
-          </div>
-
           <form @submit.prevent="submit" class="space-y-4">
             <input
               id="name"
@@ -185,8 +182,21 @@ const sidebarCollapsed = inject('sidebarCollapsed')
               type="text"
               placeholder="Name"
               autofocus
+              :aria-invalid="form.invalid('name')"
+              :aria-describedby="
+                form.errors.name ? 'environment-name-error' : null
+              "
               class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('name', $event)"
+              @input="revalidateWhenInvalid('name')"
             />
+            <p
+              v-if="form.errors.name"
+              id="environment-name-error"
+              class="-mt-2 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.name }}
+            </p>
 
             <div class="flex items-center justify-end space-x-3 pt-4">
               <Link
@@ -197,7 +207,7 @@ const sidebarCollapsed = inject('sidebarCollapsed')
               </Link>
               <button
                 type="submit"
-                :disabled="form.processing || !form.name"
+                :disabled="form.processing || form.hasErrors || !form.name"
                 class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ form.processing ? 'Creating...' : 'Create' }}

--- a/assets/js/pages/projects/new.vue
+++ b/assets/js/pages/projects/new.vue
@@ -2,6 +2,7 @@
 import { useForm, Head, Link } from '@inertiajs/vue3'
 import { inject } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -11,6 +12,10 @@ const form = useForm({
   name: '',
   description: ''
 })
+  .withPrecognition('post', '/projects')
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const submit = () => {
   form.post('/projects')
@@ -160,22 +165,25 @@ const sidebarCollapsed = inject('sidebarCollapsed')
     >
       <div class="flex justify-center">
         <div class="w-full max-w-md">
-          <!-- Error message -->
-          <div
-            v-if="form.errors.name"
-            class="mb-6 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-400"
-          >
-            {{ form.errors.name }}
-          </div>
-
           <form @submit.prevent="submit" class="space-y-4">
             <input
               id="name"
               v-model="form.name"
               type="text"
               placeholder="Project name"
+              :aria-invalid="form.invalid('name')"
+              :aria-describedby="form.errors.name ? 'project-name-error' : null"
               class="focus:border-brand h-12 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('name', $event)"
+              @input="revalidateWhenInvalid('name')"
             />
+            <p
+              v-if="form.errors.name"
+              id="project-name-error"
+              class="-mt-2 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.name }}
+            </p>
 
             <textarea
               id="description"
@@ -183,7 +191,20 @@ const sidebarCollapsed = inject('sidebarCollapsed')
               placeholder="A brief description about your project"
               class="focus:border-brand w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-3 text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
               style="field-sizing: content"
+              :aria-invalid="form.invalid('description')"
+              :aria-describedby="
+                form.errors.description ? 'project-description-error' : null
+              "
+              @blur="validateOnBlur('description', $event)"
+              @input="revalidateWhenInvalid('description')"
             ></textarea>
+            <p
+              v-if="form.errors.description"
+              id="project-description-error"
+              class="-mt-2 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.description }}
+            </p>
 
             <div class="flex items-center justify-end space-x-3 pt-4">
               <Link
@@ -194,7 +215,7 @@ const sidebarCollapsed = inject('sidebarCollapsed')
               </Link>
               <button
                 type="submit"
-                :disabled="form.processing || !form.name"
+                :disabled="form.processing || form.hasErrors || !form.name"
                 class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ form.processing ? 'Creating...' : 'Create' }}

--- a/assets/js/pages/projects/service-settings.vue
+++ b/assets/js/pages/projects/service-settings.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { Link, Head, router, usePage } from '@inertiajs/vue3'
+import { Link, Head, router, usePage, useForm } from '@inertiajs/vue3'
 import { ref, computed, inject, onMounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import { useToast } from '@/composables/toast'
 import { useEventSource } from '@/composables/sse'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -39,8 +40,17 @@ const defaults = typeDefaults[props.service.type] || {
 }
 
 // Form state
-const cpus = ref(props.service.resourceLimits?.cpus || defaults.cpus)
-const memory = ref(props.service.resourceLimits?.memory || defaults.memory)
+const settingsUrl = `/api/v1/services/${props.service.id}`
+const form = useForm({
+  resourceLimits: {
+    cpus: props.service.resourceLimits?.cpus || defaults.cpus,
+    memory: props.service.resourceLimits?.memory || defaults.memory
+  }
+})
+  .withPrecognition('patch', settingsUrl)
+  .setValidationTimeout(350)
+const { applyResponseProblems, revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 const saving = ref(false)
 const savingAndRestarting = ref(false)
 const upgradeOpen = ref(false)
@@ -77,8 +87,10 @@ const { connect: connectUpgrade, close: closeUpgrade } = useEventSource(
 
 const isDirty = computed(
   () =>
-    cpus.value !== (props.service.resourceLimits?.cpus || defaults.cpus) ||
-    memory.value !== (props.service.resourceLimits?.memory || defaults.memory)
+    form.resourceLimits.cpus !==
+      (props.service.resourceLimits?.cpus || defaults.cpus) ||
+    form.resourceLimits.memory !==
+      (props.service.resourceLimits?.memory || defaults.memory)
 )
 
 async function saveSettings({ restart = false } = {}) {
@@ -89,14 +101,14 @@ async function saveSettings({ restart = false } = {}) {
   }
 
   try {
-    const res = await fetch(`/api/v1/services/${props.service.id}`, {
+    const res = await fetch(settingsUrl, {
       method: 'PATCH',
       headers: {
         'Content-Type': 'application/json',
         'x-csrf-token': page.props._csrf || ''
       },
       body: JSON.stringify({
-        resourceLimits: { cpus: cpus.value, memory: memory.value }
+        resourceLimits: form.resourceLimits
       })
     })
 
@@ -119,6 +131,7 @@ async function saveSettings({ restart = false } = {}) {
       router.reload()
     } else {
       const data = await res.json()
+      applyResponseProblems(data.problems)
       toast({
         message: data.message || 'Failed to save settings',
         type: 'error'
@@ -531,11 +544,26 @@ const serviceTypeLabel = {
               </label>
               <input
                 id="cpuLimit"
-                v-model="cpus"
+                v-model="form.resourceLimits.cpus"
                 type="text"
                 :placeholder="defaults.cpus"
+                :aria-invalid="form.invalid('resourceLimits.cpus')"
+                :aria-describedby="
+                  form.errors['resourceLimits.cpus']
+                    ? 'service-cpu-limit-error'
+                    : null
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                @blur="validateOnBlur('resourceLimits.cpus', $event)"
+                @input="revalidateWhenInvalid('resourceLimits.cpus')"
               />
+              <p
+                v-if="form.errors['resourceLimits.cpus']"
+                id="service-cpu-limit-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors['resourceLimits.cpus'] }}
+              </p>
               <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                 Number of CPU cores, e.g.
                 <code class="text-gray-500 dark:text-gray-400">0.5</code> or
@@ -551,11 +579,26 @@ const serviceTypeLabel = {
               </label>
               <input
                 id="memoryLimit"
-                v-model="memory"
+                v-model="form.resourceLimits.memory"
                 type="text"
                 :placeholder="defaults.memory"
+                :aria-invalid="form.invalid('resourceLimits.memory')"
+                :aria-describedby="
+                  form.errors['resourceLimits.memory']
+                    ? 'service-memory-limit-error'
+                    : null
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                @blur="validateOnBlur('resourceLimits.memory', $event)"
+                @input="revalidateWhenInvalid('resourceLimits.memory')"
               />
+              <p
+                v-if="form.errors['resourceLimits.memory']"
+                id="service-memory-limit-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors['resourceLimits.memory'] }}
+              </p>
               <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                 e.g. <code class="text-gray-500 dark:text-gray-400">256m</code>,
                 <code class="text-gray-500 dark:text-gray-400">512m</code>,
@@ -569,7 +612,9 @@ const serviceTypeLabel = {
             <div class="inline-flex rounded-md shadow-sm">
               <button
                 type="submit"
-                :disabled="!isDirty || saving || savingAndRestarting"
+                :disabled="
+                  !isDirty || form.hasErrors || saving || savingAndRestarting
+                "
                 class="rounded-l-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ saving ? 'Saving...' : 'Save changes' }}
@@ -578,7 +623,9 @@ const serviceTypeLabel = {
                 <button
                   type="button"
                   @click="saveSettings({ restart: true })"
-                  :disabled="!isDirty || saving || savingAndRestarting"
+                  :disabled="
+                    !isDirty || form.hasErrors || saving || savingAndRestarting
+                  "
                   class="rounded-r-md border-l border-gray-700 bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:border-gray-200 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                 >
                   <template v-if="savingAndRestarting">

--- a/assets/js/pages/projects/settings.vue
+++ b/assets/js/pages/projects/settings.vue
@@ -2,6 +2,7 @@
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 
@@ -23,12 +24,24 @@ const form = useForm({
   description: props.project.description || '',
   repositoryUrl: props.project.repositoryUrl || ''
 })
+  .withPrecognition('patch', `/projects/${props.project.slug}`)
+  .setValidationTimeout(350)
 
 const deployForm = useForm({
   autoDeploy: props.project.autoDeploy || false,
   autoDeployBranch: props.project.autoDeployBranch || 'main',
   generateWebhookSecret: false
 })
+  .withPrecognition('patch', `/projects/${props.project.slug}`)
+  .setValidationTimeout(350)
+const {
+  revalidateWhenInvalid: revalidateProjectWhenInvalid,
+  validateOnBlur: validateProjectOnBlur
+} = usePrecognitionValidation(form)
+const {
+  revalidateWhenInvalid: revalidateDeployWhenInvalid,
+  validateOnBlur: validateDeployOnBlur
+} = usePrecognitionValidation(deployForm)
 
 const showDeleteConfirm = ref(false)
 const deleteProjectForm = useForm({
@@ -233,9 +246,17 @@ function openDeleteProject() {
               id="name"
               v-model="form.name"
               type="text"
+              :aria-invalid="form.invalid('name')"
+              :aria-describedby="form.errors.name ? 'project-name-error' : null"
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateProjectOnBlur('name', $event)"
+              @input="revalidateProjectWhenInvalid('name')"
             />
-            <p v-if="form.errors.name" class="mt-1 text-sm text-red-600">
+            <p
+              v-if="form.errors.name"
+              id="project-name-error"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
               {{ form.errors.name }}
             </p>
           </div>
@@ -253,7 +274,20 @@ function openDeleteProject() {
               placeholder="A brief description about your project"
               class="focus:border-brand w-full resize-none border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
               style="field-sizing: content"
+              :aria-invalid="form.invalid('description')"
+              :aria-describedby="
+                form.errors.description ? 'project-description-error' : null
+              "
+              @blur="validateProjectOnBlur('description', $event)"
+              @input="revalidateProjectWhenInvalid('description')"
             ></textarea>
+            <p
+              v-if="form.errors.description"
+              id="project-description-error"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.description }}
+            </p>
           </div>
 
           <div>
@@ -268,14 +302,27 @@ function openDeleteProject() {
               v-model="form.repositoryUrl"
               type="url"
               placeholder="https://github.com/your-org/your-repo"
+              :aria-invalid="form.invalid('repositoryUrl')"
+              :aria-describedby="
+                form.errors.repositoryUrl ? 'repository-url-error' : null
+              "
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateProjectOnBlur('repositoryUrl', $event)"
+              @input="revalidateProjectWhenInvalid('repositoryUrl')"
             />
+            <p
+              v-if="form.errors.repositoryUrl"
+              id="repository-url-error"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ form.errors.repositoryUrl }}
+            </p>
           </div>
 
           <div class="flex justify-end">
             <button
               type="submit"
-              :disabled="form.processing || !form.isDirty"
+              :disabled="form.processing || form.hasErrors || !form.isDirty"
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ form.processing ? 'Saving...' : 'Save changes' }}
@@ -320,16 +367,33 @@ function openDeleteProject() {
                   v-model="deployForm.autoDeployBranch"
                   type="text"
                   placeholder="main"
+                  :aria-invalid="deployForm.invalid('autoDeployBranch')"
+                  :aria-describedby="
+                    deployForm.errors.autoDeployBranch
+                      ? 'auto-deploy-branch-error'
+                      : null
+                  "
                   class="focus:border-brand w-40 border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:text-white"
+                  @blur="validateDeployOnBlur('autoDeployBranch', $event)"
+                  @input="revalidateDeployWhenInvalid('autoDeployBranch')"
                 />
                 <button
                   @click="saveDeploySettings"
-                  :disabled="deployForm.processing"
+                  :disabled="
+                    deployForm.processing || deployForm.errors.autoDeployBranch
+                  "
                   class="rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                 >
                   Save
                 </button>
               </div>
+              <p
+                v-if="deployForm.errors.autoDeployBranch"
+                id="auto-deploy-branch-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ deployForm.errors.autoDeployBranch }}
+              </p>
             </div>
 
             <!-- Webhook URL -->

--- a/tests/e2e/pages/projects/precognition-validation.test.js
+++ b/tests/e2e/pages/projects/precognition-validation.test.js
@@ -1,0 +1,70 @@
+const { test } = require('sounding')
+
+test(
+  'project and app configuration validates inline before submission',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'browser-precognition',
+          name: 'Browser Precognition'
+        }
+      }
+    }
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+
+    await page.resize(1440, 900)
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+
+    await page.goto('/projects/new')
+    await page.fill('#name', '---')
+    await page.raw.locator('#name').blur()
+    await page.raw.locator('#project-name-error').waitFor({ state: 'visible' })
+    await expect(page).toSee('Name must include at least one letter or number')
+    await page.screenshot('.tmp/issue-206-project-validation-light.png', {
+      fullPage: true
+    })
+
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await page.goto(
+      `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/settings`
+    )
+    await page.fill('#cpuLimit', '0')
+    await page.raw.locator('#cpuLimit').blur()
+    await page.raw.locator('#cpu-limit-error').waitFor({ state: 'visible' })
+    await expect(page).toSee('CPU limit must be greater than 0')
+    await page.screenshot('.tmp/issue-206-app-validation-dark.png', {
+      fullPage: true
+    })
+
+    await page.fill('#cpuLimit', '1.25')
+    await page.raw.locator('#cpu-limit-error').waitFor({ state: 'hidden' })
+    await page.raw.waitForTimeout(500)
+    const saved = page.raw.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .endsWith(
+            `/api/v1/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`
+          ) && response.request().method() === 'PATCH'
+    )
+    await page.raw
+      .locator('form')
+      .first()
+      .locator('button[type="submit"]')
+      .click()
+    expect((await saved).status()).toBe(200)
+
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)

--- a/tests/functional/pages/projects.test.js
+++ b/tests/functional/pages/projects.test.js
@@ -90,6 +90,98 @@ test(
 )
 
 test(
+  'project creation validates with Precognition without creating records',
+  { world: 'configured-slipway' },
+  async ({ sails, request, expect }) => {
+    const dashboard = await withCsrfFromPage(
+      request,
+      '/projects/new',
+      'genesisUser'
+    )
+    const projectsBefore = await sails.models.project.count()
+    const environmentsBefore = await sails.models.environment.count()
+
+    const invalid = await dashboard.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'name'
+      })
+      .post('/projects', {
+        name: '---',
+        description: ''
+      })
+
+    expect(invalid).toHaveStatus(422)
+    expect(Boolean(invalid.data.errors.name)).toBe(true)
+
+    const valid = await dashboard.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'name'
+      })
+      .post('/projects', {
+        name: 'Precognitive Launch',
+        description: ''
+      })
+
+    expect(valid).toHaveStatus(204)
+    expect(valid).toHaveHeader('precognition-success', 'true')
+    expect(await sails.models.project.count()).toBe(projectsBefore)
+    expect(await sails.models.environment.count()).toBe(environmentsBefore)
+  }
+)
+
+test(
+  'app settings validate with Precognition without changing the app',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'precognition-configuration',
+          name: 'Precognition Configuration'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const dashboard = await withCsrfFromPage(request, '/', 'genesisUser')
+    const url = `/api/v1/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`
+
+    const invalid = await dashboard.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'resourceLimits.cpus'
+      })
+      .patch(url, {
+        resourceLimits: { cpus: '0', memory: '512m' }
+      })
+
+    expect(invalid).toHaveStatus(422)
+    expect(Boolean(invalid.data.errors['resourceLimits.cpus'])).toBe(true)
+
+    const valid = await dashboard.request
+      .withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'resourceLimits.memory'
+      })
+      .patch(url, {
+        resourceLimits: { cpus: '1', memory: '1g' }
+      })
+
+    expect(valid).toHaveStatus(204)
+    expect(valid).toHaveHeader('precognition-success', 'true')
+
+    const unchanged = await sails.models.app.findOne({ id: app.id })
+    expect(unchanged.resourceLimits).toEqual(app.resourceLimits)
+  }
+)
+
+test(
   'app page uses the custom domain as the primary URL',
   {
     world: {

--- a/tests/unit/helpers/configuration/validate.test.js
+++ b/tests/unit/helpers/configuration/validate.test.js
@@ -1,0 +1,45 @@
+const { test } = require('sounding')
+
+test('configuration validation accepts production-safe values', async ({
+  sails,
+  expect
+}) => {
+  const problems = sails.helpers.configuration.validate(
+    {
+      name: 'Web worker',
+      description: 'Processes background jobs.',
+      repositoryUrl: 'https://github.com/sailscastshq/slipway',
+      autoDeploy: true,
+      autoDeployBranch: 'feat/safe-release',
+      dockerfilePath: 'docker/Dockerfile.worker',
+      healthPath: '/health',
+      routePath: null,
+      domain: 'worker.example.com',
+      resourceLimits: { cpus: '0.5', memory: '512m' }
+    },
+    ['name', 'dockerfilePath', 'healthPath']
+  )
+
+  expect(problems).toEqual([])
+})
+
+test('configuration validation rejects unsafe paths and resource limits', async ({
+  sails,
+  expect
+}) => {
+  const problems = sails.helpers.configuration.validate({
+    dockerfilePath: '../Dockerfile',
+    healthPath: 'https://example.com/health',
+    routePath: '/api/',
+    domain: 'https://example.com',
+    resourceLimits: { cpus: '0', memory: '2m' }
+  })
+  const errors = Object.assign({}, ...problems)
+
+  expect(Boolean(errors.dockerfilePath)).toBe(true)
+  expect(Boolean(errors.healthPath)).toBe(true)
+  expect(Boolean(errors.routePath)).toBe(true)
+  expect(Boolean(errors.domain)).toBe(true)
+  expect(Boolean(errors['resourceLimits.cpus'])).toBe(true)
+  expect(Boolean(errors['resourceLimits.memory'])).toBe(true)
+})


### PR DESCRIPTION
## Summary

- validate project, environment, app, and service configuration against server-owned rules before submission
- stop Precognition requests before database, Docker, Caddy, webhook, audit, and restart side effects
- keep validation minimal with inline field errors and disabled invalid actions in light and dark modes
- preserve stable environment URLs when display names change

## Verification

- 66 unit tests passed
- 82 functional tests passed
- 39 browser tests passed
- Prettier and diff checks passed

Fixes #206