### PR TITLE
Add Precognition validation to settings and integrations

### DIFF
--- a/api/controllers/api/v1/deploy-token/create.js
+++ b/api/controllers/api/v1/deploy-token/create.js
@@ -37,6 +37,12 @@ module.exports = {
     },
     forbidden: {
       statusCode: 403
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -48,6 +54,15 @@ module.exports = {
     expiresInDays
   }) {
     const user = await User.findOne({ id: this.req.session.userId })
+
+    const problems = sails.helpers.setting.validate(
+      { name, scopes, expiresInDays },
+      ['name'],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
 
     // Validate project access if scoped
     if (projectId) {
@@ -71,6 +86,10 @@ module.exports = {
       if (project.team.id !== user.team) {
         throw 'forbidden'
       }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     // Calculate expiration

--- a/api/controllers/setting/update-api-key.js
+++ b/api/controllers/setting/update-api-key.js
@@ -22,6 +22,12 @@ module.exports = {
     },
     notFound: {
       responseType: 'redirect'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -34,7 +40,19 @@ module.exports = {
       throw { notFound: '/settings/api-keys' }
     }
 
-    await CliToken.updateOne(id).set({ name })
+    const problems = sails.helpers.setting.validate(
+      { name },
+      ['name'],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
+    await CliToken.updateOne(id).set({ name: name.trim() })
 
     sails.inertia.flash('success', 'Token renamed.')
     return '/settings/api-keys'

--- a/api/controllers/setting/update-git.js
+++ b/api/controllers/setting/update-git.js
@@ -23,6 +23,12 @@ module.exports = {
     forbidden: {
       statusCode: 403,
       description: 'Only admins can configure GitHub OAuth'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -31,6 +37,18 @@ module.exports = {
 
     if (user.teamRole !== 'owner' && user.teamRole !== 'admin') {
       throw 'forbidden'
+    }
+
+    const problems = sails.helpers.setting.validate(
+      { clientId, clientSecret },
+      ['clientId', 'clientSecret'],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     await sails.helpers.setting.set('githubClientId', clientId.trim())

--- a/api/controllers/setting/update-global-env.js
+++ b/api/controllers/setting/update-global-env.js
@@ -8,6 +8,10 @@ module.exports = {
       type: 'json',
       required: true,
       description: 'Global environment variables as key-value object'
+    },
+    envSource: {
+      type: 'string',
+      description: 'Optional raw KEY=value input used to detect duplicate keys'
     }
   },
 
@@ -17,15 +21,33 @@ module.exports = {
     },
     forbidden: {
       statusCode: 403
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
-  fn: async function ({ envVars }) {
+  fn: async function ({ envVars, envSource }) {
     const user = await User.findOne({ id: this.req.session.userId })
 
     // Only owners and admins can modify global env vars
     if (user.teamRole !== 'owner' && user.teamRole !== 'admin') {
       throw 'forbidden'
+    }
+
+    const problems = sails.helpers.setting.validate(
+      { envVars, envSource },
+      [],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     await sails.helpers.setting.set(

--- a/api/controllers/setting/update-instance.js
+++ b/api/controllers/setting/update-instance.js
@@ -22,10 +22,33 @@ module.exports = {
   exits: {
     success: {
       responseType: 'inertiaRedirect'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
   fn: async function ({ instanceDomain, instanceName, acmeEmail }) {
+    const user = await User.findOne({ id: this.req.session.userId })
+    const problems = sails.helpers.setting.validate(
+      {
+        instanceDomain,
+        instanceName,
+        acmeEmail
+      },
+      [],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     if (instanceDomain !== undefined) {
       // Clean up the domain - remove protocol and trailing slashes
       let cleanDomain = instanceDomain
@@ -69,7 +92,6 @@ module.exports = {
     }
 
     // Audit log
-    const user = await User.findOne({ id: this.req.session.userId })
     await sails.helpers.audit.log.with({
       action: 'settings.updated',
       resourceType: 'settings',

--- a/api/controllers/setting/update-notifications.js
+++ b/api/controllers/setting/update-notifications.js
@@ -100,12 +100,45 @@ module.exports = {
   exits: {
     success: {
       responseType: 'inertiaRedirect'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
   fn: async function (inputs) {
+    const validationInputs = { ...inputs }
+    for (const [field, settingKey] of [
+      ['telegramBotToken', 'telegramBotToken'],
+      ['discordWebhookUrl', 'discordWebhookUrl'],
+      ['slackWebhookUrl', 'slackWebhookUrl'],
+      ['webhookUrl', 'webhookUrl']
+    ]) {
+      if (!String(validationInputs[field] || '').trim()) {
+        validationInputs[field] = await sails.helpers.setting.get(
+          settingKey,
+          ''
+        )
+      }
+    }
+
+    const problems = sails.helpers.setting.validate(
+      validationInputs,
+      [],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     // Telegram settings
-    if (inputs.telegramBotToken !== undefined) {
+    if (inputs.telegramBotToken?.trim()) {
       await sails.helpers.setting.set(
         'telegramBotToken',
         inputs.telegramBotToken.trim()
@@ -131,7 +164,7 @@ module.exports = {
     }
 
     // Discord settings
-    if (inputs.discordWebhookUrl !== undefined) {
+    if (inputs.discordWebhookUrl?.trim()) {
       await sails.helpers.setting.set(
         'discordWebhookUrl',
         inputs.discordWebhookUrl.trim()
@@ -145,7 +178,7 @@ module.exports = {
     }
 
     // Slack settings
-    if (inputs.slackWebhookUrl !== undefined) {
+    if (inputs.slackWebhookUrl?.trim()) {
       await sails.helpers.setting.set(
         'slackWebhookUrl',
         inputs.slackWebhookUrl.trim()
@@ -159,7 +192,7 @@ module.exports = {
     }
 
     // Webhook settings
-    if (inputs.webhookUrl !== undefined) {
+    if (inputs.webhookUrl?.trim()) {
       await sails.helpers.setting.set('webhookUrl', inputs.webhookUrl.trim())
     }
     if (inputs.webhookEnabled !== undefined) {

--- a/api/controllers/setting/update-uploads.js
+++ b/api/controllers/setting/update-uploads.js
@@ -41,6 +41,9 @@ module.exports = {
     },
     badRequest: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -54,6 +57,53 @@ module.exports = {
     publicUrl,
     backupSchedule
   }) {
+    let globalEnvVars = {}
+    try {
+      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
+      globalEnvVars = JSON.parse(globalJson)
+    } catch {
+      /* ignore parse errors */
+    }
+
+    const prefix = provider ? provider.toUpperCase() : null
+    const requiredFields = []
+    if (provider) {
+      requiredFields.push('provider', 'bucket')
+      if (!globalEnvVars[`${prefix}_ACCESS_KEY`]) {
+        requiredFields.push('accessKey')
+      }
+      if (!globalEnvVars[`${prefix}_SECRET_KEY`]) {
+        requiredFields.push('secretKey')
+      }
+      if (provider === 'r2' || provider === 'spaces') {
+        requiredFields.push('endpoint')
+      }
+      if (provider === 's3' || provider === 'spaces') {
+        requiredFields.push('region')
+      }
+    }
+
+    const problems = sails.helpers.setting.validate(
+      {
+        provider,
+        accessKey,
+        secretKey,
+        bucket,
+        endpoint,
+        region,
+        publicUrl,
+        backupSchedule
+      },
+      requiredFields,
+      this.req
+    )
+    if (problems.length) {
+      throw { badRequest: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
     // Handle backup schedule update
     if (backupSchedule !== undefined) {
       const existing = await sails.helpers.setting.get('backupSchedule')
@@ -77,15 +127,6 @@ module.exports = {
         sails.inertia.flash('success', 'Backup schedule updated')
         return '/settings/uploads'
       }
-    }
-
-    // Get existing global env vars
-    let globalEnvVars = {}
-    try {
-      const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
-      globalEnvVars = JSON.parse(globalJson)
-    } catch {
-      /* ignore parse errors */
     }
 
     // Preserve existing credentials before clearing

--- a/api/controllers/setting/view-notifications.js
+++ b/api/controllers/setting/view-notifications.js
@@ -125,21 +125,25 @@ module.exports = {
       page: 'settings/notifications',
       props: {
         telegram: {
-          botToken: telegramBotToken,
+          botToken: '',
+          hasBotToken: !!telegramBotToken,
           chatId: telegramChatId,
           threadId: telegramThreadId,
           enabled: telegramEnabled === 'true'
         },
         discord: {
-          webhookUrl: discordWebhookUrl,
+          webhookUrl: '',
+          hasWebhookUrl: !!discordWebhookUrl,
           enabled: discordEnabled === 'true'
         },
         slack: {
-          webhookUrl: slackWebhookUrl,
+          webhookUrl: '',
+          hasWebhookUrl: !!slackWebhookUrl,
           enabled: slackEnabled === 'true'
         },
         webhook: {
-          url: webhookUrl,
+          url: '',
+          hasUrl: !!webhookUrl,
           enabled: webhookEnabled === 'true'
         },
         smtp: {

--- a/api/controllers/team/invite-member.js
+++ b/api/controllers/team/invite-member.js
@@ -26,6 +26,12 @@ module.exports = {
     },
     conflict: {
       statusCode: 409
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -37,21 +43,37 @@ module.exports = {
       throw { redirect: '/settings/team' }
     }
 
+    const problems = sails.helpers.setting.validate(
+      { email, role },
+      [],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+
     // Check if user already exists
     const existingUser = await User.findOne({ email: email.toLowerCase() })
 
     if (existingUser) {
       if (existingUser.team === currentUser.team) {
-        // Already on this team
-        this.req.addFlash('error', `${email} is already a member of this team.`)
-        return '/settings/team'
+        throw {
+          invalid: {
+            problems: [
+              { email: 'This person is already a member of the team.' }
+            ]
+          }
+        }
       }
-      // User exists but on another team — for 0.0.1, don't support multi-team
-      this.req.addFlash(
-        'error',
-        `${email} already has an account on another team.`
-      )
-      return '/settings/team'
+      throw {
+        invalid: {
+          problems: [{ email: 'This account already belongs to another team.' }]
+        }
+      }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     // Create new user account with a temporary password

--- a/api/controllers/team/update-member-role.js
+++ b/api/controllers/team/update-member-role.js
@@ -23,6 +23,12 @@ module.exports = {
     },
     notFound: {
       statusCode: 404
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -33,6 +39,11 @@ module.exports = {
     if (currentUser.teamRole !== 'owner') {
       this.req.addFlash('error', 'Only team owners can change roles.')
       return '/settings/team'
+    }
+
+    const problems = sails.helpers.setting.validate({ role }, [], this.req)
+    if (problems.length) {
+      throw { invalid: { problems } }
     }
 
     // Can't change own role
@@ -54,6 +65,10 @@ module.exports = {
     if (targetUser.teamRole === 'owner') {
       this.req.addFlash('error', "Cannot change the team owner's role.")
       return '/settings/team'
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     await User.updateOne({ id: userId }).set({ teamRole: role })

--- a/api/controllers/team/update-team-profile.js
+++ b/api/controllers/team/update-team-profile.js
@@ -15,6 +15,12 @@ module.exports = {
   exits: {
     success: {
       responseType: 'inertiaRedirect'
+    },
+    invalid: {
+      responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -22,6 +28,18 @@ module.exports = {
     const user = await User.findOne({ id: this.req.session.userId }).populate(
       'team'
     )
+
+    const problems = sails.helpers.setting.validate(
+      { name },
+      ['name'],
+      this.req
+    )
+    if (problems.length) {
+      throw { invalid: { problems } }
+    }
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
 
     // Generate new slug from name
     const slug = name

--- a/api/helpers/setting/validate.js
+++ b/api/helpers/setting/validate.js
@@ -1,0 +1,467 @@
+const net = require('net')
+
+module.exports = {
+  friendlyName: 'Validate settings',
+
+  description: 'Validate instance, integration, storage, and team settings.',
+
+  inputs: {
+    values: {
+      type: 'ref',
+      required: true
+    },
+    requiredFields: {
+      type: 'json',
+      defaultsTo: []
+    },
+    request: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  sync: true,
+
+  fn: function ({ values, requiredFields, request }) {
+    const problems = []
+    const required = new Set(requiredFields)
+    const validateOnly = new Set(
+      String(request?.header?.('Precognition-Validate-Only') || '')
+        .split(',')
+        .map((field) => field.trim())
+        .filter(Boolean)
+    )
+
+    function add(field, message) {
+      problems.push({ [field]: message })
+    }
+
+    function isMissing(value) {
+      return (
+        value === undefined || value === null || String(value).trim() === ''
+      )
+    }
+
+    function shouldCheck(field) {
+      if (!validateOnly.size) return true
+      return [...validateOnly].some(
+        (requested) =>
+          requested === field ||
+          requested.startsWith(`${field}.`) ||
+          field.startsWith(`${requested}.`)
+      )
+    }
+
+    function validateRequired(field, label) {
+      if (!shouldCheck(field)) return false
+      if (required.has(field) && isMissing(values[field])) {
+        add(field, `${label} is required.`)
+        return false
+      }
+      return true
+    }
+
+    function isEmail(value) {
+      const email = String(value || '').trim()
+      return (
+        email.length <= 254 &&
+        /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) &&
+        !email.includes('..')
+      )
+    }
+
+    function isHostname(value) {
+      const hostname = String(value || '').toLowerCase()
+      if (hostname === 'localhost' || net.isIP(hostname)) return true
+      if (hostname.length > 253 || !hostname.includes('.')) return false
+
+      return hostname
+        .split('.')
+        .every(
+          (label) =>
+            label.length > 0 &&
+            label.length <= 63 &&
+            /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label)
+        )
+    }
+
+    function isHttpUrl(value, { httpsOnly = false } = {}) {
+      try {
+        const url = new URL(String(value || '').trim())
+        return (
+          (httpsOnly
+            ? url.protocol === 'https:'
+            : ['http:', 'https:'].includes(url.protocol)) &&
+          Boolean(url.hostname) &&
+          !url.username &&
+          !url.password
+        )
+      } catch {
+        return false
+      }
+    }
+
+    if (validateRequired('name', 'Name') && values.name !== undefined) {
+      const name = String(values.name).trim()
+      if (!name) {
+        add('name', 'Name cannot be empty.')
+      } else if (name.length > 100) {
+        add('name', 'Name must be 100 characters or less.')
+      } else if (!/[a-z0-9]/i.test(name)) {
+        add('name', 'Name must include at least one letter or number.')
+      }
+    }
+
+    if (shouldCheck('instanceName') && values.instanceName !== undefined) {
+      const instanceName = String(values.instanceName).trim()
+      if (instanceName.length > 100) {
+        add('instanceName', 'Instance name must be 100 characters or less.')
+      } else if (instanceName && !/[a-z0-9]/i.test(instanceName)) {
+        add(
+          'instanceName',
+          'Instance name must include at least one letter or number.'
+        )
+      }
+    }
+
+    if (shouldCheck('instanceDomain') && !isMissing(values.instanceDomain)) {
+      try {
+        const cleanDomain = String(values.instanceDomain)
+          .trim()
+          .replace(/^https?:\/\//i, '')
+          .replace(/\/+$/, '')
+        const url = new URL(`http://${cleanDomain}`)
+        const valid =
+          isHostname(url.hostname) &&
+          url.pathname === '/' &&
+          !url.search &&
+          !url.hash &&
+          !url.username &&
+          !url.password
+
+        if (!valid) throw new Error('invalid domain')
+      } catch {
+        add('instanceDomain', 'Enter a valid domain without a path.')
+      }
+    }
+
+    if (
+      shouldCheck('acmeEmail') &&
+      !isMissing(values.acmeEmail) &&
+      !isEmail(values.acmeEmail)
+    ) {
+      add('acmeEmail', 'Enter a valid email address.')
+    }
+    if (
+      shouldCheck('email') &&
+      !isMissing(values.email) &&
+      !isEmail(values.email)
+    ) {
+      add('email', 'Enter a valid email address.')
+    }
+
+    for (const [field, label] of [
+      ['clientId', 'Client ID'],
+      ['clientSecret', 'Client secret']
+    ]) {
+      if (validateRequired(field, label) && !isMissing(values[field])) {
+        const maxLength = field === 'clientSecret' ? 4096 : 255
+        if (String(values[field]).trim().length > maxLength) {
+          add(field, `${label} is too long.`)
+        }
+      }
+    }
+
+    if (shouldCheck('envVars') && values.envVars !== undefined) {
+      const envVars = values.envVars
+      if (!envVars || typeof envVars !== 'object' || Array.isArray(envVars)) {
+        add('envVars', 'Environment variables must be key-value pairs.')
+      } else {
+        for (const [key, value] of Object.entries(envVars)) {
+          if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+            add(
+              'envVars',
+              'Variable names may contain only letters, numbers, and underscores, and cannot start with a number.'
+            )
+            break
+          }
+          if (
+            value !== null &&
+            !['string', 'number', 'boolean'].includes(typeof value)
+          ) {
+            add('envVars', 'Environment variable values must be scalar values.')
+            break
+          }
+        }
+      }
+    }
+
+    if (shouldCheck('envVars') && !isMissing(values.envSource)) {
+      const names = new Set()
+      for (const line of String(values.envSource).split('\n')) {
+        const trimmed = line.trim()
+        if (!trimmed || trimmed.startsWith('#')) continue
+        const separator = trimmed.indexOf('=')
+        const key = separator === -1 ? '' : trimmed.slice(0, separator).trim()
+        if (!key || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
+          add(
+            'envVars',
+            'Each environment variable must use a valid KEY=value line.'
+          )
+          break
+        }
+        if (names.has(key)) {
+          add('envVars', 'Environment variable names must be unique.')
+          break
+        }
+        names.add(key)
+      }
+    }
+
+    const enabledRequirements = [
+      ['telegramEnabled', 'telegramBotToken', 'Telegram bot token'],
+      ['telegramEnabled', 'telegramChatId', 'Telegram chat ID'],
+      ['discordEnabled', 'discordWebhookUrl', 'Discord webhook URL'],
+      ['slackEnabled', 'slackWebhookUrl', 'Slack webhook URL'],
+      ['webhookEnabled', 'webhookUrl', 'Webhook URL'],
+      ['smtpEnabled', 'smtpHost', 'SMTP host'],
+      ['smtpEnabled', 'smtpFrom', 'From address'],
+      ['smtpEnabled', 'notificationEmails', 'Notification recipients']
+    ]
+    for (const [enabledField, field, label] of enabledRequirements) {
+      if (
+        shouldCheck(field) &&
+        values[enabledField] === true &&
+        isMissing(values[field])
+      ) {
+        add(field, `${label} is required when this channel is enabled.`)
+      }
+    }
+
+    if (
+      shouldCheck('telegramBotToken') &&
+      !isMissing(values.telegramBotToken) &&
+      values.telegramEnabled !== false &&
+      !/^\d{5,}:[A-Za-z0-9_-]{20,}$/.test(
+        String(values.telegramBotToken).trim()
+      )
+    ) {
+      add('telegramBotToken', 'Enter a valid Telegram bot token.')
+    }
+    if (
+      shouldCheck('telegramChatId') &&
+      !isMissing(values.telegramChatId) &&
+      values.telegramEnabled !== false &&
+      !/^-?\d+$/.test(String(values.telegramChatId).trim())
+    ) {
+      add('telegramChatId', 'Enter a valid Telegram chat ID.')
+    }
+    if (
+      shouldCheck('telegramThreadId') &&
+      !isMissing(values.telegramThreadId) &&
+      values.telegramEnabled !== false &&
+      !/^\d+$/.test(String(values.telegramThreadId).trim())
+    ) {
+      add('telegramThreadId', 'Enter a valid Telegram topic ID.')
+    }
+
+    for (const [field, label, httpsOnly] of [
+      ['discordWebhookUrl', 'Discord webhook URL', true],
+      ['slackWebhookUrl', 'Slack webhook URL', true],
+      ['webhookUrl', 'webhook URL', false],
+      ['endpoint', 'endpoint URL', false],
+      ['publicUrl', 'public URL', false]
+    ]) {
+      const enabledField = {
+        discordWebhookUrl: 'discordEnabled',
+        slackWebhookUrl: 'slackEnabled',
+        webhookUrl: 'webhookEnabled'
+      }[field]
+      if (
+        shouldCheck(field) &&
+        !isMissing(values[field]) &&
+        (!enabledField || values[enabledField] !== false) &&
+        !isHttpUrl(values[field], { httpsOnly })
+      ) {
+        add(
+          field,
+          `Enter a valid ${
+            httpsOnly ? 'HTTPS' : 'HTTP or HTTPS'
+          } ${label} without credentials.`
+        )
+      }
+    }
+
+    if (
+      shouldCheck('smtpHost') &&
+      !isMissing(values.smtpHost) &&
+      values.smtpEnabled !== false
+    ) {
+      const smtpHost = String(values.smtpHost).trim()
+      if (
+        smtpHost.length > 253 ||
+        smtpHost.includes('://') ||
+        smtpHost.includes('/') ||
+        !isHostname(smtpHost)
+      ) {
+        add('smtpHost', 'Enter a valid SMTP hostname or IP address.')
+      }
+    }
+    if (
+      shouldCheck('smtpPort') &&
+      !isMissing(values.smtpPort) &&
+      values.smtpEnabled !== false
+    ) {
+      const smtpPort = Number(values.smtpPort)
+      if (!Number.isInteger(smtpPort) || smtpPort < 1 || smtpPort > 65535) {
+        add('smtpPort', 'SMTP port must be between 1 and 65535.')
+      }
+    }
+    if (
+      shouldCheck('smtpFrom') &&
+      !isMissing(values.smtpFrom) &&
+      values.smtpEnabled !== false &&
+      !isEmail(values.smtpFrom)
+    ) {
+      add('smtpFrom', 'Enter a valid from email address.')
+    }
+    if (
+      shouldCheck('notificationEmails') &&
+      !isMissing(values.notificationEmails) &&
+      values.smtpEnabled !== false
+    ) {
+      const emails = String(values.notificationEmails)
+        .split(',')
+        .map((email) => email.trim())
+        .filter(Boolean)
+      if (!emails.length || emails.some((email) => !isEmail(email))) {
+        add(
+          'notificationEmails',
+          'Enter valid email addresses separated by commas.'
+        )
+      }
+    }
+
+    if (validateRequired('provider', 'Storage provider')) {
+      if (
+        values.provider !== undefined &&
+        !['r2', 's3', 'spaces'].includes(values.provider)
+      ) {
+        add('provider', 'Choose a supported storage provider.')
+      }
+    }
+    for (const [field, label] of [
+      ['accessKey', 'Access key'],
+      ['secretKey', 'Secret key'],
+      ['bucket', 'Bucket'],
+      ['region', 'Region'],
+      ['endpoint', 'Endpoint URL']
+    ]) {
+      validateRequired(field, label)
+    }
+
+    if (
+      shouldCheck('accessKey') &&
+      !isMissing(values.accessKey) &&
+      /\s/.test(values.accessKey)
+    ) {
+      add('accessKey', 'Access key cannot contain whitespace.')
+    }
+    if (
+      shouldCheck('secretKey') &&
+      !isMissing(values.secretKey) &&
+      /\s/.test(values.secretKey)
+    ) {
+      add('secretKey', 'Secret key cannot contain whitespace.')
+    }
+    if (shouldCheck('bucket') && !isMissing(values.bucket)) {
+      const bucket = String(values.bucket).trim()
+      if (
+        bucket.length < 3 ||
+        bucket.length > 63 ||
+        !/^[a-z0-9][a-z0-9.-]*[a-z0-9]$/.test(bucket) ||
+        bucket.includes('..') ||
+        /\.-|-\./.test(bucket) ||
+        net.isIP(bucket)
+      ) {
+        add(
+          'bucket',
+          'Enter a valid bucket name using lowercase letters, numbers, dots, or hyphens.'
+        )
+      }
+    }
+    if (
+      shouldCheck('region') &&
+      !isMissing(values.region) &&
+      !/^[a-z0-9][a-z0-9-]{0,62}$/.test(String(values.region).trim())
+    ) {
+      add('region', 'Enter a valid storage region.')
+    }
+
+    if (shouldCheck('backupSchedule') && values.backupSchedule !== undefined) {
+      const schedule = values.backupSchedule || {}
+      if (schedule.enabled) {
+        if (
+          shouldCheck('backupSchedule.intervalHours') &&
+          (!Number.isInteger(Number(schedule.intervalHours)) ||
+            Number(schedule.intervalHours) < 1 ||
+            Number(schedule.intervalHours) > 8760)
+        ) {
+          add(
+            'backupSchedule.intervalHours',
+            'Backup interval must be between 1 and 8760 hours.'
+          )
+        }
+        if (
+          shouldCheck('backupSchedule.retentionCount') &&
+          (!Number.isInteger(Number(schedule.retentionCount)) ||
+            Number(schedule.retentionCount) < 1 ||
+            Number(schedule.retentionCount) > 1000)
+        ) {
+          add(
+            'backupSchedule.retentionCount',
+            'Retention must be between 1 and 1000 backups.'
+          )
+        }
+      }
+    }
+
+    if (
+      shouldCheck('role') &&
+      values.role !== undefined &&
+      !['admin', 'member'].includes(values.role)
+    ) {
+      add('role', 'Choose a valid team role.')
+    }
+
+    if (shouldCheck('scopes') && values.scopes !== undefined) {
+      if (
+        !Array.isArray(values.scopes) ||
+        !values.scopes.length ||
+        values.scopes.some((scope) => scope !== 'deploy')
+      ) {
+        add('scopes', 'Choose a valid deploy token scope.')
+      }
+    }
+    if (shouldCheck('expiresInDays') && !isMissing(values.expiresInDays)) {
+      const expiresInDays = Number(values.expiresInDays)
+      if (
+        !Number.isInteger(expiresInDays) ||
+        expiresInDays < 1 ||
+        expiresInDays > 3650
+      ) {
+        add(
+          'expiresInDays',
+          'Token expiration must be between 1 and 3650 days.'
+        )
+      }
+    }
+
+    return problems
+  }
+}

--- a/assets/js/pages/settings/api-keys.vue
+++ b/assets/js/pages/settings/api-keys.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { Link, Head, router } from '@inertiajs/vue3'
+import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -39,32 +40,33 @@ function closeMenu() {
 
 // Rename
 const renamingId = ref(null)
-const renameValue = ref('')
+const renameForm = useForm({ name: '' })
+  .withPrecognition('patch', () => `/settings/cli-tokens/${renamingId.value}`)
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(renameForm)
 
 function startRename(token) {
   renamingId.value = token.id
-  renameValue.value = token.name
+  renameForm.name = token.name
+  renameForm.clearErrors()
   openMenu.value = null
 }
 
 function submitRename(tokenId) {
-  if (!renameValue.value.trim()) return
-  router.patch(
-    `/settings/cli-tokens/${tokenId}`,
-    {
-      name: renameValue.value.trim()
-    },
-    {
-      preserveScroll: true,
-      onSuccess: () => {
-        renamingId.value = null
-      }
+  if (!renameForm.name.trim()) return
+  renameForm.patch(`/settings/cli-tokens/${tokenId}`, {
+    preserveScroll: true,
+    onSuccess: () => {
+      renamingId.value = null
+      renameForm.resetAndClearErrors()
     }
-  )
+  })
 }
 
 function cancelRename() {
   renamingId.value = null
+  renameForm.resetAndClearErrors()
 }
 
 // Delete
@@ -282,12 +284,18 @@ function timeAgo(date) {
                 <template v-if="renamingId === token.id">
                   <div class="flex items-center space-x-2">
                     <input
-                      v-model="renameValue"
+                      v-model="renameForm.name"
                       @keydown.enter="submitRename(token.id)"
                       @keydown.escape="cancelRename"
                       ref="renameInput"
                       autofocus
+                      :aria-invalid="renameForm.invalid('name')"
+                      :aria-describedby="
+                        renameForm.errors.name ? 'cli-token-name-error' : null
+                      "
                       class="focus:border-brand w-full rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+                      @blur="validateOnBlur('name', $event)"
+                      @input="revalidateWhenInvalid('name')"
                     />
                     <button
                       @click="submitRename(token.id)"
@@ -326,6 +334,13 @@ function timeAgo(date) {
                       </svg>
                     </button>
                   </div>
+                  <p
+                    v-if="renameForm.errors.name"
+                    id="cli-token-name-error"
+                    class="mt-1 text-xs text-red-600 dark:text-red-400"
+                  >
+                    {{ renameForm.errors.name }}
+                  </p>
                 </template>
                 <template v-else>
                   <div class="flex items-center space-x-2">

--- a/assets/js/pages/settings/git.vue
+++ b/assets/js/pages/settings/git.vue
@@ -4,6 +4,7 @@ import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import { useToast } from '@/composables/toast'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -28,6 +29,12 @@ const oauthForm = useForm({
   clientId: '',
   clientSecret: ''
 })
+  .withPrecognition('patch', '/settings/git')
+  .setValidationTimeout(350)
+const {
+  revalidateWhenInvalid: revalidateOauthWhenInvalid,
+  validateOnBlur: validateOauthOnBlur
+} = usePrecognitionValidation(oauthForm)
 
 function saveOAuthConfig() {
   if (!oauthForm.clientId.trim() || !oauthForm.clientSecret.trim()) return
@@ -45,36 +52,46 @@ function connectGithub() {
 
 // ---- Deploy Tokens ----
 const showCreateToken = ref(false)
-const newToken = ref({
+const newToken = useForm({
   name: '',
   projectId: '',
   scopes: ['deploy']
 })
+  .withPrecognition('post', '/api/v1/deploy-tokens')
+  .setValidationTimeout(350)
+const {
+  applyResponseProblems: applyTokenProblems,
+  revalidateWhenInvalid: revalidateTokenWhenInvalid,
+  validateOnBlur: validateTokenOnBlur
+} = usePrecognitionValidation(newToken)
 const createdToken = ref(null)
 const creatingToken = ref(false)
 
 async function createToken() {
-  if (!newToken.value.name.trim() || creatingToken.value) return
+  if (!newToken.name.trim() || creatingToken.value) return
   creatingToken.value = true
+  newToken.clearErrors()
 
   try {
     const res = await fetch('/api/v1/deploy-tokens', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
-        name: newToken.value.name.trim(),
-        projectId: newToken.value.projectId || undefined,
-        scopes: newToken.value.scopes
+        name: newToken.name.trim(),
+        projectId: newToken.projectId || undefined,
+        scopes: newToken.scopes
       })
     })
 
+    const data = await res.json()
     if (res.ok) {
-      const data = await res.json()
       createdToken.value = data.token
-      newToken.value = { name: '', projectId: '', scopes: ['deploy'] }
+      newToken.reset()
       toast({ message: 'Deploy token created', type: 'success' })
     } else {
-      toast({ message: 'Failed to create token', type: 'error' })
+      if (!applyTokenProblems(data.problems)) {
+        toast({ message: 'Failed to create token', type: 'error' })
+      }
     }
   } catch (err) {
     toast({ message: 'Failed to create token', type: 'error' })
@@ -289,9 +306,22 @@ function timeAgo(date) {
                   v-model="oauthForm.clientId"
                   type="text"
                   placeholder="Ov23li..."
+                  :aria-invalid="oauthForm.invalid('clientId')"
+                  :aria-describedby="
+                    oauthForm.errors.clientId ? 'github-client-id-error' : null
+                  "
                   class="focus:border-brand mt-1 w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   required
+                  @blur="validateOauthOnBlur('clientId', $event)"
+                  @input="revalidateOauthWhenInvalid('clientId')"
                 />
+                <p
+                  v-if="oauthForm.errors.clientId"
+                  id="github-client-id-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ oauthForm.errors.clientId }}
+                </p>
               </div>
 
               <div>
@@ -303,16 +333,24 @@ function timeAgo(date) {
                   v-model="oauthForm.clientSecret"
                   type="password"
                   placeholder="••••••••••••••••"
+                  :aria-invalid="oauthForm.invalid('clientSecret')"
+                  :aria-describedby="
+                    oauthForm.errors.clientSecret
+                      ? 'github-client-secret-error'
+                      : null
+                  "
                   class="focus:border-brand mt-1 w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   required
+                  @blur="validateOauthOnBlur('clientSecret', $event)"
+                  @input="revalidateOauthWhenInvalid('clientSecret')"
                 />
-              </div>
-
-              <div
-                v-if="oauthForm.hasErrors"
-                class="rounded-md bg-red-50 p-3 text-sm text-red-800 dark:bg-red-900/20 dark:text-red-300"
-              >
-                Failed to save configuration
+                <p
+                  v-if="oauthForm.errors.clientSecret"
+                  id="github-client-secret-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ oauthForm.errors.clientSecret }}
+                </p>
               </div>
 
               <div class="pt-2">
@@ -321,6 +359,7 @@ function timeAgo(date) {
                   :disabled="
                     !oauthForm.clientId.trim() ||
                     !oauthForm.clientSecret.trim() ||
+                    oauthForm.hasErrors ||
                     oauthForm.processing
                   "
                   class="rounded-md bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
@@ -660,9 +699,22 @@ jobs:
                   v-model="newToken.name"
                   type="text"
                   placeholder="e.g., GitHub Actions"
+                  :aria-invalid="newToken.invalid('name')"
+                  :aria-describedby="
+                    newToken.errors.name ? 'deploy-token-name-error' : null
+                  "
                   class="focus:border-brand mt-1 w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
                   required
+                  @blur="validateTokenOnBlur('name', $event)"
+                  @input="revalidateTokenWhenInvalid('name')"
                 />
+                <p
+                  v-if="newToken.errors.name"
+                  id="deploy-token-name-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ newToken.errors.name }}
+                </p>
               </div>
 
               <div>
@@ -691,7 +743,9 @@ jobs:
                 </button>
                 <button
                   type="submit"
-                  :disabled="!newToken.name.trim() || creatingToken"
+                  :disabled="
+                    !newToken.name.trim() || newToken.hasErrors || creatingToken
+                  "
                   class="rounded-md bg-gray-900 px-4 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                 >
                   {{ creatingToken ? 'Creating...' : 'Create' }}

--- a/assets/js/pages/settings/global-env.vue
+++ b/assets/js/pages/settings/global-env.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import { useToast } from '@/composables/toast'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -56,13 +57,22 @@ function generateSecret() {
 }
 
 const envForm = useForm({
-  envVars: { ...props.globalEnvVars }
+  envVars: { ...props.globalEnvVars },
+  envSource: ''
 })
+  .withPrecognition('patch', '/settings/global-env')
+  .setValidationTimeout(350)
 
-function saveVars(vars) {
-  envForm.envVars = { ...vars }
+function replaceLocalVars(vars) {
+  Object.keys(localVars).forEach((key) => delete localVars[key])
+  Object.assign(localVars, vars)
+}
+
+function submitVars(onSuccess) {
+  saving.value = true
   envForm.patch('/settings/global-env', {
     preserveScroll: true,
+    onSuccess,
     onError: () =>
       toast({ message: 'Failed to save environment variables', type: 'error' }),
     onFinish: () => {
@@ -71,20 +81,37 @@ function saveVars(vars) {
   })
 }
 
+function saveVars(vars, { envSource = '', onSuccess } = {}) {
+  envForm.envVars = { ...vars }
+  envForm.envSource = envSource
+  envForm.validate('envVars', {
+    onPrecognitionSuccess: () => submitVars(onSuccess)
+  })
+}
+
 function addVar() {
   if (!newKey.value.trim()) return
   const key = newKey.value.trim()
-  localVars[key] = newValue.value
-  saveVars(localVars)
-  toast({ message: `Added "${key}"`, type: 'success' })
-  newKey.value = ''
-  newValue.value = ''
+  const nextVars = { ...localVars, [key]: newValue.value }
+  saveVars(nextVars, {
+    onSuccess: () => {
+      replaceLocalVars(nextVars)
+      toast({ message: `Added "${key}"`, type: 'success' })
+      newKey.value = ''
+      newValue.value = ''
+    }
+  })
 }
 
 function removeVar(key) {
-  delete localVars[key]
-  saveVars(localVars)
-  toast({ message: `Removed "${key}"`, type: 'success' })
+  const nextVars = { ...localVars }
+  delete nextVars[key]
+  saveVars(nextVars, {
+    onSuccess: () => {
+      replaceLocalVars(nextVars)
+      toast({ message: `Removed "${key}"`, type: 'success' })
+    }
+  })
 }
 
 function renameVar(oldKey, el) {
@@ -99,17 +126,29 @@ function renameVar(oldKey, el) {
     return
   }
   const value = localVars[oldKey]
-  delete localVars[oldKey]
-  localVars[trimmed] = value
-  saveVars(localVars)
-  toast({ message: `Renamed "${oldKey}" to "${trimmed}"`, type: 'success' })
+  const nextVars = { ...localVars }
+  delete nextVars[oldKey]
+  nextVars[trimmed] = value
+  saveVars(nextVars, {
+    onSuccess: () => {
+      replaceLocalVars(nextVars)
+      toast({
+        message: `Renamed "${oldKey}" to "${trimmed}"`,
+        type: 'success'
+      })
+    }
+  })
 }
 
 function updateVarValue(key, value) {
   if (localVars[key] === value) return
-  localVars[key] = value
-  saveVars(localVars)
-  toast({ message: `Updated "${key}"`, type: 'success' })
+  const nextVars = { ...localVars, [key]: value }
+  saveVars(nextVars, {
+    onSuccess: () => {
+      replaceLocalVars(nextVars)
+      toast({ message: `Updated "${key}"`, type: 'success' })
+    }
+  })
 }
 
 const bulkHasChanges = computed(() => {
@@ -158,16 +197,21 @@ function saveBulk() {
     .sort()
     .map((k) => localVars[k])
     .join(',')
-  Object.keys(localVars).forEach((k) => delete localVars[k])
-  Object.assign(localVars, vars)
-  const newKeys = Object.keys(localVars).sort().join(',')
-  const newVals = Object.keys(localVars)
+  const newKeys = Object.keys(vars).sort().join(',')
+  const newVals = Object.keys(vars)
     .sort()
-    .map((k) => localVars[k])
+    .map((k) => vars[k])
     .join(',')
   if (oldKeys !== newKeys || oldVals !== newVals) {
-    saveVars(localVars)
-    toast({ message: 'Environment variables updated', type: 'success' })
+    saveVars(vars, {
+      envSource: bulkText.value,
+      onSuccess: () => {
+        replaceLocalVars(vars)
+        bulkMode.value = false
+        toast({ message: 'Environment variables updated', type: 'success' })
+      }
+    })
+    return
   }
   bulkMode.value = false
 }
@@ -395,52 +439,60 @@ onMounted(() => {
         <!-- Variables -->
         <div class="rounded-lg border border-gray-200 dark:border-gray-800">
           <!-- Header with bulk toggle -->
-          <div class="flex items-center justify-between px-4 py-3">
-            <h2 class="text-sm font-medium text-gray-900 dark:text-white">
-              Variables
-            </h2>
-            <div class="flex items-center gap-2">
-              <span
-                class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
-              >
-                {{ sortedVarKeys.length }}
-              </span>
-              <Tooltip :text="bulkMode ? 'Single edit' : 'Bulk edit'">
-                <button
-                  @click="bulkMode ? exitBulkMode() : enterBulkMode()"
-                  class="rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+          <div class="px-4 py-3">
+            <div class="flex items-center justify-between">
+              <h2 class="text-sm font-medium text-gray-900 dark:text-white">
+                Variables
+              </h2>
+              <div class="flex items-center gap-2">
+                <span
+                  class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
                 >
-                  <svg
-                    v-if="bulkMode"
-                    class="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
+                  {{ sortedVarKeys.length }}
+                </span>
+                <Tooltip :text="bulkMode ? 'Single edit' : 'Bulk edit'">
+                  <button
+                    @click="bulkMode ? exitBulkMode() : enterBulkMode()"
+                    class="rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
                   >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M4 6h16M4 12h16M4 18h16"
-                    />
-                  </svg>
-                  <svg
-                    v-else
-                    class="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
-                    />
-                  </svg>
-                </button>
-              </Tooltip>
+                    <svg
+                      v-if="bulkMode"
+                      class="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M4 6h16M4 12h16M4 18h16"
+                      />
+                    </svg>
+                    <svg
+                      v-else
+                      class="h-4 w-4"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
+                    >
+                      <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="2"
+                        d="M10 20l4-16m4 4l4 4-4 4M6 16l-4-4 4-4"
+                      />
+                    </svg>
+                  </button>
+                </Tooltip>
+              </div>
             </div>
+            <p
+              v-if="envForm.errors.envVars"
+              class="mt-1 text-sm text-red-600 dark:text-red-400"
+            >
+              {{ envForm.errors.envVars }}
+            </p>
           </div>
 
           <!-- Bulk edit mode -->

--- a/assets/js/pages/settings/instance.vue
+++ b/assets/js/pages/settings/instance.vue
@@ -2,6 +2,7 @@
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 defineOptions({
   layout: AppLayout
 })
@@ -21,6 +22,10 @@ const form = useForm({
   instanceName: props.instanceName || '',
   acmeEmail: props.acmeEmail || ''
 })
+  .withPrecognition('patch', '/settings/instance')
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 function save() {
   form.patch('/settings/instance', { preserveScroll: true })
@@ -193,8 +198,21 @@ function save() {
                 v-model="form.instanceName"
                 type="text"
                 placeholder="Slipway"
+                :aria-invalid="form.invalid('instanceName')"
+                :aria-describedby="
+                  form.errors.instanceName ? 'instance-name-error' : null
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                @blur="validateOnBlur('instanceName', $event)"
+                @input="revalidateWhenInvalid('instanceName')"
               />
+              <p
+                v-if="form.errors.instanceName"
+                id="instance-name-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.instanceName }}
+              </p>
             </div>
           </div>
 
@@ -223,9 +241,22 @@ function save() {
                   v-model="form.instanceDomain"
                   type="text"
                   placeholder="slipway.example.com"
+                  :aria-invalid="form.invalid('instanceDomain')"
+                  :aria-describedby="
+                    form.errors.instanceDomain ? 'instance-domain-error' : null
+                  "
                   class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                  @blur="validateOnBlur('instanceDomain', $event)"
+                  @input="revalidateWhenInvalid('instanceDomain')"
                 />
               </div>
+              <p
+                v-if="form.errors.instanceDomain"
+                id="instance-domain-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.instanceDomain }}
+              </p>
             </div>
           </div>
 
@@ -251,8 +282,21 @@ function save() {
                 v-model="form.acmeEmail"
                 type="email"
                 placeholder="admin@example.com"
+                :aria-invalid="form.invalid('acmeEmail')"
+                :aria-describedby="
+                  form.errors.acmeEmail ? 'acme-email-error' : null
+                "
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                @blur="validateOnBlur('acmeEmail', $event)"
+                @input="revalidateWhenInvalid('acmeEmail')"
               />
+              <p
+                v-if="form.errors.acmeEmail"
+                id="acme-email-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.acmeEmail }}
+              </p>
             </div>
           </div>
 
@@ -260,7 +304,7 @@ function save() {
           <div class="flex justify-end">
             <button
               type="submit"
-              :disabled="form.processing || !form.isDirty"
+              :disabled="form.processing || form.hasErrors || !form.isDirty"
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ form.processing ? 'Saving...' : 'Save changes' }}

--- a/assets/js/pages/settings/notifications.vue
+++ b/assets/js/pages/settings/notifications.vue
@@ -2,6 +2,7 @@
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -53,6 +54,10 @@ const form = useForm({
   // Quest
   notifyOnJobFailure: props.preferences.jobFailure
 })
+  .withPrecognition('patch', '/settings/notifications')
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const testing = ref(null)
 const testForm = useForm({
@@ -486,9 +491,28 @@ const categoryIcons = {
                     <input
                       type="text"
                       v-model="form.discordWebhookUrl"
-                      placeholder="https://discord.com/api/webhooks/..."
+                      :placeholder="
+                        discord.hasWebhookUrl
+                          ? 'Configured — enter a new URL to replace it'
+                          : 'https://discord.com/api/webhooks/...'
+                      "
+                      :aria-invalid="form.invalid('discordWebhookUrl')"
+                      :aria-describedby="
+                        form.errors.discordWebhookUrl
+                          ? 'discord-webhook-url-error'
+                          : null
+                      "
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                      @blur="validateOnBlur('discordWebhookUrl', $event)"
+                      @input="revalidateWhenInvalid('discordWebhookUrl')"
                     />
+                    <p
+                      v-if="form.errors.discordWebhookUrl"
+                      id="discord-webhook-url-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.discordWebhookUrl }}
+                    </p>
                     <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                       Create a webhook in your Discord server settings under
                       Integrations
@@ -499,7 +523,8 @@ const categoryIcons = {
                       type="button"
                       @click="testChannel('discord')"
                       :disabled="
-                        testing === 'discord' || !form.discordWebhookUrl
+                        testing === 'discord' ||
+                        (!form.discordWebhookUrl && !discord.hasWebhookUrl)
                       "
                       class="rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
                     >
@@ -571,9 +596,28 @@ const categoryIcons = {
                     <input
                       type="text"
                       v-model="form.slackWebhookUrl"
-                      placeholder="https://hooks.slack.com/services/..."
+                      :placeholder="
+                        slack.hasWebhookUrl
+                          ? 'Configured — enter a new URL to replace it'
+                          : 'https://hooks.slack.com/services/...'
+                      "
+                      :aria-invalid="form.invalid('slackWebhookUrl')"
+                      :aria-describedby="
+                        form.errors.slackWebhookUrl
+                          ? 'slack-webhook-url-error'
+                          : null
+                      "
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                      @blur="validateOnBlur('slackWebhookUrl', $event)"
+                      @input="revalidateWhenInvalid('slackWebhookUrl')"
                     />
+                    <p
+                      v-if="form.errors.slackWebhookUrl"
+                      id="slack-webhook-url-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.slackWebhookUrl }}
+                    </p>
                     <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                       Create an incoming webhook in your Slack workspace
                       settings
@@ -583,7 +627,10 @@ const categoryIcons = {
                     <button
                       type="button"
                       @click="testChannel('slack')"
-                      :disabled="testing === 'slack' || !form.slackWebhookUrl"
+                      :disabled="
+                        testing === 'slack' ||
+                        (!form.slackWebhookUrl && !slack.hasWebhookUrl)
+                      "
                       class="rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
                     >
                       {{
@@ -653,10 +700,23 @@ const categoryIcons = {
                       <input
                         :type="revealToken ? 'text' : 'password'"
                         v-model="form.telegramBotToken"
-                        placeholder="123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ"
+                        :placeholder="
+                          telegram.hasBotToken
+                            ? 'Configured — enter a new token to replace it'
+                            : '123456789:ABCDefGhIJKlmNoPQRsTUVwxyZ'
+                        "
+                        :aria-invalid="form.invalid('telegramBotToken')"
+                        :aria-describedby="
+                          form.errors.telegramBotToken
+                            ? 'telegram-bot-token-error'
+                            : null
+                        "
                         class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                        @blur="validateOnBlur('telegramBotToken', $event)"
+                        @input="revalidateWhenInvalid('telegramBotToken')"
                       />
                       <button
+                        v-if="form.telegramBotToken"
                         type="button"
                         @click="revealToken = !revealToken"
                         class="rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
@@ -697,6 +757,13 @@ const categoryIcons = {
                         </svg>
                       </button>
                     </div>
+                    <p
+                      v-if="form.errors.telegramBotToken"
+                      id="telegram-bot-token-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.telegramBotToken }}
+                    </p>
                     <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                       Create a bot via
                       <a
@@ -716,8 +783,23 @@ const categoryIcons = {
                       type="text"
                       v-model="form.telegramChatId"
                       placeholder="-1001234567890"
+                      :aria-invalid="form.invalid('telegramChatId')"
+                      :aria-describedby="
+                        form.errors.telegramChatId
+                          ? 'telegram-chat-id-error'
+                          : null
+                      "
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                      @blur="validateOnBlur('telegramChatId', $event)"
+                      @input="revalidateWhenInvalid('telegramChatId')"
                     />
+                    <p
+                      v-if="form.errors.telegramChatId"
+                      id="telegram-chat-id-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.telegramChatId }}
+                    </p>
                     <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                       The chat, group, or channel ID to send messages to
                     </p>
@@ -734,8 +816,23 @@ const categoryIcons = {
                       type="text"
                       v-model="form.telegramThreadId"
                       placeholder="12345"
+                      :aria-invalid="form.invalid('telegramThreadId')"
+                      :aria-describedby="
+                        form.errors.telegramThreadId
+                          ? 'telegram-thread-id-error'
+                          : null
+                      "
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                      @blur="validateOnBlur('telegramThreadId', $event)"
+                      @input="revalidateWhenInvalid('telegramThreadId')"
                     />
+                    <p
+                      v-if="form.errors.telegramThreadId"
+                      id="telegram-thread-id-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.telegramThreadId }}
+                    </p>
                     <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                       For groups with Topics enabled, send to a specific topic
                       thread
@@ -747,7 +844,7 @@ const categoryIcons = {
                       @click="testChannel('telegram')"
                       :disabled="
                         testing === 'telegram' ||
-                        !form.telegramBotToken ||
+                        (!form.telegramBotToken && !telegram.hasBotToken) ||
                         !form.telegramChatId
                       "
                       class="rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
@@ -850,8 +947,21 @@ const categoryIcons = {
                         type="text"
                         v-model="form.smtpHost"
                         placeholder="smtp.example.com"
+                        :aria-invalid="form.invalid('smtpHost')"
+                        :aria-describedby="
+                          form.errors.smtpHost ? 'smtp-host-error' : null
+                        "
                         class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                        @blur="validateOnBlur('smtpHost', $event)"
+                        @input="revalidateWhenInvalid('smtpHost')"
                       />
+                      <p
+                        v-if="form.errors.smtpHost"
+                        id="smtp-host-error"
+                        class="mt-1 text-sm text-red-600 dark:text-red-400"
+                      >
+                        {{ form.errors.smtpHost }}
+                      </p>
                     </div>
                     <div>
                       <label
@@ -862,8 +972,21 @@ const categoryIcons = {
                         type="text"
                         v-model="form.smtpPort"
                         placeholder="587"
+                        :aria-invalid="form.invalid('smtpPort')"
+                        :aria-describedby="
+                          form.errors.smtpPort ? 'smtp-port-error' : null
+                        "
                         class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                        @blur="validateOnBlur('smtpPort', $event)"
+                        @input="revalidateWhenInvalid('smtpPort')"
                       />
+                      <p
+                        v-if="form.errors.smtpPort"
+                        id="smtp-port-error"
+                        class="mt-1 text-sm text-red-600 dark:text-red-400"
+                      >
+                        {{ form.errors.smtpPort }}
+                      </p>
                     </div>
                   </div>
                   <div class="grid gap-4 px-4 py-3 sm:grid-cols-2">
@@ -906,8 +1029,21 @@ const categoryIcons = {
                       type="email"
                       v-model="form.smtpFrom"
                       placeholder="noreply@example.com"
+                      :aria-invalid="form.invalid('smtpFrom')"
+                      :aria-describedby="
+                        form.errors.smtpFrom ? 'smtp-from-error' : null
+                      "
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-xs"
+                      @blur="validateOnBlur('smtpFrom', $event)"
+                      @input="revalidateWhenInvalid('smtpFrom')"
                     />
+                    <p
+                      v-if="form.errors.smtpFrom"
+                      id="smtp-from-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.smtpFrom }}
+                    </p>
                   </div>
                   <div class="px-4 py-3">
                     <label
@@ -918,8 +1054,23 @@ const categoryIcons = {
                       type="text"
                       v-model="form.notificationEmails"
                       placeholder="admin@example.com, team@example.com"
+                      :aria-invalid="form.invalid('notificationEmails')"
+                      :aria-describedby="
+                        form.errors.notificationEmails
+                          ? 'notification-emails-error'
+                          : null
+                      "
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                      @blur="validateOnBlur('notificationEmails', $event)"
+                      @input="revalidateWhenInvalid('notificationEmails')"
                     />
+                    <p
+                      v-if="form.errors.notificationEmails"
+                      id="notification-emails-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.notificationEmails }}
+                    </p>
                     <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                       Comma-separated list of email addresses
                     </p>
@@ -984,6 +1135,7 @@ const categoryIcons = {
                     class="relative inline-flex cursor-pointer items-center"
                   >
                     <input
+                      data-test="webhook-enabled"
                       type="checkbox"
                       v-model="form.webhookEnabled"
                       class="peer sr-only"
@@ -1003,11 +1155,29 @@ const categoryIcons = {
                       >Webhook URL</label
                     >
                     <input
+                      id="webhookUrl"
                       type="text"
                       v-model="form.webhookUrl"
-                      placeholder="https://example.com/webhook"
+                      :placeholder="
+                        webhook.hasUrl
+                          ? 'Configured — enter a new URL to replace it'
+                          : 'https://example.com/webhook'
+                      "
+                      :aria-invalid="form.invalid('webhookUrl')"
+                      :aria-describedby="
+                        form.errors.webhookUrl ? 'webhook-url-error' : null
+                      "
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                      @blur="validateOnBlur('webhookUrl', $event)"
+                      @input="revalidateWhenInvalid('webhookUrl')"
                     />
+                    <p
+                      v-if="form.errors.webhookUrl"
+                      id="webhook-url-error"
+                      class="mt-1 text-sm text-red-600 dark:text-red-400"
+                    >
+                      {{ form.errors.webhookUrl }}
+                    </p>
                     <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                       Receives POST with JSON payload: { event, timestamp, data
                       }
@@ -1017,7 +1187,10 @@ const categoryIcons = {
                     <button
                       type="button"
                       @click="testChannel('webhook')"
-                      :disabled="testing === 'webhook' || !form.webhookUrl"
+                      :disabled="
+                        testing === 'webhook' ||
+                        (!form.webhookUrl && !webhook.hasUrl)
+                      "
                       class="rounded-md border border-gray-200 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
                     >
                       {{
@@ -1055,7 +1228,7 @@ const categoryIcons = {
           <div class="flex justify-end pt-6">
             <button
               type="submit"
-              :disabled="form.processing || !form.isDirty"
+              :disabled="form.processing || form.hasErrors || !form.isDirty"
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ form.processing ? 'Saving...' : 'Save changes' }}

--- a/assets/js/pages/settings/team-profile.vue
+++ b/assets/js/pages/settings/team-profile.vue
@@ -3,6 +3,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -20,6 +21,10 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 const form = useForm({
   name: props.team.name
 })
+  .withPrecognition('patch', '/settings/team-profile')
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(form)
 
 const logoForm = useForm({
   logo: null
@@ -370,8 +375,19 @@ const initials = computed(() => {
                 type="text"
                 required
                 placeholder="My Team"
+                :aria-invalid="form.invalid('name')"
+                :aria-describedby="form.errors.name ? 'team-name-error' : null"
                 class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                @blur="validateOnBlur('name', $event)"
+                @input="revalidateWhenInvalid('name')"
               />
+              <p
+                v-if="form.errors.name"
+                id="team-name-error"
+                class="mt-1 text-sm text-red-600 dark:text-red-400"
+              >
+                {{ form.errors.name }}
+              </p>
               <p class="mt-2 text-xs text-gray-400 dark:text-gray-500">
                 Slug:
                 <span class="font-mono">{{
@@ -388,7 +404,12 @@ const initials = computed(() => {
           <div class="flex justify-end">
             <button
               type="submit"
-              :disabled="form.processing || !form.isDirty || !form.name.trim()"
+              :disabled="
+                form.processing ||
+                form.hasErrors ||
+                !form.isDirty ||
+                !form.name.trim()
+              "
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >
               {{ form.processing ? 'Saving...' : 'Save changes' }}

--- a/assets/js/pages/settings/team.vue
+++ b/assets/js/pages/settings/team.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { Link, Head, router } from '@inertiajs/vue3'
+import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, watch, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -36,38 +37,30 @@ const isOwner = computed(() => props.currentUserRole === 'owner')
 
 // Invite
 const showInvite = ref(false)
-const inviteEmail = ref('')
-const inviteRole = ref('member')
-const inviting = ref(false)
+const inviteForm = useForm({
+  email: '',
+  role: 'member'
+})
+  .withPrecognition('post', '/settings/team/invite')
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(inviteForm)
 
 function submitInvite() {
-  if (!inviteEmail.value.trim()) return
-  inviting.value = true
-  router.post(
-    '/settings/team/invite',
-    {
-      email: inviteEmail.value.trim(),
-      role: inviteRole.value
-    },
-    {
-      preserveScroll: true,
-      onSuccess: () => {
-        showInvite.value = false
-        inviteEmail.value = ''
-        inviteRole.value = 'member'
-      },
-      onFinish: () => {
-        inviting.value = false
-      }
+  if (!inviteForm.email.trim()) return
+  inviteForm.post('/settings/team/invite', {
+    preserveScroll: true,
+    onSuccess: () => {
+      showInvite.value = false
+      inviteForm.reset()
     }
-  )
+  })
 }
 
 function closeInvite() {
-  if (!inviting.value) {
+  if (!inviteForm.processing) {
     showInvite.value = false
-    inviteEmail.value = ''
-    inviteRole.value = 'member'
+    inviteForm.resetAndClearErrors()
   }
 }
 
@@ -99,15 +92,23 @@ function closeMenu() {
 }
 
 // Role change
+const roleMemberId = ref(null)
+const roleForm = useForm({ role: 'member' }).withPrecognition(
+  'patch',
+  () => `/settings/team/${roleMemberId.value}/role`
+)
+
 function changeRole(member, newRole) {
   openMenu.value = null
-  router.patch(
-    `/settings/team/${member.id}/role`,
-    {
-      role: newRole
-    },
-    { preserveScroll: true }
-  )
+  roleMemberId.value = member.id
+  roleForm.role = newRole
+  roleForm.validate('role', {
+    onPrecognitionSuccess: () => {
+      roleForm.patch(`/settings/team/${member.id}/role`, {
+        preserveScroll: true
+      })
+    }
+  })
 }
 
 // Remove member
@@ -515,12 +516,25 @@ function timeAgo(date) {
                     >Email</label
                   >
                   <input
-                    v-model="inviteEmail"
+                    v-model="inviteForm.email"
                     type="email"
                     placeholder="teammate@example.com"
                     required
+                    :aria-invalid="inviteForm.invalid('email')"
+                    :aria-describedby="
+                      inviteForm.errors.email ? 'invite-email-error' : null
+                    "
                     class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                    @blur="validateOnBlur('email', $event)"
+                    @input="revalidateWhenInvalid('email')"
                   />
+                  <p
+                    v-if="inviteForm.errors.email"
+                    id="invite-email-error"
+                    class="mt-1 text-sm text-red-600 dark:text-red-400"
+                  >
+                    {{ inviteForm.errors.email }}
+                  </p>
                 </div>
                 <div>
                   <label
@@ -528,7 +542,7 @@ function timeAgo(date) {
                     >Role</label
                   >
                   <select
-                    v-model="inviteRole"
+                    v-model="inviteForm.role"
                     class="focus:border-brand w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
                   >
                     <option value="member">Member</option>
@@ -539,17 +553,21 @@ function timeAgo(date) {
                   <button
                     type="button"
                     @click="closeInvite"
-                    :disabled="inviting"
+                    :disabled="inviteForm.processing"
                     class="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
                   >
                     Cancel
                   </button>
                   <button
                     type="submit"
-                    :disabled="inviting"
+                    :disabled="
+                      inviteForm.processing ||
+                      inviteForm.hasErrors ||
+                      !inviteForm.email.trim()
+                    "
                     class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                   >
-                    {{ inviting ? 'Sending...' : 'Send invite' }}
+                    {{ inviteForm.processing ? 'Sending...' : 'Send invite' }}
                   </button>
                 </div>
               </form>

--- a/assets/js/pages/settings/uploads.vue
+++ b/assets/js/pages/settings/uploads.vue
@@ -3,6 +3,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import { useToast } from '@/composables/toast'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -54,6 +55,12 @@ const storageForm = useForm({
   secretKey: '',
   ...getProviderDefaults()
 })
+  .withPrecognition('patch', '/settings/uploads')
+  .setValidationTimeout(350)
+const {
+  revalidateWhenInvalid: revalidateStorageWhenInvalid,
+  validateOnBlur: validateStorageOnBlur
+} = usePrecognitionValidation(storageForm)
 
 function onProviderChange() {
   const defaults = getProviderDefaults()
@@ -64,6 +71,7 @@ function onProviderChange() {
   storageForm.endpoint = defaults.endpoint
   storageForm.region = defaults.region
   storageForm.publicUrl = defaults.publicUrl
+  storageForm.clearErrors()
 }
 
 const isCurrentProvider = computed(
@@ -90,6 +98,12 @@ const scheduleForm = useForm({
     retentionCount: props.backupSchedule?.retentionCount || 10
   }
 })
+  .withPrecognition('patch', '/settings/uploads')
+  .setValidationTimeout(350)
+const {
+  revalidateWhenInvalid: revalidateScheduleWhenInvalid,
+  validateOnBlur: validateScheduleOnBlur
+} = usePrecognitionValidation(scheduleForm)
 
 function saveSchedule() {
   scheduleForm.patch('/settings/uploads', {
@@ -436,10 +450,25 @@ const providers = [
                 <input
                   v-model="storageForm.accessKey"
                   type="text"
-                  required
+                  :required="!isCurrentProvider"
                   placeholder="Enter access key"
+                  :aria-invalid="storageForm.invalid('accessKey')"
+                  :aria-describedby="
+                    storageForm.errors.accessKey
+                      ? 'storage-access-key-error'
+                      : null
+                  "
                   class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                  @blur="validateStorageOnBlur('accessKey', $event)"
+                  @input="revalidateStorageWhenInvalid('accessKey')"
                 />
+                <p
+                  v-if="storageForm.errors.accessKey"
+                  id="storage-access-key-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ storageForm.errors.accessKey }}
+                </p>
               </div>
 
               <!-- Secret Key -->
@@ -452,9 +481,17 @@ const providers = [
                   <input
                     v-model="storageForm.secretKey"
                     :type="showSecrets ? 'text' : 'password'"
-                    required
+                    :required="!isCurrentProvider"
                     placeholder="Enter secret key"
+                    :aria-invalid="storageForm.invalid('secretKey')"
+                    :aria-describedby="
+                      storageForm.errors.secretKey
+                        ? 'storage-secret-key-error'
+                        : null
+                    "
                     class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                    @blur="validateStorageOnBlur('secretKey', $event)"
+                    @input="revalidateStorageWhenInvalid('secretKey')"
                   />
                   <button
                     type="button"
@@ -497,6 +534,13 @@ const providers = [
                     </svg>
                   </button>
                 </div>
+                <p
+                  v-if="storageForm.errors.secretKey"
+                  id="storage-secret-key-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ storageForm.errors.secretKey }}
+                </p>
               </div>
 
               <!-- Bucket -->
@@ -510,8 +554,21 @@ const providers = [
                   type="text"
                   required
                   placeholder="my-bucket"
+                  :aria-invalid="storageForm.invalid('bucket')"
+                  :aria-describedby="
+                    storageForm.errors.bucket ? 'storage-bucket-error' : null
+                  "
                   class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                  @blur="validateStorageOnBlur('bucket', $event)"
+                  @input="revalidateStorageWhenInvalid('bucket')"
                 />
+                <p
+                  v-if="storageForm.errors.bucket"
+                  id="storage-bucket-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ storageForm.errors.bucket }}
+                </p>
               </div>
 
               <!-- Region (S3/Spaces only) -->
@@ -530,8 +587,21 @@ const providers = [
                   :placeholder="
                     selectedProvider === 's3' ? 'us-east-1' : 'nyc3'
                   "
+                  :aria-invalid="storageForm.invalid('region')"
+                  :aria-describedby="
+                    storageForm.errors.region ? 'storage-region-error' : null
+                  "
                   class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:max-w-md"
+                  @blur="validateStorageOnBlur('region', $event)"
+                  @input="revalidateStorageWhenInvalid('region')"
                 />
+                <p
+                  v-if="storageForm.errors.region"
+                  id="storage-region-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ storageForm.errors.region }}
+                </p>
               </div>
 
               <!-- Endpoint -->
@@ -557,8 +627,23 @@ const providers = [
                   :required="
                     selectedProvider === 'r2' || selectedProvider === 'spaces'
                   "
+                  :aria-invalid="storageForm.invalid('endpoint')"
+                  :aria-describedby="
+                    storageForm.errors.endpoint
+                      ? 'storage-endpoint-error'
+                      : null
+                  "
                   class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                  @blur="validateStorageOnBlur('endpoint', $event)"
+                  @input="revalidateStorageWhenInvalid('endpoint')"
                 />
+                <p
+                  v-if="storageForm.errors.endpoint"
+                  id="storage-endpoint-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ storageForm.errors.endpoint }}
+                </p>
               </div>
 
               <!-- Public URL -->
@@ -581,8 +666,23 @@ const providers = [
                       ? 'https://my-bucket.nyc3.cdn.digitaloceanspaces.com'
                       : 'https://my-bucket.s3.us-east-1.amazonaws.com'
                   "
+                  :aria-invalid="storageForm.invalid('publicUrl')"
+                  :aria-describedby="
+                    storageForm.errors.publicUrl
+                      ? 'storage-public-url-error'
+                      : null
+                  "
                   class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+                  @blur="validateStorageOnBlur('publicUrl', $event)"
+                  @input="revalidateStorageWhenInvalid('publicUrl')"
                 />
+                <p
+                  v-if="storageForm.errors.publicUrl"
+                  id="storage-public-url-error"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ storageForm.errors.publicUrl }}
+                </p>
                 <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
                   The public-facing URL for accessing uploaded files (e.g. R2
                   public bucket URL, CloudFront distribution, or custom domain)
@@ -597,6 +697,7 @@ const providers = [
               type="submit"
               :disabled="
                 storageForm.processing ||
+                storageForm.hasErrors ||
                 !storageForm.bucket ||
                 (!isCurrentProvider &&
                   (!storageForm.accessKey || !storageForm.secretKey))
@@ -667,7 +768,21 @@ const providers = [
                 >
                 <select
                   v-model="scheduleForm.backupSchedule.intervalHours"
+                  :aria-invalid="
+                    scheduleForm.invalid('backupSchedule.intervalHours')
+                  "
                   class="focus:border-brand w-full rounded-md border border-gray-200 bg-transparent px-3 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:text-white"
+                  @change="
+                    revalidateScheduleWhenInvalid(
+                      'backupSchedule.intervalHours'
+                    )
+                  "
+                  @blur="
+                    validateScheduleOnBlur(
+                      'backupSchedule.intervalHours',
+                      $event
+                    )
+                  "
                 >
                   <option :value="6">Every 6 hours</option>
                   <option :value="12">Every 12 hours</option>
@@ -675,6 +790,12 @@ const providers = [
                   <option :value="48">Every 48 hours</option>
                   <option :value="168">Weekly</option>
                 </select>
+                <p
+                  v-if="scheduleForm.errors['backupSchedule.intervalHours']"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ scheduleForm.errors['backupSchedule.intervalHours'] }}
+                </p>
               </div>
               <div>
                 <label
@@ -683,20 +804,40 @@ const providers = [
                 >
                 <select
                   v-model="scheduleForm.backupSchedule.retentionCount"
+                  :aria-invalid="
+                    scheduleForm.invalid('backupSchedule.retentionCount')
+                  "
                   class="focus:border-brand w-full rounded-md border border-gray-200 bg-transparent px-3 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:text-white"
+                  @change="
+                    revalidateScheduleWhenInvalid(
+                      'backupSchedule.retentionCount'
+                    )
+                  "
+                  @blur="
+                    validateScheduleOnBlur(
+                      'backupSchedule.retentionCount',
+                      $event
+                    )
+                  "
                 >
                   <option :value="5">Keep last 5</option>
                   <option :value="10">Keep last 10</option>
                   <option :value="20">Keep last 20</option>
                   <option :value="50">Keep last 50</option>
                 </select>
+                <p
+                  v-if="scheduleForm.errors['backupSchedule.retentionCount']"
+                  class="mt-1 text-sm text-red-600 dark:text-red-400"
+                >
+                  {{ scheduleForm.errors['backupSchedule.retentionCount'] }}
+                </p>
               </div>
             </div>
 
             <div class="flex justify-end">
               <button
                 @click="saveSchedule"
-                :disabled="scheduleForm.processing"
+                :disabled="scheduleForm.processing || scheduleForm.hasErrors"
                 class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
               >
                 {{ scheduleForm.processing ? 'Saving...' : 'Save schedule' }}

--- a/tests/e2e/pages/settings/precognition-validation.test.js
+++ b/tests/e2e/pages/settings/precognition-validation.test.js
@@ -1,0 +1,62 @@
+const { test } = require('sounding')
+
+test(
+  'settings validate inline in light and dark mode before saving',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+
+    await page.resize(1440, 1000)
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+
+    await page.goto('/settings/instance')
+    await page.fill('#instanceDomain', 'example.com/admin')
+    await page.raw.locator('#instanceDomain').blur()
+    await page.raw
+      .locator('#instance-domain-error')
+      .waitFor({ state: 'visible' })
+    await expect(page).toSee('Enter a valid domain without a path')
+    await page.screenshot('.tmp/issue-207-instance-validation-light.png', {
+      fullPage: true
+    })
+
+    await page.fill('#instanceDomain', 'slipway.example.com')
+    await page.raw
+      .locator('#instance-domain-error')
+      .waitFor({ state: 'hidden' })
+
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await page.goto('/settings/notifications')
+    const webhookEnabled = page.raw.locator('[data-test="webhook-enabled"]')
+    if (!(await webhookEnabled.isChecked())) {
+      await webhookEnabled.check({ force: true })
+    }
+    await page.fill(
+      '#webhookUrl',
+      'https://operator:private-token@example.com/hook'
+    )
+    await page.raw.locator('#webhookUrl').blur()
+    await page.raw.locator('#webhook-url-error').waitFor({ state: 'visible' })
+    await expect(page).toSee(
+      'Enter a valid HTTP or HTTPS webhook URL without credentials'
+    )
+    await page.screenshot('.tmp/issue-207-notification-validation-dark.png', {
+      fullPage: true
+    })
+
+    await page.fill('#webhookUrl', 'https://events.example.com/slipway')
+    await page.raw.locator('#webhook-url-error').waitFor({ state: 'hidden' })
+    const saved = page.raw.waitForResponse(
+      (response) =>
+        response.url().endsWith('/settings/notifications') &&
+        response.request().method() === 'PATCH'
+    )
+    await page.raw.getByRole('button', { name: 'Save changes' }).click()
+    expect((await saved).status()).toBe(409)
+
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)

--- a/tests/functional/pages/settings-validation.test.js
+++ b/tests/functional/pages/settings-validation.test.js
@@ -1,0 +1,308 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+function precognitive(request, field) {
+  return request.withHeaders({
+    Precognition: 'true',
+    'Precognition-Validate-Only': field
+  })
+}
+
+test(
+  'instance settings validate without writes and still save normally',
+  { world: 'configured-slipway' },
+  async ({ sails, request, expect }) => {
+    const browser = await withCsrfFromPage(
+      request,
+      '/settings/instance',
+      'genesisUser'
+    )
+    const originalDomain = await sails.helpers.setting.get('instanceDomain')
+    const originalName = await sails.helpers.setting.get('instanceName')
+
+    const invalid = await precognitive(browser.request, 'instanceDomain').patch(
+      '/settings/instance',
+      {
+        instanceDomain: 'https://example.com/admin'
+      }
+    )
+
+    expect(invalid).toHaveStatus(422)
+    expect(Boolean(invalid.data.errors.instanceDomain)).toBe(true)
+    expect(await sails.helpers.setting.get('instanceDomain')).toBe(
+      originalDomain
+    )
+
+    const valid = await precognitive(browser.request, 'instanceName').patch(
+      '/settings/instance',
+      {
+        instanceName: 'Slipway Harbor'
+      }
+    )
+
+    expect(valid).toHaveStatus(204)
+    expect(valid).toHaveHeader('precognition-success', 'true')
+    expect(await sails.helpers.setting.get('instanceName')).toBe(originalName)
+
+    const saved = await browser.request.patch('/settings/instance', {
+      instanceName: 'Slipway Harbor'
+    })
+
+    expect(saved).toHaveStatus(409)
+    expect(saved).toHaveHeader('x-inertia-location', '/settings/instance')
+    expect(await sails.helpers.setting.get('instanceName')).toBe(
+      'Slipway Harbor'
+    )
+  }
+)
+
+test(
+  'integration settings reject unsafe values without leaking or persisting them',
+  { world: 'configured-slipway' },
+  async ({ sails, request, expect }) => {
+    const secret = 'do-not-return-this-credential'
+    await sails.helpers.setting.set('telegramBotToken', secret)
+    await sails.helpers.setting.set(
+      'discordWebhookUrl',
+      `https://discord.example.com/${secret}`
+    )
+    const browser = await withCsrfFromPage(
+      request,
+      '/settings/notifications',
+      'genesisUser'
+    )
+    expect(browser.page).toHaveInertiaProp('telegram.botToken', '')
+    expect(browser.page).toHaveInertiaProp('telegram.hasBotToken', true)
+    expect(browser.page).toHaveInertiaProp('discord.webhookUrl', '')
+    expect(browser.page).toHaveInertiaProp('discord.hasWebhookUrl', true)
+    expect(JSON.stringify(browser.page.data.props).includes(secret)).toBe(false)
+    const originalWebhook = await sails.helpers.setting.get('webhookUrl')
+
+    const invalid = await precognitive(browser.request, 'webhookUrl').patch(
+      '/settings/notifications',
+      {
+        webhookEnabled: true,
+        webhookUrl: `https://admin:${secret}@example.com/hook`
+      }
+    )
+
+    expect(invalid).toHaveStatus(422)
+    expect(Boolean(invalid.data.errors.webhookUrl)).toBe(true)
+    expect(JSON.stringify(invalid.data).includes(secret)).toBe(false)
+    expect(await sails.helpers.setting.get('webhookUrl')).toBe(originalWebhook)
+
+    const valid = await precognitive(browser.request, 'webhookUrl').patch(
+      '/settings/notifications',
+      {
+        webhookEnabled: true,
+        webhookUrl: 'https://events.example.com/slipway'
+      }
+    )
+
+    expect(valid).toHaveStatus(204)
+    expect(valid).toHaveHeader('precognition-success', 'true')
+    expect(await sails.helpers.setting.get('webhookUrl')).toBe(originalWebhook)
+
+    const originalClientId = await sails.helpers.setting.get('githubClientId')
+    const invalidGit = await precognitive(
+      browser.request,
+      'clientSecret'
+    ).patch('/settings/git', {
+      clientId: 'github-client-id',
+      clientSecret: secret.repeat(200)
+    })
+
+    expect(invalidGit).toHaveStatus(422)
+    expect(Boolean(invalidGit.data.errors.clientSecret)).toBe(true)
+    expect(JSON.stringify(invalidGit.data).includes(secret)).toBe(false)
+    expect(await sails.helpers.setting.get('githubClientId')).toBe(
+      originalClientId
+    )
+  }
+)
+
+test(
+  'global environment and upload validation cannot alter stored settings',
+  { world: 'configured-slipway' },
+  async ({ sails, request, expect }) => {
+    const envBrowser = await withCsrfFromPage(
+      request,
+      '/settings/global-env',
+      'genesisUser'
+    )
+    const originalEnv = await sails.helpers.setting.get('globalEnvVars')
+
+    const duplicateEnv = await precognitive(
+      envBrowser.request,
+      'envVars'
+    ).patch('/settings/global-env', {
+      envVars: { API_KEY: 'second-secret' },
+      envSource: 'API_KEY=first-secret\nAPI_KEY=second-secret'
+    })
+
+    expect(duplicateEnv).toHaveStatus(422)
+    expect(Boolean(duplicateEnv.data.errors.envVars)).toBe(true)
+    expect(JSON.stringify(duplicateEnv.data).includes('first-secret')).toBe(
+      false
+    )
+    expect(await sails.helpers.setting.get('globalEnvVars')).toBe(originalEnv)
+
+    const uploadsBrowser = await withCsrfFromPage(
+      request,
+      '/settings/uploads',
+      'genesisUser'
+    )
+    const originalSchedule = await sails.helpers.setting.get('backupSchedule')
+    const invalidStorage = await precognitive(
+      uploadsBrowser.request,
+      'endpoint'
+    ).patch('/settings/uploads', {
+      provider: 'r2',
+      accessKey: 'test-access-key',
+      secretKey: 'test-secret-key',
+      bucket: 'slipway-backups',
+      endpoint: 'https://operator:private@example.com'
+    })
+
+    expect(invalidStorage).toHaveStatus(422)
+    expect(Boolean(invalidStorage.data.errors.endpoint)).toBe(true)
+    expect(await sails.helpers.setting.get('globalEnvVars')).toBe(originalEnv)
+
+    const invalidSchedule = await precognitive(
+      uploadsBrowser.request,
+      'backupSchedule.intervalHours'
+    ).patch('/settings/uploads', {
+      backupSchedule: {
+        enabled: true,
+        intervalHours: 0,
+        retentionCount: 10
+      }
+    })
+
+    expect(invalidSchedule).toHaveStatus(422)
+    expect(
+      Boolean(invalidSchedule.data.errors['backupSchedule.intervalHours'])
+    ).toBe(true)
+    expect(await sails.helpers.setting.get('backupSchedule')).toBe(
+      originalSchedule
+    )
+  }
+)
+
+test(
+  'notification tests keep using credentials hidden from page props',
+  { world: 'configured-slipway' },
+  async ({ sails, request, expect }) => {
+    const originalFetch = global.fetch
+    const storedWebhook = 'https://discord.example.com/stored-secret'
+    const deliveries = []
+
+    try {
+      await sails.helpers.setting.set('discordWebhookUrl', storedWebhook)
+      global.fetch = async (url) => {
+        deliveries.push(url)
+        return { ok: true, text: async () => '' }
+      }
+      const browser = await withCsrfFromPage(
+        request,
+        '/settings/notifications',
+        'genesisUser'
+      )
+
+      expect(
+        JSON.stringify(browser.page.data.props).includes(storedWebhook)
+      ).toBe(false)
+
+      const response = await browser.request.post(
+        '/settings/notifications/test',
+        {
+          channel: 'discord',
+          discordWebhookUrl: ''
+        }
+      )
+
+      expect(response).toHaveStatus(302)
+      expect(response).toRedirectTo('/settings/notifications')
+      expect(deliveries).toEqual([storedWebhook])
+    } finally {
+      global.fetch = originalFetch
+    }
+  }
+)
+
+test(
+  'team and token Precognition requests perform no side effects',
+  { world: 'configured-slipway' },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const team = current.teams.genesisTeam
+    const user = current.users.genesisUser
+    const browser = await withCsrfFromPage(
+      request,
+      '/settings/team-profile',
+      'genesisUser'
+    )
+    const cliToken = await sails.models.clitoken
+      .create({
+        token: 'settings-validation-token-hash',
+        user: user.id,
+        name: 'Workstation'
+      })
+      .fetch()
+    const member = await world.create('user').with({
+      fullName: 'Settings Member',
+      email: 'settings-member@example.com',
+      team: team.id,
+      teamRole: 'member'
+    })
+    const usersBefore = await sails.models.user.count()
+    const deployTokensBefore = await sails.models.deploytoken.count()
+
+    const invalidTeam = await precognitive(browser.request, 'name').patch(
+      '/settings/team-profile',
+      { name: '---' }
+    )
+    expect(invalidTeam).toHaveStatus(422)
+    expect((await sails.models.team.findOne({ id: team.id })).name).toBe(
+      team.name
+    )
+
+    const invite = await precognitive(browser.request, 'email').post(
+      '/settings/team/invite',
+      {
+        email: 'future-teammate@example.com',
+        role: 'member'
+      }
+    )
+    expect(invite).toHaveStatus(204)
+    expect(await sails.models.user.count()).toBe(usersBefore)
+
+    const role = await precognitive(browser.request, 'role').patch(
+      `/settings/team/${member.id}/role`,
+      { role: 'admin' }
+    )
+    expect(role).toHaveStatus(204)
+    expect((await sails.models.user.findOne({ id: member.id })).teamRole).toBe(
+      'member'
+    )
+
+    const rename = await precognitive(browser.request, 'name').patch(
+      `/settings/cli-tokens/${cliToken.id}`,
+      { name: 'Production laptop' }
+    )
+    expect(rename).toHaveStatus(204)
+    expect(
+      (await sails.models.clitoken.findOne({ id: cliToken.id })).name
+    ).toBe('Workstation')
+
+    const deployToken = await precognitive(browser.request, 'name').post(
+      '/api/v1/deploy-tokens',
+      {
+        name: 'Release workflow',
+        scopes: ['deploy']
+      }
+    )
+    expect(deployToken).toHaveStatus(204)
+    expect(await sails.models.deploytoken.count()).toBe(deployTokensBefore)
+  }
+)

--- a/tests/unit/helpers/setting/validate.test.js
+++ b/tests/unit/helpers/setting/validate.test.js
@@ -1,0 +1,104 @@
+const { test } = require('sounding')
+
+test('settings validation accepts production-safe values', async ({
+  sails,
+  expect
+}) => {
+  const problems = sails.helpers.setting.validate(
+    {
+      instanceName: 'Slipway EU',
+      instanceDomain: 'slipway.example.com',
+      acmeEmail: 'ops@example.com',
+      provider: 'r2',
+      accessKey: 'safe-access-key',
+      secretKey: 'safe-secret-key',
+      bucket: 'slipway-backups',
+      endpoint: 'https://account.r2.cloudflarestorage.com',
+      publicUrl: 'https://assets.example.com',
+      backupSchedule: {
+        enabled: true,
+        intervalHours: 24,
+        retentionCount: 20
+      }
+    },
+    ['provider', 'accessKey', 'secretKey', 'bucket', 'endpoint']
+  )
+
+  expect(problems).toEqual([])
+})
+
+test('settings validation rejects unsafe integration values without echoing secrets', async ({
+  sails,
+  expect
+}) => {
+  const secret = 'do-not-echo-this-secret'
+  const problems = sails.helpers.setting.validate({
+    instanceDomain: 'example.com/admin',
+    acmeEmail: 'not-an-email',
+    telegramEnabled: true,
+    telegramBotToken: secret,
+    telegramChatId: 'not-a-chat',
+    discordEnabled: true,
+    discordWebhookUrl: 'http://discord.example.com/hook',
+    smtpEnabled: true,
+    smtpHost: 'https://smtp.example.com',
+    smtpPort: '70000',
+    smtpFrom: 'not-an-email',
+    notificationEmails: 'ops@example.com, invalid'
+  })
+  const errors = Object.assign({}, ...problems)
+
+  expect(Boolean(errors.instanceDomain)).toBe(true)
+  expect(Boolean(errors.acmeEmail)).toBe(true)
+  expect(Boolean(errors.telegramBotToken)).toBe(true)
+  expect(Boolean(errors.telegramChatId)).toBe(true)
+  expect(Boolean(errors.discordWebhookUrl)).toBe(true)
+  expect(Boolean(errors.smtpHost)).toBe(true)
+  expect(Boolean(errors.smtpPort)).toBe(true)
+  expect(Boolean(errors.smtpFrom)).toBe(true)
+  expect(Boolean(errors.notificationEmails)).toBe(true)
+  expect(JSON.stringify(problems).includes(secret)).toBe(false)
+})
+
+test('settings validation rejects invalid and duplicate environment names', async ({
+  sails,
+  expect
+}) => {
+  const invalid = sails.helpers.setting.validate({
+    envVars: { 'INVALID-KEY': 'value' }
+  })
+  const duplicates = sails.helpers.setting.validate({
+    envVars: { API_KEY: 'second-value' },
+    envSource: 'API_KEY=first-value\nAPI_KEY=second-value'
+  })
+
+  expect(Boolean(Object.assign({}, ...invalid).envVars)).toBe(true)
+  expect(Boolean(Object.assign({}, ...duplicates).envVars)).toBe(true)
+  expect(JSON.stringify(duplicates).includes('first-value')).toBe(false)
+  expect(JSON.stringify(duplicates).includes('second-value')).toBe(false)
+})
+
+test('precognition validates only the requested field', async ({
+  sails,
+  expect
+}) => {
+  const request = {
+    header(name) {
+      if (name === 'Precognition-Validate-Only') return 'bucket'
+      return undefined
+    }
+  }
+  const problems = sails.helpers.setting.validate(
+    {
+      provider: 'r2',
+      accessKey: '',
+      secretKey: '',
+      bucket: 'valid-bucket',
+      endpoint: ''
+    },
+    ['provider', 'accessKey', 'secretKey', 'bucket', 'endpoint'],
+    request
+  )
+
+  expect(problems).toEqual([])
+})


### PR DESCRIPTION
## Summary
- add shared, field-scoped server validation across instance, Git, environment, notification, upload, team, and token settings
- validate inline with the existing minimal form language in light and dark mode
- keep stored notification credentials out of Inertia props and validation payloads while preserving test actions
- prevent Precognition requests from mutating settings, creating users or tokens, or sending mail

## Tests
- npm run lint
- npm run test:functional (87 passed)
- npx sounding test --file tests/unit/helpers/setting/validate.test.js --test-concurrency=1 --reporter spec (4 passed)
- npx sounding test --file tests/e2e/pages/settings/precognition-validation.test.js --test-concurrency=1 --reporter spec (1 passed)

Fixes #207