### PR TITLE
feat: validate Bridge and content workflows with Precognition

### DIFF
--- a/api/controllers/project/bridge-create-record.js
+++ b/api/controllers/project/bridge-create-record.js
@@ -38,6 +38,9 @@ module.exports = {
     },
     badRequest: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -58,6 +61,7 @@ module.exports = {
       throw { badRequest: { error: 'App is not running' } }
     }
     const { project, environment, app, actor, actorId } = resolved
+    const validateOnly = bridgeValidateOnly(this.req)
 
     let loaded
     let allowedValues
@@ -77,7 +81,8 @@ module.exports = {
           actorId,
           projectId: project.id,
           environmentId: environment.id
-        }
+        },
+        validateOnly
       })
       await sails.helpers.bridge.authorizeRelationshipValues.with({
         containerName: app.containerName,
@@ -86,8 +91,17 @@ module.exports = {
         actor,
         values: allowedValues
       })
+      await sails.helpers.bridge.validateResourceValues.with({
+        containerName: app.containerName,
+        resource: loaded.resource,
+        values: allowedValues
+      })
     } catch (error) {
       throw { badRequest: toBadRequest(error) }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     try {
@@ -118,7 +132,14 @@ function toBadRequest(error) {
   return {
     error: error.message,
     problems: Object.entries(error.fieldErrors).map(([field, message]) => ({
-      [field]: message
+      [`values.${field}`]: message
     }))
   }
+}
+
+function bridgeValidateOnly(req) {
+  return sails.inertia
+    .validateOnly(req)
+    .filter((field) => field.startsWith('values.'))
+    .map((field) => field.slice('values.'.length))
 }

--- a/api/controllers/project/bridge-update-record.js
+++ b/api/controllers/project/bridge-update-record.js
@@ -42,6 +42,9 @@ module.exports = {
     },
     badRequest: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -69,6 +72,7 @@ module.exports = {
       throw { badRequest: { error: 'App is not running' } }
     }
     const { project, environment, app, actor, actorId } = resolved
+    const validateOnly = bridgeValidateOnly(this.req)
 
     let loaded
     let allowedValues
@@ -89,7 +93,8 @@ module.exports = {
           actorId,
           projectId: project.id,
           environmentId: environment.id
-        }
+        },
+        validateOnly
       })
       await sails.helpers.bridge.authorizeRelationshipValues.with({
         containerName: app.containerName,
@@ -98,8 +103,18 @@ module.exports = {
         actor,
         values: allowedValues
       })
+      await sails.helpers.bridge.validateResourceValues.with({
+        containerName: app.containerName,
+        resource: loaded.resource,
+        values: allowedValues,
+        recordId: loaded.recordId
+      })
     } catch (error) {
       throw { badRequest: toBadRequest(error) }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     const criteria = {
@@ -140,7 +155,14 @@ function toBadRequest(error) {
   return {
     error: error.message,
     problems: Object.entries(error.fieldErrors).map(([field, message]) => ({
-      [field]: message
+      [`values.${field}`]: message
     }))
   }
+}
+
+function bridgeValidateOnly(req) {
+  return sails.inertia
+    .validateOnly(req)
+    .filter((field) => field.startsWith('values.'))
+    .map((field) => field.slice('values.'.length))
 }

--- a/api/controllers/project/content-create.js
+++ b/api/controllers/project/content-create.js
@@ -42,6 +42,9 @@ module.exports = {
     },
     badRequest: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -88,29 +91,36 @@ module.exports = {
         }
       }))
 
-    // Sanitize slug
-    const safeSlug = contentSlug
-      .toLowerCase()
-      .replace(/[^a-z0-9-]/g, '-')
-      .replace(/-+/g, '-')
-      .replace(/^-|-$/g, '')
-
-    if (!safeSlug) {
+    const validateOnly = sails.inertia.validateOnly(this.req)
+    const problems = sails.helpers.content.validate(
+      { contentSlug, title },
+      validateOnly
+    )
+    if (problems.length) {
       throw {
-        badRequest: {
-          problems: [{ contentSlug: 'Enter a valid content slug.' }]
-        }
+        badRequest: { problems }
       }
     }
+
+    const safeSlug = contentSlug.trim()
 
     const collectionPath = path.join(appPath, contentDir, collection)
     const filePath = path.join(collectionPath, `${safeSlug}.md`)
 
     // Check if file already exists
-    if (fs.existsSync(filePath)) {
+    if (
+      sails.inertia.shouldValidate('contentSlug', this.req) &&
+      fs.existsSync(filePath)
+    ) {
       throw {
-        badRequest: { error: `Content file "${safeSlug}.md" already exists` }
+        badRequest: {
+          problems: [{ contentSlug: 'This content slug is already in use.' }]
+        }
       }
+    }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
     }
 
     // Build frontmatter

--- a/api/controllers/project/content-update.js
+++ b/api/controllers/project/content-update.js
@@ -62,6 +62,9 @@ module.exports = {
     },
     badRequest: {
       responseType: 'badRequest'
+    },
+    precognitionSuccess: {
+      responseType: 'precognitionSuccess'
     }
   },
 
@@ -129,23 +132,34 @@ module.exports = {
     if (!fs.existsSync(filePath)) {
       filePath = path.join(appPath, contentDir, collection, `${file}.md`)
       fileType = 'markdown'
-
-      // Ensure collection directory exists
-      const collectionPath = path.join(appPath, contentDir, collection)
-      if (!fs.existsSync(collectionPath)) {
-        fs.mkdirSync(collectionPath, { recursive: true })
-      }
     }
 
-    // Generate content
-    let content
-    if (raw !== undefined) {
-      content = raw
-    } else if (fileType === 'markdown') {
-      content = serializeFrontmatter(frontmatter, body)
-    } else {
-      content = JSON.stringify(frontmatter, null, 2)
+    const problems = sails.helpers.content.validate(
+      {
+        frontmatter,
+        body,
+        raw,
+        fileType
+      },
+      sails.inertia.validateOnly(this.req)
+    )
+    if (problems.length) {
+      throw { badRequest: { problems } }
     }
+
+    if (sails.inertia.isPrecognitive(this.req)) {
+      throw 'precognitionSuccess'
+    }
+
+    const useRawMarkdown =
+      fileType === 'markdown' &&
+      raw !== undefined &&
+      frontmatter === undefined &&
+      body === undefined
+    const content =
+      fileType === 'json' || useRawMarkdown
+        ? raw
+        : serializeFrontmatter(frontmatter, body)
 
     if (deploy) {
       const sourceReadiness =
@@ -194,6 +208,10 @@ module.exports = {
 
     // Keep the local build context in sync only after the source-of-truth
     // write succeeds. Repository deployments will refresh this exact commit.
+    const collectionPath = path.dirname(filePath)
+    if (!fs.existsSync(collectionPath)) {
+      fs.mkdirSync(collectionPath, { recursive: true })
+    }
     fs.writeFileSync(filePath, content, 'utf8')
 
     sails.log.info(`[content] Updated ${collection}/${file} in ${slug}`)

--- a/api/helpers/bridge/allow-resource-values.js
+++ b/api/helpers/bridge/allow-resource-values.js
@@ -22,6 +22,11 @@ module.exports = {
       type: 'ref',
       description:
         'Authorized actor and resource context used to verify Bridge upload receipts.'
+    },
+    validateOnly: {
+      type: 'json',
+      defaultsTo: [],
+      description: 'Optional Bridge field names to validate from the payload.'
     }
   },
 
@@ -31,7 +36,13 @@ module.exports = {
     }
   },
 
-  fn: async function ({ values, resource, surface, uploadContext }) {
+  fn: async function ({
+    values,
+    resource,
+    surface,
+    uploadContext,
+    validateOnly
+  }) {
     if (
       !values ||
       typeof values !== 'object' ||
@@ -60,8 +71,11 @@ module.exports = {
     const rejectedFields = []
     const unsafeMarkdownFields = []
     const fieldErrors = {}
+    const requestedFields = validateOnly.length
+      ? Array.from(new Set(validateOnly))
+      : Object.keys(values)
 
-    for (const key of Object.keys(values)) {
+    for (const key of requestedFields) {
       if (
         !allowedFields.has(key) ||
         ['__proto__', 'constructor', 'prototype'].includes(key)
@@ -128,6 +142,7 @@ module.exports = {
 
     if (surface === 'create') {
       for (const key of allowedFields) {
+        if (validateOnly.length && !validateOnly.includes(key)) continue
         const attribute = resource.attributes[key]
         if (
           attribute.required === true &&

--- a/api/helpers/bridge/validate-resource-values.js
+++ b/api/helpers/bridge/validate-resource-values.js
@@ -1,0 +1,129 @@
+module.exports = {
+  friendlyName: 'Validate Bridge resource values',
+
+  description:
+    'Validate normalized Bridge values against the target Waterline model without mutating it.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    values: {
+      type: 'ref',
+      required: true
+    },
+    recordId: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, resource, values, recordId }) {
+    const fields = Object.keys(values)
+    if (!fields.length) return {}
+
+    const validationContract = {
+      identity: resource.identity,
+      primaryKey: resource.primaryKey,
+      fields: Object.fromEntries(
+        fields.map((field) => {
+          const attribute = resource.attributes[field] || {}
+          return [
+            field,
+            {
+              label: attribute.label || field,
+              unique: attribute.unique === true,
+              association: (resource.associations || []).some(
+                (candidate) =>
+                  candidate.type === 'model' && candidate.alias === field
+              )
+            }
+          ]
+        })
+      )
+    }
+    const validationCode = `
+      const contract = ${JSON.stringify(validationContract)};
+      const values = ${JSON.stringify(values)};
+      const recordId = ${JSON.stringify(recordId)};
+      const model = sails.models[contract.identity];
+      if (!model) throw new Error('Configured Bridge model is unavailable.');
+
+      const fieldErrors = {};
+      for (const [field, value] of Object.entries(values)) {
+        const fieldContract = contract.fields[field];
+        if (!fieldContract || fieldContract.association) continue;
+
+        try {
+          if (typeof model.validate === 'function') {
+            model.validate(field, value);
+          }
+        } catch (_error) {
+          fieldErrors[field] = fieldContract.label + ' is invalid.';
+          continue;
+        }
+
+        if (fieldContract.unique && value !== null && value !== undefined) {
+          const existing = await model.findOne({ [field]: value }).select([
+            contract.primaryKey
+          ]);
+          if (
+            existing &&
+            (recordId === null ||
+              recordId === undefined ||
+              String(existing[contract.primaryKey]) !== String(recordId))
+          ) {
+            fieldErrors[field] = fieldContract.label + ' is already in use.';
+          }
+        }
+      }
+
+      return { fieldErrors };
+    `
+    const wrappedCode = await sails.helpers.bridge.buildSailsWrapper(
+      validationCode
+    )
+    const result = await sails.helpers.bridge.executeInContainer(
+      containerName,
+      wrappedCode
+    )
+
+    if (!result.success) {
+      const error = new Error(
+        result.error || 'Bridge could not validate this record.'
+      )
+      error.code = 'BRIDGE_VALIDATION_FAILED'
+      throw error
+    }
+
+    let fieldErrors
+    try {
+      fieldErrors = JSON.parse(result.output).fieldErrors || {}
+    } catch (cause) {
+      const error = new Error('Bridge could not read the validation result.')
+      error.code = 'BRIDGE_VALIDATION_FAILED'
+      error.cause = cause
+      throw error
+    }
+
+    if (Object.keys(fieldErrors).length) {
+      const error = new Error('Some Bridge fields are invalid.')
+      error.code = 'BRIDGE_FIELD_INVALID'
+      error.fields = Object.keys(fieldErrors)
+      error.fieldErrors = fieldErrors
+      throw error
+    }
+
+    return values
+  }
+}

--- a/api/helpers/content/validate.js
+++ b/api/helpers/content/validate.js
@@ -1,0 +1,131 @@
+const MAX_CONTENT_BYTES = 5 * 1024 * 1024
+
+module.exports = {
+  friendlyName: 'Validate content values',
+
+  description:
+    'Validate Content Manager create and editor values before source mutation.',
+
+  inputs: {
+    values: {
+      type: 'ref',
+      required: true
+    },
+    validateOnly: {
+      type: 'json',
+      defaultsTo: []
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  sync: true,
+
+  fn: function ({ values, validateOnly }) {
+    const problems = []
+
+    function shouldValidate(field) {
+      if (!validateOnly.length) return true
+      return validateOnly.some(
+        (requested) =>
+          requested === field ||
+          requested.startsWith(`${field}.`) ||
+          field.startsWith(`${requested}.`)
+      )
+    }
+
+    function add(field, message) {
+      problems.push({ [field]: message })
+    }
+
+    if (shouldValidate('contentSlug') && values.contentSlug !== undefined) {
+      const slug = String(values.contentSlug).trim()
+      if (!slug) {
+        add('contentSlug', 'Enter a content slug.')
+      } else if (slug.length > 120) {
+        add('contentSlug', 'Content slug must be 120 characters or less.')
+      } else if (!/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)) {
+        add(
+          'contentSlug',
+          'Use lowercase letters, numbers, and single hyphens.'
+        )
+      }
+    }
+
+    if (shouldValidate('title') && values.title !== undefined) {
+      const title = String(values.title)
+      if (title.length > 200) {
+        add('title', 'Title must be 200 characters or less.')
+      } else if (/\0/.test(title)) {
+        add('title', 'Title contains an unsupported character.')
+      }
+    }
+
+    if (shouldValidate('frontmatter') && values.frontmatter !== undefined) {
+      const frontmatter = values.frontmatter
+      if (!isPlainObject(frontmatter)) {
+        add('frontmatter', 'Metadata must be key-value pairs.')
+      } else if (Object.keys(frontmatter).length > 100) {
+        add('frontmatter', 'Metadata cannot contain more than 100 fields.')
+      } else {
+        const requestedKeys = validateOnly
+          .filter((field) => field.startsWith('frontmatter.'))
+          .map((field) => field.slice('frontmatter.'.length))
+        const entries = requestedKeys.length
+          ? requestedKeys
+              .filter((key) => Object.hasOwn(frontmatter, key))
+              .map((key) => [key, frontmatter[key]])
+          : Object.entries(frontmatter)
+        for (const [key, value] of entries) {
+          if (!/^[A-Za-z_][A-Za-z0-9_.-]*$/.test(key)) {
+            add(`frontmatter.${key}`, 'Use a valid metadata field name.')
+            continue
+          }
+          try {
+            const serialized = JSON.stringify(value)
+            if (serialized === undefined) throw new Error('not serializable')
+          } catch {
+            add(`frontmatter.${key}`, 'Enter a serializable metadata value.')
+          }
+        }
+      }
+    }
+
+    if (shouldValidate('body') && values.body !== undefined) {
+      if (typeof values.body !== 'string') {
+        add('body', 'Content body must be text.')
+      } else if (Buffer.byteLength(values.body, 'utf8') > MAX_CONTENT_BYTES) {
+        add('body', 'Content body must be 5 MB or less.')
+      }
+    }
+
+    if (shouldValidate('raw') && values.raw !== undefined) {
+      if (typeof values.raw !== 'string') {
+        add('raw', 'Source must be text.')
+      } else if (Buffer.byteLength(values.raw, 'utf8') > MAX_CONTENT_BYTES) {
+        add('raw', 'Source must be 5 MB or less.')
+      } else if (values.fileType === 'json') {
+        try {
+          JSON.parse(values.raw)
+        } catch {
+          add('raw', 'Enter valid JSON before saving.')
+        }
+      }
+    }
+
+    return problems
+  }
+}
+
+function isPlainObject(value) {
+  return (
+    value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    [Object.prototype, null].includes(Object.getPrototypeOf(value))
+  )
+}

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -12,6 +12,7 @@ import {
   validateBridgeFieldValue
 } from '@/lib/bridge/fields.mjs'
 import { containsRawHtml } from '@/lib/content/markdown.mjs'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -48,6 +49,13 @@ const bridgeApiBasePath = computed(() =>
 )
 
 const isEdit = computed(() => props.mode === 'edit')
+const actionUrl = computed(() =>
+  isEdit.value
+    ? `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
+        props.recordId
+      )}/update`
+    : `${bridgeBasePath.value}/${props.modelIdentity}/create`
+)
 
 function encodePathSegment(value) {
   return encodeURIComponent(String(value))
@@ -63,6 +71,9 @@ function displayIdentifier(value) {
 const formValues = ref({})
 const formErrors = ref({})
 const form = useForm({ values: {} })
+  .withPrecognition('post', () => actionUrl.value)
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid } = usePrecognitionValidation(form)
 
 // Initialize form values from props
 onMounted(() => {
@@ -89,6 +100,7 @@ onMounted(() => {
   }
 
   formValues.value = values
+  form.values = values
 })
 
 // Editable fields
@@ -127,11 +139,19 @@ function hasRequiredValue(field) {
   return validateField(field) === ''
 }
 
+const hasBridgeFieldErrors = computed(() =>
+  Object.keys(form.errors).some((field) => field.startsWith('values.'))
+)
 const isFormReady = computed(
   () =>
     editableFields.value.every(hasRequiredValue) &&
-    Object.keys(formErrors.value).length === 0
+    Object.keys(formErrors.value).length === 0 &&
+    !hasBridgeFieldErrors.value
 )
+
+function serverFieldName(field) {
+  return `values.${field.name}`
+}
 
 function validateField(field) {
   const attr = field.attr
@@ -149,25 +169,32 @@ function validateField(field) {
   })
 }
 
-function validateAndRemember(field) {
+function validateAndRemember(field, validateOnServer = true) {
   const error = validateField(field)
-  if (error) formErrors.value[field.name] = error
-  else delete formErrors.value[field.name]
+  const fieldName = serverFieldName(field)
+  if (error) {
+    formErrors.value[field.name] = error
+    form.clearErrors(fieldName)
+    return
+  }
+
+  delete formErrors.value[field.name]
+  if (validateOnServer) form.validate(fieldName)
 }
 
 function updateField(field, value) {
   formValues.value[field.name] = value
-  if (formErrors.value[field.name]) validateAndRemember(field)
-  if (form.errors[field.name]) form.clearErrors(field.name)
+  if (formErrors.value[field.name]) validateAndRemember(field, false)
+  revalidateWhenInvalid(serverFieldName(field))
 }
 
 function clearFieldError(field) {
   delete formErrors.value[field.name]
-  form.clearErrors(field.name)
+  form.clearErrors(serverFieldName(field))
 }
 
 function handleSubmit() {
-  for (const field of editableFields.value) validateAndRemember(field)
+  for (const field of editableFields.value) validateAndRemember(field, false)
   if (!isFormReady.value) {
     toast({ message: 'Complete the required fields first.', type: 'error' })
     return
@@ -185,13 +212,7 @@ function handleSubmit() {
   }
 
   form.values = values
-  const actionUrl = isEdit.value
-    ? `${bridgeBasePath.value}/${props.modelIdentity}/${encodePathSegment(
-        props.recordId
-      )}/update`
-    : `${bridgeBasePath.value}/${props.modelIdentity}/create`
-
-  form.post(actionUrl, {
+  form.post(actionUrl.value, {
     onSuccess: () => {
       toast({
         message: isEdit.value ? 'Record updated.' : 'Record created.',
@@ -199,7 +220,9 @@ function handleSubmit() {
       })
     },
     onError: (errors) => {
-      toast({ message: errors.error || 'Failed to save record', type: 'error' })
+      if (errors.error) {
+        toast({ message: errors.error, type: 'error' })
+      }
     }
   })
 }
@@ -431,7 +454,11 @@ function recordUrl() {
               :key="field.name"
               :field="field"
               :model-value="formValues[field.name]"
-              :error="formErrors[field.name] || form.errors[field.name] || ''"
+              :error="
+                formErrors[field.name] ||
+                form.errors[serverFieldName(field)] ||
+                ''
+              "
               :is-edit="isEdit"
               :model-identity="modelIdentity"
               :record-id="recordId"

--- a/assets/js/pages/projects/content-editor.vue
+++ b/assets/js/pages/projects/content-editor.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
 import Tooltip from '@/components/Tooltip.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -57,6 +58,18 @@ const saveForm = useForm({
   appSlug: props.app.slug,
   sourceSha: props.content?.sourceSha || ''
 })
+  .withPrecognition('post', () => getActionPath('update'))
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid } = usePrecognitionValidation(saveForm)
+const hasContentErrors = computed(() =>
+  Object.keys(saveForm.errors).some(
+    (field) =>
+      field === 'frontmatter' ||
+      field.startsWith('frontmatter.') ||
+      field === 'body' ||
+      field === 'raw'
+  )
+)
 
 const deleteForm = useForm({
   appSlug: props.app.slug,
@@ -86,10 +99,7 @@ function getUploadPath() {
   return `/api/v1/projects/${props.project.slug}${envPath.value}/content/${props.collection}/${props.file}/images`
 }
 
-// Save content
-function saveContent(triggerDeploy = false) {
-  if (saveForm.processing) return
-
+function syncSaveForm(triggerDeploy = saveForm.deploy) {
   if (fileType.value === 'json') {
     saveForm.raw = raw.value
     saveForm.frontmatter = {}
@@ -100,8 +110,19 @@ function saveContent(triggerDeploy = false) {
     saveForm.raw = ''
   }
   saveForm.deploy = triggerDeploy
-  saveForm.clearErrors()
+}
 
+function validateEditorField(field) {
+  syncSaveForm()
+  saveForm.validate(field)
+}
+
+function revalidateEditorField(field) {
+  syncSaveForm()
+  revalidateWhenInvalid(field)
+}
+
+function submitContent() {
   saveForm.post(getActionPath('update'), {
     preserveScroll: true,
     onSuccess: (page) => {
@@ -113,6 +134,30 @@ function saveContent(triggerDeploy = false) {
       }
     },
     onError: () => {
+      showSaveMenu.value = true
+    }
+  })
+}
+
+// Save content
+function saveContent(triggerDeploy = false) {
+  if (saveForm.processing || saveForm.validating) return
+
+  syncSaveForm(triggerDeploy)
+  saveForm.clearErrors()
+  saveForm.validate({
+    only:
+      fileType.value === 'json'
+        ? ['raw']
+        : [
+            'frontmatter',
+            ...Object.keys(frontmatter.value).map(
+              (key) => `frontmatter.${key}`
+            ),
+            'body'
+          ],
+    onPrecognitionSuccess: submitContent,
+    onValidationError: () => {
       showSaveMenu.value = true
     }
   })
@@ -459,7 +504,12 @@ function handleKeydown(e) {
           <button
             type="button"
             @click="saveContent(false)"
-            :disabled="saveForm.processing || !hasChanges"
+            :disabled="
+              saveForm.processing ||
+              saveForm.validating ||
+              !hasChanges ||
+              hasContentErrors
+            "
             class="rounded-l-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
           >
             {{
@@ -477,7 +527,7 @@ function handleKeydown(e) {
             :aria-expanded="showSaveMenu"
             aria-controls="content-save-menu"
             @click="showSaveMenu = !showSaveMenu"
-            :disabled="saveForm.processing"
+            :disabled="saveForm.processing || saveForm.validating"
             class="rounded-r-md border-l border-gray-700 bg-gray-900 px-2 py-1.5 text-white hover:bg-gray-800 disabled:opacity-50 dark:border-gray-300 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
           >
             <svg
@@ -567,7 +617,18 @@ function handleKeydown(e) {
           data-test="content-json-source"
           class="flex-1 resize-none bg-transparent p-5 font-mono text-sm leading-7 text-gray-900 outline-none dark:text-white"
           spellcheck="false"
+          :aria-invalid="saveForm.invalid('raw')"
+          :aria-describedby="saveForm.errors.raw ? 'content-raw-error' : null"
+          @blur="validateEditorField('raw')"
+          @input="revalidateEditorField('raw')"
         ></textarea>
+        <p
+          v-if="saveForm.errors.raw"
+          id="content-raw-error"
+          class="px-5 pb-3 text-xs text-red-600 dark:text-red-400"
+        >
+          {{ saveForm.errors.raw }}
+        </p>
       </div>
 
       <!-- Markdown document workspace -->
@@ -619,18 +680,51 @@ function handleKeydown(e) {
                   :id="`content-metadata-${key}`"
                   v-model="frontmatter[key]"
                   type="text"
+                  :aria-invalid="saveForm.invalid(`frontmatter.${key}`)"
+                  :aria-describedby="
+                    saveForm.errors[`frontmatter.${key}`]
+                      ? `content-metadata-${key}-error`
+                      : null
+                  "
                   class="focus:border-brand dark:focus:border-brand-400 w-full border-0 border-b border-gray-200 bg-transparent px-0 py-1.5 text-sm text-gray-900 outline-none transition-colors dark:border-gray-700 dark:text-white"
+                  @blur="validateEditorField(`frontmatter.${key}`)"
+                  @input="revalidateEditorField(`frontmatter.${key}`)"
                 />
+                <p
+                  v-if="saveForm.errors[`frontmatter.${key}`]"
+                  :id="`content-metadata-${key}-error`"
+                  class="mt-1 text-xs text-red-600 dark:text-red-400"
+                >
+                  {{ saveForm.errors[`frontmatter.${key}`] }}
+                </p>
               </dd>
             </div>
           </dl>
+          <p
+            v-if="saveForm.errors.frontmatter"
+            class="mt-2 text-xs text-red-600 dark:text-red-400"
+          >
+            {{ saveForm.errors.frontmatter }}
+          </p>
         </details>
+
+        <p
+          v-if="saveForm.errors.body"
+          id="content-body-error"
+          class="mx-auto w-full max-w-3xl px-5 pt-4 text-xs text-red-600 dark:text-red-400 sm:px-8"
+        >
+          {{ saveForm.errors.body }}
+        </p>
 
         <MarkdownEditor
           ref="markdownEditor"
           v-model="body"
           :uploads-configured="uploadsConfigured"
           :upload-url="getUploadPath()"
+          :aria-invalid="saveForm.invalid('body')"
+          :aria-describedby="saveForm.errors.body ? 'content-body-error' : null"
+          @blur="validateEditorField('body')"
+          @update:model-value="revalidateEditorField('body')"
           @mode-change="updateEditorMode"
           @compatibility-change="updateEditorCompatibility"
         />

--- a/assets/js/pages/projects/content-manager.vue
+++ b/assets/js/pages/projects/content-manager.vue
@@ -3,6 +3,7 @@ import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, onMounted, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
+import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
   layout: AppLayout
@@ -32,35 +33,45 @@ const createForm = useForm({
   title: '',
   appSlug: props.app.slug
 })
+  .withPrecognition('post', () => getCreatePath())
+  .setValidationTimeout(350)
+const { revalidateWhenInvalid, validateOnBlur } =
+  usePrecognitionValidation(createForm)
+
+function getCreatePath() {
+  const envPath =
+    props.environment.slug !== 'production'
+      ? `/environments/${props.environment.slug}`
+      : ''
+  return `/projects/${props.project.slug}${envPath}/content/${selectedCollection.value?.slug}/create`
+}
 
 function openCreateModal(collection) {
   selectedCollection.value = collection
-  createForm.reset()
+  createForm.resetAndClearErrors()
   createModalOpen.value = true
 }
 
 function createContent() {
   if (!createForm.contentSlug.trim()) return
 
-  const envPath =
-    props.environment.slug !== 'production'
-      ? `/environments/${props.environment.slug}`
-      : ''
-
-  createForm.post(
-    `/projects/${props.project.slug}${envPath}/content/${selectedCollection.value.slug}/create`,
-    {
-      onSuccess: () => {
-        createModalOpen.value = false
-      }
+  createForm.validate({
+    only: ['contentSlug', 'title'],
+    onPrecognitionSuccess: () => {
+      createForm.post(getCreatePath(), {
+        onSuccess: () => {
+          createModalOpen.value = false
+        }
+      })
     }
-  )
+  })
 }
 
 function closeCreateModal() {
   if (!createForm.processing) {
     createModalOpen.value = false
     selectedCollection.value = null
+    createForm.resetAndClearErrors()
   }
 }
 
@@ -474,15 +485,28 @@ function refresh() {
             >
             <input
               v-model="createForm.contentSlug"
+              id="contentSlug"
               type="text"
               placeholder="my-new-post"
+              :aria-invalid="createForm.invalid('contentSlug')"
+              :aria-describedby="
+                createForm.errors.contentSlug
+                  ? 'content-create-slug-error'
+                  : 'content-create-slug-help'
+              "
               class="focus:border-brand mt-1 block w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('contentSlug', $event)"
+              @input="revalidateWhenInvalid('contentSlug')"
             />
-            <p class="mt-1 text-xs text-gray-500 dark:text-gray-400">
+            <p
+              id="content-create-slug-help"
+              class="mt-1 text-xs text-gray-500 dark:text-gray-400"
+            >
               Will be used as the filename
             </p>
             <p
               v-if="createForm.errors.contentSlug"
+              id="content-create-slug-error"
               class="mt-1 text-xs text-red-600 dark:text-red-400"
             >
               {{ createForm.errors.contentSlug }}
@@ -495,10 +519,24 @@ function refresh() {
             >
             <input
               v-model="createForm.title"
+              id="contentTitle"
               type="text"
               placeholder="My New Post"
+              :aria-invalid="createForm.invalid('title')"
+              :aria-describedby="
+                createForm.errors.title ? 'content-create-title-error' : null
+              "
               class="focus:border-brand mt-1 block w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-2 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
+              @blur="validateOnBlur('title', $event)"
+              @input="revalidateWhenInvalid('title')"
             />
+            <p
+              v-if="createForm.errors.title"
+              id="content-create-title-error"
+              class="mt-1 text-xs text-red-600 dark:text-red-400"
+            >
+              {{ createForm.errors.title }}
+            </p>
           </div>
           <div class="flex items-center justify-end space-x-3 pt-2">
             <button
@@ -511,7 +549,10 @@ function refresh() {
             <button
               type="submit"
               :disabled="
-                !createForm.contentSlug.trim() || createForm.processing
+                !createForm.contentSlug.trim() ||
+                createForm.processing ||
+                createForm.validating ||
+                createForm.hasErrors
               "
               class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
             >

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -49,6 +49,9 @@ test(
     const sailscastsScreenshotRoot = path.resolve(
       '.tmp/screenshots/issue-225-sailscasts-bridge-parity'
     )
+    const precognitionScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-208-precognition'
+    )
 
     fs.mkdirSync(screenshotRoot, { recursive: true })
     fs.mkdirSync(identifierScreenshotRoot, { recursive: true })
@@ -58,6 +61,7 @@ test(
     fs.mkdirSync(actionScreenshotRoot, { recursive: true })
     fs.mkdirSync(filterScreenshotRoot, { recursive: true })
     fs.mkdirSync(sailscastsScreenshotRoot, { recursive: true })
+    fs.mkdirSync(precognitionScreenshotRoot, { recursive: true })
 
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: resourceMetadata(),
@@ -152,6 +156,15 @@ test(
       }
       if (code.includes('const missing = [];')) {
         return successfulResult({ missing: [] })
+      }
+      if (code.includes('const fieldErrors = {};')) {
+        const values = readEmbeddedValue(code, 'values')
+        return successfulResult({
+          fieldErrors:
+            values.title === 'Existing course'
+              ? { title: 'Course title is already in use.' }
+              : {}
+        })
       }
       if (code.includes('const where = definition.query')) {
         const definition = readEmbeddedValue(code, 'definition')
@@ -639,7 +652,27 @@ test(
         ),
         { fullPage: true }
       )
-      await page.raw.getByLabel('Course title').fill('Ship a durable course')
+      const courseTitle = page.raw.getByLabel('Course title')
+      await courseTitle.fill('Existing course')
+      await courseTitle.blur()
+      await page.wait('text=Course title is already in use')
+      await courseTitle.evaluate((element) => {
+        element.scrollIntoView({ block: 'center' })
+      })
+      await page.screenshot(
+        path.join(precognitionScreenshotRoot, 'bridge-field-error-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(precognitionScreenshotRoot, 'bridge-field-error-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await courseTitle.fill('Ship a durable course')
+      await page.raw
+        .getByText('Course title is already in use', { exact: false })
+        .waitFor({ state: 'hidden' })
       await page.raw.getByLabel('Price').fill('49')
       await page.raw.setViewportSize({ width: 1440, height: 1100 })
       const creatorRelationshipSelect = page.raw.getByRole('combobox', {
@@ -1300,7 +1333,8 @@ function resourceMetadata() {
         },
         title: {
           type: 'string',
-          required: true
+          required: true,
+          unique: true
         },
         description: {
           type: 'string',

--- a/tests/e2e/pages/projects/content-manager.test.js
+++ b/tests/e2e/pages/projects/content-manager.test.js
@@ -23,6 +23,9 @@ test(
     const tempRoot = fs.mkdtempSync(
       path.join(os.tmpdir(), 'slipway-content-manager-ui-')
     )
+    const precognitionScreenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-208-precognition'
+    )
     const projectRoot = path.join(
       tempRoot,
       current.projects.deploymentTarget.slug
@@ -31,6 +34,7 @@ test(
     const originalAppsDir = sails.config.custom.slipwayAppsDir
     const originalGetContainerStatus = sails.helpers.docker.getContainerStatus
 
+    fs.mkdirSync(precognitionScreenshotRoot, { recursive: true })
     fs.mkdirSync(collectionRoot, { recursive: true })
     fs.writeFileSync(
       path.join(collectionRoot, 'welcome.md'),
@@ -220,7 +224,24 @@ test(
       await page.wait('@content-create-modal')
       await expect(page).toSee('Create new content in posts')
       expect(await page.raw.getByText('Target app').count()).toBe(0)
-      await page.raw.getByPlaceholder('my-new-post').fill('release-notes')
+      const contentSlug = page.raw.getByPlaceholder('my-new-post')
+      await contentSlug.fill('Release Notes')
+      await contentSlug.blur()
+      await page.wait('text=Use lowercase letters')
+      await page.screenshot(
+        path.join(precognitionScreenshotRoot, 'content-slug-error-light.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(precognitionScreenshotRoot, 'content-slug-error-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await contentSlug.fill('release-notes')
+      await page.raw
+        .getByText('Use lowercase letters', { exact: false })
+        .waitFor({ state: 'hidden' })
       expect(
         await page.raw
           .getByRole('button', { name: 'Create' })
@@ -229,7 +250,15 @@ test(
       await page.screenshot('.tmp/content-manager-create.png', {
         fullPage: true
       })
-      expect(page).toHaveNoSmoke()
+      await page.raw.getByRole('button', { name: 'Create' }).click()
+      await page.raw.waitForURL(
+        (url) => url.pathname.endsWith('/content/posts/release-notes'),
+        { timeout: 10000 }
+      )
+      expect(fs.existsSync(path.join(collectionRoot, 'release-notes.md'))).toBe(
+        true
+      )
+      expect(page).toHaveNoJavascriptErrors()
     } finally {
       sails.helpers.docker.getContainerStatus = originalGetContainerStatus
       sails.config.custom.slipwayAppsDir = originalAppsDir

--- a/tests/functional/pages/bridge-precognition.test.js
+++ b/tests/functional/pages/bridge-precognition.test.js
@@ -1,0 +1,128 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'Bridge validates generated fields without creating a target record',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-precognition',
+          name: 'Bridge Precognition'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    let validationExecutions = 0
+    let mutationExecutions = 0
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: {
+        subscriber: {
+          identity: 'subscriber',
+          globalId: 'Subscriber',
+          tableName: 'subscriber',
+          primaryKey: 'id',
+          attributes: {
+            id: { type: 'number', autoIncrement: true },
+            name: { type: 'string', required: true },
+            email: {
+              type: 'string',
+              required: true,
+              isEmail: true,
+              unique: true
+            }
+          },
+          associations: []
+        }
+      },
+      config: {}
+    })
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-precognition-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources
+      })
+      sails.helpers.bridge.executeInContainer = async (
+        _containerName,
+        code
+      ) => {
+        if (code.includes('const fieldErrors = {};')) {
+          validationExecutions += 1
+          return successfulResult({
+            fieldErrors: code.includes('taken@example.com')
+              ? { email: 'Email is already in use.' }
+              : {}
+          })
+        }
+        if (
+          code.includes('model.create') ||
+          code.includes('model.update') ||
+          code.includes('model.destroy')
+        ) {
+          mutationExecutions += 1
+        }
+        return {
+          success: false,
+          output: '',
+          error: 'A Precognition request must not mutate the target app.',
+          exitCode: 1
+        }
+      }
+
+      const basePath = `/projects/${project.slug}/environments/${environment.slug}/bridge/subscriber`
+      const browser = await withCsrfFromPage(
+        request,
+        `${basePath}/new`,
+        'genesisUser'
+      )
+      const precognitive = browser.request.withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'values.email'
+      })
+
+      const invalid = await precognitive.post(`${basePath}/create`, {
+        values: { email: 'taken@example.com' }
+      })
+      expect(invalid).toHaveStatus(422)
+      expect(invalid.data.errors['values.email'][0]).toContain(
+        'Email is already in use'
+      )
+
+      const valid = await precognitive.post(`${basePath}/create`, {
+        values: { email: 'available@example.com' }
+      })
+      expect(valid).toHaveStatus(204)
+      expect(valid).toHaveHeader('precognition-success', 'true')
+      expect(validationExecutions).toBe(2)
+      expect(mutationExecutions).toBe(0)
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}

--- a/tests/functional/pages/content-manager.test.js
+++ b/tests/functional/pages/content-manager.test.js
@@ -301,6 +301,101 @@ test(
 )
 
 test(
+  'Content Manager validates create and editor values without writing source',
+  { world: contentWorld('content-precognition') },
+  async ({ sails, world, request, expect }) => {
+    const workspace = await prepareContentWorkspace({ sails, world })
+
+    try {
+      const managerPath = `/projects/${workspace.project.slug}/content`
+      const manager = await withCsrfFromPage(
+        request,
+        managerPath,
+        'genesisUser'
+      )
+      const createRequest = manager.request.withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'contentSlug'
+      })
+
+      const invalidSlug = await createRequest.post(
+        `${managerPath}/posts/create`,
+        {
+          contentSlug: 'Release Notes',
+          title: 'Release notes',
+          appSlug: workspace.app.slug
+        }
+      )
+      expect(invalidSlug).toHaveStatus(422)
+      expect(invalidSlug.data.errors.contentSlug[0]).toContain(
+        'Use lowercase letters'
+      )
+
+      const duplicateSlug = await createRequest.post(
+        `${managerPath}/posts/create`,
+        {
+          contentSlug: 'welcome',
+          title: 'Another welcome',
+          appSlug: workspace.app.slug
+        }
+      )
+      expect(duplicateSlug).toHaveStatus(422)
+      expect(duplicateSlug.data.errors.contentSlug[0]).toContain(
+        'This content slug is already in use'
+      )
+
+      const availableSlug = await createRequest.post(
+        `${managerPath}/posts/create`,
+        {
+          contentSlug: 'release-notes',
+          title: 'Release notes',
+          appSlug: workspace.app.slug
+        }
+      )
+      expect(availableSlug).toHaveStatus(204)
+      expect(availableSlug).toHaveHeader('precognition-success', 'true')
+
+      const editor = await withCsrfFromPage(
+        request,
+        workspace.editorPath,
+        'genesisUser'
+      )
+      const editorRequest = editor.request.withHeaders({
+        Precognition: 'true',
+        'Precognition-Validate-Only': 'frontmatter.bad/key'
+      })
+      const invalidMetadata = await editorRequest.post(workspace.updatePath, {
+        frontmatter: { 'bad/key': 'unsafe' },
+        body: 'This request must not be written.',
+        appSlug: workspace.app.slug
+      })
+      expect(invalidMetadata).toHaveStatus(422)
+      expect(invalidMetadata.data.errors['frontmatter.bad/key'][0]).toContain(
+        'valid metadata field name'
+      )
+
+      const validEditor = await editorRequest.post(workspace.updatePath, {
+        frontmatter: { title: 'Welcome' },
+        body: 'This valid preflight must not be written either.',
+        appSlug: workspace.app.slug
+      })
+      expect(validEditor).toHaveStatus(204)
+      expect(validEditor).toHaveHeader('precognition-success', 'true')
+      expect(
+        fs.existsSync(
+          path.join(path.dirname(workspace.filePath), 'release-notes.md')
+        )
+      ).toBe(false)
+      expect(fs.readFileSync(workspace.filePath, 'utf8')).toBe(
+        workspace.originalContent
+      )
+    } finally {
+      workspace.restore()
+    }
+  }
+)
+
+test(
   'Content Manager deletes Git-backed content with a conventional commit',
   { world: contentWorld('content-git-delete') },
   async ({ sails, world, request, expect }) => {

--- a/tests/unit/helpers/bridge/precognition-validation.test.js
+++ b/tests/unit/helpers/bridge/precognition-validation.test.js
@@ -1,0 +1,126 @@
+const { test } = require('sounding')
+
+test('Bridge validates only the generated field being edited', async ({
+  sails,
+  expect
+}) => {
+  const resource = {
+    identity: 'subscriber',
+    primaryKey: 'id',
+    create: ['name', 'email'],
+    edit: ['name', 'email'],
+    attributes: {
+      id: { type: 'number' },
+      name: { type: 'string', required: true, label: 'Name' },
+      email: {
+        type: 'string',
+        required: true,
+        isEmail: true,
+        label: 'Email'
+      }
+    },
+    associations: []
+  }
+
+  const values = await sails.helpers.bridge.allowResourceValues.with({
+    resource,
+    surface: 'create',
+    values: { email: 'editor@example.com' },
+    validateOnly: ['email']
+  })
+
+  expect(values).toEqual({ email: 'editor@example.com' })
+})
+
+test('Bridge runs target Waterline validation without mutating a record', async ({
+  sails,
+  expect
+}) => {
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  const executions = []
+  const resource = {
+    identity: 'subscriber',
+    primaryKey: 'id',
+    attributes: {
+      email: { type: 'string', unique: true, label: 'Email' }
+    },
+    associations: []
+  }
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      executions.push({ containerName, code })
+      return {
+        success: true,
+        output: JSON.stringify({ fieldErrors: {} }),
+        error: null,
+        exitCode: 0
+      }
+    }
+
+    const values = await sails.helpers.bridge.validateResourceValues.with({
+      containerName: 'bridge-web',
+      resource,
+      values: { email: 'editor@example.com' }
+    })
+
+    expect(values).toEqual({ email: 'editor@example.com' })
+    expect(executions.length).toBe(1)
+    expect(executions[0].containerName).toBe('bridge-web')
+    expect(executions[0].code).toContain('model.validate(field, value)')
+    expect(executions[0].code).toContain('await model.findOne')
+    expect(executions[0].code.includes('model.create')).toBe(false)
+    expect(executions[0].code.includes('model.update')).toBe(false)
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+test('Bridge returns target validation errors under stable generated field keys', async ({
+  sails,
+  expect
+}) => {
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async () => ({
+      success: true,
+      output: JSON.stringify({
+        fieldErrors: { email: 'Email is already in use.' }
+      }),
+      error: null,
+      exitCode: 0
+    })
+
+    let receivedError
+    try {
+      await sails.helpers.bridge.validateResourceValues.with({
+        containerName: 'bridge-web',
+        resource: {
+          identity: 'subscriber',
+          primaryKey: 'id',
+          attributes: {
+            email: { type: 'string', unique: true, label: 'Email' }
+          },
+          associations: []
+        },
+        values: { email: 'taken@example.com' }
+      })
+    } catch (error) {
+      receivedError = error
+    }
+
+    expect(receivedError.code).toBe('BRIDGE_FIELD_INVALID')
+    expect(receivedError.fieldErrors).toEqual({
+      email: 'Email is already in use.'
+    })
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})

--- a/tests/unit/helpers/content/validate.test.js
+++ b/tests/unit/helpers/content/validate.test.js
@@ -1,0 +1,40 @@
+const { test } = require('sounding')
+
+test('Content validation checks slugs and JSON before a source write', ({
+  sails,
+  expect
+}) => {
+  expect(
+    sails.helpers.content.validate({ contentSlug: 'Release Notes' }, [
+      'contentSlug'
+    ])
+  ).toEqual([
+    {
+      contentSlug: 'Use lowercase letters, numbers, and single hyphens.'
+    }
+  ])
+
+  expect(
+    sails.helpers.content.validate({ raw: '{ not json', fileType: 'json' }, [
+      'raw'
+    ])
+  ).toEqual([{ raw: 'Enter valid JSON before saving.' }])
+})
+
+test('Content validation keeps unrelated editor fields quiet', ({
+  sails,
+  expect
+}) => {
+  const problems = sails.helpers.content.validate(
+    {
+      frontmatter: {
+        title: 'A valid title',
+        'bad\nkey': 'This is not safe to serialize'
+      },
+      body: 42
+    },
+    ['frontmatter.title']
+  )
+
+  expect(problems).toEqual([])
+})


### PR DESCRIPTION
## Summary
- validate generated Bridge fields against the target app’s Waterline model before mutation
- validate Content Manager slugs, metadata, Markdown, and JSON without losing local edits
- keep validation inline in the existing minimal forms and preserve normal raw Markdown saves
- cover zero-mutation preflights and browser correction/submission flows in Sounding

## Verification
- `npm run lint`
- `npm run test:unit` (242 passed)
- `npm run test:functional` (89 passed)
- `npm run test:e2e` (40 passed)

Fixes #208