### PR TITLE
feat(ingress): harden public bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,23 +35,12 @@ curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.s
 
 This installs two containers (Slipway + Caddy proxy) and gives you a dashboard URL.
 
-Slipway publishes direct application URLs from TCP ports `1338-1500`. The
-installer adds that range to UFW or firewalld when either firewall is already
-active; it does not enable a firewall or change your SSH rules. If your VPS
-provider has a separate network firewall, allow inbound TCP `1338-1500` there
-as well. Applications reached through a configured domain only require ports
-`80` and `443`.
-
-After the first deployment, validate direct access from a different machine or
-network so the request crosses the provider firewall:
-
-```bash
-curl -I --connect-timeout 5 http://YOUR_SERVER_IP:ALLOCATED_PORT/health
-```
-
-The deployment log confirms the container health and live Docker mapping. If
-those checks pass but this external request times out, the remaining boundary
-is the VPS provider or host firewall.
+Fresh installations expose only Caddy on TCP `80` and `443`. The dashboard and
+deployed app ports bind to loopback; Caddy is the single public HTTP/S entry
+point. Raw `IP:port` app URLs remain available as an explicit mode, and
+Cloudflare Tunnel can replace public origin ports entirely. See the
+[ingress and firewall guide](docs/ingress.md) for both options and for upgrading
+an older installation without changing its access unexpectedly.
 
 ### Run Slipway locally like production
 

--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -99,7 +99,7 @@ module.exports = {
             containerName: app.containerName,
             containerPort: app.port || 1337,
             hostPort: app.hostPort,
-            host: sails.config.custom.slipwayPortHost || '0.0.0.0'
+            host: sails.config.custom.slipwayPortHost || '127.0.0.1'
           })
         } catch (error) {
           portBinding = {

--- a/api/helpers/caddy/format-site-label.js
+++ b/api/helpers/caddy/format-site-label.js
@@ -1,0 +1,32 @@
+module.exports = {
+  friendlyName: 'Format Caddy site label',
+
+  description:
+    'Format hostnames for public TLS ingress or private Cloudflare Tunnel ingress.',
+
+  inputs: {
+    domains: {
+      type: 'ref',
+      required: true,
+      description: 'Hostnames Caddy should route.'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'string'
+    }
+  },
+
+  fn: async function ({ domains }) {
+    const normalizedDomains = (domains || [])
+      .map((domain) => String(domain || '').trim())
+      .filter(Boolean)
+
+    if (sails.config.custom.slipwayIngress === 'cloudflare-tunnel') {
+      return normalizedDomains.map((domain) => `http://${domain}`).join(',')
+    }
+
+    return normalizedDomains.join(',')
+  }
+}

--- a/api/helpers/caddy/update-dashboard-route.js
+++ b/api/helpers/caddy/update-dashboard-route.js
@@ -28,7 +28,11 @@ module.exports = {
     const dockerPath = sails.config.docker?.binaryPath || 'docker'
     const network = sails.config.custom.slipwayNetwork || 'slipway'
     const containerName = 'slipway-route-dashboard'
+    const bootstrapContainerName = 'slipway-route-bootstrap'
     const port = sails.config.port || 1337
+    const siteLabel = await sails.helpers.caddy.formatSiteLabel.with({
+      domains: [domain]
+    })
 
     // Remove existing route container
     await new Promise((resolve) => {
@@ -46,14 +50,17 @@ module.exports = {
       '--restart',
       'unless-stopped',
       '--label',
-      `caddy=${domain}`,
+      `caddy=${siteLabel}`,
       '--label',
       `caddy.reverse_proxy=slipway:${port}`
     ]
 
     // Add TLS email if configured
     const acmeEmail = await sails.helpers.setting.get('acmeEmail')
-    if (acmeEmail) {
+    if (
+      acmeEmail &&
+      sails.config.custom.slipwayIngress !== 'cloudflare-tunnel'
+    ) {
       args.push('--label', `caddy.tls=${acmeEmail}`)
     }
 
@@ -65,10 +72,13 @@ module.exports = {
           sails.log.error(
             `Dashboard route container creation failed: ${err.message}`
           )
-          throw 'caddyError'
+          reject('caddyError')
+          return
         }
-        sails.log.info(`Caddy dashboard route created for ${domain}`)
-        resolve({ domain, action: 'created' })
+        execFile(dockerPath, ['rm', '-f', bootstrapContainerName], () => {
+          sails.log.info(`Caddy dashboard route created for ${domain}`)
+          resolve({ domain, action: 'created' })
+        })
       })
     })
   }

--- a/api/helpers/caddy/update-route.js
+++ b/api/helpers/caddy/update-route.js
@@ -193,6 +193,9 @@ async function buildCreateArgs({
   config,
   routableApps
 }) {
+  const siteLabel = await sails.helpers.caddy.formatSiteLabel.with({
+    domains: config.domains
+  })
   const args = [
     'create',
     '--name',
@@ -202,7 +205,7 @@ async function buildCreateArgs({
     '--restart',
     'unless-stopped',
     '--label',
-    `caddy=${config.domains.join(',')}`
+    `caddy=${siteLabel}`
   ]
 
   if (routableApps.length === 1) {
@@ -232,7 +235,7 @@ async function buildCreateArgs({
   }
 
   const acmeEmail = await sails.helpers.setting.get('acmeEmail')
-  if (acmeEmail) {
+  if (acmeEmail && sails.config.custom.slipwayIngress !== 'cloudflare-tunnel') {
     args.push('--label', `caddy.tls=${acmeEmail}`)
   }
 

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -115,7 +115,7 @@ module.exports = {
       const appSlug = targetApp ? targetApp.slug : undefined
       const isPubliclyRoutable = !targetApp || targetApp.routePath !== null
       const appBindHost = isPubliclyRoutable
-        ? sails.config.custom.slipwayPortHost || '0.0.0.0'
+        ? sails.config.custom.slipwayPortHost || '127.0.0.1'
         : '127.0.0.1'
 
       // 3. Generate image name and container names

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -110,7 +110,7 @@ module.exports = {
       const appSlug = existingApp?.slug
       const isPubliclyRoutable = !existingApp || existingApp.routePath !== null
       const appBindHost = isPubliclyRoutable
-        ? sails.config.custom.slipwayPortHost || '0.0.0.0'
+        ? sails.config.custom.slipwayPortHost || '127.0.0.1'
         : '127.0.0.1'
       const healthPath = App.normalizeHealthPath(existingApp?.healthPath)
       const oldContainerName = existingApp?.containerName

--- a/api/helpers/docker/allocate-port.js
+++ b/api/helpers/docker/allocate-port.js
@@ -47,7 +47,7 @@ module.exports = {
   fn: async function ({ host, ownerType, ownerId, ttl, checkHost }) {
     const portRange = sails.config.custom.slipwayPortRange
     const bindHost = normalizeHost(
-      host || sails.config.custom.slipwayPortHost || '0.0.0.0'
+      host || sails.config.custom.slipwayPortHost || '127.0.0.1'
     )
 
     await releaseExpiredReservations()

--- a/api/helpers/docker/release-port.js
+++ b/api/helpers/docker/release-port.js
@@ -32,7 +32,7 @@ module.exports = {
 
   fn: async function ({ hostPort, host, ownerType, ownerId }) {
     const bindHost = normalizeHost(
-      host || sails.config.custom.slipwayPortHost || '0.0.0.0'
+      host || sails.config.custom.slipwayPortHost || '127.0.0.1'
     )
     const criteria = {
       reservationKey: `${bindHost}:${hostPort}`

--- a/api/helpers/docker/run-container.js
+++ b/api/helpers/docker/run-container.js
@@ -81,7 +81,7 @@ module.exports = {
     const networkName =
       network || sails.config.custom.slipwayNetwork || 'slipway'
     const bindHost = normalizeHost(
-      host || sails.config.custom.slipwayPortHost || '0.0.0.0'
+      host || sails.config.custom.slipwayPortHost || '127.0.0.1'
     )
     const portBindingArgument =
       await sails.helpers.docker.formatPortBinding.with({

--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -32,7 +32,7 @@ module.exports = {
     const imageRepository = `ghcr.io/${githubRepo}`
     const CACHE_KEY = 'slipway_update_progress'
     const appsDir = sails.config.custom.slipwayAppsDir || '/var/slipway/apps'
-    const portHost = sails.config.custom.slipwayPortHost || '0.0.0.0'
+    const portHost = sails.config.custom.slipwayPortHost || '127.0.0.1'
     let tempPort = null
     let tempPortReserved = false
 

--- a/api/helpers/system/build-update-docker-args.js
+++ b/api/helpers/system/build-update-docker-args.js
@@ -37,10 +37,18 @@ module.exports = {
 
     const portBindings = containerInfo.HostConfig?.PortBindings || {}
     for (const [containerPort, bindings] of Object.entries(portBindings)) {
+      const publishedBindings = new Set()
       for (const binding of bindings || []) {
         const hostPort = binding.HostPort || ''
         if (hostPort) {
-          runArgs.push('-p', `${hostPort}:${containerPort.replace('/tcp', '')}`)
+          const publishedBinding = formatPortBinding(
+            binding.HostIp,
+            hostPort,
+            containerPort.replace('/tcp', '')
+          )
+          if (publishedBindings.has(publishedBinding)) continue
+          publishedBindings.add(publishedBinding)
+          runArgs.push('-p', publishedBinding)
         }
       }
     }
@@ -64,8 +72,22 @@ module.exports = {
   }
 }
 
+function formatPortBinding(host, hostPort, containerPort) {
+  const normalizedHost = String(host || '0.0.0.0').trim() || '0.0.0.0'
+
+  if (normalizedHost === '0.0.0.0' || normalizedHost === '::') {
+    return `${hostPort}:${containerPort}`
+  }
+
+  const formattedHost = normalizedHost.includes(':')
+    ? `[${normalizedHost}]`
+    : normalizedHost
+  return `${formattedHost}:${hostPort}:${containerPort}`
+}
+
 function buildEnvArgs(envVars = []) {
   const normalized = []
+  let hasAppPortHost = false
 
   for (const envVar of envVars || []) {
     const value = String(envVar)
@@ -75,9 +97,19 @@ function buildEnvArgs(envVars = []) {
       continue
     }
 
+    if (key === 'SLIPWAY_APP_PORT_HOST') {
+      hasAppPortHost = true
+    }
+
     normalized.push(value)
   }
 
+  // Releases before the private-ingress default always published routable
+  // apps. Preserve that behavior during self-update; fresh installs pass an
+  // explicit loopback value.
+  if (!hasAppPortHost) {
+    normalized.push('SLIPWAY_APP_PORT_HOST=0.0.0.0')
+  }
   normalized.push('NODE_ENV=production')
 
   return normalized.flatMap((envVar) => ['-e', envVar])

--- a/config/custom.js
+++ b/config/custom.js
@@ -60,8 +60,13 @@ module.exports.custom = {
   // Port range for app containers (Slipway allocates from this range)
   slipwayPortRange: { start: 1338, end: 1500 },
 
-  // Host interface used when checking and reserving app container ports
-  slipwayPortHost: '0.0.0.0',
+  // Host interface used when checking and reserving app container ports.
+  // Keep apps private by default; 0.0.0.0 is an explicit direct-access mode.
+  slipwayPortHost: '127.0.0.1',
+
+  // Caddy terminates TLS by default. Cloudflare Tunnel terminates it at the
+  // edge and asks Caddy to serve HTTP on the private origin connection.
+  slipwayIngress: 'public',
 
   // Keep database transfers bounded on memory-constrained VPS hosts.
   databaseOperations: {

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -8,6 +8,8 @@ module.exports = {
       start: Number(process.env.SLIPWAY_APP_PORT_START) || 1338,
       end: Number(process.env.SLIPWAY_APP_PORT_END) || 1500
     },
+    slipwayPortHost: bindHost(process.env.SLIPWAY_APP_PORT_HOST),
+    slipwayIngress: ingressMode(process.env.SLIPWAY_INGRESS),
     observability: {
       containerMetricsRetentionMs:
         positiveNumber(
@@ -115,4 +117,14 @@ function positiveNumber(value, fallback) {
 
 function positiveInteger(value, fallback) {
   return Math.floor(positiveNumber(value, fallback))
+}
+
+function bindHost(value) {
+  return String(value || '').trim() === '0.0.0.0' ? '0.0.0.0' : '127.0.0.1'
+}
+
+function ingressMode(value) {
+  return String(value || '').trim() === 'cloudflare-tunnel'
+    ? 'cloudflare-tunnel'
+    : 'public'
 }

--- a/docs/ingress.md
+++ b/docs/ingress.md
@@ -1,0 +1,138 @@
+# Ingress and firewall
+
+Slipway has one default traffic path:
+
+```text
+Internet -> Caddy (80/443) -> Slipway dashboard or app container
+```
+
+On a fresh installation, only Caddy binds publicly. The dashboard binds to
+`127.0.0.1:1337`, deployed apps bind to loopback ports in `1338-1500`, and
+Caddy reaches every container over the private `slipway` Docker network. The
+initial dashboard URL also passes through Caddy, so setup does not require a
+temporary public dashboard port.
+
+## Default public VPS mode
+
+The normal installer uses this contract:
+
+| Port        | Default binding      | Purpose                               |
+| ----------- | -------------------- | ------------------------------------- |
+| `22`        | Provider/host choice | SSH; Slipway does not change it       |
+| `80`        | `0.0.0.0`            | Caddy HTTP and certificate challenges |
+| `443`       | `0.0.0.0`            | Caddy HTTPS                           |
+| `1337`      | `127.0.0.1`          | Slipway dashboard behind Caddy        |
+| `1338-1500` | `127.0.0.1`          | App containers behind Caddy           |
+
+The installer aligns active UFW or firewalld rules with these bindings. It does
+not enable a firewall or edit SSH policy. Match the same contract in the VPS
+provider firewall: allow inbound TCP `80` and `443`, retain your chosen SSH
+rule, and deny the rest.
+
+Check the effective Docker bindings after installation:
+
+```bash
+sudo docker ps --format 'table {{.Names}}\t{{.Ports}}'
+sudo ss -lntp
+```
+
+`slipway-proxy` should show public `80` and `443`. `slipway` and deployed apps
+should show `127.0.0.1` bindings.
+
+## Explicit raw IP and port access
+
+Direct `http://SERVER_IP:PORT` URLs are useful for diagnostics or deployments
+without DNS, but they bypass Caddy TLS and increase the public attack surface.
+Enable them deliberately by running the installer with:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env SLIPWAY_APP_PORT_HOST=0.0.0.0 bash /tmp/install-slipway.sh
+```
+
+The value is persisted in `/etc/slipway/.env`. Redeploy an app before testing
+its direct URL so Docker recreates that app with the new binding, then allow
+TCP `1338-1500` in the VPS provider firewall. Verify from another network:
+
+```bash
+curl -I --connect-timeout 5 http://SERVER_IP:ALLOCATED_PORT/health
+```
+
+Set `SLIPWAY_APP_PORT_HOST=127.0.0.1` and rerun the installer to return to
+Caddy-only ingress. Redeploy existing apps and remove the range from the VPS
+provider firewall; existing containers retain their old Docker bindings until
+they are replaced.
+
+Older Slipway installations keep their existing public dashboard and app bind
+defaults the first time the new installer migrates them. This avoids silently
+breaking working raw URLs. Set both of these values to loopback when you are
+ready to harden an existing host:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env \
+  SLIPWAY_DASHBOARD_HOST=127.0.0.1 \
+  SLIPWAY_APP_PORT_HOST=127.0.0.1 \
+  bash /tmp/install-slipway.sh
+```
+
+Then redeploy the apps and close `1337` and `1338-1500` in the provider
+firewall.
+
+## Optional Cloudflare Tunnel mode
+
+Cloudflare Tunnel is optional. It changes the traffic path to:
+
+```text
+Internet -> Cloudflare -> outbound cloudflared tunnel -> loopback Caddy -> container
+```
+
+Install Slipway with a real dashboard hostname and tunnel ingress:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/sailscastshq/slipway/main/install.sh -o /tmp/install-slipway.sh
+sudo env \
+  SLIPWAY_INGRESS=cloudflare-tunnel \
+  SLIPWAY_URL=https://slipway.example.com \
+  bash /tmp/install-slipway.sh
+```
+
+This binds Caddy, the dashboard, and app ports to `127.0.0.1`. Caddy serves
+plain HTTP only on the private origin connection; Cloudflare owns browser TLS.
+Point the tunnel at loopback Caddy and keep the original request hostname so
+Caddy can select the correct Slipway route:
+
+```yaml
+tunnel: YOUR_TUNNEL_UUID
+credentials-file: /etc/cloudflared/YOUR_TUNNEL_UUID.json
+
+ingress:
+  - hostname: slipway.example.com
+    service: http://127.0.0.1:80
+  - hostname: '*.apps.example.com'
+    service: http://127.0.0.1:80
+  - service: http_status:404
+```
+
+Validate and start the locally managed tunnel:
+
+```bash
+cloudflared tunnel ingress validate
+sudo cloudflared service install
+sudo systemctl enable --now cloudflared
+```
+
+Do not set `httpHostHeader`; Slipway and Caddy use the incoming hostname for
+routing. Add every custom app domain as a Cloudflare Tunnel public hostname (or
+use a wildcard for the generated app domain). Webhooks, streaming telemetry,
+SSE, and CLI requests use ordinary HTTP through the same route.
+
+Cloudflare Tunnel uses outbound connections. The provider firewall can deny
+all inbound Slipway ports and keep only the SSH access you choose. A restrictive
+egress firewall must permit Cloudflare Tunnel on TCP/UDP `7844`. See
+[Cloudflare's tunnel firewall guide](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/configure-tunnels/tunnel-with-firewall/)
+and [ingress configuration reference](https://developers.cloudflare.com/tunnel/advanced/local-management/configuration-file/).
+
+Tradeoffs: Tunnel mode depends on Cloudflare for public availability and DNS,
+and every custom hostname must be routed through that tunnel. The default public
+mode has fewer moving parts and remains the recommended starting point.

--- a/install.sh
+++ b/install.sh
@@ -22,6 +22,7 @@ SLIPWAY_CONTAINER="${SLIPWAY_CONTAINER:-slipway}"
 SLIPWAY_VALIDATION_CONTAINER="${SLIPWAY_VALIDATION_CONTAINER:-slipway-next}"
 SLIPWAY_PREVIOUS_CONTAINER="${SLIPWAY_PREVIOUS_CONTAINER:-slipway-previous}"
 SLIPWAY_PROXY_CONTAINER="${SLIPWAY_PROXY_CONTAINER:-slipway-proxy}"
+SLIPWAY_BOOTSTRAP_ROUTE_CONTAINER="${SLIPWAY_BOOTSTRAP_ROUTE_CONTAINER:-slipway-route-bootstrap}"
 SLIPWAY_NETWORK="${SLIPWAY_NETWORK:-slipway}"
 SLIPWAY_DB_VOLUME="${SLIPWAY_DB_VOLUME:-slipway-db}"
 SLIPWAY_CERTS_VOLUME="${SLIPWAY_CERTS_VOLUME:-slipway-certs}"
@@ -33,6 +34,11 @@ SLIPWAY_APP_PORT_END="${SLIPWAY_APP_PORT_END:-1500}"
 SLIPWAY_CONFIGURE_FIREWALL="${SLIPWAY_CONFIGURE_FIREWALL:-true}"
 SLIPWAY_HEALTH_ATTEMPTS="${SLIPWAY_HEALTH_ATTEMPTS:-30}"
 SLIPWAY_SKIP_PULL="${SLIPWAY_SKIP_PULL:-false}"
+REQUESTED_SLIPWAY_URL="${SLIPWAY_URL:-}"
+REQUESTED_SLIPWAY_INGRESS="${SLIPWAY_INGRESS:-}"
+REQUESTED_SLIPWAY_PROXY_HOST="${SLIPWAY_PROXY_HOST:-}"
+REQUESTED_SLIPWAY_DASHBOARD_HOST="${SLIPWAY_DASHBOARD_HOST:-}"
+REQUESTED_SLIPWAY_APP_PORT_HOST="${SLIPWAY_APP_PORT_HOST:-}"
 IS_UPDATE=false
 
 container_exists() {
@@ -50,7 +56,7 @@ run_slipway_container() {
     local restart_args=()
 
     if [ -n "$host_port" ]; then
-        port_args=(-p "$host_port:1337")
+        port_args=(-p "$SLIPWAY_DASHBOARD_HOST:$host_port:1337")
         restart_args=(--restart unless-stopped)
     fi
 
@@ -65,6 +71,8 @@ run_slipway_container() {
         -e NODE_ENV=production \
         -e PORT=1337 \
         -e SLIPWAY_URL="$SLIPWAY_URL" \
+        -e SLIPWAY_INGRESS="$SLIPWAY_INGRESS" \
+        -e SLIPWAY_APP_PORT_HOST="$SLIPWAY_APP_PORT_HOST" \
         -e SLIPWAY_APP_PORT_START="$SLIPWAY_APP_PORT_START" \
         -e SLIPWAY_APP_PORT_END="$SLIPWAY_APP_PORT_END" \
         -e SESSION_SECRET="$SESSION_SECRET" \
@@ -159,6 +167,106 @@ replace_live_container() {
     fi
 }
 
+is_public_bind_host() {
+    [ "$1" = "0.0.0.0" ]
+}
+
+validate_bind_host() {
+    local name="$1"
+    local value="$2"
+
+    if [ "$value" != "127.0.0.1" ] && [ "$value" != "0.0.0.0" ]; then
+        echo -e "${RED}$name must be 127.0.0.1 or 0.0.0.0 (received: $value).${NC}" >&2
+        exit 1
+    fi
+}
+
+persist_setting() {
+    local key="$1"
+    local value="$2"
+    local temp_file="${SLIPWAY_ENV_FILE}.tmp"
+
+    awk -v key="$key" -v value="$value" '
+        BEGIN { updated = 0 }
+        index($0, key "=") == 1 { print key "=" value; updated = 1; next }
+        { print }
+        END { if (!updated) print key "=" value }
+    ' "$SLIPWAY_ENV_FILE" > "$temp_file"
+    mv "$temp_file" "$SLIPWAY_ENV_FILE"
+}
+
+configure_bootstrap_dashboard_route() {
+    local authority="${SLIPWAY_URL#*://}"
+    local host
+    local site
+
+    authority="${authority%%/*}"
+    if [[ "$authority" == \[* ]]; then
+        host="${authority%%]*}]"
+    else
+        host="${authority%%:*}"
+    fi
+
+    if [ "$SLIPWAY_INGRESS" = "cloudflare-tunnel" ] || [[ "$SLIPWAY_URL" == http://* ]]; then
+        site="http://$host"
+    else
+        site="$host"
+    fi
+
+    echo "Preparing initial dashboard route..."
+    remove_container "$SLIPWAY_BOOTSTRAP_ROUTE_CONTAINER"
+    docker run -d \
+        --name "$SLIPWAY_BOOTSTRAP_ROUTE_CONTAINER" \
+        --network "$SLIPWAY_NETWORK" \
+        --restart unless-stopped \
+        --label "caddy=$site" \
+        --label "caddy.reverse_proxy=$SLIPWAY_CONTAINER:1337" \
+        alpine sleep infinity >/dev/null
+    echo -e "${GREEN}Initial dashboard route ready${NC}"
+}
+
+sync_ufw_port() {
+    local host="$1"
+    local port="$2"
+    local comment="$3"
+
+    if is_public_bind_host "$host"; then
+        ufw allow "$port/tcp" comment "$comment" >/dev/null
+    else
+        ufw --force delete allow "$port/tcp" >/dev/null 2>&1 || true
+    fi
+}
+
+sync_firewalld_port() {
+    local host="$1"
+    local port="$2"
+
+    if is_public_bind_host "$host"; then
+        firewall-cmd --permanent --add-port="$port/tcp" >/dev/null
+    else
+        firewall-cmd --permanent --remove-port="$port/tcp" >/dev/null 2>&1 || true
+    fi
+}
+
+allow_ufw_ports() {
+    local status=0
+    sync_ufw_port "$SLIPWAY_PROXY_HOST" "$SLIPWAY_HTTP_PORT" 'Slipway HTTP' || status=1
+    sync_ufw_port "$SLIPWAY_PROXY_HOST" "$SLIPWAY_HTTPS_PORT" 'Slipway HTTPS' || status=1
+    sync_ufw_port "$SLIPWAY_DASHBOARD_HOST" "$SLIPWAY_PORT" 'Slipway dashboard' || status=1
+    sync_ufw_port "$SLIPWAY_APP_PORT_HOST" "$SLIPWAY_APP_PORT_START:$SLIPWAY_APP_PORT_END" 'Slipway direct app access' || status=1
+    return "$status"
+}
+
+allow_firewalld_ports() {
+    local status=0
+    sync_firewalld_port "$SLIPWAY_PROXY_HOST" "$SLIPWAY_HTTP_PORT" || status=1
+    sync_firewalld_port "$SLIPWAY_PROXY_HOST" "$SLIPWAY_HTTPS_PORT" || status=1
+    sync_firewalld_port "$SLIPWAY_DASHBOARD_HOST" "$SLIPWAY_PORT" || status=1
+    sync_firewalld_port "$SLIPWAY_APP_PORT_HOST" "$SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END" || status=1
+    firewall-cmd --reload >/dev/null || status=1
+    return "$status"
+}
+
 configure_host_firewall() {
     if [ "$SLIPWAY_CONFIGURE_FIREWALL" != true ]; then
         echo -e "${YELLOW}Host firewall configuration skipped (SLIPWAY_CONFIGURE_FIREWALL=$SLIPWAY_CONFIGURE_FIREWALL).${NC}"
@@ -166,28 +274,21 @@ configure_host_firewall() {
     fi
 
     if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q '^Status: active'; then
-        echo "Allowing Slipway ports through UFW..."
-        if ufw allow "$SLIPWAY_PORT/tcp" comment 'Slipway dashboard' >/dev/null \
-            && ufw allow "$SLIPWAY_HTTP_PORT/tcp" comment 'Slipway HTTP' >/dev/null \
-            && ufw allow "$SLIPWAY_HTTPS_PORT/tcp" comment 'Slipway HTTPS' >/dev/null \
-            && ufw allow "$SLIPWAY_APP_PORT_START:$SLIPWAY_APP_PORT_END/tcp" comment 'Slipway direct app access' >/dev/null; then
-            echo -e "${GREEN}UFW allows the dashboard, proxy, and direct app port range${NC}"
+        echo "Aligning UFW with Slipway's public bindings..."
+        if allow_ufw_ports; then
+            echo -e "${GREEN}UFW matches Slipway's public bindings${NC}"
         else
-            echo -e "${YELLOW}Slipway could not update every UFW rule. Review 'ufw status' before using direct app URLs.${NC}"
+            echo -e "${YELLOW}Slipway could not update every UFW rule. Review 'ufw status'.${NC}"
         fi
         return
     fi
 
     if command -v firewall-cmd >/dev/null 2>&1 && firewall-cmd --state >/dev/null 2>&1; then
-        echo "Allowing Slipway ports through firewalld..."
-        if firewall-cmd --permanent --add-port="$SLIPWAY_PORT/tcp" >/dev/null \
-            && firewall-cmd --permanent --add-port="$SLIPWAY_HTTP_PORT/tcp" >/dev/null \
-            && firewall-cmd --permanent --add-port="$SLIPWAY_HTTPS_PORT/tcp" >/dev/null \
-            && firewall-cmd --permanent --add-port="$SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END/tcp" >/dev/null \
-            && firewall-cmd --reload >/dev/null; then
-            echo -e "${GREEN}firewalld allows the dashboard, proxy, and direct app port range${NC}"
+        echo "Aligning firewalld with Slipway's public bindings..."
+        if allow_firewalld_ports; then
+            echo -e "${GREEN}firewalld matches Slipway's public bindings${NC}"
         else
-            echo -e "${YELLOW}Slipway could not update every firewalld rule. Review 'firewall-cmd --list-ports' before using direct app URLs.${NC}"
+            echo -e "${YELLOW}Slipway could not update every firewalld rule. Review 'firewall-cmd --list-ports'.${NC}"
         fi
         return
     fi
@@ -237,8 +338,6 @@ if [ -z "$IP" ]; then
     echo -e "${YELLOW}Could not detect public IP. Using localhost.${NC}"
     IP="localhost"
 fi
-SLIPWAY_URL="${SLIPWAY_URL:-http://$IP:$SLIPWAY_PORT}"
-echo -e "${GREEN}Server URL: $SLIPWAY_URL${NC}"
 
 # 5. Load or generate secrets
 if [ -f "$SLIPWAY_ENV_FILE" ]; then
@@ -251,17 +350,73 @@ else
     echo "Generating secrets..."
     SESSION_SECRET=$(openssl rand -hex 32)
     DATA_ENCRYPTION_KEY=$(openssl rand -base64 32)
+fi
 
+SLIPWAY_INGRESS="${REQUESTED_SLIPWAY_INGRESS:-${SLIPWAY_INGRESS:-public}}"
+if [ "$SLIPWAY_INGRESS" != "public" ] && [ "$SLIPWAY_INGRESS" != "cloudflare-tunnel" ]; then
+    echo -e "${RED}SLIPWAY_INGRESS must be public or cloudflare-tunnel.${NC}" >&2
+    exit 1
+fi
+
+if [ "$IS_UPDATE" = true ]; then
+    DEFAULT_DASHBOARD_HOST="0.0.0.0"
+    DEFAULT_APP_PORT_HOST="0.0.0.0"
+else
+    DEFAULT_DASHBOARD_HOST="127.0.0.1"
+    DEFAULT_APP_PORT_HOST="127.0.0.1"
+fi
+
+DEFAULT_PROXY_HOST="0.0.0.0"
+if [ "$SLIPWAY_INGRESS" = "cloudflare-tunnel" ]; then
+    DEFAULT_PROXY_HOST="127.0.0.1"
+fi
+
+SLIPWAY_PROXY_HOST="${REQUESTED_SLIPWAY_PROXY_HOST:-${SLIPWAY_PROXY_HOST:-$DEFAULT_PROXY_HOST}}"
+SLIPWAY_DASHBOARD_HOST="${REQUESTED_SLIPWAY_DASHBOARD_HOST:-${SLIPWAY_DASHBOARD_HOST:-$DEFAULT_DASHBOARD_HOST}}"
+SLIPWAY_APP_PORT_HOST="${REQUESTED_SLIPWAY_APP_PORT_HOST:-${SLIPWAY_APP_PORT_HOST:-$DEFAULT_APP_PORT_HOST}}"
+
+validate_bind_host SLIPWAY_PROXY_HOST "$SLIPWAY_PROXY_HOST"
+validate_bind_host SLIPWAY_DASHBOARD_HOST "$SLIPWAY_DASHBOARD_HOST"
+validate_bind_host SLIPWAY_APP_PORT_HOST "$SLIPWAY_APP_PORT_HOST"
+
+if [ "$SLIPWAY_INGRESS" = "cloudflare-tunnel" ] && [ -z "$REQUESTED_SLIPWAY_URL" ] && [ -z "${SLIPWAY_URL:-}" ]; then
+    echo -e "${RED}Cloudflare Tunnel mode requires SLIPWAY_URL (for example, https://slipway.example.com).${NC}" >&2
+    exit 1
+fi
+
+if [ -n "$REQUESTED_SLIPWAY_URL" ]; then
+    SLIPWAY_URL="$REQUESTED_SLIPWAY_URL"
+elif [ -z "${SLIPWAY_URL:-}" ]; then
+    if is_public_bind_host "$SLIPWAY_DASHBOARD_HOST"; then
+        SLIPWAY_URL="http://$IP:$SLIPWAY_PORT"
+    else
+        SLIPWAY_URL="http://$IP"
+    fi
+fi
+
+if [ "$IS_UPDATE" = false ]; then
     mkdir -p "$(dirname "$SLIPWAY_ENV_FILE")"
     cat > "$SLIPWAY_ENV_FILE" <<EOF
 SESSION_SECRET=$SESSION_SECRET
 DATA_ENCRYPTION_KEY=$DATA_ENCRYPTION_KEY
+SLIPWAY_URL=$SLIPWAY_URL
+SLIPWAY_INGRESS=$SLIPWAY_INGRESS
+SLIPWAY_PROXY_HOST=$SLIPWAY_PROXY_HOST
+SLIPWAY_DASHBOARD_HOST=$SLIPWAY_DASHBOARD_HOST
+SLIPWAY_APP_PORT_HOST=$SLIPWAY_APP_PORT_HOST
 SLIPWAY_APP_PORT_START=$SLIPWAY_APP_PORT_START
 SLIPWAY_APP_PORT_END=$SLIPWAY_APP_PORT_END
 EOF
-    chmod 600 "$SLIPWAY_ENV_FILE"
-    echo -e "${GREEN}Secrets generated and saved to $SLIPWAY_ENV_FILE${NC}"
+else
+    persist_setting SLIPWAY_URL "$SLIPWAY_URL"
+    persist_setting SLIPWAY_INGRESS "$SLIPWAY_INGRESS"
+    persist_setting SLIPWAY_PROXY_HOST "$SLIPWAY_PROXY_HOST"
+    persist_setting SLIPWAY_DASHBOARD_HOST "$SLIPWAY_DASHBOARD_HOST"
+    persist_setting SLIPWAY_APP_PORT_HOST "$SLIPWAY_APP_PORT_HOST"
 fi
+chmod 600 "$SLIPWAY_ENV_FILE"
+echo -e "${GREEN}Configuration saved to $SLIPWAY_ENV_FILE${NC}"
+echo -e "${GREEN}Server URL: $SLIPWAY_URL${NC}"
 
 # 6. Start Caddy (reverse proxy with automatic HTTPS)
 echo "Starting Caddy proxy..."
@@ -270,8 +425,8 @@ docker run -d \
     --name "$SLIPWAY_PROXY_CONTAINER" \
     --network "$SLIPWAY_NETWORK" \
     --restart unless-stopped \
-    -p "$SLIPWAY_HTTP_PORT:80" \
-    -p "$SLIPWAY_HTTPS_PORT:443" \
+    -p "$SLIPWAY_PROXY_HOST:$SLIPWAY_HTTP_PORT:80" \
+    -p "$SLIPWAY_PROXY_HOST:$SLIPWAY_HTTPS_PORT:443" \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
     -v "$SLIPWAY_CERTS_VOLUME:/data" \
     -e CADDY_INGRESS_NETWORKS="$SLIPWAY_NETWORK" \
@@ -339,14 +494,17 @@ fi
 # 9. Validate target image before touching the live dashboard
 validate_slipway_image
 
-# 10. Replace the live dashboard only after validation succeeds
+# 10. Route initial setup through Caddy before making the dashboard live
+configure_bootstrap_dashboard_route
+
+# 11. Replace the live dashboard only after validation succeeds
 replace_live_container
 echo -e "${GREEN}Slipway dashboard running${NC}"
 
-# 11. Keep host firewall rules aligned with Slipway's published ports
+# 12. Keep host firewall rules aligned with Slipway's published ports
 configure_host_firewall
 
-# 12. Show access info
+# 13. Show access info
 echo ""
 echo -e "${GREEN}========================================================${NC}"
 if [ "$IS_UPDATE" = true ]; then
@@ -357,15 +515,34 @@ fi
 echo -e "${GREEN}========================================================${NC}"
 echo ""
 echo "  Dashboard: $SLIPWAY_URL"
-echo "  Direct app ports: TCP $SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END"
-echo "  If your VPS provider has a network firewall, allow inbound TCP $SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END for direct app URLs."
-echo "  Domains proxied through Caddy only require TCP $SLIPWAY_HTTP_PORT and $SLIPWAY_HTTPS_PORT."
+if [ "$SLIPWAY_INGRESS" = "cloudflare-tunnel" ]; then
+    echo "  Public ingress: Cloudflare Tunnel (Caddy listens on loopback)"
+elif is_public_bind_host "$SLIPWAY_PROXY_HOST"; then
+    echo "  Public ingress: TCP $SLIPWAY_HTTP_PORT and $SLIPWAY_HTTPS_PORT through Caddy"
+else
+    echo "  Public ingress: none (Caddy listens on loopback)"
+fi
+if is_public_bind_host "$SLIPWAY_APP_PORT_HOST"; then
+    echo "  Direct app ports: TCP $SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END (explicitly public)"
+    echo "  Allow that range in your VPS provider firewall before using raw IP:port URLs."
+else
+    echo "  Direct app ports: private (set SLIPWAY_APP_PORT_HOST=0.0.0.0 to opt in)"
+fi
+if is_public_bind_host "$SLIPWAY_DASHBOARD_HOST"; then
+    echo "  Dashboard port: TCP $SLIPWAY_PORT (legacy or explicitly public binding)"
+fi
 echo ""
 if [ "$IS_UPDATE" = false ]; then
     echo "  Next steps:"
-    echo "  1. Open the dashboard URL above to complete setup"
-    echo "  2. Point a domain to this server (e.g., slipway.yourdomain.com)"
-    echo "  3. SSL will be configured automatically when you add a domain"
+    if [ "$SLIPWAY_INGRESS" = "cloudflare-tunnel" ]; then
+        echo "  1. Route $SLIPWAY_URL through Cloudflare Tunnel to http://127.0.0.1:$SLIPWAY_HTTP_PORT"
+        echo "  2. Open the dashboard URL above to complete setup"
+        echo "  3. Add generated and custom app hostnames to the tunnel"
+    else
+        echo "  1. Open the dashboard URL above to complete setup"
+        echo "  2. Point a domain to this server (e.g., slipway.yourdomain.com)"
+        echo "  3. SSL will be configured automatically when you add a domain"
+    fi
     echo ""
     echo "  To deploy apps, install the CLI:"
     echo "    npm install -g slipway-cli"

--- a/tests/unit/config/production.test.js
+++ b/tests/unit/config/production.test.js
@@ -29,6 +29,39 @@ test('production custom config keeps the public URL and domain settings together
   }
 })
 
+test('production ingress keeps app ports private unless direct access is explicit', ({
+  expect
+}) => {
+  const names = ['SLIPWAY_APP_PORT_HOST', 'SLIPWAY_INGRESS']
+  const original = Object.fromEntries(
+    names.map((name) => [name, process.env[name]])
+  )
+
+  try {
+    delete process.env.SLIPWAY_APP_PORT_HOST
+    delete process.env.SLIPWAY_INGRESS
+    delete require.cache[productionConfigPath]
+
+    let productionConfig = require(productionConfigPath)
+    expect(productionConfig.custom.slipwayPortHost).toBe('127.0.0.1')
+    expect(productionConfig.custom.slipwayIngress).toBe('public')
+
+    process.env.SLIPWAY_APP_PORT_HOST = '0.0.0.0'
+    process.env.SLIPWAY_INGRESS = 'cloudflare-tunnel'
+    delete require.cache[productionConfigPath]
+
+    productionConfig = require(productionConfigPath)
+    expect(productionConfig.custom.slipwayPortHost).toBe('0.0.0.0')
+    expect(productionConfig.custom.slipwayIngress).toBe('cloudflare-tunnel')
+  } finally {
+    delete require.cache[productionConfigPath]
+    for (const name of names) {
+      if (original[name] === undefined) delete process.env[name]
+      else process.env[name] = original[name]
+    }
+  }
+})
+
 test('production observability retention has documented defaults and positive overrides', ({
   expect
 }) => {

--- a/tests/unit/helpers/caddy/format-site-label.test.js
+++ b/tests/unit/helpers/caddy/format-site-label.test.js
@@ -1,0 +1,27 @@
+const { test } = require('sounding')
+
+test('Caddy site labels follow the configured ingress owner', async ({
+  sails,
+  expect
+}) => {
+  const originalIngress = sails.config.custom.slipwayIngress
+
+  try {
+    sails.config.custom.slipwayIngress = 'public'
+    const publicLabel = await sails.helpers.caddy.formatSiteLabel.with({
+      domains: ['slipway.example.com', 'app.example.com']
+    })
+
+    sails.config.custom.slipwayIngress = 'cloudflare-tunnel'
+    const tunnelLabel = await sails.helpers.caddy.formatSiteLabel.with({
+      domains: ['slipway.example.com', 'app.example.com']
+    })
+
+    expect(publicLabel).toBe('slipway.example.com,app.example.com')
+    expect(tunnelLabel).toBe(
+      'http://slipway.example.com,http://app.example.com'
+    )
+  } finally {
+    sails.config.custom.slipwayIngress = originalIngress
+  }
+})

--- a/tests/unit/helpers/caddy/update-dashboard-route.test.js
+++ b/tests/unit/helpers/caddy/update-dashboard-route.test.js
@@ -1,0 +1,48 @@
+const childProcess = require('node:child_process')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const helperPath = path.resolve(
+  __dirname,
+  '../../../../api/helpers/caddy/update-dashboard-route.js'
+)
+
+test('dashboard route replaces bootstrap access and keeps Tunnel TLS at the edge', async ({
+  sails,
+  expect
+}) => {
+  const calls = []
+  const originalExecFile = childProcess.execFile
+  const originalIngress = sails.config.custom.slipwayIngress
+  const originalGetSetting = sails.helpers.setting.get
+
+  childProcess.execFile = (dockerPath, args, callback) => {
+    calls.push({ dockerPath, args })
+    callback(null, '', '')
+  }
+  sails.config.custom.slipwayIngress = 'cloudflare-tunnel'
+  sails.helpers.setting.get = async () => 'ops@example.com'
+  delete require.cache[require.resolve(helperPath)]
+
+  try {
+    const helper = require(helperPath)
+    const result = await helper.fn({ domain: 'slipway.example.com' })
+    const commands = calls.map(({ args }) => args)
+    const createCommand = commands.find((args) => args[0] === 'run')
+
+    expect(result.action).toBe('created')
+    expect(createCommand.includes('caddy=http://slipway.example.com')).toBe(
+      true
+    )
+    expect(createCommand.some((value) => value.startsWith('caddy.tls='))).toBe(
+      false
+    )
+    expect(commands.at(-1)).toEqual(['rm', '-f', 'slipway-route-bootstrap'])
+  } finally {
+    childProcess.execFile = originalExecFile
+    sails.config.custom.slipwayIngress = originalIngress
+    sails.helpers.setting.get = originalGetSetting
+    delete require.cache[require.resolve(helperPath)]
+  }
+})

--- a/tests/unit/helpers/caddy/update-route.test.js
+++ b/tests/unit/helpers/caddy/update-route.test.js
@@ -43,6 +43,39 @@ test(
   }
 )
 
+test('Cloudflare Tunnel routes keep TLS at the edge', async ({
+  sails,
+  expect
+}) => {
+  const originalIngress = sails.config.custom.slipwayIngress
+  const originalGetSetting = sails.helpers.setting.get
+
+  try {
+    sails.config.custom.slipwayIngress = 'cloudflare-tunnel'
+    sails.helpers.setting.get = async () => 'ops@example.com'
+
+    const helper = require(helperPath)
+    const args = await helper._private.buildCreateArgs({
+      candidateName: 'slipway-route-candidate',
+      network: 'slipway',
+      config: { domains: ['app.example.com'] },
+      routableApps: [
+        {
+          routePath: '/',
+          containerName: 'slipway-app',
+          port: 1337
+        }
+      ]
+    })
+
+    expect(args.includes('caddy=http://app.example.com')).toBe(true)
+    expect(args.some((value) => value.startsWith('caddy.tls='))).toBe(false)
+  } finally {
+    sails.config.custom.slipwayIngress = originalIngress
+    sails.helpers.setting.get = originalGetSetting
+  }
+})
+
 test(
   'candidate route verification failure removes the candidate and verifies the still-active previous route',
   { world: routeWorld('route-restoration') },

--- a/tests/unit/helpers/system/apply-update.test.js
+++ b/tests/unit/helpers/system/apply-update.test.js
@@ -93,6 +93,50 @@ test('self-update docker args keep an existing apps mount without duplicating it
   ).toBe(1)
 })
 
+test('self-update preserves loopback-only dashboard port bindings', async ({
+  sails,
+  expect
+}) => {
+  const { runArgs } = await sails.helpers.system.buildUpdateDockerArgs.with({
+    containerInfo: {
+      Mounts: [],
+      NetworkSettings: { Networks: {} },
+      HostConfig: {
+        PortBindings: {
+          '1337/tcp': [{ HostIp: '127.0.0.1', HostPort: '1337' }]
+        }
+      },
+      Config: { Env: [], Labels: {} }
+    }
+  })
+
+  expect(runArgs.includes('127.0.0.1:1337:1337')).toBe(true)
+  expect(runArgs.includes('1337:1337')).toBe(false)
+})
+
+test('self-update collapses equivalent public IPv4 and IPv6 bindings', async ({
+  sails,
+  expect
+}) => {
+  const { runArgs } = await sails.helpers.system.buildUpdateDockerArgs.with({
+    containerInfo: {
+      Mounts: [],
+      NetworkSettings: { Networks: {} },
+      HostConfig: {
+        PortBindings: {
+          '1337/tcp': [
+            { HostIp: '0.0.0.0', HostPort: '1337' },
+            { HostIp: '::', HostPort: '1337' }
+          ]
+        }
+      },
+      Config: { Env: [], Labels: {} }
+    }
+  })
+
+  expect(runArgs.filter((value) => value === '1337:1337').length).toBe(1)
+})
+
 test('self-update docker args force production node environment', async ({
   sails,
   expect
@@ -116,6 +160,27 @@ test('self-update docker args force production node environment', async ({
   expect(runArgs.includes('NODE_ENV=production')).toBe(true)
   expect(runArgs.includes('PORT=1337')).toBe(true)
   expect(runArgs.includes('SLIPWAY_URL=https://x')).toBe(true)
+  expect(runArgs.includes('SLIPWAY_APP_PORT_HOST=0.0.0.0')).toBe(true)
+})
+
+test('self-update keeps an explicit private app binding', async ({
+  sails,
+  expect
+}) => {
+  const { envArgs } = await sails.helpers.system.buildUpdateDockerArgs.with({
+    containerInfo: {
+      Mounts: [],
+      NetworkSettings: { Networks: {} },
+      HostConfig: { PortBindings: {} },
+      Config: {
+        Env: ['SLIPWAY_APP_PORT_HOST=127.0.0.1'],
+        Labels: {}
+      }
+    }
+  })
+
+  expect(envArgs.includes('SLIPWAY_APP_PORT_HOST=127.0.0.1')).toBe(true)
+  expect(envArgs.includes('SLIPWAY_APP_PORT_HOST=0.0.0.0')).toBe(false)
 })
 
 test('self-update image refs use the advertised release tag instead of latest', async ({

--- a/tests/unit/helpers/system/install-config.test.js
+++ b/tests/unit/helpers/system/install-config.test.js
@@ -78,7 +78,11 @@ test('installer validates the target image before replacing the live dashboard',
   ).toBe(true)
   expect(
     script.indexOf('# 9. Validate target image') <
-      script.indexOf('# 10. Replace the live dashboard')
+      script.indexOf('# 10. Route initial setup through Caddy')
+  ).toBe(true)
+  expect(
+    script.indexOf('# 10. Route initial setup through Caddy') <
+      script.indexOf('# 11. Replace the live dashboard')
   ).toBe(true)
 })
 
@@ -117,8 +121,12 @@ test('installer keeps production defaults overridable for isolated rehearsals', 
   expect(script.includes('if [ "$SLIPWAY_SKIP_PULL" = true ]; then')).toBe(true)
   expect(script.includes('docker network create "$SLIPWAY_NETWORK"')).toBe(true)
   expect(script.includes('-v "$SLIPWAY_DB_VOLUME:/app/db"')).toBe(true)
-  expect(script.includes('-p "$SLIPWAY_HTTP_PORT:80"')).toBe(true)
-  expect(script.includes('-p "$SLIPWAY_HTTPS_PORT:443"')).toBe(true)
+  expect(
+    script.includes('-p "$SLIPWAY_PROXY_HOST:$SLIPWAY_HTTP_PORT:80"')
+  ).toBe(true)
+  expect(
+    script.includes('-p "$SLIPWAY_PROXY_HOST:$SLIPWAY_HTTPS_PORT:443"')
+  ).toBe(true)
   expect(
     script.includes('SLIPWAY_APP_PORT_START="${SLIPWAY_APP_PORT_START:-1338}"')
   ).toBe(true)
@@ -131,20 +139,35 @@ test('installer keeps production defaults overridable for isolated rehearsals', 
   expect(script.includes('SLIPWAY_APP_PORT_END=$SLIPWAY_APP_PORT_END')).toBe(
     true
   )
+  expect(script.includes('DEFAULT_DASHBOARD_HOST="127.0.0.1"')).toBe(true)
+  expect(script.includes('DEFAULT_APP_PORT_HOST="127.0.0.1"')).toBe(true)
+  expect(script.includes('-p "$SLIPWAY_DASHBOARD_HOST:$host_port:1337"')).toBe(
+    true
+  )
+  expect(
+    script.includes('-e SLIPWAY_APP_PORT_HOST="$SLIPWAY_APP_PORT_HOST"')
+  ).toBe(true)
+  expect(script.includes('configure_bootstrap_dashboard_route()')).toBe(true)
+  expect(
+    script.includes('--label "caddy.reverse_proxy=$SLIPWAY_CONTAINER:1337"')
+  ).toBe(true)
   expect(script.includes('configure_host_firewall()')).toBe(true)
   expect(
+    script.includes('if is_public_bind_host "$SLIPWAY_APP_PORT_HOST"; then')
+  ).toBe(true)
+  expect(
     script.includes(
-      'ufw allow "$SLIPWAY_APP_PORT_START:$SLIPWAY_APP_PORT_END/tcp"'
+      'sync_ufw_port "$SLIPWAY_APP_PORT_HOST" "$SLIPWAY_APP_PORT_START:$SLIPWAY_APP_PORT_END"'
     )
   ).toBe(true)
   expect(
     script.includes(
-      'firewall-cmd --permanent --add-port="$SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END/tcp"'
+      'sync_firewalld_port "$SLIPWAY_APP_PORT_HOST" "$SLIPWAY_APP_PORT_START-$SLIPWAY_APP_PORT_END"'
     )
   ).toBe(true)
   expect(
     script.includes(
-      'If your VPS provider has a network firewall, allow inbound TCP'
+      'Direct app ports: private (set SLIPWAY_APP_PORT_HOST=0.0.0.0 to opt in)'
     )
   ).toBe(true)
 })


### PR DESCRIPTION
## Summary
- make Caddy the only public HTTP/S entry point on fresh installations
- keep dashboard and app ports loopback-only by default while preserving an explicit raw IP:port mode
- add optional Cloudflare Tunnel ingress without changing the default deployment path
- preserve legacy public bindings during upgrades and self-updates
- synchronize active host firewall rules with the configured bindings
- document public, direct-access, upgrade, and tunnel modes

## Verification
- full unit suite: 248 passed
- full functional suite: 89 passed
- full E2E suite: 40 passed
- focused update regression suite: 8 passed
- focused installer contract suite: 4 passed
- npm run lint
- npm run check:consistency
- bash -n install.sh
- isolated Docker fresh-install and Cloudflare Tunnel upgrade rehearsals, with Caddy and direct loopback health checks returning HTTP 200

Fixes #202