### PR TITLE
feat(config): harden deployment-native secrets

### DIFF
--- a/api/controllers/api/v1/app/update-app.js
+++ b/api/controllers/api/v1/app/update-app.js
@@ -37,6 +37,9 @@ module.exports = {
     envVars: {
       type: 'json'
     },
+    envVarMetadata: {
+      type: 'json'
+    },
     resourceLimits: {
       type: 'json'
     }
@@ -59,6 +62,7 @@ module.exports = {
     routePath,
     healthPath,
     envVars,
+    envVarMetadata,
     resourceLimits
   }) {
     const user = await User.findOne({ id: this.req.session.userId })
@@ -77,7 +81,7 @@ module.exports = {
     const app = await App.findOne({
       environment: environment.id,
       slug: appSlug
-    })
+    }).decrypt()
     if (!app) throw 'notFound'
 
     const problems = sails.helpers.configuration.validate({
@@ -87,6 +91,27 @@ module.exports = {
       healthPath,
       resourceLimits
     })
+    const currentEnvVars = app.secureEnvVars || app.envVars || {}
+    const nextEnvVars = envVars === undefined ? currentEnvVars : envVars
+    if (envVars !== undefined || envVarMetadata !== undefined) {
+      const managedKeys = (await Service.find({ environment: environment.id }))
+        .map((service) => service.envVarKey)
+        .filter(Boolean)
+      for (const key of managedKeys) {
+        if (Object.prototype.hasOwnProperty.call(nextEnvVars, key)) {
+          problems.push({
+            envVars: `"${key}" is managed by Slipway at the environment scope and cannot be overridden by an app.`
+          })
+          break
+        }
+      }
+      problems.push(
+        ...sails.helpers.configuration.validateEnvVarMetadata(
+          nextEnvVars,
+          envVarMetadata || app.envVarMetadata || {}
+        )
+      )
+    }
     if (problems.length) {
       throw { badRequest: { problems } }
     }
@@ -99,7 +124,21 @@ module.exports = {
     if (dockerfilePath !== undefined) updates.dockerfilePath = dockerfilePath
     if (routePath !== undefined) updates.routePath = routePath
     if (healthPath !== undefined) updates.healthPath = healthPath
-    if (envVars !== undefined) updates.envVars = envVars
+    let normalizedMetadata = app.envVarMetadata || {}
+    if (envVars !== undefined || envVarMetadata !== undefined) {
+      normalizedMetadata =
+        sails.helpers.configuration.normalizeEnvVarMetadata.with({
+          values: nextEnvVars,
+          metadata: envVarMetadata || app.envVarMetadata || {},
+          currentValues: currentEnvVars,
+          currentMetadata: app.envVarMetadata || {},
+          changedBy: String(user.id),
+          changedByName: user.fullName
+        })
+      updates.secureEnvVars = nextEnvVars
+      updates.envVars = {}
+      updates.envVarMetadata = normalizedMetadata
+    }
     if (resourceLimits !== undefined) {
       updates.resourceLimits = resourceLimits
 
@@ -131,6 +170,27 @@ module.exports = {
 
     const updated = await App.updateOne({ id: app.id }).set(updates)
 
-    return { app: updated }
+    if (envVars !== undefined || envVarMetadata !== undefined) {
+      await sails.helpers.configuration.recordEnvVarChanges.with({
+        before: currentEnvVars,
+        after: nextEnvVars,
+        beforeMetadata: app.envVarMetadata || {},
+        afterMetadata: normalizedMetadata,
+        scope: 'app',
+        resourceType: 'app',
+        resourceId: String(app.id),
+        userId: String(user.id),
+        teamId: String(project.team.id),
+        ipAddress: this.req.ip
+      })
+    }
+
+    const {
+      envVars: legacyEnvVars,
+      secureEnvVars,
+      bridgeSecret,
+      ...publicApp
+    } = updated
+    return { app: publicApp }
   }
 }

--- a/api/controllers/api/v1/deploy/get-deployment-status.js
+++ b/api/controllers/api/v1/deploy/get-deployment-status.js
@@ -69,6 +69,8 @@ module.exports = {
         duration,
         queuePosition,
         errorMessage: deployment.errorMessage,
+        configHash: deployment.configHash,
+        configManifest: deployment.configManifest || [],
         environment: {
           id: deployment.environment.id,
           name: deployment.environment.name,

--- a/api/controllers/api/v1/environment/create-environment.js
+++ b/api/controllers/api/v1/environment/create-environment.js
@@ -23,6 +23,11 @@ module.exports = {
     domain: {
       type: 'string',
       description: 'Custom domain for this environment'
+    },
+    sourceEnvironmentSlug: {
+      type: 'string',
+      description:
+        'Optional environment whose config should be copied using preview policies'
     }
   },
 
@@ -41,7 +46,13 @@ module.exports = {
     }
   },
 
-  fn: async function ({ projectSlug, name, isProduction, domain }) {
+  fn: async function ({
+    projectSlug,
+    name,
+    isProduction,
+    domain,
+    sourceEnvironmentSlug
+  }) {
     const user = await User.findOne({ id: this.req.session.userId })
 
     const project = await Project.findOne({ slug: projectSlug }).populate(
@@ -56,6 +67,19 @@ module.exports = {
       throw 'forbidden'
     }
 
+    let inherited = { values: {}, metadata: {} }
+    if (sourceEnvironmentSlug) {
+      const sourceEnvironment = await Environment.findOne({
+        project: project.id,
+        slug: sourceEnvironmentSlug
+      }).decrypt()
+      if (!sourceEnvironment) throw 'notFound'
+      inherited = sails.helpers.configuration.applyPreviewPolicy(
+        sourceEnvironment.envVars || {},
+        sourceEnvironment.envVarMetadata || {}
+      )
+    }
+
     let environment
     try {
       const { telemetryToken, telemetryTokenHash } =
@@ -64,6 +88,8 @@ module.exports = {
         name,
         isProduction,
         domain,
+        envVars: inherited.values,
+        envVarMetadata: inherited.metadata,
         telemetryToken,
         telemetryTokenHash,
         project: project.id
@@ -82,6 +108,21 @@ module.exports = {
       }
       throw error
     }
+
+    await sails.helpers.audit.log.with({
+      action: 'environment.created',
+      resourceType: 'environment',
+      resourceId: String(environment.id),
+      details: {
+        projectSlug,
+        environmentSlug: environment.slug,
+        sourceEnvironmentSlug: sourceEnvironmentSlug || null,
+        inheritedConfigKeys: Object.keys(inherited.values).sort()
+      },
+      userId: String(user.id),
+      teamId: String(project.team.id),
+      ipAddress: this.req.ip
+    })
 
     return { environment }
   }

--- a/api/controllers/api/v1/environment/get-environment.js
+++ b/api/controllers/api/v1/environment/get-environment.js
@@ -71,12 +71,16 @@ module.exports = {
           // Container not found or inspect failed
         }
       }
-      appsWithHealth.push({ ...a, containerHealth })
+      const { envVars, secureEnvVars, bridgeSecret, ...publicApp } = a
+      appsWithHealth.push({ ...publicApp, containerHealth })
     }
+
+    const { telemetryToken, telemetryTokenHash, ...publicEnvironment } =
+      environment
 
     return {
       environment: {
-        ...environment,
+        ...publicEnvironment,
         fullDomain,
         generatedDomain,
         domains,

--- a/api/controllers/api/v1/environment/update-environment.js
+++ b/api/controllers/api/v1/environment/update-environment.js
@@ -31,6 +31,10 @@ module.exports = {
       type: 'json',
       description: 'Environment variables (key-value object)'
     },
+    envVarMetadata: {
+      type: 'json',
+      description: 'Non-secret type and preview metadata keyed by variable name'
+    },
     resourceLimits: {
       type: 'json',
       description: 'Docker resource limits for the app (cpus, memory)'
@@ -62,6 +66,7 @@ module.exports = {
     isProduction,
     domain,
     envVars,
+    envVarMetadata,
     resourceLimits
   }) {
     const user = await User.findOne({ id: this.req.session.userId })
@@ -78,7 +83,10 @@ module.exports = {
       throw 'forbidden'
     }
 
-    const environment = await Environment.findOne({ project: project.id, slug })
+    const environment = await Environment.findOne({
+      project: project.id,
+      slug
+    }).decrypt()
 
     if (!environment) {
       throw 'notFound'
@@ -89,6 +97,49 @@ module.exports = {
       domain,
       resourceLimits
     })
+    const nextEnvVars =
+      envVars === undefined ? environment.envVars || {} : envVars
+    if (envVars !== undefined || envVarMetadata !== undefined) {
+      problems.push(
+        ...sails.helpers.configuration.validateEnvVarMetadata(
+          nextEnvVars,
+          envVarMetadata || environment.envVarMetadata || {}
+        )
+      )
+    }
+
+    const services = await Service.find({ environment: environment.id })
+    const managedKeys = services
+      .map((service) => service.envVarKey)
+      .filter(Boolean)
+    if (envVars !== undefined) {
+      for (const key of managedKeys) {
+        if (envVars[key] !== (environment.envVars || {})[key]) {
+          problems.push({
+            envVars: `"${key}" is managed by Slipway. Change or remove its service instead.`
+          })
+          break
+        }
+      }
+    }
+    if (envVarMetadata !== undefined) {
+      for (const key of managedKeys) {
+        const previous = environment.envVarMetadata?.[key] || {}
+        const requested = envVarMetadata?.[key]
+        if (!requested) continue
+        const changed = ['kind', 'previewPolicy', 'description'].some(
+          (field) =>
+            requested[field] !== undefined &&
+            requested[field] !== previous[field]
+        )
+        if (changed) {
+          problems.push({
+            envVarMetadata: `"${key}" is managed by Slipway. Its policy cannot be changed directly.`
+          })
+          break
+        }
+      }
+    }
     if (problems.length) {
       throw { badRequest: { problems } }
     }
@@ -101,9 +152,38 @@ module.exports = {
     if (name !== undefined) updates.name = name
     if (isProduction !== undefined) updates.isProduction = isProduction
     if (domain !== undefined) updates.domain = domain
-    if (envVars !== undefined) updates.envVars = envVars
+    let normalizedMetadata = environment.envVarMetadata || {}
+    if (envVars !== undefined || envVarMetadata !== undefined) {
+      normalizedMetadata =
+        sails.helpers.configuration.normalizeEnvVarMetadata.with({
+          values: nextEnvVars,
+          metadata: envVarMetadata || environment.envVarMetadata || {},
+          currentValues: environment.envVars || {},
+          currentMetadata: environment.envVarMetadata || {},
+          managedKeys,
+          changedBy: String(user.id),
+          changedByName: user.fullName
+        })
+      updates.envVars = nextEnvVars
+      updates.envVarMetadata = normalizedMetadata
+    }
 
     await Environment.updateOne({ id: environment.id }).set(updates)
+
+    if (envVars !== undefined || envVarMetadata !== undefined) {
+      await sails.helpers.configuration.recordEnvVarChanges.with({
+        before: environment.envVars || {},
+        after: nextEnvVars,
+        beforeMetadata: environment.envVarMetadata || {},
+        afterMetadata: normalizedMetadata,
+        scope: 'environment',
+        resourceType: 'environment',
+        resourceId: String(environment.id),
+        userId: String(user.id),
+        teamId: String(project.team.id),
+        ipAddress: this.req.ip
+      })
+    }
 
     // If resource limits changed, update the App record
     if (resourceLimits !== undefined) {
@@ -142,6 +222,11 @@ module.exports = {
       .populate('app')
       .populate('services')
 
-    return { environment: updatedEnv }
+    const {
+      envVars: privateEnvVars,
+      telemetryToken,
+      ...publicEnvironment
+    } = updatedEnv
+    return { environment: publicEnvironment }
   }
 }

--- a/api/controllers/api/v1/service/create-service.js
+++ b/api/controllers/api/v1/service/create-service.js
@@ -156,10 +156,41 @@ module.exports = {
         envVarKey = `${name.replace(/-/g, '_').toUpperCase()}_URL`
       }
       const updatedVars = { ...currentVars, [envVarKey]: connectionUrl }
+      const updatedMetadata =
+        sails.helpers.configuration.normalizeEnvVarMetadata.with({
+          values: updatedVars,
+          metadata: {
+            ...(environment.envVarMetadata || {}),
+            [envVarKey]: {
+              kind: 'secret',
+              managed: true,
+              previewPolicy: 'omit',
+              description: `Connection URL managed by ${name}`
+            }
+          },
+          currentValues: currentVars,
+          currentMetadata: environment.envVarMetadata || {},
+          managedKeys: [envVarKey],
+          changedBy: String(user.id),
+          changedByName: user.fullName
+        })
       await Environment.updateOne({ id: environment.id }).set({
-        envVars: updatedVars
+        envVars: updatedVars,
+        envVarMetadata: updatedMetadata
       })
       await Service.updateOne({ id: service.id }).set({ envVarKey })
+      await sails.helpers.configuration.recordEnvVarChanges.with({
+        before: currentVars,
+        after: updatedVars,
+        beforeMetadata: environment.envVarMetadata || {},
+        afterMetadata: updatedMetadata,
+        scope: 'environment',
+        resourceType: 'environment',
+        resourceId: String(environment.id),
+        userId: String(user.id),
+        teamId: String(project.team.id),
+        ipAddress: this.req.ip
+      })
     }
 
     sails.log.info(

--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -201,13 +201,15 @@ module.exports = {
       environment,
       project
     })
+    const publicEnvironment = omitPrivateEnvironmentFields(environment)
+    const publicApp = omitPrivateAppFields(app)
 
     return {
       page: 'projects/app',
       props: {
         project,
         environment: {
-          ...environment,
+          ...publicEnvironment,
           fullDomain,
           generatedDomain,
           domains,
@@ -215,14 +217,23 @@ module.exports = {
           services
         },
         app: {
-          ...app,
+          ...publicApp,
           containerHealth,
           directAccess,
           primaryUrl,
           accessUrls,
           bridgeUrl: bridgeUrl ? `${bridgeUrl}/bridge` : null
         },
-        appEnvVars: decryptedApp.envVars || {},
+        appEnvVars: decryptedApp.secureEnvVars || decryptedApp.envVars || {},
+        appEnvVarMetadata:
+          sails.helpers.configuration.normalizeEnvVarMetadata.with({
+            values: decryptedApp.secureEnvVars || decryptedApp.envVars || {},
+            metadata: decryptedApp.envVarMetadata || {},
+            currentValues:
+              decryptedApp.secureEnvVars || decryptedApp.envVars || {},
+            currentMetadata: decryptedApp.envVarMetadata || {},
+            now: decryptedApp.updatedAt
+          }),
         inheritedVars,
         deploymentHistory,
         services,
@@ -233,4 +244,21 @@ module.exports = {
       }
     }
   }
+}
+
+function omitPrivateEnvironmentFields(environment) {
+  const {
+    envVars,
+    envVarMetadata,
+    telemetryToken,
+    telemetryTokenHash,
+    ...publicEnvironment
+  } = environment
+  return publicEnvironment
+}
+
+function omitPrivateAppFields(app) {
+  const { envVars, secureEnvVars, envVarMetadata, bridgeSecret, ...publicApp } =
+    app
+  return publicApp
 }

--- a/api/controllers/project/view-environment.js
+++ b/api/controllers/project/view-environment.js
@@ -163,6 +163,18 @@ module.exports = {
     const checklist = await sails.helpers.environment.generateChecklist(
       environment.id
     )
+    const managedEnvVarKeys = (environment.services || [])
+      .map((service) => service.envVarKey)
+      .filter(Boolean)
+    const envVarMetadata =
+      sails.helpers.configuration.normalizeEnvVarMetadata.with({
+        values: environment.envVars || {},
+        metadata: environment.envVarMetadata || {},
+        currentValues: environment.envVars || {},
+        currentMetadata: environment.envVarMetadata || {},
+        managedKeys: managedEnvVarKeys,
+        now: environment.updatedAt
+      })
 
     // Check if GitHub is connected for this team
     const gitProvider = await GitProvider.findOne({
@@ -180,22 +192,24 @@ module.exports = {
           app: appRecord
         })
     }
+    const publicEnvironment = omitPrivateEnvironmentFields(environment)
 
     return {
       page: 'projects/environment',
       props: {
         project,
         environment: {
-          ...environment,
+          ...publicEnvironment,
           fullDomain,
           generatedDomain,
           domains,
           serverIp,
           services
         },
-        app: app || null,
-        apps: appsWithHealth,
+        app: app ? omitPrivateAppFields(app) : null,
+        apps: appsWithHealth.map(omitPrivateAppFields),
         envVars: environment.envVars || {},
+        envVarMetadata,
         deploymentHistory,
         checklist,
         serviceVersions: getPublicMatrix(),
@@ -217,4 +231,21 @@ module.exports = {
       }
     }
   }
+}
+
+function omitPrivateEnvironmentFields(environment) {
+  const {
+    envVars,
+    envVarMetadata,
+    telemetryToken,
+    telemetryTokenHash,
+    ...publicEnvironment
+  } = environment
+  return publicEnvironment
+}
+
+function omitPrivateAppFields(app) {
+  const { envVars, secureEnvVars, envVarMetadata, bridgeSecret, ...publicApp } =
+    app
+  return publicApp
 }

--- a/api/controllers/setting/update-global-env.js
+++ b/api/controllers/setting/update-global-env.js
@@ -12,6 +12,11 @@ module.exports = {
     envSource: {
       type: 'string',
       description: 'Optional raw KEY=value input used to detect duplicate keys'
+    },
+    envVarMetadata: {
+      type: 'json',
+      defaultsTo: {},
+      description: 'Non-secret type and preview metadata keyed by variable name'
     }
   },
 
@@ -30,7 +35,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ envVars, envSource }) {
+  fn: async function ({ envVars, envSource, envVarMetadata }) {
     const user = await User.findOne({ id: this.req.session.userId })
 
     // Only owners and admins can modify global env vars
@@ -43,6 +48,12 @@ module.exports = {
       [],
       this.req
     )
+    problems.push(
+      ...sails.helpers.configuration.validateEnvVarMetadata(
+        envVars,
+        envVarMetadata
+      )
+    )
     if (problems.length) {
       throw { invalid: { problems } }
     }
@@ -50,12 +61,60 @@ module.exports = {
       throw 'precognitionSuccess'
     }
 
+    const previousValuesJson = await sails.helpers.setting.get(
+      'globalEnvVars',
+      '{}'
+    )
+    const previousMetadataJson = await sails.helpers.setting.get(
+      'globalEnvVarMetadata',
+      '{}'
+    )
+    const previousValues = parseObject(previousValuesJson)
+    const previousMetadata = parseObject(previousMetadataJson)
+    const normalizedMetadata =
+      sails.helpers.configuration.normalizeEnvVarMetadata.with({
+        values: envVars,
+        metadata: envVarMetadata,
+        currentValues: previousValues,
+        currentMetadata: previousMetadata,
+        changedBy: String(user.id),
+        changedByName: user.fullName
+      })
+
     await sails.helpers.setting.set(
       'globalEnvVars',
       JSON.stringify(envVars),
       'Instance-wide environment variables injected into all deployed applications'
     )
+    await sails.helpers.setting.set(
+      'globalEnvVarMetadata',
+      JSON.stringify(normalizedMetadata),
+      'Non-secret metadata for instance-wide environment variables'
+    )
+    await sails.helpers.configuration.recordEnvVarChanges.with({
+      before: previousValues,
+      after: envVars,
+      beforeMetadata: previousMetadata,
+      afterMetadata: normalizedMetadata,
+      scope: 'global',
+      resourceType: 'setting',
+      resourceId: 'globalEnvVars',
+      userId: String(user.id),
+      teamId: String(user.team),
+      ipAddress: this.req.ip
+    })
 
     return '/settings/global-env'
+  }
+}
+
+function parseObject(value) {
+  try {
+    const parsed = JSON.parse(value || '{}')
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed
+      : {}
+  } catch {
+    return {}
   }
 }

--- a/api/controllers/setting/update-uploads.js
+++ b/api/controllers/setting/update-uploads.js
@@ -57,10 +57,20 @@ module.exports = {
     publicUrl,
     backupSchedule
   }) {
+    const user = await User.findOne({ id: this.req.session.userId })
     let globalEnvVars = {}
     try {
       const globalJson = await sails.helpers.setting.get('globalEnvVars', '{}')
       globalEnvVars = JSON.parse(globalJson)
+    } catch {
+      /* ignore parse errors */
+    }
+    const previousGlobalEnvVars = { ...globalEnvVars }
+    let previousMetadata = {}
+    try {
+      previousMetadata = JSON.parse(
+        await sails.helpers.setting.get('globalEnvVarMetadata', '{}')
+      )
     } catch {
       /* ignore parse errors */
     }
@@ -197,6 +207,44 @@ module.exports = {
       'globalEnvVars',
       JSON.stringify(globalEnvVars)
     )
+    const requestedMetadata = Object.fromEntries(
+      Object.keys(globalEnvVars).map((key) => {
+        const isCredential = /_(ACCESS|SECRET)_KEY$/.test(key)
+        return [
+          key,
+          previousMetadata[key] || {
+            kind: isCredential ? 'secret' : 'plain',
+            previewPolicy: isCredential ? 'omit' : 'inherit'
+          }
+        ]
+      })
+    )
+    const normalizedMetadata =
+      sails.helpers.configuration.normalizeEnvVarMetadata.with({
+        values: globalEnvVars,
+        metadata: requestedMetadata,
+        currentValues: previousGlobalEnvVars,
+        currentMetadata: previousMetadata,
+        changedBy: String(user.id),
+        changedByName: user.fullName
+      })
+    await sails.helpers.setting.set(
+      'globalEnvVarMetadata',
+      JSON.stringify(normalizedMetadata),
+      'Non-secret metadata for instance-wide environment variables'
+    )
+    await sails.helpers.configuration.recordEnvVarChanges.with({
+      before: previousGlobalEnvVars,
+      after: globalEnvVars,
+      beforeMetadata: previousMetadata,
+      afterMetadata: normalizedMetadata,
+      scope: 'global',
+      resourceType: 'setting',
+      resourceId: 'globalEnvVars',
+      userId: String(user.id),
+      teamId: String(user.team),
+      ipAddress: this.req.ip
+    })
 
     sails.inertia.flash('success', 'Storage configuration saved')
     return '/settings/uploads'

--- a/api/controllers/setting/view-global-env.js
+++ b/api/controllers/setting/view-global-env.js
@@ -14,10 +14,18 @@ module.exports = {
   fn: async function () {
     const globalEnvJson = await sails.helpers.setting.get('globalEnvVars', '{}')
     let globalEnvVars = {}
+    let globalEnvVarMetadata = {}
     try {
       globalEnvVars = JSON.parse(globalEnvJson)
     } catch {
       globalEnvVars = {}
+    }
+    try {
+      globalEnvVarMetadata = JSON.parse(
+        await sails.helpers.setting.get('globalEnvVarMetadata', '{}')
+      )
+    } catch {
+      globalEnvVarMetadata = {}
     }
 
     // Check if backup storage is configured
@@ -31,6 +39,7 @@ module.exports = {
       page: 'settings/global-env',
       props: {
         globalEnvVars,
+        globalEnvVarMetadata,
         backupConfigured
       }
     }

--- a/api/helpers/bridge/get-upload-storage-config.js
+++ b/api/helpers/bridge/get-upload-storage-config.js
@@ -22,20 +22,7 @@ module.exports = {
   },
 
   fn: async function ({ app, environment }) {
-    let globalEnvVars = {}
-    try {
-      const stored = await sails.helpers.setting.get('globalEnvVars', '{}')
-      const parsed = JSON.parse(stored)
-      if (isPlainObject(parsed)) globalEnvVars = parsed
-    } catch {
-      // A malformed optional global setting must not expose or replace scoped values.
-    }
-
-    const scopes = [
-      storageValues(globalEnvVars),
-      storageValues(environment.envVars),
-      storageValues(app.envVars)
-    ]
+    const scopes = await resolveStorageScopes({ app, environment })
     const provider = resolveProvider(scopes)
     if (!['r2', 's3'].includes(provider)) {
       throw storageError(
@@ -83,6 +70,26 @@ module.exports = {
   }
 }
 
+async function resolveStorageScopes({ app, environment }) {
+  if (app.id && environment.id) {
+    const runtimeConfig =
+      await sails.helpers.configuration.resolveRuntimeConfig.with({
+        environmentId: String(environment.id),
+        appId: String(app.id)
+      })
+    return runtimeConfig.scopes.map((scope) => storageValues(scope.values))
+  }
+
+  const globalValues = parseObject(
+    await sails.helpers.setting.get('globalEnvVars', '{}')
+  )
+  return [
+    storageValues(globalValues),
+    storageValues(environment.envVars),
+    storageValues(app.secureEnvVars || app.envVars)
+  ]
+}
+
 function storageValues(value) {
   if (!isPlainObject(value)) return {}
   return Object.fromEntries(
@@ -93,6 +100,15 @@ function storageValues(value) {
         key.startsWith('S3_')
     )
   )
+}
+
+function parseObject(value) {
+  try {
+    const parsed = JSON.parse(value || '{}')
+    return isPlainObject(parsed) ? parsed : {}
+  } catch {
+    return {}
+  }
 }
 
 function resolveProvider(scopes) {

--- a/api/helpers/cleanup/remove-records.js
+++ b/api/helpers/cleanup/remove-records.js
@@ -28,7 +28,10 @@ module.exports = {
     await sails.getDatastore().transaction(async (db) => {
       for (const update of environmentVars) {
         await Environment.updateOne({ id: update.environmentId })
-          .set({ envVars: update.envVars })
+          .set({
+            envVars: update.envVars,
+            envVarMetadata: update.envVarMetadata
+          })
           .usingConnection(db)
       }
 
@@ -153,10 +156,12 @@ async function getEnvironmentVarUpdates(services) {
     if (!environment) continue
 
     const envVars = { ...(environment.envVars || {}) }
+    const envVarMetadata = { ...(environment.envVarMetadata || {}) }
     for (const key of keys) {
       delete envVars[key]
+      delete envVarMetadata[key]
     }
-    updates.push({ environmentId, envVars })
+    updates.push({ environmentId, envVars, envVarMetadata })
   }
 
   return updates

--- a/api/helpers/configuration/apply-preview-policy.js
+++ b/api/helpers/configuration/apply-preview-policy.js
@@ -1,0 +1,57 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Apply preview configuration policy',
+
+  description:
+    'Prepare inherited configuration for a preview without blindly copying secrets.',
+
+  sync: true,
+
+  inputs: {
+    values: { type: 'ref', required: true },
+    metadata: { type: 'ref', defaultsTo: {} }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({ values, metadata }) {
+    const previewValues = {}
+    const previewMetadata = {}
+
+    for (const [key, value] of Object.entries(values || {})) {
+      const entry = metadata?.[key] || {}
+      const kind = entry.kind === 'plain' ? 'plain' : 'secret'
+      const policy = ['inherit', 'omit', 'randomize'].includes(
+        entry.previewPolicy
+      )
+        ? entry.previewPolicy
+        : kind === 'secret'
+        ? 'omit'
+        : 'inherit'
+
+      if (policy === 'omit') continue
+      previewValues[key] =
+        policy === 'randomize'
+          ? crypto.randomBytes(32).toString('base64url')
+          : value
+      previewMetadata[key] = {
+        ...entry,
+        kind,
+        previewPolicy: policy,
+        managed: false,
+        ...(policy === 'randomize'
+          ? {
+              changedAt: Date.now(),
+              changedBy: null,
+              changedByName: 'Slipway'
+            }
+          : {})
+      }
+    }
+
+    return { values: previewValues, metadata: previewMetadata }
+  }
+}

--- a/api/helpers/configuration/diff-env-vars.js
+++ b/api/helpers/configuration/diff-env-vars.js
@@ -1,0 +1,59 @@
+module.exports = {
+  friendlyName: 'Diff environment variables',
+
+  description:
+    'Describe configuration changes without returning or logging variable values.',
+
+  sync: true,
+
+  inputs: {
+    before: { type: 'ref', defaultsTo: {} },
+    after: { type: 'ref', defaultsTo: {} },
+    beforeMetadata: { type: 'ref', defaultsTo: {} },
+    afterMetadata: { type: 'ref', defaultsTo: {} }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({ before, after, beforeMetadata, afterMetadata }) {
+    const changes = []
+    const keys = new Set([
+      ...Object.keys(before || {}),
+      ...Object.keys(after || {})
+    ])
+
+    for (const key of [...keys].sort()) {
+      const existed = Object.prototype.hasOwnProperty.call(before || {}, key)
+      const exists = Object.prototype.hasOwnProperty.call(after || {}, key)
+      const previous = beforeMetadata?.[key] || {}
+      const next = afterMetadata?.[key] || {}
+      let operation
+
+      if (!existed && exists) operation = 'created'
+      else if (existed && !exists) operation = 'deleted'
+      else if (before[key] !== after[key]) {
+        operation =
+          (next.kind || previous.kind) === 'secret' ? 'rotated' : 'updated'
+      } else if (metadataChanged(previous, next)) operation = 'updated'
+      else continue
+
+      changes.push({
+        key,
+        operation,
+        kind: next.kind || previous.kind || 'secret',
+        managed: next.managed === true || previous.managed === true,
+        previewPolicy: next.previewPolicy || previous.previewPolicy || 'omit'
+      })
+    }
+
+    return changes
+  }
+}
+
+function metadataChanged(before, after) {
+  return ['kind', 'managed', 'previewPolicy', 'description'].some(
+    (field) => (before?.[field] || '') !== (after?.[field] || '')
+  )
+}

--- a/api/helpers/configuration/ensure-schema.js
+++ b/api/helpers/configuration/ensure-schema.js
@@ -1,0 +1,54 @@
+module.exports = {
+  friendlyName: 'Ensure runtime configuration schema',
+
+  description:
+    'Add deployment-native configuration metadata and encrypted app storage to existing installations.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore()
+
+    await addColumns(datastore, 'environments', [
+      ['env_var_metadata', "TEXT NOT NULL DEFAULT '{}'"]
+    ])
+    await addColumns(datastore, 'apps', [
+      ['secure_env_vars', 'TEXT'],
+      ['env_var_metadata', "TEXT NOT NULL DEFAULT '{}'"]
+    ])
+    await addColumns(datastore, 'deployments', [
+      ['config_hash', 'TEXT'],
+      ['config_manifest', "TEXT NOT NULL DEFAULT '[]'"]
+    ])
+
+    const apps = await App.find().decrypt()
+    for (const app of apps) {
+      if (app.secureEnvVars !== null && app.secureEnvVars !== undefined) {
+        continue
+      }
+      const legacyValues = app.envVars || {}
+      if (Object.keys(legacyValues).length === 0) continue
+
+      await App.updateOne({ id: app.id }).set({
+        secureEnvVars: legacyValues,
+        envVars: {}
+      })
+    }
+  }
+}
+
+async function addColumns(datastore, table, columns) {
+  const result = await datastore.sendNativeQuery(`PRAGMA table_info(${table})`)
+  const existing = new Set(rows(result).map((column) => column.name))
+
+  for (const [name, definition] of columns) {
+    if (existing.has(name)) continue
+    await datastore.sendNativeQuery(
+      `ALTER TABLE ${table} ADD COLUMN ${name} ${definition}`
+    )
+  }
+}
+
+function rows(result) {
+  return result.rows || result || []
+}

--- a/api/helpers/configuration/fingerprint-runtime-config.js
+++ b/api/helpers/configuration/fingerprint-runtime-config.js
@@ -1,0 +1,68 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Fingerprint runtime configuration',
+
+  description:
+    'Create a keyed fingerprint and value-free manifest for resolved runtime configuration.',
+
+  sync: true,
+
+  inputs: {
+    values: { type: 'ref', required: true },
+    manifest: { type: 'ref', defaultsTo: [] }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({ values, manifest }) {
+    const metadata = new Map(
+      (manifest || []).map((entry) => [entry.key, sanitize(entry)])
+    )
+    for (const key of Object.keys(values || {})) {
+      if (!metadata.has(key)) {
+        metadata.set(key, {
+          key,
+          scope: 'platform',
+          kind: 'secret',
+          managed: true,
+          previewPolicy: 'omit'
+        })
+      }
+    }
+
+    const sortedValues = Object.keys(values || {})
+      .sort()
+      .map((key) => [key, values[key]])
+    const key = sails.config.models.dataEncryptionKeys.default
+    const hash = crypto
+      .createHmac('sha256', key)
+      .update(JSON.stringify(sortedValues))
+      .digest('hex')
+
+    return {
+      hash,
+      manifest: [...metadata.values()].sort((a, b) =>
+        a.key.localeCompare(b.key)
+      )
+    }
+  }
+}
+
+function sanitize(entry) {
+  return {
+    key: String(entry.key),
+    scope: ['global', 'environment', 'app', 'platform'].includes(entry.scope)
+      ? entry.scope
+      : 'platform',
+    kind: entry.kind === 'plain' ? 'plain' : 'secret',
+    managed: entry.managed === true,
+    previewPolicy: ['inherit', 'omit', 'randomize'].includes(
+      entry.previewPolicy
+    )
+      ? entry.previewPolicy
+      : 'omit'
+  }
+}

--- a/api/helpers/configuration/normalize-env-var-metadata.js
+++ b/api/helpers/configuration/normalize-env-var-metadata.js
@@ -1,0 +1,91 @@
+module.exports = {
+  friendlyName: 'Normalize environment variable metadata',
+
+  description:
+    'Build safe metadata for a variable map while preserving server-owned fields.',
+
+  sync: true,
+
+  inputs: {
+    values: { type: 'ref', required: true },
+    metadata: { type: 'ref', defaultsTo: {} },
+    currentValues: { type: 'ref', defaultsTo: {} },
+    currentMetadata: { type: 'ref', defaultsTo: {} },
+    managedKeys: { type: 'ref', defaultsTo: [] },
+    changedBy: { type: 'string', allowNull: true },
+    changedByName: { type: 'string', allowNull: true },
+    now: { type: 'number', defaultsTo: 0 }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({
+    values,
+    metadata,
+    currentValues,
+    currentMetadata,
+    managedKeys,
+    changedBy,
+    changedByName,
+    now
+  }) {
+    const normalized = {}
+    const managed = new Set((managedKeys || []).map(String))
+    const changedAt = now || Date.now()
+
+    for (const key of Object.keys(values || {})) {
+      const previous = currentMetadata?.[key] || {}
+      const requested = metadata?.[key] || {}
+      const kind = allowed(requested.kind, ['secret', 'plain'])
+        ? requested.kind
+        : allowed(previous.kind, ['secret', 'plain'])
+        ? previous.kind
+        : 'secret'
+      const previewPolicy = allowed(requested.previewPolicy, [
+        'inherit',
+        'omit',
+        'randomize'
+      ])
+        ? requested.previewPolicy
+        : allowed(previous.previewPolicy, ['inherit', 'omit', 'randomize'])
+        ? previous.previewPolicy
+        : kind === 'secret'
+        ? 'omit'
+        : 'inherit'
+      const description = String(
+        requested.description ?? previous.description ?? ''
+      )
+        .trim()
+        .slice(0, 160)
+      const next = {
+        kind,
+        managed: managed.has(key) || previous.managed === true,
+        previewPolicy
+      }
+      if (description) next.description = description
+
+      const changed =
+        !Object.prototype.hasOwnProperty.call(currentValues || {}, key) ||
+        currentValues[key] !== values[key] ||
+        previous.kind !== next.kind ||
+        previous.managed !== next.managed ||
+        previous.previewPolicy !== next.previewPolicy ||
+        String(previous.description || '') !== description
+
+      next.changedAt = changed ? changedAt : previous.changedAt || changedAt
+      next.changedBy = changed ? changedBy || null : previous.changedBy || null
+      next.changedByName = changed
+        ? changedByName || null
+        : previous.changedByName || null
+      normalized[key] = next
+    }
+
+    return normalized
+  }
+}
+
+function allowed(value, values) {
+  return values.includes(value)
+}

--- a/api/helpers/configuration/record-env-var-changes.js
+++ b/api/helpers/configuration/record-env-var-changes.js
@@ -1,0 +1,57 @@
+module.exports = {
+  friendlyName: 'Record environment variable changes',
+
+  description:
+    'Write one value-free audit event for every created, updated, rotated, or deleted variable.',
+
+  inputs: {
+    before: { type: 'ref', defaultsTo: {} },
+    after: { type: 'ref', defaultsTo: {} },
+    beforeMetadata: { type: 'ref', defaultsTo: {} },
+    afterMetadata: { type: 'ref', defaultsTo: {} },
+    scope: {
+      type: 'string',
+      required: true,
+      isIn: ['global', 'environment', 'app']
+    },
+    resourceType: { type: 'string', required: true },
+    resourceId: { type: 'string' },
+    userId: { type: 'string' },
+    teamId: { type: 'string' },
+    ipAddress: { type: 'string' }
+  },
+
+  fn: async function ({
+    before,
+    after,
+    beforeMetadata,
+    afterMetadata,
+    scope,
+    resourceType,
+    resourceId,
+    userId,
+    teamId,
+    ipAddress
+  }) {
+    const changes = sails.helpers.configuration.diffEnvVars(
+      before,
+      after,
+      beforeMetadata,
+      afterMetadata
+    )
+
+    for (const change of changes) {
+      await sails.helpers.audit.log.with({
+        action: `configuration.${change.operation}`,
+        resourceType,
+        resourceId,
+        details: { scope, ...change },
+        userId,
+        teamId,
+        ipAddress
+      })
+    }
+
+    return changes
+  }
+}

--- a/api/helpers/configuration/resolve-runtime-config.js
+++ b/api/helpers/configuration/resolve-runtime-config.js
@@ -1,0 +1,89 @@
+module.exports = {
+  friendlyName: 'Resolve runtime configuration',
+
+  description:
+    'Resolve global, environment, and app configuration using Slipway precedence.',
+
+  inputs: {
+    environmentId: { type: 'string', required: true },
+    appId: { type: 'string' }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: async function ({ environmentId, appId }) {
+    const [globalValuesJson, globalMetadataJson, environment, app] =
+      await Promise.all([
+        sails.helpers.setting.get('globalEnvVars', '{}'),
+        sails.helpers.setting.get('globalEnvVarMetadata', '{}'),
+        Environment.findOne({ id: environmentId }).decrypt(),
+        appId ? App.findOne({ id: appId }).decrypt() : null
+      ])
+
+    const scopes = [
+      {
+        name: 'global',
+        values: parseObject(globalValuesJson),
+        metadata: parseObject(globalMetadataJson)
+      },
+      {
+        name: 'environment',
+        values: environment?.envVars || {},
+        metadata: environment?.envVarMetadata || {}
+      },
+      {
+        name: 'app',
+        values: app?.secureEnvVars || app?.envVars || {},
+        metadata: app?.envVarMetadata || {}
+      }
+    ]
+    const values = {}
+    const effective = {}
+
+    for (const scope of scopes) {
+      for (const [key, value] of Object.entries(scope.values)) {
+        values[key] = value
+        effective[key] = {
+          key,
+          scope: scope.name,
+          ...safeMetadata(scope.metadata[key])
+        }
+      }
+    }
+
+    return {
+      values,
+      scopes,
+      manifest: Object.values(effective).sort((a, b) =>
+        a.key.localeCompare(b.key)
+      )
+    }
+  }
+}
+
+function parseObject(value) {
+  try {
+    const parsed = JSON.parse(value || '{}')
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? parsed
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+function safeMetadata(metadata = {}) {
+  return {
+    kind: metadata.kind === 'plain' ? 'plain' : 'secret',
+    managed: metadata.managed === true,
+    previewPolicy: ['inherit', 'omit', 'randomize'].includes(
+      metadata.previewPolicy
+    )
+      ? metadata.previewPolicy
+      : metadata.kind === 'plain'
+      ? 'inherit'
+      : 'omit'
+  }
+}

--- a/api/helpers/configuration/validate-env-var-metadata.js
+++ b/api/helpers/configuration/validate-env-var-metadata.js
@@ -1,0 +1,61 @@
+module.exports = {
+  friendlyName: 'Validate environment variable metadata',
+
+  description: 'Validate client-editable config metadata without trusting it.',
+
+  sync: true,
+
+  inputs: {
+    values: { type: 'ref', required: true },
+    metadata: { type: 'ref', defaultsTo: {} }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({ values, metadata }) {
+    if (!metadata || typeof metadata !== 'object' || Array.isArray(metadata)) {
+      return [
+        { envVarMetadata: 'Variable metadata must be keyed by variable name.' }
+      ]
+    }
+
+    for (const [key, entry] of Object.entries(metadata)) {
+      if (!Object.prototype.hasOwnProperty.call(values || {}, key)) {
+        return [
+          { envVarMetadata: `Metadata references unknown variable "${key}".` }
+        ]
+      }
+      if (!entry || typeof entry !== 'object' || Array.isArray(entry)) {
+        return [{ envVarMetadata: `Metadata for "${key}" must be an object.` }]
+      }
+      if (entry.kind && !['secret', 'plain'].includes(entry.kind)) {
+        return [
+          { envVarMetadata: `Variable "${key}" has an invalid value type.` }
+        ]
+      }
+      if (
+        entry.previewPolicy &&
+        !['inherit', 'omit', 'randomize'].includes(entry.previewPolicy)
+      ) {
+        return [
+          { envVarMetadata: `Variable "${key}" has an invalid preview policy.` }
+        ]
+      }
+      if (
+        entry.description !== undefined &&
+        (typeof entry.description !== 'string' ||
+          entry.description.trim().length > 160)
+      ) {
+        return [
+          {
+            envVarMetadata: `Description for "${key}" must be 160 characters or fewer.`
+          }
+        ]
+      }
+    }
+
+    return []
+  }
+}

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -189,27 +189,16 @@ module.exports = {
       deployHostPortReserved = true
       await recordStage('container_startup', { hostPort: deployHostPort })
 
-      // 7. 3-tier env var merge: global < environment < app-specific
-      let globalEnvVars = {}
-      try {
-        const globalJson = await sails.helpers.setting.get(
-          'globalEnvVars',
-          '{}'
-        )
-        globalEnvVars = JSON.parse(globalJson)
-      } catch {
-        /* ignore parse errors */
-      }
-
+      // 7. Resolve deployment config: global < environment < app-specific.
       const envRecord = await Environment.findOne({
         id: environment.id
       }).decrypt()
-      const appEnvVars = (targetApp && targetApp.envVars) || {}
-      const envVars = {
-        ...globalEnvVars,
-        ...(envRecord.envVars || {}),
-        ...appEnvVars
-      }
+      const runtimeConfig =
+        await sails.helpers.configuration.resolveRuntimeConfig.with({
+          environmentId: String(environment.id),
+          ...(targetApp?.id ? { appId: String(targetApp.id) } : {})
+        })
+      const envVars = { ...runtimeConfig.values }
 
       // 7b. Auto-inject Slipway telemetry env vars for sails-hook-slipway
       if (envRecord.telemetryToken) {
@@ -234,6 +223,22 @@ module.exports = {
         envVars.SLIPWAY_BRIDGE_SECRET =
           await sails.helpers.bridge.ensureAppSecret(String(targetApp.id))
       }
+
+      const fingerprint =
+        sails.helpers.configuration.fingerprintRuntimeConfig.with({
+          values: envVars,
+          manifest: runtimeConfig.manifest
+        })
+      await updateDeployment({
+        configHash: fingerprint.hash,
+        configManifest: fingerprint.manifest
+      })
+      await Deployment.appendDeployLog(
+        deploymentId,
+        `Config: ${fingerprint.hash.slice(0, 12)} (${
+          fingerprint.manifest.length
+        } variables)\n`
+      )
 
       // 8. Get resource limits from existing app
       const existingApp =

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -131,25 +131,12 @@ module.exports = {
       hostPortReserved = true
       await recordStage('container_startup', { hostPort })
 
-      let globalEnvVars = {}
-      try {
-        const globalJson = await sails.helpers.setting.get(
-          'globalEnvVars',
-          '{}'
-        )
-        globalEnvVars = JSON.parse(globalJson)
-      } catch {
-        /* ignore invalid legacy settings */
-      }
-
-      const envRecord = await Environment.findOne({
-        id: environment.id
-      }).decrypt()
-      const envVars = {
-        ...globalEnvVars,
-        ...(envRecord.envVars || {}),
-        ...(existingApp?.envVars || {})
-      }
+      const runtimeConfig =
+        await sails.helpers.configuration.resolveRuntimeConfig.with({
+          environmentId: String(environment.id),
+          ...(existingApp?.id ? { appId: String(existingApp.id) } : {})
+        })
+      const envVars = { ...runtimeConfig.values }
 
       if (existingApp?.bridgeEnabled) {
         const bridgeHost =
@@ -162,6 +149,22 @@ module.exports = {
         envVars.SLIPWAY_BRIDGE_SECRET =
           await sails.helpers.bridge.ensureAppSecret(String(existingApp.id))
       }
+
+      const fingerprint =
+        sails.helpers.configuration.fingerprintRuntimeConfig.with({
+          values: envVars,
+          manifest: runtimeConfig.manifest
+        })
+      await updateDeployment({
+        configHash: fingerprint.hash,
+        configManifest: fingerprint.manifest
+      })
+      await Deployment.appendDeployLog(
+        rollbackId,
+        `Config: ${fingerprint.hash.slice(0, 12)} (${
+          fingerprint.manifest.length
+        } variables)\n`
+      )
 
       const containerResult = await sails.helpers.docker.runContainer.with({
         imageName: targetDeployment.imageName,

--- a/api/models/App.js
+++ b/api/models/App.js
@@ -62,8 +62,26 @@ module.exports = {
     envVars: {
       type: 'json',
       defaultsTo: {},
-      description: 'App-specific environment variable overrides',
+      protect: true,
+      description:
+        'Legacy app-specific environment variable overrides retained for migration',
       columnName: 'app_env_vars'
+    },
+
+    secureEnvVars: {
+      type: 'json',
+      encrypt: true,
+      protect: true,
+      description: 'Encrypted app-specific environment variable overrides',
+      columnName: 'secure_env_vars'
+    },
+
+    envVarMetadata: {
+      type: 'json',
+      defaultsTo: {},
+      description:
+        'Non-secret metadata for app environment variables, keyed by variable name',
+      columnName: 'env_var_metadata'
     },
 
     isDefault: {

--- a/api/models/Deployment.js
+++ b/api/models/Deployment.js
@@ -86,6 +86,22 @@ module.exports = {
       columnName: 'error_message'
     },
 
+    configHash: {
+      type: 'string',
+      allowNull: true,
+      description:
+        'Keyed SHA-256 fingerprint of the resolved runtime configuration',
+      columnName: 'config_hash'
+    },
+
+    configManifest: {
+      type: 'json',
+      defaultsTo: [],
+      description:
+        'Non-secret manifest describing the source and policy of deployed variables',
+      columnName: 'config_manifest'
+    },
+
     // Timing
     startedAt: {
       type: 'number',

--- a/api/models/Environment.js
+++ b/api/models/Environment.js
@@ -40,8 +40,17 @@ module.exports = {
     envVars: {
       type: 'json',
       encrypt: true,
+      protect: true,
       description: 'Environment variables passed to containers at deploy time',
       columnName: 'env_vars'
+    },
+
+    envVarMetadata: {
+      type: 'json',
+      defaultsTo: {},
+      description:
+        'Non-secret metadata for environment variables, keyed by variable name',
+      columnName: 'env_var_metadata'
     },
 
     /**
@@ -66,6 +75,7 @@ module.exports = {
     telemetryToken: {
       type: 'string',
       encrypt: true,
+      protect: true,
       description: 'Token for authenticating telemetry data from deployed apps',
       columnName: 'telemetry_token'
     },

--- a/assets/js/components/ConfigVariableMenu.vue
+++ b/assets/js/components/ConfigVariableMenu.vue
@@ -1,0 +1,100 @@
+<script setup>
+const props = defineProps({
+  variableKey: { type: String, required: true },
+  metadata: { type: Object, required: true }
+})
+
+const emit = defineEmits(['update', 'remove'])
+
+function update(field, value) {
+  emit('update', {
+    ...props.metadata,
+    [field]: value
+  })
+}
+</script>
+
+<template>
+  <details :data-test="`config-menu-${variableKey}`" class="relative">
+    <summary
+      :aria-label="`Configure ${variableKey}`"
+      class="flex cursor-pointer list-none rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700 [&::-webkit-details-marker]:hidden"
+    >
+      <svg
+        class="h-4 w-4"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        aria-hidden="true"
+      >
+        <circle cx="5" cy="12" r="1.5" />
+        <circle cx="12" cy="12" r="1.5" />
+        <circle cx="19" cy="12" r="1.5" />
+      </svg>
+    </summary>
+
+    <div
+      class="absolute right-0 z-30 mt-1 w-64 space-y-4 rounded-lg bg-white p-4 shadow-lg ring-1 ring-black/5 dark:bg-gray-900 dark:ring-white/10"
+    >
+      <p
+        v-if="metadata.managed"
+        class="text-xs leading-5 text-gray-500 dark:text-gray-400"
+      >
+        Managed by Slipway. Change or remove the service that owns this value.
+      </p>
+
+      <template v-else>
+        <label class="block">
+          <span class="text-xs font-medium text-gray-700 dark:text-gray-300"
+            >Value type</span
+          >
+          <select
+            :value="metadata.kind"
+            @change="update('kind', $event.target.value)"
+            class="mt-1 block w-full rounded-md border-0 bg-gray-50 px-2 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-800 dark:focus:ring-gray-600"
+          >
+            <option value="secret">Secret</option>
+            <option value="plain">Plain config</option>
+          </select>
+        </label>
+
+        <label class="block">
+          <span class="text-xs font-medium text-gray-700 dark:text-gray-300"
+            >Preview environments</span
+          >
+          <select
+            :value="metadata.previewPolicy"
+            @change="update('previewPolicy', $event.target.value)"
+            class="mt-1 block w-full rounded-md border-0 bg-gray-50 px-2 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-800 dark:focus:ring-gray-600"
+          >
+            <option value="omit">Omit</option>
+            <option value="inherit">Inherit</option>
+            <option value="randomize">Generate a new value</option>
+          </select>
+        </label>
+
+        <label class="block">
+          <span class="text-xs font-medium text-gray-700 dark:text-gray-300"
+            >Description
+            <span class="font-normal text-gray-400">(optional)</span></span
+          >
+          <input
+            :value="metadata.description || ''"
+            @blur="update('description', $event.target.value)"
+            maxlength="160"
+            class="mt-1 block w-full rounded-md border-0 bg-gray-50 px-2 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-200 placeholder:text-gray-400 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-800 dark:focus:ring-gray-600"
+            placeholder="What uses this value?"
+          />
+        </label>
+
+        <button
+          type="button"
+          @pointerdown.prevent
+          @click="emit('remove')"
+          class="text-sm text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+        >
+          Remove variable
+        </button>
+      </template>
+    </div>
+  </details>
+</template>

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -16,6 +16,7 @@ import Breadcrumb from '@/components/Breadcrumb.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
+import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
 import { useToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
@@ -30,6 +31,7 @@ const props = defineProps({
   environment: Object,
   app: Object,
   appEnvVars: Object,
+  appEnvVarMetadata: Object,
   inheritedVars: Object,
   deploymentHistory: Object,
   services: Array,
@@ -378,11 +380,19 @@ function toggleServiceUrlReveal(id) {
 
 // --- App-specific env vars ---
 const localVars = reactive({ ...props.appEnvVars })
+const localMetadata = reactive({ ...props.appEnvVarMetadata })
 watch(
   () => props.appEnvVars,
   (newVars) => {
     Object.keys(localVars).forEach((k) => delete localVars[k])
     Object.assign(localVars, newVars)
+  }
+)
+watch(
+  () => props.appEnvVarMetadata,
+  (newMetadata) => {
+    Object.keys(localMetadata).forEach((k) => delete localMetadata[k])
+    Object.assign(localMetadata, newMetadata || {})
   }
 )
 const revealedKeys = ref(new Set())
@@ -407,7 +417,7 @@ function exitBulkMode() {
   bulkMode.value = false
 }
 
-function saveBulk() {
+async function saveBulk() {
   const vars = {}
   for (const line of bulkText.value.split('\n')) {
     const trimmed = line.trim()
@@ -418,14 +428,55 @@ function saveBulk() {
     const value = trimmed.slice(eqIdx + 1).trim()
     if (key) vars[key] = value
   }
+  const nextMetadata = Object.fromEntries(
+    Object.keys(vars).map((key) => [
+      key,
+      localMetadata[key] || { kind: 'secret', previewPolicy: 'omit' }
+    ])
+  )
+  if (!(await saveEnvVars(vars, nextMetadata))) return
   Object.keys(localVars).forEach((k) => delete localVars[k])
   Object.assign(localVars, vars)
-  saveEnvVars()
+  Object.keys(localMetadata).forEach((key) => delete localMetadata[key])
+  Object.assign(localMetadata, nextMetadata)
   bulkMode.value = false
 }
 
-function isSensitive() {
-  return true
+function metadataFor(key) {
+  const metadata = localMetadata[key] || {}
+  const kind = metadata.kind === 'plain' ? 'plain' : 'secret'
+  return {
+    ...metadata,
+    kind,
+    managed: metadata.managed === true,
+    previewPolicy:
+      metadata.previewPolicy || (kind === 'plain' ? 'inherit' : 'omit')
+  }
+}
+
+function isSensitive(key) {
+  return metadataFor(key).kind === 'secret'
+}
+
+function metadataSummary(key) {
+  const metadata = metadataFor(key)
+  const type = metadata.kind === 'secret' ? 'Secret' : 'Plain config'
+  const preview = {
+    omit: 'omitted from previews',
+    inherit: 'inherited by previews',
+    randomize: 'regenerated for previews'
+  }[metadata.previewPolicy]
+  return `${type} · ${preview}`
+}
+
+function changeSummary(key) {
+  const metadata = metadataFor(key)
+  return [
+    metadata.changedByName,
+    metadata.changedAt ? timeAgo(metadata.changedAt) : null
+  ]
+    .filter(Boolean)
+    .join(' · ')
 }
 
 function toggleReveal(key) {
@@ -446,37 +497,63 @@ function generateSecret() {
   ).join('')
 }
 
-async function saveEnvVars() {
+async function saveEnvVars(vars = localVars, metadata = localMetadata) {
   savingVars.value = true
   try {
-    await fetch(
+    const response = await fetch(
       `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ envVars: { ...localVars } })
+        body: JSON.stringify({
+          envVars: { ...vars },
+          envVarMetadata: { ...metadata }
+        })
       }
     )
-    router.reload({ only: ['appEnvVars'] })
+    if (!response.ok) {
+      throw new Error('Environment variables could not be saved.')
+    }
+    router.reload({ only: ['appEnvVars', 'appEnvVarMetadata'] })
+    return true
+  } catch (error) {
+    toast({ message: error.message, type: 'error' })
+    router.reload({
+      only: ['appEnvVars', 'appEnvVarMetadata'],
+      preserveScroll: true
+    })
+    return false
   } finally {
     savingVars.value = false
   }
 }
 
-function addVar() {
+async function addVar() {
   if (!newKey.value.trim()) return
-  localVars[newKey.value.trim()] = newValue.value
-  saveEnvVars()
+  const key = newKey.value.trim()
+  const nextVars = { ...localVars, [key]: newValue.value }
+  const nextMetadata = {
+    ...localMetadata,
+    [key]: { kind: 'secret', previewPolicy: 'omit' }
+  }
+  if (!(await saveEnvVars(nextVars, nextMetadata))) return
+  Object.assign(localVars, nextVars)
+  Object.assign(localMetadata, nextMetadata)
   newKey.value = ''
   newValue.value = ''
 }
 
-function removeVar(key) {
+async function removeVar(key) {
+  const nextVars = { ...localVars }
+  const nextMetadata = { ...localMetadata }
+  delete nextVars[key]
+  delete nextMetadata[key]
+  if (!(await saveEnvVars(nextVars, nextMetadata))) return
   delete localVars[key]
-  saveEnvVars()
+  delete localMetadata[key]
 }
 
-function renameVar(oldKey, el) {
+async function renameVar(oldKey, el) {
   const trimmed = el.value.trim()
   if (!trimmed || trimmed === oldKey) {
     el.value = oldKey
@@ -487,17 +564,34 @@ function renameVar(oldKey, el) {
     el.value = oldKey
     return
   }
-  const value = localVars[oldKey]
+  const nextVars = { ...localVars }
+  const nextMetadata = { ...localMetadata }
+  const value = nextVars[oldKey]
+  const metadata = metadataFor(oldKey)
+  delete nextVars[oldKey]
+  delete nextMetadata[oldKey]
+  nextVars[trimmed] = value
+  nextMetadata[trimmed] = metadata
+  if (!(await saveEnvVars(nextVars, nextMetadata))) return
   delete localVars[oldKey]
+  delete localMetadata[oldKey]
   localVars[trimmed] = value
-  saveEnvVars()
+  localMetadata[trimmed] = metadata
   toast({ message: `Renamed "${oldKey}" to "${trimmed}"`, type: 'success' })
 }
 
-function updateVarValue(key, value) {
+async function updateVarMetadata(key, metadata) {
+  const nextMetadata = { ...localMetadata, [key]: metadata }
+  if (!(await saveEnvVars(localVars, nextMetadata))) return
+  localMetadata[key] = metadata
+  toast({ message: `Updated "${key}"`, type: 'success' })
+}
+
+async function updateVarValue(key, value) {
   if (localVars[key] === value) return
+  const nextVars = { ...localVars, [key]: value }
+  if (!(await saveEnvVars(nextVars, localMetadata))) return
   localVars[key] = value
-  saveEnvVars()
   toast({ message: `Updated "${key}"`, type: 'success' })
 }
 
@@ -1367,7 +1461,7 @@ onBeforeUnmount(() => {
           </div>
 
           <!-- App Variables -->
-          <div>
+          <div data-test="app-config">
             <div class="flex items-center justify-between px-4 py-3">
               <button
                 @click="envVarsOpen = !envVarsOpen"
@@ -1491,7 +1585,7 @@ onBeforeUnmount(() => {
                         class="min-w-0 flex-1 border-b border-dashed border-transparent bg-transparent font-mono text-sm font-medium text-gray-900 focus:border-gray-300 focus:outline-none dark:text-white dark:focus:border-gray-600"
                       />
                       <div
-                        class="flex items-center space-x-1 opacity-0 transition-opacity group-hover:opacity-100"
+                        class="has-[details[open]]:visible invisible flex items-center space-x-1 focus-within:visible group-hover:visible"
                       >
                         <button
                           v-if="isSensitive(key)"
@@ -1533,24 +1627,12 @@ onBeforeUnmount(() => {
                             />
                           </svg>
                         </button>
-                        <button
-                          @click="removeVar(key)"
-                          class="rounded p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
-                        >
-                          <svg
-                            class="h-4 w-4"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                          </svg>
-                        </button>
+                        <ConfigVariableMenu
+                          :variable-key="key"
+                          :metadata="metadataFor(key)"
+                          @update="updateVarMetadata(key, $event)"
+                          @remove="removeVar(key)"
+                        />
                       </div>
                     </div>
                     <input
@@ -1566,6 +1648,12 @@ onBeforeUnmount(() => {
                       spellcheck="false"
                       class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                     />
+                    <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                      {{ metadataSummary(key) }}
+                      <template v-if="changeSummary(key)">
+                        · {{ changeSummary(key) }}
+                      </template>
+                    </p>
                   </div>
                 </div>
                 <div

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -592,7 +592,7 @@ function executeRollback() {
         </div>
 
         <!-- Metadata -->
-        <div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
+        <div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-5">
           <div>
             <dt class="text-xs text-gray-500 dark:text-gray-400">
               Triggered by
@@ -625,6 +625,18 @@ function executeRollback() {
                 class="ml-1 font-mono text-xs text-gray-500"
               >
                 {{ deployment.gitCommit.slice(0, 7) }}
+              </span>
+            </dd>
+          </div>
+          <div v-if="deployment.configHash" data-test="config-fingerprint">
+            <dt class="text-xs text-gray-500 dark:text-gray-400">Config</dt>
+            <dd
+              :title="deployment.configHash"
+              class="mt-1 font-mono text-sm text-gray-900 dark:text-white"
+            >
+              {{ deployment.configHash.slice(0, 12) }}
+              <span class="font-sans text-xs text-gray-400 dark:text-gray-500">
+                · {{ deployment.configManifest?.length || 0 }} vars
               </span>
             </dd>
           </div>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -15,6 +15,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
+import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
 import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
@@ -31,6 +32,7 @@ const props = defineProps({
   app: Object,
   apps: Array,
   envVars: Object,
+  envVarMetadata: Object,
   deploymentHistory: Object,
   checklist: Array,
   serviceVersions: Object,
@@ -293,11 +295,19 @@ function cancelAddApp() {
 
 // --- Env vars management ---
 const localVars = reactive({ ...props.envVars })
+const localMetadata = reactive({ ...props.envVarMetadata })
 watch(
   () => props.envVars,
   (newVars) => {
     Object.keys(localVars).forEach((k) => delete localVars[k])
     Object.assign(localVars, newVars)
+  }
+)
+watch(
+  () => props.envVarMetadata,
+  (newMetadata) => {
+    Object.keys(localMetadata).forEach((k) => delete localMetadata[k])
+    Object.assign(localMetadata, newMetadata || {})
   }
 )
 const revealedKeys = ref(new Set())
@@ -339,7 +349,7 @@ function exitBulkMode() {
   bulkMode.value = false
 }
 
-function saveBulk() {
+async function saveBulk() {
   const vars = {}
   for (const line of bulkText.value.split('\n')) {
     const trimmed = line.trim()
@@ -355,15 +365,23 @@ function saveBulk() {
     .sort()
     .map((k) => localVars[k])
     .join(',')
-  Object.keys(localVars).forEach((k) => delete localVars[k])
-  Object.assign(localVars, vars)
-  const newKeys = Object.keys(localVars).sort().join(',')
-  const newVals = Object.keys(localVars)
+  const nextMetadata = Object.fromEntries(
+    Object.keys(vars).map((key) => [
+      key,
+      localMetadata[key] || { kind: 'secret', previewPolicy: 'omit' }
+    ])
+  )
+  const newKeys = Object.keys(vars).sort().join(',')
+  const newVals = Object.keys(vars)
     .sort()
-    .map((k) => localVars[k])
+    .map((k) => vars[k])
     .join(',')
   if (oldKeys !== newKeys || oldVals !== newVals) {
-    saveEnvVars(localVars)
+    if (!(await saveEnvVars(vars, nextMetadata))) return
+    Object.keys(localVars).forEach((k) => delete localVars[k])
+    Object.assign(localVars, vars)
+    Object.keys(localMetadata).forEach((key) => delete localMetadata[key])
+    Object.assign(localMetadata, nextMetadata)
     toast({ message: 'Environment variables updated', type: 'success' })
   }
   bulkMode.value = false
@@ -409,8 +427,45 @@ function closeAllDropdowns() {
 }
 
 // --- Env vars helpers ---
-function isSensitive() {
-  return true
+function metadataFor(key) {
+  const metadata = localMetadata[key] || {}
+  const kind = metadata.kind === 'plain' ? 'plain' : 'secret'
+  return {
+    ...metadata,
+    kind,
+    managed: metadata.managed === true,
+    previewPolicy:
+      metadata.previewPolicy || (kind === 'plain' ? 'inherit' : 'omit')
+  }
+}
+
+function isSensitive(key) {
+  return metadataFor(key).kind === 'secret'
+}
+
+function metadataSummary(key) {
+  const metadata = metadataFor(key)
+  const type = metadata.managed
+    ? 'Managed secret'
+    : metadata.kind === 'secret'
+    ? 'Secret'
+    : 'Plain config'
+  const preview = {
+    omit: 'omitted from previews',
+    inherit: 'inherited by previews',
+    randomize: 'regenerated for previews'
+  }[metadata.previewPolicy]
+  return `${type} · ${preview}`
+}
+
+function changeSummary(key) {
+  const metadata = metadataFor(key)
+  return [
+    metadata.changedByName,
+    metadata.changedAt ? timeAgo(metadata.changedAt) : null
+  ]
+    .filter(Boolean)
+    .join(' · ')
 }
 
 function toggleReveal(key) {
@@ -434,43 +489,73 @@ function generateSecret() {
   ).join('')
 }
 
-async function saveEnvVars(vars) {
+async function saveEnvVars(vars, metadata = localMetadata) {
   saving.value = true
   try {
-    await fetch(
+    const response = await fetch(
       `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}`,
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ envVars: vars })
+        body: JSON.stringify({
+          envVars: { ...vars },
+          envVarMetadata: { ...metadata }
+        })
       }
     )
+    if (!response.ok) {
+      throw new Error('Environment variables could not be saved.')
+    }
     router.reload({
-      only: ['envVars', 'environment', 'checklist'],
+      only: ['envVars', 'envVarMetadata', 'environment', 'checklist'],
       preserveScroll: true
     })
+    return true
+  } catch (error) {
+    toast({ message: error.message, type: 'error' })
+    router.reload({
+      only: ['envVars', 'envVarMetadata'],
+      preserveScroll: true
+    })
+    return false
   } finally {
     saving.value = false
   }
 }
 
-function addVar() {
+async function addVar() {
   if (!newKey.value.trim()) return
   const key = newKey.value.trim()
-  localVars[key] = newValue.value
-  saveEnvVars(localVars)
+  const nextVars = { ...localVars, [key]: newValue.value }
+  const nextMetadata = {
+    ...localMetadata,
+    [key]: { kind: 'secret', previewPolicy: 'omit' }
+  }
+  if (!(await saveEnvVars(nextVars, nextMetadata))) return
+  Object.assign(localVars, nextVars)
+  Object.assign(localMetadata, nextMetadata)
   toast({ message: `Added "${key}"`, type: 'success' })
   newKey.value = ''
   newValue.value = ''
 }
 
-function removeVar(key) {
+async function removeVar(key) {
+  if (metadataFor(key).managed) return
+  const nextVars = { ...localVars }
+  const nextMetadata = { ...localMetadata }
+  delete nextVars[key]
+  delete nextMetadata[key]
+  if (!(await saveEnvVars(nextVars, nextMetadata))) return
   delete localVars[key]
-  saveEnvVars(localVars)
+  delete localMetadata[key]
   toast({ message: `Removed "${key}"`, type: 'success' })
 }
 
-function renameVar(oldKey, el) {
+async function renameVar(oldKey, el) {
+  if (metadataFor(oldKey).managed) {
+    el.value = oldKey
+    return
+  }
   const trimmed = el.value.trim()
   if (!trimmed || trimmed === oldKey) {
     el.value = oldKey
@@ -481,17 +566,36 @@ function renameVar(oldKey, el) {
     el.value = oldKey
     return
   }
-  const value = localVars[oldKey]
+  const nextVars = { ...localVars }
+  const nextMetadata = { ...localMetadata }
+  const value = nextVars[oldKey]
+  const metadata = metadataFor(oldKey)
+  delete nextVars[oldKey]
+  delete nextMetadata[oldKey]
+  nextVars[trimmed] = value
+  nextMetadata[trimmed] = metadata
+  if (!(await saveEnvVars(nextVars, nextMetadata))) return
   delete localVars[oldKey]
+  delete localMetadata[oldKey]
   localVars[trimmed] = value
-  saveEnvVars(localVars)
+  localMetadata[trimmed] = metadata
   toast({ message: `Renamed "${oldKey}" to "${trimmed}"`, type: 'success' })
 }
 
-function updateVarValue(key, value) {
+async function updateVarValue(key, value) {
+  if (metadataFor(key).managed) return
   if (localVars[key] === value) return
+  const nextVars = { ...localVars, [key]: value }
+  if (!(await saveEnvVars(nextVars, localMetadata))) return
   localVars[key] = value
-  saveEnvVars(localVars)
+  toast({ message: `Updated "${key}"`, type: 'success' })
+}
+
+async function updateVarMetadata(key, metadata) {
+  if (metadataFor(key).managed) return
+  const nextMetadata = { ...localMetadata, [key]: metadata }
+  if (!(await saveEnvVars(localVars, nextMetadata))) return
+  localMetadata[key] = metadata
   toast({ message: `Updated "${key}"`, type: 'success' })
 }
 
@@ -627,7 +731,9 @@ async function createService() {
     newServiceVersion.value = selectedServicePolicy.value?.defaultVersion || ''
     customServiceVersion.value = false
     addServiceOpen.value = false
-    router.reload({ only: ['environment', 'envVars', 'checklist'] })
+    router.reload({
+      only: ['environment', 'envVars', 'envVarMetadata', 'checklist']
+    })
   } catch (err) {
     completeAction(actionId, false)
     toast({
@@ -721,7 +827,9 @@ async function executeDeleteService() {
         type: 'error'
       })
     }
-    router.reload({ only: ['environment', 'envVars', 'checklist'] })
+    router.reload({
+      only: ['environment', 'envVars', 'envVarMetadata', 'checklist']
+    })
   } catch (error) {
     toast({
       message: error.message || 'Failed to delete service',
@@ -2411,7 +2519,7 @@ onBeforeUnmount(() => {
           </div>
 
           <!-- Environment Variables -->
-          <div>
+          <div data-test="environment-config">
             <div class="flex items-center justify-between px-4 py-3">
               <button
                 @click="envVarsOpen = !envVarsOpen"
@@ -2528,6 +2636,7 @@ onBeforeUnmount(() => {
                     <div class="flex items-center justify-between">
                       <input
                         :value="key"
+                        :readonly="metadataFor(key).managed"
                         @blur="renameVar(key, $event.target)"
                         @keydown.enter="$event.target.blur()"
                         autocomplete="off"
@@ -2535,7 +2644,7 @@ onBeforeUnmount(() => {
                         class="min-w-0 flex-1 border-b border-dashed border-transparent bg-transparent font-mono text-sm font-medium text-gray-900 focus:border-gray-300 focus:outline-none dark:text-white dark:focus:border-gray-600"
                       />
                       <div
-                        class="flex items-center space-x-1 opacity-0 transition-opacity group-hover:opacity-100"
+                        class="has-[details[open]]:visible invisible flex items-center space-x-1 focus-within:visible group-hover:visible"
                       >
                         <button
                           v-if="isSensitive(key)"
@@ -2577,28 +2686,17 @@ onBeforeUnmount(() => {
                             />
                           </svg>
                         </button>
-                        <button
-                          @click="removeVar(key)"
-                          class="rounded p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
-                        >
-                          <svg
-                            class="h-4 w-4"
-                            fill="none"
-                            stroke="currentColor"
-                            viewBox="0 0 24 24"
-                          >
-                            <path
-                              stroke-linecap="round"
-                              stroke-linejoin="round"
-                              stroke-width="2"
-                              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                            />
-                          </svg>
-                        </button>
+                        <ConfigVariableMenu
+                          :variable-key="key"
+                          :metadata="metadataFor(key)"
+                          @update="updateVarMetadata(key, $event)"
+                          @remove="removeVar(key)"
+                        />
                       </div>
                     </div>
                     <input
                       :value="localVars[key]"
+                      :readonly="metadataFor(key).managed"
                       :type="
                         isSensitive(key) && !revealedKeys.has(key)
                           ? 'password'
@@ -2610,6 +2708,12 @@ onBeforeUnmount(() => {
                       spellcheck="false"
                       class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                     />
+                    <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                      {{ metadataSummary(key) }}
+                      <template v-if="changeSummary(key)">
+                        · {{ changeSummary(key) }}
+                      </template>
+                    </p>
                   </div>
                 </div>
                 <div

--- a/assets/js/pages/settings/global-env.vue
+++ b/assets/js/pages/settings/global-env.vue
@@ -4,6 +4,7 @@ import { inject, ref, reactive, computed, watch, onMounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
+import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
 import { useToast } from '@/composables/toast'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
@@ -13,6 +14,7 @@ defineOptions({
 
 const props = defineProps({
   globalEnvVars: Object,
+  globalEnvVarMetadata: Object,
   backupConfigured: Boolean
 })
 
@@ -22,6 +24,7 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 const toast = useToast()
 
 const localVars = reactive({ ...props.globalEnvVars })
+const localMetadata = reactive({ ...props.globalEnvVarMetadata })
 const newKey = ref('')
 const newValue = ref('')
 const saving = ref(false)
@@ -31,8 +34,62 @@ const revealedKeys = ref(new Set())
 
 const sortedVarKeys = computed(() => Object.keys(localVars).sort())
 
-function isSensitive() {
-  return true
+function metadataFor(key) {
+  const metadata = localMetadata[key] || {}
+  const kind = metadata.kind === 'plain' ? 'plain' : 'secret'
+  return {
+    ...metadata,
+    kind,
+    managed: metadata.managed === true,
+    previewPolicy:
+      metadata.previewPolicy || (kind === 'plain' ? 'inherit' : 'omit')
+  }
+}
+
+function isSensitive(key) {
+  return metadataFor(key).kind === 'secret'
+}
+
+function metadataSummary(key) {
+  const metadata = metadataFor(key)
+  const type = metadata.managed
+    ? 'Managed secret'
+    : metadata.kind === 'secret'
+    ? 'Secret'
+    : 'Plain config'
+  const preview = {
+    omit: 'omitted from previews',
+    inherit: 'inherited by previews',
+    randomize: 'regenerated for previews'
+  }[metadata.previewPolicy]
+  return `${type} · ${preview}`
+}
+
+function changeSummary(key) {
+  const metadata = metadataFor(key)
+  return [
+    metadata.changedByName,
+    metadata.changedAt ? timeAgo(metadata.changedAt) : null
+  ]
+    .filter(Boolean)
+    .join(' · ')
+}
+
+function timeAgo(timestamp) {
+  const seconds = Math.max(0, Math.floor((Date.now() - timestamp) / 1000))
+  const intervals = [
+    ['year', 31536000],
+    ['month', 2592000],
+    ['week', 604800],
+    ['day', 86400],
+    ['hour', 3600],
+    ['minute', 60]
+  ]
+  for (const [label, interval] of intervals) {
+    const count = Math.floor(seconds / interval)
+    if (count >= 1) return `${count} ${label}${count > 1 ? 's' : ''} ago`
+  }
+  return 'just now'
 }
 
 function toggleReveal(key) {
@@ -58,6 +115,7 @@ function generateSecret() {
 
 const envForm = useForm({
   envVars: { ...props.globalEnvVars },
+  envVarMetadata: { ...props.globalEnvVarMetadata },
   envSource: ''
 })
   .withPrecognition('patch', '/settings/global-env')
@@ -66,6 +124,11 @@ const envForm = useForm({
 function replaceLocalVars(vars) {
   Object.keys(localVars).forEach((key) => delete localVars[key])
   Object.assign(localVars, vars)
+}
+
+function replaceLocalMetadata(metadata) {
+  Object.keys(localMetadata).forEach((key) => delete localMetadata[key])
+  Object.assign(localMetadata, metadata)
 }
 
 function submitVars(onSuccess) {
@@ -81,8 +144,12 @@ function submitVars(onSuccess) {
   })
 }
 
-function saveVars(vars, { envSource = '', onSuccess } = {}) {
+function saveVars(
+  vars,
+  { metadata = localMetadata, envSource = '', onSuccess } = {}
+) {
   envForm.envVars = { ...vars }
+  envForm.envVarMetadata = { ...metadata }
   envForm.envSource = envSource
   envForm.validate('envVars', {
     onPrecognitionSuccess: () => submitVars(onSuccess)
@@ -93,9 +160,15 @@ function addVar() {
   if (!newKey.value.trim()) return
   const key = newKey.value.trim()
   const nextVars = { ...localVars, [key]: newValue.value }
+  const nextMetadata = {
+    ...localMetadata,
+    [key]: { kind: 'secret', previewPolicy: 'omit' }
+  }
   saveVars(nextVars, {
+    metadata: nextMetadata,
     onSuccess: () => {
       replaceLocalVars(nextVars)
+      replaceLocalMetadata(nextMetadata)
       toast({ message: `Added "${key}"`, type: 'success' })
       newKey.value = ''
       newValue.value = ''
@@ -105,10 +178,14 @@ function addVar() {
 
 function removeVar(key) {
   const nextVars = { ...localVars }
+  const nextMetadata = { ...localMetadata }
   delete nextVars[key]
+  delete nextMetadata[key]
   saveVars(nextVars, {
+    metadata: nextMetadata,
     onSuccess: () => {
       replaceLocalVars(nextVars)
+      replaceLocalMetadata(nextMetadata)
       toast({ message: `Removed "${key}"`, type: 'success' })
     }
   })
@@ -127,15 +204,32 @@ function renameVar(oldKey, el) {
   }
   const value = localVars[oldKey]
   const nextVars = { ...localVars }
+  const nextMetadata = { ...localMetadata }
   delete nextVars[oldKey]
+  const metadata = nextMetadata[oldKey]
+  delete nextMetadata[oldKey]
   nextVars[trimmed] = value
+  nextMetadata[trimmed] = metadata || metadataFor(oldKey)
   saveVars(nextVars, {
+    metadata: nextMetadata,
     onSuccess: () => {
       replaceLocalVars(nextVars)
+      replaceLocalMetadata(nextMetadata)
       toast({
         message: `Renamed "${oldKey}" to "${trimmed}"`,
         type: 'success'
       })
+    }
+  })
+}
+
+function updateVarMetadata(key, metadata) {
+  const nextMetadata = { ...localMetadata, [key]: metadata }
+  saveVars(localVars, {
+    metadata: nextMetadata,
+    onSuccess: () => {
+      replaceLocalMetadata(nextMetadata)
+      toast({ message: `Updated "${key}"`, type: 'success' })
     }
   })
 }
@@ -203,10 +297,18 @@ function saveBulk() {
     .map((k) => vars[k])
     .join(',')
   if (oldKeys !== newKeys || oldVals !== newVals) {
+    const nextMetadata = Object.fromEntries(
+      Object.keys(vars).map((key) => [
+        key,
+        localMetadata[key] || { kind: 'secret', previewPolicy: 'omit' }
+      ])
+    )
     saveVars(vars, {
+      metadata: nextMetadata,
       envSource: bulkText.value,
       onSuccess: () => {
         replaceLocalVars(vars)
+        replaceLocalMetadata(nextMetadata)
         bulkMode.value = false
         toast({ message: 'Environment variables updated', type: 'success' })
       }
@@ -437,7 +539,10 @@ onMounted(() => {
         </div>
 
         <!-- Variables -->
-        <div class="rounded-lg border border-gray-200 dark:border-gray-800">
+        <div
+          data-test="global-config"
+          class="rounded-lg border border-gray-200 dark:border-gray-800"
+        >
           <!-- Header with bulk toggle -->
           <div class="px-4 py-3">
             <div class="flex items-center justify-between">
@@ -488,10 +593,10 @@ onMounted(() => {
               </div>
             </div>
             <p
-              v-if="envForm.errors.envVars"
+              v-if="envForm.errors.envVars || envForm.errors.envVarMetadata"
               class="mt-1 text-sm text-red-600 dark:text-red-400"
             >
-              {{ envForm.errors.envVars }}
+              {{ envForm.errors.envVars || envForm.errors.envVarMetadata }}
             </p>
           </div>
 
@@ -534,6 +639,7 @@ onMounted(() => {
                 <div class="flex items-center justify-between">
                   <input
                     :value="key"
+                    :readonly="metadataFor(key).managed"
                     @blur="renameVar(key, $event.target)"
                     @keydown.enter="$event.target.blur()"
                     autocomplete="off"
@@ -581,28 +687,17 @@ onMounted(() => {
                         />
                       </svg>
                     </button>
-                    <button
-                      @click="removeVar(key)"
-                      class="rounded p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400"
-                    >
-                      <svg
-                        class="h-4 w-4"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
-                        />
-                      </svg>
-                    </button>
+                    <ConfigVariableMenu
+                      :variable-key="key"
+                      :metadata="metadataFor(key)"
+                      @update="updateVarMetadata(key, $event)"
+                      @remove="removeVar(key)"
+                    />
                   </div>
                 </div>
                 <input
                   :value="localVars[key]"
+                  :readonly="metadataFor(key).managed"
                   :type="
                     isSensitive(key) && !revealedKeys.has(key)
                       ? 'password'
@@ -614,6 +709,12 @@ onMounted(() => {
                   spellcheck="false"
                   class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                 />
+                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                  {{ metadataSummary(key) }}
+                  <template v-if="changeSummary(key)">
+                    · {{ changeSummary(key) }}
+                  </template>
+                </p>
               </div>
             </div>
 

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -13,6 +13,7 @@ module.exports.bootstrap = async function () {
   // Production uses `migrate: safe`; create coordinator tables before any
   // deployment job queries run on an existing installation.
   await sails.helpers.cleanup.ensureSchema()
+  await sails.helpers.configuration.ensureSchema()
   await sails.helpers.deploy.ensureQueueSchema()
   await sails.helpers.service.ensureVersionSchema()
   await sails.helpers.lookout.ensureObservabilitySchema()

--- a/packages/cli/src/commands/env-list.js
+++ b/packages/cli/src/commands/env-list.js
@@ -23,6 +23,7 @@ export default async function envList(options) {
     )
 
     const vars = env.envVars || {}
+    const metadata = env.envVarMetadata || {}
     const keys = Object.keys(vars).sort()
 
     if (keys.length === 0) {
@@ -39,7 +40,7 @@ export default async function envList(options) {
     for (const key of keys) {
       const value = vars[key]
       // Mask sensitive values
-      const masked = shouldMask(key) ? '••••••••' : value
+      const masked = shouldMask(key, metadata) ? '••••••••' : value
       console.log(`  ${c.dim(key + '=')}${masked}`)
     }
 
@@ -50,7 +51,9 @@ export default async function envList(options) {
 }
 
 // Keys that should have their values masked
-function shouldMask(key) {
+function shouldMask(key, metadata) {
+  if (metadata[key]?.kind) return metadata[key].kind !== 'plain'
+
   const sensitivePatterns = [
     'PASSWORD',
     'SECRET',

--- a/packages/cli/src/commands/environment-create.js
+++ b/packages/cli/src/commands/environment-create.js
@@ -21,6 +21,7 @@ export default async function environmentCreate(options, positionals) {
     const data = { name }
     if (options.production) data.isProduction = true
     if (options.domain) data.domain = options.domain
+    if (options.from) data.sourceEnvironmentSlug = options.from
 
     const { environment } = await api.environments.create(project.project, data)
 

--- a/packages/cli/src/index.js
+++ b/packages/cli/src/index.js
@@ -65,7 +65,8 @@ const commands = {
     args: '<name>',
     options: {
       production: { type: 'boolean', short: 'p' },
-      domain: { type: 'string', short: 'd' }
+      domain: { type: 'string', short: 'd' },
+      from: { type: 'string', short: 'f' }
     }
   },
   'environment:update': {

--- a/tests/e2e/pages/projects/configuration-secrets.test.js
+++ b/tests/e2e/pages/projects/configuration-secrets.test.js
@@ -1,0 +1,194 @@
+const { test } = require('sounding')
+
+const world = {
+  name: 'configured-slipway',
+  context: {
+    deploymentTarget: {
+      slug: 'configuration-secrets-ui',
+      name: 'Configuration Secrets UI'
+    }
+  }
+}
+
+async function navigateAfterUpdateCheck(page, target) {
+  const updateCheckFinished = page.raw.waitForResponse(
+    '**/api/v1/system/check-update'
+  )
+  await page.goto(target)
+  await updateCheckFinished
+}
+
+async function screenshotConfig(page, selector, path) {
+  const section = page.raw.locator(`[data-test="${selector}"]`)
+  await section.evaluate((element) =>
+    element.scrollIntoView({ block: 'center', inline: 'nearest' })
+  )
+  await page.wait(100)
+  await page.screenshot(path)
+}
+
+test(
+  'configuration metadata stays minimal and legible in light and dark mode',
+  { browser: true, world },
+  async ({ sails, world: currentWorld, login, page, expect }) => {
+    const current = currentWorld.current
+    const changedAt = Date.now() - 5 * 60 * 1000
+    const changedBy = String(current.users.genesisUser.id)
+    const changedByName = current.users.genesisUser.fullName
+
+    await sails.models.environment
+      .updateOne({ id: current.environments.production.id })
+      .set({
+        envVars: {
+          DATABASE_URL: 'postgresql://managed',
+          RELEASE_CHANNEL: 'stable'
+        },
+        envVarMetadata: {
+          DATABASE_URL: {
+            kind: 'secret',
+            managed: true,
+            previewPolicy: 'omit',
+            description: 'Connection URL managed by main-db',
+            changedAt,
+            changedBy,
+            changedByName
+          },
+          RELEASE_CHANNEL: {
+            kind: 'plain',
+            managed: false,
+            previewPolicy: 'inherit',
+            changedAt,
+            changedBy,
+            changedByName
+          }
+        }
+      })
+    await currentWorld.create('service').with({
+      name: 'main-db',
+      environment: current.environments.production.id,
+      envVarKey: 'DATABASE_URL',
+      status: 'stopped'
+    })
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      secureEnvVars: { APP_SIGNING_SECRET: 'app-secret' },
+      envVars: {},
+      envVarMetadata: {
+        APP_SIGNING_SECRET: {
+          kind: 'secret',
+          managed: false,
+          previewPolicy: 'randomize',
+          description: 'Signs application sessions',
+          changedAt,
+          changedBy,
+          changedByName
+        }
+      }
+    })
+    await sails.helpers.setting.set(
+      'globalEnvVars',
+      JSON.stringify({ GLOBAL_REGION: 'eu-central' })
+    )
+    await sails.helpers.setting.set(
+      'globalEnvVarMetadata',
+      JSON.stringify({
+        GLOBAL_REGION: {
+          kind: 'plain',
+          managed: false,
+          previewPolicy: 'inherit',
+          changedAt,
+          changedBy,
+          changedByName
+        }
+      })
+    )
+    const deployment = await currentWorld.create('deployment').with({
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      status: 'running',
+      startedAt: Date.now() - 10000,
+      finishedAt: Date.now(),
+      configHash:
+        '01ac25cead174bfd49274d3ce5f84fc880118092f44470a4ad6e1204b7c2d75',
+      configManifest: [
+        { key: 'GLOBAL_REGION', scope: 'global', kind: 'plain' },
+        { key: 'DATABASE_URL', scope: 'environment', kind: 'secret' },
+        { key: 'APP_SIGNING_SECRET', scope: 'app', kind: 'secret' }
+      ]
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await page.resize(1440, 1000)
+    await page.inLightMode()
+    const loginUpdateCheckFinished = page.raw.waitForResponse(
+      '**/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await loginUpdateCheckFinished
+
+    await navigateAfterUpdateCheck(
+      page,
+      '/projects/configuration-secrets-ui/environments/production?env=1'
+    )
+    await page.wait('@environment-config')
+    await page.raw.locator('input[value="DATABASE_URL"]').hover()
+    await page.raw
+      .locator('[data-test="config-menu-DATABASE_URL"] summary')
+      .click()
+    await expect(page).toSee(
+      'Managed by Slipway. Change or remove the service that owns this value.'
+    )
+    await screenshotConfig(
+      page,
+      'environment-config',
+      '.tmp/issue-200-environment-secrets-light.png'
+    )
+
+    await page.inDarkMode()
+    await navigateAfterUpdateCheck(
+      page,
+      '/projects/configuration-secrets-ui/environments/production/apps/web?env=1'
+    )
+    await page.wait('@app-config')
+    await page.raw.locator('input[value="APP_SIGNING_SECRET"]').hover()
+    await page.raw
+      .locator('[data-test="config-menu-APP_SIGNING_SECRET"] summary')
+      .click()
+    await expect(page).toSee('Generate a new value')
+    await screenshotConfig(
+      page,
+      'app-config',
+      '.tmp/issue-200-app-secrets-dark.png'
+    )
+
+    await page.inLightMode()
+    await navigateAfterUpdateCheck(page, '/settings/global-env')
+    await page.wait('@global-config')
+    await page.raw
+      .locator('[data-test="config-menu-GLOBAL_REGION"] summary')
+      .click()
+    await screenshotConfig(
+      page,
+      'global-config',
+      '.tmp/issue-200-global-config-light.png'
+    )
+
+    await page.inDarkMode()
+    await navigateAfterUpdateCheck(
+      page,
+      `/projects/configuration-secrets-ui/deployments/${deployment.id}`
+    )
+    await page.wait('@config-fingerprint')
+    await page.screenshot('.tmp/issue-200-deployment-config-dark.png')
+    await expect(page).toSee('01ac25cead17')
+    await expect(page).toSee('3 vars')
+    expect(page).toHaveNoSmoke()
+  }
+)

--- a/tests/functional/api/configuration-secrets.test.js
+++ b/tests/functional/api/configuration-secrets.test.js
@@ -1,0 +1,217 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'app secrets are encrypted and configuration audits never retain their values',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'encrypted-app-secrets',
+          name: 'Encrypted app secrets'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const secret = 'never-write-this-value-to-an-audit-log'
+    const dashboard = await withCsrfFromPage(
+      request,
+      `/projects/encrypted-app-secrets/environments/production/apps/${app.slug}`,
+      'genesisUser'
+    )
+
+    const response = await dashboard.request.patch(
+      `/api/v1/projects/encrypted-app-secrets/environments/production/apps/${app.slug}`,
+      {
+        envVars: { APP_SECRET: secret },
+        envVarMetadata: {
+          APP_SECRET: {
+            kind: 'secret',
+            previewPolicy: 'randomize',
+            description: 'Application signing secret'
+          }
+        }
+      }
+    )
+
+    expect(response).toHaveStatus(200)
+    expect(JSON.stringify(response.data).includes(secret)).toBe(false)
+    const persisted = await sails.models.app.findOne({ id: app.id }).decrypt()
+    expect(persisted.secureEnvVars.APP_SECRET).toBe(secret)
+    expect(persisted.envVars).toEqual({})
+    expect(persisted.envVarMetadata.APP_SECRET.kind).toBe('secret')
+    expect(persisted.envVarMetadata.APP_SECRET.previewPolicy).toBe('randomize')
+
+    const audit = await sails.models.auditlog.findOne({
+      action: 'configuration.created',
+      resourceType: 'app',
+      resourceId: String(app.id)
+    })
+    expect(audit.details.key).toBe('APP_SECRET')
+    expect(JSON.stringify(audit).includes(secret)).toBe(false)
+  }
+)
+
+test(
+  'managed service variables cannot be changed through the environment API',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'managed-environment-secrets',
+          name: 'Managed environment secrets'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const environment = current.environments.production
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      envVars: { DATABASE_URL: 'postgresql://managed' },
+      envVarMetadata: {
+        DATABASE_URL: {
+          kind: 'secret',
+          managed: true,
+          previewPolicy: 'omit'
+        }
+      }
+    })
+    await world.create('service').with({
+      name: 'main-db',
+      environment: environment.id,
+      envVarKey: 'DATABASE_URL'
+    })
+    const dashboard = await withCsrfFromPage(
+      request,
+      '/projects/managed-environment-secrets/environments/production',
+      'genesisUser'
+    )
+
+    const response = await dashboard.request.patch(
+      '/api/v1/projects/managed-environment-secrets/environments/production',
+      {
+        envVars: { DATABASE_URL: 'postgresql://managed' },
+        envVarMetadata: {
+          DATABASE_URL: { kind: 'plain', previewPolicy: 'inherit' }
+        }
+      }
+    )
+
+    expect(response).toHaveStatus(303)
+    const persisted = await sails.models.environment
+      .findOne({ id: environment.id })
+      .decrypt()
+    expect(persisted.envVars.DATABASE_URL).toBe('postgresql://managed')
+    expect(persisted.envVarMetadata.DATABASE_URL.managed).toBe(true)
+
+    const appResponse = await dashboard.request.patch(
+      '/api/v1/projects/managed-environment-secrets/environments/production/apps/web',
+      {
+        envVars: { DATABASE_URL: 'postgresql://app-shadow' },
+        envVarMetadata: {
+          DATABASE_URL: { kind: 'secret', previewPolicy: 'omit' }
+        }
+      }
+    )
+    expect(appResponse).toHaveStatus(303)
+  }
+)
+
+test(
+  'global configuration changes retain metadata and write value-free audits',
+  { world: 'configured-slipway' },
+  async ({ sails, request, expect }) => {
+    const secret = 'global-secret-that-must-not-enter-the-audit-log'
+    const dashboard = await withCsrfFromPage(
+      request,
+      '/settings/global-env',
+      'genesisUser'
+    )
+
+    const response = await dashboard.request.patch('/settings/global-env', {
+      envVars: { GLOBAL_SIGNING_KEY: secret },
+      envVarMetadata: {
+        GLOBAL_SIGNING_KEY: { kind: 'secret', previewPolicy: 'omit' }
+      }
+    })
+
+    expect(response).toHaveStatus(409)
+    expect(response).toHaveHeader('x-inertia-location', '/settings/global-env')
+    const values = JSON.parse(
+      await sails.helpers.setting.get('globalEnvVars', '{}')
+    )
+    const metadata = JSON.parse(
+      await sails.helpers.setting.get('globalEnvVarMetadata', '{}')
+    )
+    expect(values.GLOBAL_SIGNING_KEY).toBe(secret)
+    expect(metadata.GLOBAL_SIGNING_KEY.previewPolicy).toBe('omit')
+
+    const audit = await sails.models.auditlog.findOne({
+      action: 'configuration.created',
+      resourceType: 'setting',
+      resourceId: 'globalEnvVars'
+    })
+    expect(audit.details.key).toBe('GLOBAL_SIGNING_KEY')
+    expect(JSON.stringify(audit).includes(secret)).toBe(false)
+  }
+)
+
+test(
+  'preview environments apply explicit per-variable inheritance policies',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'preview-config-policy',
+          name: 'Preview config policy'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const environment = world.current.environments.production
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      envVars: {
+        OMITTED_SECRET: 'production-only',
+        RANDOM_SECRET: 'production-random-source',
+        PUBLIC_MODE: 'staging'
+      },
+      envVarMetadata: {
+        OMITTED_SECRET: { kind: 'secret', previewPolicy: 'omit' },
+        RANDOM_SECRET: { kind: 'secret', previewPolicy: 'randomize' },
+        PUBLIC_MODE: { kind: 'plain', previewPolicy: 'inherit' }
+      }
+    })
+    const dashboard = await withCsrfFromPage(
+      request,
+      '/projects/preview-config-policy/environments/production',
+      'genesisUser'
+    )
+
+    const response = await dashboard.request.post(
+      '/api/v1/projects/preview-config-policy/environments',
+      {
+        name: 'Preview 42',
+        sourceEnvironmentSlug: 'production'
+      }
+    )
+
+    expect(response).toHaveStatus(201)
+    const preview = await sails.models.environment
+      .findOne({ project: environment.project, slug: 'preview-42' })
+      .decrypt()
+    expect(preview.envVars.OMITTED_SECRET).toBe(undefined)
+    expect(preview.envVars.RANDOM_SECRET === 'production-random-source').toBe(
+      false
+    )
+    expect(preview.envVars.PUBLIC_MODE).toBe('staging')
+    expect(preview.envVarMetadata.RANDOM_SECRET.previewPolicy).toBe('randomize')
+  }
+)

--- a/tests/unit/helpers/configuration/runtime-config.test.js
+++ b/tests/unit/helpers/configuration/runtime-config.test.js
@@ -1,0 +1,87 @@
+const { test } = require('sounding')
+
+test('config metadata defaults secrets to omit and keeps plain config inheritable', async ({
+  sails,
+  expect
+}) => {
+  const metadata = sails.helpers.configuration.normalizeEnvVarMetadata.with({
+    values: {
+      API_SECRET: 'do-not-log-this',
+      LOG_LEVEL: 'info'
+    },
+    metadata: {
+      LOG_LEVEL: { kind: 'plain' }
+    },
+    changedBy: '7',
+    changedByName: 'Builder'
+  })
+
+  expect(metadata.API_SECRET.kind).toBe('secret')
+  expect(metadata.API_SECRET.previewPolicy).toBe('omit')
+  expect(metadata.LOG_LEVEL.kind).toBe('plain')
+  expect(metadata.LOG_LEVEL.previewPolicy).toBe('inherit')
+  expect(metadata.API_SECRET.changedByName).toBe('Builder')
+})
+
+test('preview policy omits production secrets and regenerates selected values', async ({
+  sails,
+  expect
+}) => {
+  const sourceSecret = 'production-only-secret'
+  const preview = sails.helpers.configuration.applyPreviewPolicy(
+    {
+      DATABASE_URL: sourceSecret,
+      SESSION_SECRET: sourceSecret,
+      LOG_LEVEL: 'debug'
+    },
+    {
+      DATABASE_URL: { kind: 'secret', previewPolicy: 'omit' },
+      SESSION_SECRET: { kind: 'secret', previewPolicy: 'randomize' },
+      LOG_LEVEL: { kind: 'plain', previewPolicy: 'inherit' }
+    }
+  )
+
+  expect(preview.values.DATABASE_URL).toBe(undefined)
+  expect(preview.values.SESSION_SECRET === sourceSecret).toBe(false)
+  expect(preview.values.SESSION_SECRET.length > 20).toBe(true)
+  expect(preview.values.LOG_LEVEL).toBe('debug')
+})
+
+test('config diffs and fingerprints never contain secret values', async ({
+  sails,
+  expect
+}) => {
+  const oldSecret = 'old-private-value'
+  const newSecret = 'new-private-value'
+  const changes = sails.helpers.configuration.diffEnvVars(
+    { API_SECRET: oldSecret },
+    { API_SECRET: newSecret },
+    { API_SECRET: { kind: 'secret', previewPolicy: 'omit' } },
+    { API_SECRET: { kind: 'secret', previewPolicy: 'omit' } }
+  )
+  const fingerprint = sails.helpers.configuration.fingerprintRuntimeConfig.with(
+    {
+      values: { API_SECRET: newSecret, LOG_LEVEL: 'info' },
+      manifest: [
+        {
+          key: 'API_SECRET',
+          scope: 'app',
+          kind: 'secret',
+          managed: false,
+          previewPolicy: 'omit'
+        }
+      ]
+    }
+  )
+
+  expect(changes[0].operation).toBe('rotated')
+  expect(fingerprint.hash.length).toBe(64)
+  expect(fingerprint.manifest[0].key).toBe('API_SECRET')
+  expect(fingerprint.manifest[1].scope).toBe('platform')
+  expect(JSON.stringify({ changes, fingerprint }).includes(oldSecret)).toBe(
+    false
+  )
+  expect(JSON.stringify({ changes, fingerprint }).includes(newSecret)).toBe(
+    false
+  )
+})


### PR DESCRIPTION
## Summary

- add encrypted app-level configuration with safe metadata, managed ownership, and value-free audit history
- apply explicit inherit, omit, and randomize policies when creating preview environments
- resolve global, environment, app, and platform config centrally and attach a keyed fingerprint plus value-free manifest to every deployment
- evolve the existing minimal config surfaces for light and dark mode, including managed-value protection and change attribution
- preserve Bridge credential scope precedence and add CLI support for policy-aware environment copies

## Verification

- npm run lint
- npm run check:consistency
- 252 unit tests
- 93 functional tests
- 41 browser tests

Fixes #200