### PR TITLE
feat(flags): add safe Sails-native rollouts

### DIFF
--- a/api/controllers/api/v1/flag/create-flag.js
+++ b/api/controllers/api/v1/flag/create-flag.js
@@ -1,0 +1,100 @@
+module.exports = {
+  friendlyName: 'Create release flag',
+
+  description: 'Create a boolean release flag for one deployed app.',
+
+  inputs: {
+    projectSlug: { type: 'string', required: true },
+    environmentSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    key: { type: 'string', required: true },
+    description: { type: 'string', allowNull: true },
+    enabled: { type: 'boolean', defaultsTo: false },
+    rolloutPercentage: { type: 'number', defaultsTo: 0 },
+    targets: { type: 'json', defaultsTo: [] }
+  },
+
+  exits: {
+    success: { statusCode: 201 },
+    notFound: { statusCode: 404 },
+    badRequest: { responseType: 'badRequest' }
+  },
+
+  fn: async function (inputs) {
+    const context = await sails.helpers.flag.resolveApp
+      .with({
+        userId: String(this.req.session.userId),
+        projectSlug: inputs.projectSlug,
+        environmentSlug: inputs.environmentSlug,
+        appSlug: inputs.appSlug
+      })
+      .intercept('notFound', 'notFound')
+    const normalized = sails.helpers.flag.normalizeDefinition.with({
+      values: inputs,
+      requireKey: true
+    })
+    if (normalized.problems.length > 0) {
+      throw { badRequest: { problems: normalized.problems } }
+    }
+
+    if (
+      await FeatureFlag.findOne({
+        environment: context.environment.id,
+        app: context.app.id,
+        key: normalized.values.key
+      })
+    ) {
+      throw {
+        badRequest: {
+          problems: [{ key: 'A release flag with this key already exists.' }]
+        }
+      }
+    }
+
+    if (
+      (await FeatureFlag.count({
+        environment: context.environment.id,
+        app: context.app.id
+      })) >= 100
+    ) {
+      throw {
+        badRequest: {
+          problems: [{ key: 'An app can have at most 100 release flags.' }]
+        }
+      }
+    }
+
+    const flag = await FeatureFlag.create({
+      ...normalized.values,
+      environment: context.environment.id,
+      app: context.app.id,
+      changedBy: context.user.id,
+      changedByName: context.user.fullName
+    }).fetch()
+
+    await sails.helpers.audit.log.with({
+      action: 'feature_flag.created',
+      resourceType: 'feature_flag',
+      resourceId: String(flag.id),
+      details: auditDetails(flag, context),
+      userId: String(context.user.id),
+      teamId: String(context.project.team),
+      ipAddress: this.req.ip
+    })
+
+    return { flag: sails.helpers.flag.present(flag) }
+  }
+}
+
+function auditDetails(flag, context) {
+  return {
+    key: flag.key,
+    projectSlug: context.project.slug,
+    environmentSlug: context.environment.slug,
+    appSlug: context.app.slug,
+    enabled: flag.enabled === true,
+    rolloutPercentage: flag.rolloutPercentage,
+    targetCount: flag.targets.length,
+    version: flag.version
+  }
+}

--- a/api/controllers/api/v1/flag/destroy-flag.js
+++ b/api/controllers/api/v1/flag/destroy-flag.js
@@ -1,0 +1,52 @@
+module.exports = {
+  friendlyName: 'Destroy release flag',
+
+  description: 'Remove a retired release flag.',
+
+  inputs: {
+    projectSlug: { type: 'string', required: true },
+    environmentSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    flagId: { type: 'string', required: true }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 }
+  },
+
+  fn: async function (inputs) {
+    const context = await sails.helpers.flag.resolveApp
+      .with({
+        userId: String(this.req.session.userId),
+        projectSlug: inputs.projectSlug,
+        environmentSlug: inputs.environmentSlug,
+        appSlug: inputs.appSlug
+      })
+      .intercept('notFound', 'notFound')
+    const flag = await FeatureFlag.destroyOne({
+      id: inputs.flagId,
+      environment: context.environment.id,
+      app: context.app.id
+    })
+    if (!flag) throw 'notFound'
+
+    await sails.helpers.audit.log.with({
+      action: 'feature_flag.deleted',
+      resourceType: 'feature_flag',
+      resourceId: String(flag.id),
+      details: {
+        key: flag.key,
+        projectSlug: context.project.slug,
+        environmentSlug: context.environment.slug,
+        appSlug: context.app.slug,
+        version: flag.version
+      },
+      userId: String(context.user.id),
+      teamId: String(context.project.team),
+      ipAddress: this.req.ip
+    })
+
+    return { deleted: true }
+  }
+}

--- a/api/controllers/api/v1/flag/get-config.js
+++ b/api/controllers/api/v1/flag/get-config.js
@@ -1,0 +1,58 @@
+const crypto = require('crypto')
+
+module.exports = {
+  friendlyName: 'Get release flag config',
+
+  description:
+    'Return compiled boolean flag configuration to an authenticated deployed app.',
+
+  inputs: {
+    appId: { type: 'string', required: true }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    unauthorized: { statusCode: 401 },
+    notFound: { statusCode: 404 }
+  },
+
+  fn: async function ({ appId }) {
+    const authHeader = this.req.headers.authorization
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      throw 'unauthorized'
+    }
+    const token = authHeader.slice(7)
+    if (!token || !token.startsWith('stk_')) throw 'unauthorized'
+
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex')
+    const environment = await Environment.findOne({
+      telemetryTokenHash: tokenHash
+    })
+    if (!environment) throw 'unauthorized'
+
+    const app = await App.findOne({ id: appId, environment: environment.id })
+    if (!app) throw 'notFound'
+
+    const flags = (
+      await FeatureFlag.find({
+        environment: environment.id,
+        app: app.id
+      }).sort('key ASC')
+    ).map((flag) => sails.helpers.flag.present(flag))
+    const compiled = flags.map((flag) => ({
+      key: flag.key,
+      enabled: flag.enabled,
+      rolloutPercentage: flag.rolloutPercentage,
+      targets: flag.targets,
+      version: flag.version
+    }))
+    const version = crypto
+      .createHash('sha256')
+      .update(JSON.stringify(compiled))
+      .digest('hex')
+      .slice(0, 16)
+
+    this.res.set('Cache-Control', 'private, no-store')
+    return { version, flags: compiled }
+  }
+}

--- a/api/controllers/api/v1/flag/update-flag.js
+++ b/api/controllers/api/v1/flag/update-flag.js
@@ -1,0 +1,84 @@
+module.exports = {
+  friendlyName: 'Update release flag',
+
+  description:
+    'Update rollout rules or use the master switch without redeploying.',
+
+  inputs: {
+    projectSlug: { type: 'string', required: true },
+    environmentSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true },
+    flagId: { type: 'string', required: true },
+    description: { type: 'string', allowNull: true },
+    enabled: { type: 'boolean', required: true },
+    rolloutPercentage: { type: 'number', required: true },
+    targets: { type: 'json', required: true }
+  },
+
+  exits: {
+    success: { statusCode: 200 },
+    notFound: { statusCode: 404 },
+    badRequest: { responseType: 'badRequest' }
+  },
+
+  fn: async function (inputs) {
+    const context = await sails.helpers.flag.resolveApp
+      .with({
+        userId: String(this.req.session.userId),
+        projectSlug: inputs.projectSlug,
+        environmentSlug: inputs.environmentSlug,
+        appSlug: inputs.appSlug
+      })
+      .intercept('notFound', 'notFound')
+    const current = await FeatureFlag.findOne({
+      id: inputs.flagId,
+      environment: context.environment.id,
+      app: context.app.id
+    })
+    if (!current) throw 'notFound'
+
+    const normalized = sails.helpers.flag.normalizeDefinition.with({
+      values: inputs
+    })
+    if (normalized.problems.length > 0) {
+      throw { badRequest: { problems: normalized.problems } }
+    }
+
+    const flag = await FeatureFlag.updateOne({ id: current.id }).set({
+      ...normalized.values,
+      version: Number(current.version || 1) + 1,
+      changedBy: context.user.id,
+      changedByName: context.user.fullName
+    })
+
+    await sails.helpers.audit.log.with({
+      action:
+        current.enabled !== true && flag.enabled === true
+          ? 'feature_flag.released'
+          : current.enabled === true && flag.enabled !== true
+          ? 'feature_flag.killed'
+          : 'feature_flag.updated',
+      resourceType: 'feature_flag',
+      resourceId: String(flag.id),
+      details: auditDetails(flag, context),
+      userId: String(context.user.id),
+      teamId: String(context.project.team),
+      ipAddress: this.req.ip
+    })
+
+    return { flag: sails.helpers.flag.present(flag) }
+  }
+}
+
+function auditDetails(flag, context) {
+  return {
+    key: flag.key,
+    projectSlug: context.project.slug,
+    environmentSlug: context.environment.slug,
+    appSlug: context.app.slug,
+    enabled: flag.enabled === true,
+    rolloutPercentage: flag.rolloutPercentage,
+    targetCount: flag.targets.length,
+    version: flag.version
+  }
+}

--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -201,6 +201,12 @@ module.exports = {
       environment,
       project
     })
+    const releaseFlags = (
+      await FeatureFlag.find({
+        environment: environment.id,
+        app: app.id
+      }).sort('key ASC')
+    ).map((flag) => sails.helpers.flag.present(flag))
     const publicEnvironment = omitPrivateEnvironmentFields(environment)
     const publicApp = omitPrivateAppFields(app)
 
@@ -240,6 +246,7 @@ module.exports = {
         backupConfigured,
         checklist,
         sourceReadiness,
+        releaseFlags,
         canManageBridge: ['owner', 'admin'].includes(user.teamRole)
       }
     }

--- a/api/controllers/project/view-lookout.js
+++ b/api/controllers/project/view-lookout.js
@@ -196,6 +196,11 @@ module.exports = {
       durations.length > 0
         ? durations.reduce((a, b) => a + b, 0) / durations.length
         : 0
+    const flagComparisons = summarizeFeatureFlags(
+      recentSpans,
+      app?.id,
+      recentExceptions
+    )
 
     // Group exceptions by type+message
     const exceptionGroups = {}
@@ -296,6 +301,7 @@ module.exports = {
           recordedAt: m.recordedAt
         }))
       },
+      flags: flagComparisons,
       hasTelemetry:
         recentSpans.length > 0 ||
         recentExceptions.length > 0 ||
@@ -322,5 +328,61 @@ module.exports = {
         telemetry
       }
     }
+  }
+}
+
+function summarizeFeatureFlags(spans, appId, exceptions = []) {
+  const summaries = new Map()
+  const exceptionCounts = new Map()
+  for (const exception of exceptions) {
+    if (!exception.traceId) continue
+    exceptionCounts.set(
+      exception.traceId,
+      (exceptionCounts.get(exception.traceId) || 0) + 1
+    )
+  }
+
+  for (const span of spans) {
+    const spanAppId = span.attributes?.['feature.app_id']
+    if (spanAppId && String(spanAppId) !== String(appId)) continue
+    const evaluations = span.attributes?.['feature.flags']
+    if (!evaluations || typeof evaluations !== 'object') continue
+
+    for (const [key, evaluation] of Object.entries(evaluations)) {
+      if (!summaries.has(key)) {
+        summaries.set(key, {
+          key,
+          on: { requests: 0, errors: 0, exceptions: 0, duration: 0 },
+          off: { requests: 0, errors: 0, exceptions: 0, duration: 0 }
+        })
+      }
+      const group = evaluation?.value === true ? 'on' : 'off'
+      const bucket = summaries.get(key)[group]
+      bucket.requests++
+      if (span.statusCode >= 500) bucket.errors++
+      bucket.exceptions += exceptionCounts.get(span.traceId) || 0
+      bucket.duration += Number(span.duration || 0)
+    }
+  }
+
+  return [...summaries.values()]
+    .map((summary) => ({
+      key: summary.key,
+      on: presentFlagBucket(summary.on),
+      off: presentFlagBucket(summary.off)
+    }))
+    .sort((left, right) => left.key.localeCompare(right.key))
+}
+
+function presentFlagBucket(bucket) {
+  return {
+    requests: bucket.requests,
+    exceptions: bucket.exceptions,
+    errorRate:
+      bucket.requests > 0
+        ? Number(((bucket.errors / bucket.requests) * 100).toFixed(1))
+        : null,
+    avg:
+      bucket.requests > 0 ? Math.round(bucket.duration / bucket.requests) : null
   }
 }

--- a/api/helpers/cleanup/remove-records.js
+++ b/api/helpers/cleanup/remove-records.js
@@ -36,6 +36,11 @@ module.exports = {
       }
 
       if (target.scopeType === 'app') {
+        removed.default.featureFlags = await destroyCriteriaCount(
+          FeatureFlag,
+          { app: { in: records.appIds } },
+          db
+        )
         removed.default.bridgeLaunchCodes = await destroyCriteriaCount(
           BridgeLaunchCode,
           { app: { in: records.appIds } },
@@ -76,6 +81,11 @@ module.exports = {
       }
 
       await updateCount(App, records.appIds, { currentDeployment: null }, db)
+      removed.default.featureFlags = await destroyCriteriaCount(
+        FeatureFlag,
+        { app: { in: records.appIds } },
+        db
+      )
       removed.default.bridgeLaunchCodes = await destroyCriteriaCount(
         BridgeLaunchCode,
         { app: { in: records.appIds } },

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -208,6 +208,12 @@ module.exports = {
             : 'host.docker.internal'
         envVars.SLIPWAY_TELEMETRY_URL = `http://${telemetryHost}:1337/api/v1/telemetry/ingest`
         envVars.SLIPWAY_TELEMETRY_TOKEN = envRecord.telemetryToken
+
+        if (targetApp?.id) {
+          envVars.SLIPWAY_FLAGS_URL = `http://${telemetryHost}:1337/api/v1/flags/apps/${targetApp.id}`
+          envVars.SLIPWAY_FLAGS_TOKEN = envRecord.telemetryToken
+          envVars.SLIPWAY_FLAGS_APP_ID = String(targetApp.id)
+        }
       }
 
       // 7c. App-local Bridge is an explicit, app-scoped capability. Its

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -137,6 +137,24 @@ module.exports = {
           ...(existingApp?.id ? { appId: String(existingApp.id) } : {})
         })
       const envVars = { ...runtimeConfig.values }
+      const envRecord = await Environment.findOne({
+        id: environment.id
+      }).decrypt()
+
+      if (envRecord.telemetryToken) {
+        const telemetryHost =
+          sails.config.environment === 'production'
+            ? 'slipway'
+            : 'host.docker.internal'
+        envVars.SLIPWAY_TELEMETRY_URL = `http://${telemetryHost}:1337/api/v1/telemetry/ingest`
+        envVars.SLIPWAY_TELEMETRY_TOKEN = envRecord.telemetryToken
+
+        if (existingApp?.id) {
+          envVars.SLIPWAY_FLAGS_URL = `http://${telemetryHost}:1337/api/v1/flags/apps/${existingApp.id}`
+          envVars.SLIPWAY_FLAGS_TOKEN = envRecord.telemetryToken
+          envVars.SLIPWAY_FLAGS_APP_ID = String(existingApp.id)
+        }
+      }
 
       if (existingApp?.bridgeEnabled) {
         const bridgeHost =

--- a/api/helpers/flag/ensure-schema.js
+++ b/api/helpers/flag/ensure-schema.js
@@ -1,0 +1,40 @@
+module.exports = {
+  friendlyName: 'Ensure release flag schema',
+
+  description:
+    'Create the environment-scoped release flag table on existing production databases.',
+
+  inputs: {},
+
+  fn: async function () {
+    const datastore = sails.getDatastore()
+
+    await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS feature_flags (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER,
+        key TEXT NOT NULL,
+        description TEXT,
+        enabled INTEGER NOT NULL DEFAULT 0,
+        rollout_percentage INTEGER NOT NULL DEFAULT 0,
+        targets TEXT NOT NULL DEFAULT '[]',
+        version INTEGER NOT NULL DEFAULT 1,
+        changed_by_name TEXT,
+        changed_by INTEGER,
+        environment INTEGER NOT NULL,
+        app INTEGER NOT NULL
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE UNIQUE INDEX IF NOT EXISTS feature_flags_app_key
+      ON feature_flags (environment, app, key)
+    `)
+
+    await datastore.sendNativeQuery(`
+      CREATE INDEX IF NOT EXISTS feature_flags_environment_updated
+      ON feature_flags (environment, updated_at DESC)
+    `)
+  }
+}

--- a/api/helpers/flag/normalize-definition.js
+++ b/api/helpers/flag/normalize-definition.js
@@ -1,0 +1,92 @@
+const TARGET_PATTERN = /^(user|account|tenant|team):([^\s].{0,119})$/
+
+module.exports = {
+  friendlyName: 'Normalize release flag definition',
+
+  description:
+    'Validate and normalize the small boolean release flag contract.',
+
+  sync: true,
+
+  inputs: {
+    values: { type: 'ref', required: true },
+    requireKey: { type: 'boolean', defaultsTo: false }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({ values, requireKey }) {
+    const problems = []
+    const normalized = {}
+
+    if (requireKey || values.key !== undefined) {
+      const key = String(values.key || '')
+        .trim()
+        .toLowerCase()
+      if (!/^[a-z][a-z0-9-]{0,63}$/.test(key)) {
+        problems.push({
+          key: 'Use 1–64 lowercase letters, numbers, and hyphens, beginning with a letter.'
+        })
+      } else {
+        normalized.key = key
+      }
+    }
+
+    const description = String(values.description || '').trim()
+    if (description.length > 160) {
+      problems.push({
+        description: 'Description must be 160 characters or fewer.'
+      })
+    } else {
+      normalized.description = description || null
+    }
+
+    if (typeof values.enabled !== 'boolean') {
+      problems.push({ enabled: 'Enabled must be true or false.' })
+    } else {
+      normalized.enabled = values.enabled
+    }
+
+    const rolloutPercentage = Number(values.rolloutPercentage)
+    if (
+      !Number.isInteger(rolloutPercentage) ||
+      rolloutPercentage < 0 ||
+      rolloutPercentage > 100
+    ) {
+      problems.push({
+        rolloutPercentage:
+          'Rollout percentage must be a whole number from 0 to 100.'
+      })
+    } else {
+      normalized.rolloutPercentage = rolloutPercentage
+    }
+
+    if (!Array.isArray(values.targets)) {
+      problems.push({ targets: 'Allowlist targets must be an array.' })
+    } else if (values.targets.length > 100) {
+      problems.push({
+        targets: 'A flag can have at most 100 allowlist targets.'
+      })
+    } else {
+      const targets = []
+      for (const rawTarget of values.targets) {
+        const target = String(rawTarget || '').trim()
+        const match = target.match(TARGET_PATTERN)
+        if (!match) {
+          problems.push({
+            targets:
+              'Use typed targets such as user:42, account:acme, tenant:north, or team:staff.'
+          })
+          break
+        }
+        const normalizedTarget = `${match[1]}:${match[2].trim()}`
+        if (!targets.includes(normalizedTarget)) targets.push(normalizedTarget)
+      }
+      normalized.targets = targets.sort()
+    }
+
+    return { values: normalized, problems }
+  }
+}

--- a/api/helpers/flag/present.js
+++ b/api/helpers/flag/present.js
@@ -1,0 +1,30 @@
+module.exports = {
+  friendlyName: 'Present release flag',
+
+  description: 'Return the public boolean release flag contract.',
+
+  sync: true,
+
+  inputs: {
+    flag: { type: 'ref', required: true }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({ flag }) {
+    return {
+      id: flag.id,
+      key: flag.key,
+      description: flag.description || null,
+      enabled: flag.enabled === true,
+      rolloutPercentage: Number(flag.rolloutPercentage || 0),
+      targets: Array.isArray(flag.targets) ? flag.targets : [],
+      version: Number(flag.version || 1),
+      changedByName: flag.changedByName || null,
+      updatedAt: flag.updatedAt,
+      createdAt: flag.createdAt
+    }
+  }
+}

--- a/api/helpers/flag/resolve-app.js
+++ b/api/helpers/flag/resolve-app.js
@@ -1,0 +1,42 @@
+module.exports = {
+  friendlyName: 'Resolve release flag app',
+
+  description: 'Resolve an app inside the signed-in user team.',
+
+  inputs: {
+    userId: { type: 'string', required: true },
+    projectSlug: { type: 'string', required: true },
+    environmentSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true }
+  },
+
+  exits: {
+    success: { outputType: 'ref' },
+    notFound: {}
+  },
+
+  fn: async function ({ userId, projectSlug, environmentSlug, appSlug }) {
+    const user = await User.findOne({ id: userId })
+    if (!user) throw 'notFound'
+
+    const project = await Project.findOne({
+      slug: projectSlug,
+      team: user.team
+    })
+    if (!project) throw 'notFound'
+
+    const environment = await Environment.findOne({
+      slug: environmentSlug,
+      project: project.id
+    })
+    if (!environment) throw 'notFound'
+
+    const app = await App.findOne({
+      slug: appSlug,
+      environment: environment.id
+    })
+    if (!app) throw 'notFound'
+
+    return { user, project, environment, app }
+  }
+}

--- a/api/models/FeatureFlag.js
+++ b/api/models/FeatureFlag.js
@@ -1,0 +1,71 @@
+/**
+ * FeatureFlag.js
+ *
+ * A boolean release flag for one app in one environment.
+ */
+
+module.exports = {
+  tableName: 'feature_flags',
+
+  attributes: {
+    key: {
+      type: 'string',
+      required: true,
+      regex: /^[a-z][a-z0-9-]{0,63}$/,
+      description: 'Stable application-facing flag key'
+    },
+
+    description: {
+      type: 'string',
+      allowNull: true,
+      maxLength: 160
+    },
+
+    enabled: {
+      type: 'boolean',
+      defaultsTo: false,
+      description: 'Master release switch; false is the kill switch'
+    },
+
+    rolloutPercentage: {
+      type: 'number',
+      defaultsTo: 0,
+      min: 0,
+      max: 100,
+      columnName: 'rollout_percentage'
+    },
+
+    targets: {
+      type: 'json',
+      defaultsTo: [],
+      description:
+        'Typed allowlist entries such as user:42, account:acme, or tenant:north'
+    },
+
+    version: {
+      type: 'number',
+      defaultsTo: 1
+    },
+
+    changedByName: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'changed_by_name'
+    },
+
+    changedBy: {
+      model: 'user',
+      columnName: 'changed_by'
+    },
+
+    environment: {
+      model: 'environment',
+      required: true
+    },
+
+    app: {
+      model: 'app',
+      required: true
+    }
+  }
+}

--- a/assets/js/components/ReleaseFlagMenu.vue
+++ b/assets/js/components/ReleaseFlagMenu.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { ref, watch } from 'vue'
+
+const props = defineProps({ flag: { type: Object, required: true } })
+const emit = defineEmits(['update', 'remove'])
+
+const description = ref('')
+const rolloutPercentage = ref(0)
+const targets = ref('')
+
+watch(
+  () => props.flag,
+  (flag) => {
+    description.value = flag.description || ''
+    rolloutPercentage.value = Number(flag.rolloutPercentage || 0)
+    targets.value = (flag.targets || []).join('\n')
+  },
+  { immediate: true, deep: true }
+)
+
+function save(event) {
+  emit('update', {
+    description: description.value.trim() || null,
+    rolloutPercentage: Number(rolloutPercentage.value),
+    targets: targets.value
+      .split(/[\n,]/)
+      .map((target) => target.trim())
+      .filter(Boolean)
+  })
+  event.currentTarget.closest('details').removeAttribute('open')
+}
+
+function remove(event) {
+  emit('remove')
+  event.currentTarget.closest('details').removeAttribute('open')
+}
+</script>
+
+<template>
+  <details class="relative">
+    <summary
+      class="list-none rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
+      aria-label="Release flag settings"
+    >
+      <svg class="h-4 w-4" viewBox="0 0 24 24" fill="currentColor">
+        <circle cx="5" cy="12" r="1.5" />
+        <circle cx="12" cy="12" r="1.5" />
+        <circle cx="19" cy="12" r="1.5" />
+      </svg>
+    </summary>
+    <form
+      @submit.prevent="save"
+      class="absolute right-0 z-30 mt-1 w-72 rounded-lg border border-gray-200 bg-white p-3 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+    >
+      <label class="block text-xs font-medium text-gray-700 dark:text-gray-300">
+        Description
+        <input
+          v-model="description"
+          maxlength="160"
+          class="mt-1 w-full border-b border-gray-200 bg-transparent py-1.5 text-sm font-normal text-gray-900 placeholder-gray-400 focus:border-gray-500 focus:outline-none dark:border-gray-700 dark:text-white"
+          placeholder="What this release changes"
+        />
+      </label>
+      <label
+        class="mt-3 block text-xs font-medium text-gray-700 dark:text-gray-300"
+      >
+        Rollout
+        <div class="mt-1 flex items-center gap-2">
+          <input
+            v-model.number="rolloutPercentage"
+            type="range"
+            min="0"
+            max="100"
+            step="1"
+            class="min-w-0 flex-1 accent-gray-900 dark:accent-white"
+          />
+          <span class="w-10 text-right font-mono text-xs text-gray-500"
+            >{{ rolloutPercentage }}%</span
+          >
+        </div>
+      </label>
+      <label
+        class="mt-3 block text-xs font-medium text-gray-700 dark:text-gray-300"
+      >
+        Allowlist
+        <textarea
+          v-model="targets"
+          rows="3"
+          class="mt-1 w-full resize-none border-b border-gray-200 bg-transparent py-1.5 font-mono text-xs font-normal text-gray-900 placeholder-gray-400 focus:border-gray-500 focus:outline-none dark:border-gray-700 dark:text-white"
+          placeholder="user:42&#10;account:acme"
+        ></textarea>
+      </label>
+      <p class="mt-1 text-[11px] leading-4 text-gray-400">
+        One user, account, tenant, or team per line.
+      </p>
+      <div class="mt-3 flex items-center justify-between">
+        <button
+          type="button"
+          @click="remove"
+          class="text-xs font-medium text-red-600 hover:text-red-700 dark:text-red-400"
+        >
+          Delete
+        </button>
+        <button
+          type="submit"
+          class="rounded-md bg-gray-900 px-3 py-1.5 text-xs font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+        >
+          Save
+        </button>
+      </div>
+    </form>
+  </details>
+</template>

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -17,6 +17,7 @@ import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
+import ReleaseFlagMenu from '@/components/ReleaseFlagMenu.vue'
 import { useToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
@@ -38,6 +39,7 @@ const props = defineProps({
   backupConfigured: Boolean,
   checklist: Array,
   sourceReadiness: Object,
+  releaseFlags: Array,
   canManageBridge: Boolean
 })
 
@@ -667,6 +669,125 @@ watch(logsOpen, (open) => {
 
 // --- Accordion state ---
 const servicesOpen = ref(false)
+
+// --- Release flags ---
+const releaseFlagsOpen = ref(_params.has('flags'))
+const localReleaseFlags = ref([...(props.releaseFlags || [])])
+const newFlagKey = ref('')
+const savingFlag = ref(false)
+
+watch(
+  () => props.releaseFlags,
+  (flags) => {
+    localReleaseFlags.value = [...(flags || [])]
+  },
+  { deep: true }
+)
+
+const validNewFlagKey = computed(() =>
+  /^[a-z][a-z0-9-]{0,63}$/.test(newFlagKey.value.trim())
+)
+
+function flagSummary(flag) {
+  if (!flag.enabled) return 'Off'
+  const parts = []
+  if (flag.rolloutPercentage === 100) parts.push('Everyone')
+  else if (flag.rolloutPercentage > 0) parts.push(`${flag.rolloutPercentage}%`)
+  if (flag.targets?.length)
+    parts.push(
+      `${flag.targets.length} target${flag.targets.length === 1 ? '' : 's'}`
+    )
+  return parts.join(' · ') || 'No audience'
+}
+
+function flagUrl(flag) {
+  const base = `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/flags`
+  return flag ? `${base}/${flag.id}` : base
+}
+
+async function flagRequest(url, options) {
+  const response = await fetch(url, {
+    headers: { 'Content-Type': 'application/json' },
+    ...options
+  })
+  const data = await response.json().catch(() => ({}))
+  if (!response.ok) {
+    const firstProblem = data.problems?.[0]
+    throw new Error(
+      firstProblem
+        ? Object.values(firstProblem)[0]
+        : data.message || 'Release flag could not be saved.'
+    )
+  }
+  return data
+}
+
+async function createReleaseFlag() {
+  if (!validNewFlagKey.value || savingFlag.value) return
+  savingFlag.value = true
+  try {
+    const data = await flagRequest(flagUrl(), {
+      method: 'POST',
+      body: JSON.stringify({ key: newFlagKey.value.trim() })
+    })
+    localReleaseFlags.value.push(data.flag)
+    localReleaseFlags.value.sort((a, b) => a.key.localeCompare(b.key))
+    newFlagKey.value = ''
+    toast({ message: 'Release flag created', type: 'success' })
+  } catch (error) {
+    toast({ message: error.message, type: 'error' })
+  } finally {
+    savingFlag.value = false
+  }
+}
+
+async function updateReleaseFlag(flag, updates) {
+  if (savingFlag.value) return
+  savingFlag.value = true
+  try {
+    const data = await flagRequest(flagUrl(flag), {
+      method: 'PATCH',
+      body: JSON.stringify({
+        description: flag.description,
+        enabled: flag.enabled,
+        rolloutPercentage: flag.rolloutPercentage,
+        targets: flag.targets,
+        ...updates
+      })
+    })
+    const index = localReleaseFlags.value.findIndex(
+      (candidate) => candidate.id === flag.id
+    )
+    if (index >= 0) localReleaseFlags.value[index] = data.flag
+  } catch (error) {
+    toast({ message: error.message, type: 'error' })
+  } finally {
+    savingFlag.value = false
+  }
+}
+
+async function removeReleaseFlag(flag) {
+  if (savingFlag.value) return
+  savingFlag.value = true
+  try {
+    await flagRequest(flagUrl(flag), { method: 'DELETE' })
+    localReleaseFlags.value = localReleaseFlags.value.filter(
+      (candidate) => candidate.id !== flag.id
+    )
+    toast({ message: 'Release flag deleted', type: 'success' })
+  } catch (error) {
+    toast({ message: error.message, type: 'error' })
+  } finally {
+    savingFlag.value = false
+  }
+}
+
+watch(releaseFlagsOpen, (open) => {
+  const url = new URL(window.location)
+  if (open) url.searchParams.set('flags', '1')
+  else url.searchParams.delete('flags')
+  window.history.replaceState({}, '', url)
+})
 
 // --- Escape key ---
 function handleEscapeKey(e) {
@@ -1696,6 +1817,135 @@ onBeforeUnmount(() => {
                   </div>
                 </div>
               </template>
+            </div>
+          </div>
+
+          <!-- Release flags -->
+          <div data-test="release-flags">
+            <div class="flex items-center justify-between px-4 py-3">
+              <button
+                @click="releaseFlagsOpen = !releaseFlagsOpen"
+                class="flex flex-1 items-center space-x-3 text-left hover:opacity-80"
+              >
+                <h2 class="text-sm font-medium text-gray-900 dark:text-white">
+                  Release flags
+                </h2>
+                <span
+                  class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+                >
+                  {{ localReleaseFlags.length }}
+                </span>
+              </button>
+              <button
+                @click="releaseFlagsOpen = !releaseFlagsOpen"
+                class="rounded p-0.5 hover:bg-gray-100 dark:hover:bg-gray-800"
+                aria-label="Toggle release flags"
+              >
+                <svg
+                  :class="[
+                    'h-4 w-4 text-gray-400 transition-transform duration-200',
+                    releaseFlagsOpen ? 'rotate-90' : ''
+                  ]"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M9 5l7 7-7 7"
+                  />
+                </svg>
+              </button>
+            </div>
+            <div
+              v-show="releaseFlagsOpen"
+              class="border-t border-gray-200 dark:border-gray-800"
+            >
+              <div
+                v-if="localReleaseFlags.length"
+                class="divide-y divide-gray-100 px-4 dark:divide-gray-800"
+              >
+                <div
+                  v-for="flag in localReleaseFlags"
+                  :key="flag.id"
+                  class="flex items-center gap-3 py-3"
+                  :data-test="`release-flag-${flag.key}`"
+                >
+                  <div class="min-w-0 flex-1">
+                    <div class="flex items-baseline gap-2">
+                      <code
+                        class="truncate text-sm font-medium text-gray-900 dark:text-white"
+                        >{{ flag.key }}</code
+                      >
+                      <span class="shrink-0 text-xs text-gray-400">{{
+                        flagSummary(flag)
+                      }}</span>
+                    </div>
+                    <p
+                      v-if="flag.description"
+                      class="mt-0.5 truncate text-xs text-gray-500 dark:text-gray-400"
+                    >
+                      {{ flag.description }}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    role="switch"
+                    :aria-checked="flag.enabled"
+                    :aria-label="`${flag.enabled ? 'Disable' : 'Enable'} ${
+                      flag.key
+                    }`"
+                    :disabled="savingFlag"
+                    @click="updateReleaseFlag(flag, { enabled: !flag.enabled })"
+                    :class="[
+                      'relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors disabled:opacity-50',
+                      flag.enabled
+                        ? 'bg-gray-900 dark:bg-white'
+                        : 'bg-gray-200 dark:bg-gray-700'
+                    ]"
+                  >
+                    <span
+                      :class="[
+                        'mt-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform dark:bg-gray-900',
+                        flag.enabled ? 'translate-x-[18px]' : 'translate-x-0.5'
+                      ]"
+                    ></span>
+                  </button>
+                  <ReleaseFlagMenu
+                    :flag="flag"
+                    @update="updateReleaseFlag(flag, $event)"
+                    @remove="removeReleaseFlag(flag)"
+                  />
+                </div>
+              </div>
+              <p
+                v-else
+                class="px-4 pt-5 text-center text-sm text-gray-500 dark:text-gray-400"
+              >
+                No release flags yet.
+              </p>
+              <div class="flex items-center gap-3 px-4 py-3">
+                <input
+                  v-model="newFlagKey"
+                  type="text"
+                  autocomplete="off"
+                  spellcheck="false"
+                  placeholder="new-checkout"
+                  aria-label="Release flag key"
+                  class="min-w-0 flex-1 border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:border-gray-500 focus:outline-none dark:border-gray-700 dark:text-white"
+                  @keydown.enter="createReleaseFlag"
+                />
+                <button
+                  type="button"
+                  @click="createReleaseFlag"
+                  :disabled="!validNewFlagKey || savingFlag"
+                  class="rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-40 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+                >
+                  Add
+                </button>
+              </div>
             </div>
           </div>
 

--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -42,6 +42,7 @@ const props = defineProps({
         topKeys: [],
         recent: []
       },
+      flags: [],
       hasTelemetry: false,
       telemetryToken: null
     })
@@ -225,6 +226,12 @@ const expandedRequest = useQueryState('request', '', { replace: true })
 
 function toggleRequest(traceId) {
   expandedRequest.value = expandedRequest.value === traceId ? '' : traceId
+}
+
+function requestFlags(request) {
+  return Object.entries(request.attributes?.['feature.flags'] || {}).map(
+    ([key, evaluation]) => ({ key, ...evaluation })
+  )
 }
 
 // Exception detail
@@ -1447,6 +1454,58 @@ async function copyToken() {
             </div>
           </div>
 
+          <!-- Release flag comparison -->
+          <div v-if="telemetry.flags?.length" class="mb-6">
+            <h3
+              class="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              Release flags
+            </h3>
+            <div
+              class="overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+            >
+              <div
+                class="grid grid-cols-[minmax(0,1fr)_repeat(2,minmax(110px,auto))] gap-4 bg-gray-50 px-4 py-2 text-[10px] font-medium uppercase tracking-wider text-gray-400 dark:bg-gray-900 dark:text-gray-500"
+              >
+                <span>Flag</span>
+                <span>On</span>
+                <span>Off</span>
+              </div>
+              <div
+                v-for="flag in telemetry.flags"
+                :key="flag.key"
+                class="grid grid-cols-[minmax(0,1fr)_repeat(2,minmax(110px,auto))] gap-4 border-t border-gray-100 px-4 py-2.5 text-xs dark:border-gray-800"
+              >
+                <code
+                  class="truncate font-medium text-gray-900 dark:text-white"
+                  >{{ flag.key }}</code
+                >
+                <span class="text-gray-500 dark:text-gray-400">
+                  {{ flag.on.requests }} req ·
+                  {{ flag.on.avg === null ? '—' : formatDuration(flag.on.avg) }}
+                  <template v-if="flag.on.errorRate !== null">
+                    · {{ flag.on.errorRate }}% err</template
+                  >
+                  <template v-if="flag.on.exceptions">
+                    · {{ flag.on.exceptions }} exc</template
+                  >
+                </span>
+                <span class="text-gray-500 dark:text-gray-400">
+                  {{ flag.off.requests }} req ·
+                  {{
+                    flag.off.avg === null ? '—' : formatDuration(flag.off.avg)
+                  }}
+                  <template v-if="flag.off.errorRate !== null">
+                    · {{ flag.off.errorRate }}% err</template
+                  >
+                  <template v-if="flag.off.exceptions">
+                    · {{ flag.off.exceptions }} exc</template
+                  >
+                </span>
+              </div>
+            </div>
+          </div>
+
           <!-- Recent requests -->
           <div v-if="telemetry.requests.recent.length > 0">
             <!-- Search & filters -->
@@ -1729,6 +1788,25 @@ async function copyToken() {
                           class="min-w-0 truncate text-xs text-gray-700 dark:text-gray-300"
                         >
                           {{ req.attributes['http.user_agent'] }}
+                        </dd>
+                      </div>
+                      <div
+                        v-if="requestFlags(req).length"
+                        class="flex items-start gap-4 px-4 py-2"
+                      >
+                        <dt
+                          class="w-24 shrink-0 text-[10px] font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500"
+                        >
+                          Flags
+                        </dt>
+                        <dd class="flex min-w-0 flex-wrap gap-1.5">
+                          <span
+                            v-for="flag in requestFlags(req)"
+                            :key="flag.key"
+                            class="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-[10px] text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+                          >
+                            {{ flag.key }}={{ flag.value ? 'on' : 'off' }}
+                          </span>
                         </dd>
                       </div>
                       <div

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -14,6 +14,7 @@ module.exports.bootstrap = async function () {
   // deployment job queries run on an existing installation.
   await sails.helpers.cleanup.ensureSchema()
   await sails.helpers.configuration.ensureSchema()
+  await sails.helpers.flag.ensureSchema()
   await sails.helpers.deploy.ensureQueueSchema()
   await sails.helpers.service.ensureVersionSchema()
   await sails.helpers.lookout.ensureObservabilitySchema()

--- a/config/policies.js
+++ b/config/policies.js
@@ -75,6 +75,9 @@ module.exports.policies = {
   // Telemetry ingest is public (token-verified in controller)
   'api/v1/telemetry/ingest': true,
 
+  // Deployed apps fetch release flags with their environment telemetry token.
+  'api/v1/flag/get-config': true,
+
   // Bridge handoff endpoints authenticate with a dedicated app credential or
   // a short-lived, single-use launch code.
   'api/v1/bridge/exchange': 'rate-limit-bridge-exchange',

--- a/config/routes.js
+++ b/config/routes.js
@@ -222,6 +222,18 @@ module.exports.routes = {
   'DELETE /api/v1/projects/:projectSlug/environments/:environmentSlug/apps/:appSlug':
     'api/v1/app/destroy-app',
 
+  // Sails-native release flags
+  'GET /api/v1/flags/apps/:appId': {
+    action: 'api/v1/flag/get-config',
+    csrf: false
+  },
+  'POST /api/v1/projects/:projectSlug/environments/:environmentSlug/apps/:appSlug/flags':
+    'api/v1/flag/create-flag',
+  'PATCH /api/v1/projects/:projectSlug/environments/:environmentSlug/apps/:appSlug/flags/:flagId':
+    'api/v1/flag/update-flag',
+  'DELETE /api/v1/projects/:projectSlug/environments/:environmentSlug/apps/:appSlug/flags/:flagId':
+    'api/v1/flag/destroy-flag',
+
   // App-scoped deploy/lifecycle
   'POST /api/v1/projects/:projectSlug/environments/:environmentSlug/apps/:appSlug/deploy':
     'api/v1/deploy/trigger-deployment',

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -5,7 +5,8 @@ The Sails hook that connects an application to Slipway.
 It currently provides:
 
 - automatic request, exception, Waterline, Quest, and cache telemetry for
-  Lookout; and
+  Lookout;
+- app-scoped boolean release flags with deterministic rollouts; and
 - a secure app-local `/bridge` entry point for people who manage application
   data without receiving Slipway infrastructure access.
 
@@ -153,3 +154,22 @@ module.exports.slipway = {
 ```
 
 Telemetry failures never break the host application.
+
+## Release flags
+
+Slipway injects the private flag endpoint and app identity during deployments
+and rollbacks. Evaluate a flag with an explicit safe default:
+
+```js
+const enabled = await sails.helpers.flags.enabled.with({
+  key: 'new-checkout',
+  req: this.req,
+  defaultValue: false
+})
+```
+
+For a background job, pass a stable `context` containing a `user`, `account`,
+`tenant`, or `team` identifier. Configuration is cached and refreshed in the
+background; an unavailable control plane never fails or delays the host-app
+request. See the [release flag guide](https://docs.sailscasts.com/slipway/release-flags)
+for rollout behavior and Lookout comparisons.

--- a/packages/hook/index.js
+++ b/packages/hook/index.js
@@ -27,6 +27,7 @@
 const http = require('http')
 const https = require('https')
 const crypto = require('crypto')
+const { createReleaseFlags } = require('./lib/release-flags')
 
 module.exports = function defineSlipwayHook(sails) {
   // Telemetry buffers
@@ -38,6 +39,8 @@ module.exports = function defineSlipwayHook(sails) {
   // Config (populated in initialize)
   let config = {}
   let bridgeConfig = {}
+  let flagsConfig = {}
+  let releaseFlags = null
 
   return {
     defaults: {
@@ -54,6 +57,11 @@ module.exports = function defineSlipwayHook(sails) {
             emailVerifiedAttribute: 'emailVerified',
             verifiedEmailStatuses: ['verified', 'confirmed']
           }
+        },
+        flags: {
+          enabled: true,
+          refreshInterval: 15000,
+          requestTimeout: 3000
         },
         lookout: {
           enabled: true,
@@ -76,6 +84,16 @@ module.exports = function defineSlipwayHook(sails) {
       if (envUrl) sails.config.slipway.lookout.telemetryUrl = envUrl
       if (envToken) sails.config.slipway.lookout.telemetryToken = envToken
 
+      if (process.env.SLIPWAY_FLAGS_URL) {
+        sails.config.slipway.flags.url = process.env.SLIPWAY_FLAGS_URL
+      }
+      if (process.env.SLIPWAY_FLAGS_TOKEN) {
+        sails.config.slipway.flags.token = process.env.SLIPWAY_FLAGS_TOKEN
+      }
+      if (process.env.SLIPWAY_FLAGS_APP_ID) {
+        sails.config.slipway.flags.appId = process.env.SLIPWAY_FLAGS_APP_ID
+      }
+
       if (process.env.SLIPWAY_BRIDGE_ENABLED === 'true') {
         sails.config.slipway.bridge.enabled = true
       }
@@ -94,6 +112,12 @@ module.exports = function defineSlipwayHook(sails) {
     initialize: function (done) {
       config = sails.config.slipway.lookout
       bridgeConfig = sails.config.slipway.bridge
+      flagsConfig = sails.config.slipway.flags || {
+        enabled: true,
+        refreshInterval: 15000,
+        requestTimeout: 3000
+      }
+      initializeReleaseFlags()
 
       // Skip if not configured
       if (!config.telemetryUrl || !config.telemetryToken) {
@@ -222,7 +246,15 @@ module.exports = function defineSlipwayHook(sails) {
                   'http.client_ip':
                     req.ip || req.headers['x-forwarded-for'] || '',
                   'http.referrer': req.headers.referer || '',
-                  'http.accept': req.headers.accept || ''
+                  'http.accept': req.headers.accept || '',
+                  ...(req._slipwayFlagEvaluations
+                    ? {
+                        'feature.flags': req._slipwayFlagEvaluations,
+                        ...(flagsConfig.appId
+                          ? { 'feature.app_id': String(flagsConfig.appId) }
+                          : {})
+                      }
+                    : {})
                 }
               })
 
@@ -748,6 +780,67 @@ module.exports = function defineSlipwayHook(sails) {
   function safeLocalPath(value, fallback) {
     const path = String(value || fallback)
     return path.startsWith('/') && !path.startsWith('//') ? path : fallback
+  }
+
+  function initializeReleaseFlags() {
+    releaseFlags = createReleaseFlags({
+      url: flagsConfig.url,
+      token: flagsConfig.token,
+      refreshInterval: flagsConfig.refreshInterval,
+      requestTimeout: flagsConfig.requestTimeout
+    })
+
+    const enabled = async function (inputs = {}) {
+      const defaultValue = inputs.defaultValue === true
+      if (!flagsConfig.enabled || !flagsConfig.url || !flagsConfig.token) {
+        recordFlagEvaluation(inputs.req, inputs.key, defaultValue, 'default')
+        return defaultValue
+      }
+
+      const evaluation = await releaseFlags.evaluate({
+        key: String(inputs.key || ''),
+        context: requestFlagContext(inputs.req, inputs.context),
+        defaultValue
+      })
+      recordFlagEvaluation(
+        inputs.req,
+        inputs.key,
+        evaluation.value,
+        evaluation.reason,
+        evaluation.flagVersion
+      )
+      return evaluation.value
+    }
+    enabled.with = enabled
+    sails.helpers.flags = sails.helpers.flags || {}
+    sails.helpers.flags.enabled = enabled
+
+    if (flagsConfig.enabled && flagsConfig.url && flagsConfig.token) {
+      releaseFlags.refresh().catch(() => {})
+    }
+  }
+
+  function requestFlagContext(req, supplied = {}) {
+    supplied = supplied || {}
+    const me = req?.me || {}
+    const session = req?.session || {}
+    return {
+      user: supplied.user ?? me.id ?? session.userId,
+      account: supplied.account ?? me.account ?? session.accountId,
+      tenant: supplied.tenant ?? me.tenant ?? session.tenantId,
+      team: supplied.team ?? me.team ?? session.teamId,
+      session: supplied.session ?? req?.sessionID ?? session.id
+    }
+  }
+
+  function recordFlagEvaluation(req, key, value, reason, version) {
+    if (!req || !key) return
+    req._slipwayFlagEvaluations = req._slipwayFlagEvaluations || {}
+    req._slipwayFlagEvaluations[String(key)] = {
+      value: value === true,
+      reason,
+      version: version || null
+    }
   }
 
   function requestJson({ url, token, body }) {

--- a/packages/hook/lib/release-flags.js
+++ b/packages/hook/lib/release-flags.js
@@ -1,0 +1,193 @@
+const crypto = require('crypto')
+const http = require('http')
+const https = require('https')
+
+function createReleaseFlags(options = {}) {
+  const url = options.url
+  const token = options.token
+  const refreshInterval = options.refreshInterval || 15000
+  const requestTimeout = options.requestTimeout || 3000
+  const requestJson = options.requestJson || fetchJson
+  const now = options.now || Date.now
+  let snapshot = null
+  let fetchedAt = 0
+  let inFlight = null
+
+  async function refresh() {
+    if (!url || !token) return null
+    if (inFlight) return inFlight
+
+    inFlight = requestJson({ url, token, timeout: requestTimeout })
+      .then((payload) => {
+        snapshot = {
+          version: payload.version || null,
+          flags: new Map(
+            (Array.isArray(payload.flags) ? payload.flags : []).map((flag) => [
+              flag.key,
+              flag
+            ])
+          )
+        }
+        fetchedAt = now()
+        return snapshot
+      })
+      .finally(() => {
+        inFlight = null
+      })
+
+    return inFlight
+  }
+
+  async function evaluate({ key, context, defaultValue = false }) {
+    if (!snapshot) {
+      refresh().catch(() => {})
+      return result(defaultValue, 'default', null)
+    } else if (now() - fetchedAt >= refreshInterval) {
+      refresh().catch(() => {})
+    }
+
+    const flag = snapshot?.flags.get(key)
+    if (!flag) return result(defaultValue, 'default', snapshot?.version)
+    if (flag.enabled !== true) {
+      return result(false, 'disabled', snapshot.version, flag.version)
+    }
+
+    const normalizedContext = normalizeContext(context)
+    const targets = Array.isArray(flag.targets) ? flag.targets : []
+    if (targets.some((target) => matchesTarget(target, normalizedContext))) {
+      return result(true, 'targeted', snapshot.version, flag.version)
+    }
+
+    const percentage = Math.max(
+      0,
+      Math.min(100, Number(flag.rolloutPercentage) || 0)
+    )
+    if (percentage === 100) {
+      return result(true, 'rollout', snapshot.version, flag.version)
+    }
+    if (percentage === 0) {
+      return result(false, 'rollout', snapshot.version, flag.version)
+    }
+
+    const targetingKey = stableTargetingKey(normalizedContext)
+    if (!targetingKey) {
+      return result(false, 'missing-context', snapshot.version, flag.version)
+    }
+
+    return result(
+      bucket(`${key}:${targetingKey}`) < percentage,
+      'rollout',
+      snapshot.version,
+      flag.version
+    )
+  }
+
+  return { evaluate, refresh }
+}
+
+function normalizeContext(context = {}) {
+  const normalized = {}
+  for (const type of ['user', 'account', 'tenant', 'team', 'session']) {
+    const candidate = context[type]
+    const value =
+      candidate && typeof candidate === 'object' && candidate.id != null
+        ? candidate.id
+        : candidate
+    if (value !== undefined && value !== null && String(value).trim()) {
+      normalized[type] = String(value).trim()
+    }
+  }
+  return normalized
+}
+
+function matchesTarget(target, context) {
+  const separator = String(target).indexOf(':')
+  if (separator < 1) return false
+  const type = target.slice(0, separator)
+  const value = target.slice(separator + 1)
+  return context[type] === value
+}
+
+function stableTargetingKey(context) {
+  for (const type of ['user', 'account', 'tenant', 'team', 'session']) {
+    if (context[type]) return `${type}:${context[type]}`
+  }
+  return null
+}
+
+function bucket(value) {
+  return (
+    crypto.createHash('sha256').update(value).digest().readUInt32BE(0) % 100
+  )
+}
+
+function result(value, reason, configVersion, flagVersion) {
+  return {
+    value: value === true,
+    reason,
+    configVersion: configVersion || null,
+    flagVersion: flagVersion || null
+  }
+}
+
+function fetchJson({ url, token, timeout }) {
+  return new Promise((resolve, reject) => {
+    let endpoint
+    try {
+      endpoint = new URL(url)
+    } catch {
+      return reject(new Error('The release flag URL is invalid.'))
+    }
+
+    const transport = endpoint.protocol === 'https:' ? https : http
+    const request = transport.request(
+      {
+        hostname: endpoint.hostname,
+        port: endpoint.port,
+        path: `${endpoint.pathname}${endpoint.search}`,
+        method: 'GET',
+        headers: { Authorization: `Bearer ${token}` },
+        timeout
+      },
+      (response) => {
+        let body = ''
+        response.on('data', (chunk) => {
+          body += chunk
+          if (body.length > 2 * 1024 * 1024) {
+            response.destroy(
+              new Error('The release flag response was too large.')
+            )
+          }
+        })
+        response.on('end', () => {
+          let payload
+          try {
+            payload = body ? JSON.parse(body) : {}
+          } catch {
+            return reject(new Error('The release flag response was invalid.'))
+          }
+          if (response.statusCode < 200 || response.statusCode >= 300) {
+            return reject(
+              new Error(
+                `Release flag fetch returned HTTP ${response.statusCode}.`
+              )
+            )
+          }
+          return resolve(payload)
+        })
+      }
+    )
+    request.on('error', reject)
+    request.on('timeout', () => {
+      request.destroy(new Error('Release flag fetch timed out.'))
+    })
+    request.end()
+  })
+}
+
+module.exports = {
+  createReleaseFlags,
+  normalizeContext,
+  stableTargetingKey,
+  bucket
+}

--- a/tests/e2e/pages/release-flags.test.js
+++ b/tests/e2e/pages/release-flags.test.js
@@ -1,0 +1,130 @@
+const { test } = require('sounding')
+
+test(
+  'release flags stay minimal in the app and explain their impact in Lookout',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'release-flags-ui',
+          name: 'Release Flags UI'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    await sails.models.featureflag.createEach([
+      {
+        key: 'new-checkout',
+        description: 'Release the simpler checkout safely',
+        enabled: true,
+        rolloutPercentage: 25,
+        targets: ['account:acme', 'user:42'],
+        changedByName: current.users.genesisUser.fullName,
+        changedBy: current.users.genesisUser.id,
+        environment: environment.id,
+        app: app.id
+      },
+      {
+        key: 'faster-search',
+        enabled: false,
+        rolloutPercentage: 100,
+        targets: [],
+        changedByName: current.users.genesisUser.fullName,
+        changedBy: current.users.genesisUser.id,
+        environment: environment.id,
+        app: app.id
+      }
+    ])
+    await sails.models.telemetryspan.createEach([
+      requestSpan(environment.id, app.id, 'trace-on-1', true, 118, 200),
+      requestSpan(environment.id, app.id, 'trace-on-2', true, 132, 200),
+      requestSpan(environment.id, app.id, 'trace-off-1', false, 245, 500),
+      requestSpan(environment.id, app.id, 'trace-off-2', false, 181, 200)
+    ])
+    await sails.models.telemetryexception.create({
+      exceptionType: 'CheckoutError',
+      message: 'Checkout failed',
+      handled: true,
+      method: 'GET',
+      url: '/checkout',
+      traceId: 'trace-off-1',
+      occurredAt: Date.now(),
+      environment: String(environment.id)
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    const appPath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}?flags=1`
+
+    await page.inLightMode()
+    await page.goto(appPath)
+    await page.wait('@release-flags')
+    await expect(page).toSee('new-checkout')
+    await expect(page).toSee('25% · 2 targets')
+    await page.screenshot('.tmp/issue-227-release-flags-light.png', {
+      fullPage: true
+    })
+
+    await page.inDarkMode()
+    await page.wait(250)
+    await page.screenshot('.tmp/issue-227-release-flags-dark.png', {
+      fullPage: true
+    })
+
+    await page.goto(
+      `/projects/${project.slug}/environments/${environment.slug}/lookout?tab=requests`
+    )
+    await expect(page).toSee('Release flags')
+    await expect(page).toSee('50% err')
+    await expect(page).toSee('1 exc')
+    await page.screenshot('.tmp/issue-227-lookout-flags-dark.png', {
+      fullPage: true
+    })
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)
+
+function requestSpan(
+  environmentId,
+  appId,
+  traceId,
+  value,
+  duration,
+  statusCode
+) {
+  return {
+    traceId,
+    spanId: `${traceId}-span`,
+    name: 'GET /checkout',
+    kind: 'server',
+    method: 'GET',
+    url: '/checkout',
+    statusCode,
+    duration,
+    startedAt: Date.now(),
+    attributes: {
+      'http.route': '/checkout',
+      'feature.app_id': String(appId),
+      'feature.flags': {
+        'new-checkout': { value, reason: 'rollout', version: 1 }
+      }
+    },
+    environment: String(environmentId)
+  }
+}

--- a/tests/functional/api/release-flags.test.js
+++ b/tests/functional/api/release-flags.test.js
@@ -1,0 +1,118 @@
+const crypto = require('node:crypto')
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'release flags are app-scoped, audited, and available to the deployed app without redeploying',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'release-flags',
+          name: 'Release flags'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const { projects, environments, apps } = world.current
+    const project = projects.deploymentTarget
+    const environment = environments.production
+    const app = apps.web
+    const token = 'stk_' + crypto.randomBytes(24).toString('hex')
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      telemetryToken: token,
+      telemetryTokenHash: crypto
+        .createHash('sha256')
+        .update(token)
+        .digest('hex')
+    })
+    const pagePath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`
+    const dashboard = await withCsrfFromPage(request, pagePath, 'genesisUser')
+    const flagsPath = `/api/v1/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/flags`
+
+    const created = await dashboard.request.post(flagsPath, {
+      key: 'new-checkout'
+    })
+    expect(created).toHaveStatus(201)
+    expect(created.data.flag.enabled).toBe(false)
+    expect(created.data.flag.rolloutPercentage).toBe(0)
+    const duplicate = await dashboard.request.post(flagsPath, {
+      key: 'new-checkout'
+    })
+    expect(duplicate).toHaveStatus(303)
+
+    const updated = await dashboard.request.patch(
+      `${flagsPath}/${created.data.flag.id}`,
+      {
+        description: 'Release checkout safely',
+        enabled: true,
+        rolloutPercentage: 25,
+        targets: ['user:42', 'account:acme']
+      }
+    )
+    expect(updated).toHaveStatus(200)
+    expect(updated.data.flag.version).toBe(2)
+
+    const appClient = request.withHeaders({
+      authorization: `Bearer ${token}`,
+      accept: 'application/json'
+    })
+    const config = await appClient.get(`/api/v1/flags/apps/${app.id}`)
+    expect(config).toHaveStatus(200)
+    expect(config.data.flags).toEqual([
+      {
+        key: 'new-checkout',
+        enabled: true,
+        rolloutPercentage: 25,
+        targets: ['account:acme', 'user:42'],
+        version: 2
+      }
+    ])
+
+    const audit = await sails.models.auditlog.findOne({
+      action: 'feature_flag.released',
+      resourceType: 'feature_flag',
+      resourceId: String(created.data.flag.id)
+    })
+    expect(audit.details.targetCount).toBe(2)
+    expect(JSON.stringify(audit).includes('user:42')).toBe(false)
+
+    const wrongToken = await request
+      .withHeaders({
+        authorization: 'Bearer stk_wrong',
+        accept: 'application/json'
+      })
+      .get(`/api/v1/flags/apps/${app.id}`)
+    expect(wrongToken).toHaveStatus(401)
+
+    const killed = await dashboard.request.patch(
+      `${flagsPath}/${created.data.flag.id}`,
+      {
+        description: updated.data.flag.description,
+        enabled: false,
+        rolloutPercentage: 25,
+        targets: updated.data.flag.targets
+      }
+    )
+    expect(killed).toHaveStatus(200)
+    expect(killed.data.flag.enabled).toBe(false)
+    expect(
+      Boolean(
+        await sails.models.auditlog.findOne({
+          action: 'feature_flag.killed',
+          resourceId: String(created.data.flag.id)
+        })
+      )
+    ).toBe(true)
+
+    const deleted = await dashboard.request.delete(
+      `${flagsPath}/${created.data.flag.id}`
+    )
+    expect(deleted).toHaveStatus(200)
+    expect(
+      (await appClient.get(`/api/v1/flags/apps/${app.id}`)).data.flags
+    ).toEqual([])
+  }
+)

--- a/tests/unit/packages/hook-flags.test.js
+++ b/tests/unit/packages/hook-flags.test.js
@@ -1,0 +1,123 @@
+const { test } = require('sounding')
+const {
+  createReleaseFlags,
+  bucket
+} = require('../../../packages/hook/lib/release-flags')
+
+test('release flags honor typed targets before percentage rollout', async ({
+  expect
+}) => {
+  const flags = createReleaseFlags({
+    url: 'https://slipway.example/flags',
+    token: 'stk_test',
+    requestJson: async () => ({
+      version: 'config-1',
+      flags: [
+        {
+          key: 'new-checkout',
+          enabled: true,
+          rolloutPercentage: 0,
+          targets: ['user:42'],
+          version: 2
+        }
+      ]
+    })
+  })
+  await flags.refresh()
+
+  const targeted = await flags.evaluate({
+    key: 'new-checkout',
+    context: { user: 42 }
+  })
+  const untargeted = await flags.evaluate({
+    key: 'new-checkout',
+    context: { user: 43 }
+  })
+
+  expect(targeted.value).toBe(true)
+  expect(targeted.reason).toBe('targeted')
+  expect(untargeted.value).toBe(false)
+})
+
+test('percentage rollout is deterministic and fails safe without context', async ({
+  expect
+}) => {
+  const percentage = 37
+  const flags = createReleaseFlags({
+    url: 'https://slipway.example/flags',
+    token: 'stk_test',
+    requestJson: async () => ({
+      flags: [
+        {
+          key: 'new-checkout',
+          enabled: true,
+          rolloutPercentage: percentage,
+          targets: []
+        }
+      ]
+    })
+  })
+  await flags.refresh()
+  const expected = bucket('new-checkout:user:customer-7') < percentage
+
+  const first = await flags.evaluate({
+    key: 'new-checkout',
+    context: { user: 'customer-7' }
+  })
+  const second = await flags.evaluate({
+    key: 'new-checkout',
+    context: { user: 'customer-7' }
+  })
+  const anonymous = await flags.evaluate({ key: 'new-checkout' })
+
+  expect(first.value).toBe(expected)
+  expect(second.value).toBe(expected)
+  expect(anonymous.value).toBe(false)
+  expect(anonymous.reason).toBe('missing-context')
+})
+
+test('release flag config refreshes without redeploying and uses explicit defaults when unavailable', async ({
+  expect
+}) => {
+  let enabled = false
+  let available = true
+  let now = 1000
+  const flags = createReleaseFlags({
+    url: 'https://slipway.example/flags',
+    token: 'stk_test',
+    refreshInterval: 1,
+    now: () => now,
+    requestJson: async () => {
+      if (!available) throw new Error('offline')
+      return {
+        flags: [
+          {
+            key: 'new-checkout',
+            enabled,
+            rolloutPercentage: 100,
+            targets: []
+          }
+        ]
+      }
+    }
+  })
+
+  await flags.refresh()
+  expect((await flags.evaluate({ key: 'new-checkout' })).value).toBe(false)
+  enabled = true
+  now += 2
+  await flags.refresh()
+  expect((await flags.evaluate({ key: 'new-checkout' })).value).toBe(true)
+
+  available = false
+  const empty = createReleaseFlags({
+    url: 'https://slipway.example/flags',
+    token: 'stk_test',
+    requestJson: async () => {
+      throw new Error('offline')
+    }
+  })
+  expect(
+    (await empty.evaluate({ key: 'unknown', defaultValue: true })).value
+  ).toBe(true)
+})


### PR DESCRIPTION
## Summary
- add app- and environment-scoped boolean release flags with an audited kill switch, typed allowlists, and deterministic percentage rollouts
- inject a private cached flag contract into normal deployments and rollbacks through sails-hook-slipway without blocking app requests
- add a minimal app accordion plus Lookout on/off comparisons for requests, latency, errors, and trace-linked exceptions
- clean flags with their app and cover the evaluator, API, audits, UI, light/dark themes, and telemetry

## Verification
- npm run lint
- npm run check:consistency
- npm run test:unit (255 passed)
- npm run test:functional (94 passed)
- npm run test:e2e (42 passed)
- focused release-flag unit, functional, and browser trials

Fixes #227