### PR TITLE
fix(hook): furnish release flags as a Sails helper

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm run check:consistency
 
   test:
-    timeout-minutes: 10
+    timeout-minutes: 15
     runs-on: ubuntu-latest
 
     steps:

--- a/RELEASE_0.0.52.md
+++ b/RELEASE_0.0.52.md
@@ -345,6 +345,11 @@ deterministic 0–100% cohorts. `sails-hook-slipway` caches the private contract
 refreshes in the background, and uses the last valid snapshot or explicit
 default when the control plane is unavailable.
 
+The app-facing API is a genuine Sails helper machine furnished through the
+built-in helpers hook. Sails validates its inputs, the helper works through the
+ordinary `.with()` contract, and an app-owned `flags.enabled` helper is never
+overwritten (#314, PR #316).
+
 The useful unit is not only the switch. Lookout compares flag-on and flag-off
 request count, latency, 5xx rate, and trace-linked exceptions. A team can
 release to itself, expand gradually, observe whether the new path is healthier,

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -171,5 +171,8 @@ const enabled = await sails.helpers.flags.enabled.with({
 For a background job, pass a stable `context` containing a `user`, `account`,
 `tenant`, or `team` identifier. Configuration is cached and refreshed in the
 background; an unavailable control plane never fails or delays the host-app
-request. See the [release flag guide](https://docs.sailscasts.com/slipway/release-flags)
-for rollout behavior and Lookout comparisons.
+request. `flags.enabled` is a regular Sails helper machine, so Sails validates
+its declared inputs before evaluation. An app-defined helper at the same
+identity is preserved. See the
+[release flag guide](https://docs.sailscasts.com/slipway/release-flags) for
+rollout behavior and Lookout comparisons.

--- a/packages/hook/index.js
+++ b/packages/hook/index.js
@@ -28,6 +28,7 @@ const http = require('http')
 const https = require('https')
 const crypto = require('crypto')
 const { createReleaseFlags } = require('./lib/release-flags')
+const buildFlagsEnabledHelper = require('./lib/helpers/flags/enabled')
 
 module.exports = function defineSlipwayHook(sails) {
   // Telemetry buffers
@@ -117,53 +118,10 @@ module.exports = function defineSlipwayHook(sails) {
         refreshInterval: 15000,
         requestTimeout: 3000
       }
-      initializeReleaseFlags()
-
-      // Skip if not configured
-      if (!config.telemetryUrl || !config.telemetryToken) {
-        sails.log.verbose(
-          'sails-hook-slipway: No telemetry endpoint configured, skipping.'
-        )
-        return done()
-      }
-
-      if (!config.enabled) {
-        sails.log.verbose('sails-hook-slipway: Disabled via config.')
-        return done()
-      }
-
-      sails.log.info(
-        'sails-hook-slipway: Initializing telemetry instrumentation'
-      )
-
-      // Start flush timer
-      flushTimer = setInterval(flush, config.flushInterval)
-
-      // Instrument unhandled exceptions (process-level handlers only)
-      if (config.captureExceptions) {
-        instrumentExceptions()
-      }
-
-      // Instrument Waterline queries
-      if (config.captureQueries) {
-        sails.after('hook:orm:loaded', () => {
-          instrumentQueries()
-        })
-      }
-
-      // Instrument Quest job lifecycle events
-      if (config.captureQuestEvents) {
-        instrumentQuest()
-      }
-
-      // Instrument sails-stash cache operations
-      if (config.captureCache) {
-        sails.after('hook:stash:loaded', () => {
-          instrumentCache()
-        })
-      }
-
-      return done()
+      return initializeReleaseFlags((error) => {
+        if (error) return done(error)
+        return initializeTelemetry(done)
+      })
     },
 
     // ─── HTTP Request & Exception Instrumentation ───────────────
@@ -364,6 +322,45 @@ module.exports = function defineSlipwayHook(sails) {
       flush()
       return done()
     }
+  }
+
+  function initializeTelemetry(done) {
+    if (!config.telemetryUrl || !config.telemetryToken) {
+      sails.log.verbose(
+        'sails-hook-slipway: No telemetry endpoint configured, skipping.'
+      )
+      return done()
+    }
+
+    if (!config.enabled) {
+      sails.log.verbose('sails-hook-slipway: Disabled via config.')
+      return done()
+    }
+
+    sails.log.info('sails-hook-slipway: Initializing telemetry instrumentation')
+    flushTimer = setInterval(flush, config.flushInterval)
+
+    if (config.captureExceptions) {
+      instrumentExceptions()
+    }
+
+    if (config.captureQueries) {
+      sails.after('hook:orm:loaded', () => {
+        instrumentQueries()
+      })
+    }
+
+    if (config.captureQuestEvents) {
+      instrumentQuest()
+    }
+
+    if (config.captureCache) {
+      sails.after('hook:stash:loaded', () => {
+        instrumentCache()
+      })
+    }
+
+    return done()
   }
 
   // ─── Exception Instrumentation (process-level) ─────────────────
@@ -782,7 +779,7 @@ module.exports = function defineSlipwayHook(sails) {
     return path.startsWith('/') && !path.startsWith('//') ? path : fallback
   }
 
-  function initializeReleaseFlags() {
+  function initializeReleaseFlags(done) {
     releaseFlags = createReleaseFlags({
       url: flagsConfig.url,
       token: flagsConfig.token,
@@ -790,34 +787,58 @@ module.exports = function defineSlipwayHook(sails) {
       requestTimeout: flagsConfig.requestTimeout
     })
 
-    const enabled = async function (inputs = {}) {
-      const defaultValue = inputs.defaultValue === true
-      if (!flagsConfig.enabled || !flagsConfig.url || !flagsConfig.token) {
-        recordFlagEvaluation(inputs.req, inputs.key, defaultValue, 'default')
-        return defaultValue
+    if (!sails.hooks.helpers) {
+      return done(
+        new Error(
+          'Cannot load sails-hook-slipway without enabling the "helpers" hook!'
+        )
+      )
+    }
+
+    sails.after('hook:helpers:loaded', () => {
+      try {
+        if (sails.helpers.flags?.enabled) {
+          sails.log.warn(
+            'sails-hook-slipway: Keeping the app-owned `flags.enabled` helper.'
+          )
+          return done()
+        }
+
+        sails.hooks.helpers.furnishHelper(
+          'flags.enabled',
+          buildFlagsEnabledHelper({ evaluate: evaluateReleaseFlag })
+        )
+      } catch (error) {
+        return done(error)
       }
 
-      const evaluation = await releaseFlags.evaluate({
-        key: String(inputs.key || ''),
-        context: requestFlagContext(inputs.req, inputs.context),
-        defaultValue
-      })
-      recordFlagEvaluation(
-        inputs.req,
-        inputs.key,
-        evaluation.value,
-        evaluation.reason,
-        evaluation.flagVersion
-      )
-      return evaluation.value
-    }
-    enabled.with = enabled
-    sails.helpers.flags = sails.helpers.flags || {}
-    sails.helpers.flags.enabled = enabled
+      if (flagsConfig.enabled && flagsConfig.url && flagsConfig.token) {
+        releaseFlags.refresh().catch(() => {})
+      }
+      return done()
+    })
+  }
 
-    if (flagsConfig.enabled && flagsConfig.url && flagsConfig.token) {
-      releaseFlags.refresh().catch(() => {})
+  async function evaluateReleaseFlag(inputs) {
+    const defaultValue = inputs.defaultValue === true
+    if (!flagsConfig.enabled || !flagsConfig.url || !flagsConfig.token) {
+      recordFlagEvaluation(inputs.req, inputs.key, defaultValue, 'default')
+      return defaultValue
     }
+
+    const evaluation = await releaseFlags.evaluate({
+      key: inputs.key,
+      context: requestFlagContext(inputs.req, inputs.context),
+      defaultValue
+    })
+    recordFlagEvaluation(
+      inputs.req,
+      inputs.key,
+      evaluation.value,
+      evaluation.reason,
+      evaluation.flagVersion
+    )
+    return evaluation.value
   }
 
   function requestFlagContext(req, supplied = {}) {

--- a/packages/hook/lib/helpers/flags/enabled.js
+++ b/packages/hook/lib/helpers/flags/enabled.js
@@ -1,0 +1,40 @@
+module.exports = function buildFlagsEnabledHelper({ evaluate }) {
+  if (typeof evaluate !== 'function') {
+    throw new Error('A release flag evaluator is required.')
+  }
+
+  return {
+    friendlyName: 'Check release flag',
+
+    description:
+      'Return whether a Slipway release flag is enabled for this request or context.',
+
+    inputs: {
+      key: {
+        type: 'string',
+        required: true,
+        regex: /\S/
+      },
+      req: {
+        type: 'ref'
+      },
+      context: {
+        type: 'ref'
+      },
+      defaultValue: {
+        type: 'boolean',
+        defaultsTo: false
+      }
+    },
+
+    exits: {
+      success: {
+        outputType: 'boolean'
+      }
+    },
+
+    fn: async function (inputs) {
+      return await evaluate(inputs)
+    }
+  }
+}

--- a/tests/unit/packages/hook-bridge.test.js
+++ b/tests/unit/packages/hook-bridge.test.js
@@ -139,6 +139,11 @@ async function createBridgeRoute({
         }
       }
     },
+    hooks: {
+      helpers: {
+        furnishHelper: () => {}
+      }
+    },
     log: {
       verbose: () => {},
       info: () => {},
@@ -152,7 +157,9 @@ async function createBridgeRoute({
       }
     },
     helpers: {},
-    after: () => {},
+    after: (event, callback) => {
+      if (event === 'hook:helpers:loaded') callback()
+    },
     on: () => {}
   }
   const hook = defineSlipwayHook(sails)

--- a/tests/unit/packages/hook-helper-machine.test.js
+++ b/tests/unit/packages/hook-helper-machine.test.js
@@ -1,0 +1,148 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { Sails } = require('sails')
+const { test } = require('sounding')
+
+const hookPath = path.resolve(__dirname, '../../../packages/hook')
+
+test('Sails furnishes the release flag helper as a genuine helper machine', async ({
+  expect
+}) => {
+  const appPath = createTestApp()
+  let app
+
+  try {
+    app = await liftTestApp(appPath)
+
+    expect(typeof app.helpers.flags.enabled).toBe('function')
+    expect(typeof app.helpers.flags.enabled.with).toBe('function')
+
+    const req = {}
+    const enabled = await app.helpers.flags.enabled.with({
+      key: 'new-checkout',
+      req,
+      defaultValue: true
+    })
+
+    expect(enabled).toBe(true)
+    expect(req._slipwayFlagEvaluations['new-checkout'].value).toBe(true)
+    expect(req._slipwayFlagEvaluations['new-checkout'].reason).toBe('default')
+
+    let validationError
+    try {
+      await app.helpers.flags.enabled.with({ defaultValue: true })
+    } catch (error) {
+      validationError = error
+    }
+
+    expect(Boolean(validationError)).toBe(true)
+    expect(validationError.message).toContain('key')
+  } finally {
+    await lowerTestApp(app)
+    fs.rmSync(appPath, { recursive: true, force: true })
+  }
+})
+
+test('the hook preserves an app-owned flags.enabled helper', async ({
+  expect
+}) => {
+  const appPath = createTestApp({ appOwnedHelper: true })
+  let app
+
+  try {
+    app = await liftTestApp(appPath)
+
+    const enabled = await app.helpers.flags.enabled.with({
+      key: 'new-checkout',
+      defaultValue: true
+    })
+
+    expect(enabled).toBe(false)
+  } finally {
+    await lowerTestApp(app)
+    fs.rmSync(appPath, { recursive: true, force: true })
+  }
+})
+
+function createTestApp({ appOwnedHelper = false } = {}) {
+  const appPath = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'sails-hook-slipway-helper-')
+  )
+  const nodeModulesPath = path.join(appPath, 'node_modules')
+  fs.mkdirSync(nodeModulesPath)
+  fs.writeFileSync(
+    path.join(appPath, 'package.json'),
+    JSON.stringify({
+      name: 'sails-hook-slipway-test-app',
+      private: true,
+      dependencies: {
+        'sails-hook-slipway': '0.0.4'
+      }
+    })
+  )
+  fs.symlinkSync(hookPath, path.join(nodeModulesPath, 'sails-hook-slipway'))
+
+  if (appOwnedHelper) {
+    const helperPath = path.join(appPath, 'api/helpers/flags')
+    fs.mkdirSync(helperPath, { recursive: true })
+    fs.writeFileSync(
+      path.join(helperPath, 'enabled.js'),
+      `module.exports = {
+  friendlyName: 'App-owned release flag',
+  sync: true,
+  inputs: {
+    key: { type: 'string', required: true },
+    defaultValue: { type: 'boolean', defaultsTo: false }
+  },
+  exits: {
+    success: { outputType: 'boolean' }
+  },
+  fn: function () {
+    return false
+  }
+}
+`
+    )
+  }
+
+  return appPath
+}
+
+function liftTestApp(appPath) {
+  return new Promise((resolve, reject) => {
+    const app = new Sails()
+    app.lift(
+      {
+        appPath,
+        port: 0,
+        environment: 'test',
+        globals: false,
+        log: { level: 'silent' },
+        hooks: {
+          blueprints: false,
+          grunt: false,
+          i18n: false,
+          orm: false,
+          policies: false,
+          pubsub: false,
+          security: false,
+          session: false,
+          sockets: false,
+          views: false
+        },
+        slipway: {
+          bridge: { enabled: false },
+          flags: { enabled: false },
+          lookout: { enabled: false }
+        }
+      },
+      (error) => (error ? reject(error) : resolve(app))
+    )
+  })
+}
+
+function lowerTestApp(app) {
+  if (!app) return Promise.resolve()
+  return new Promise((resolve) => app.lower(resolve))
+}


### PR DESCRIPTION
## What changed

- register `flags.enabled` through the built-in Sails helpers hook, following the proven `sails-hook-mail` lifecycle
- declare and validate `key`, `req`, `context`, and `defaultValue` as genuine machine inputs
- preserve an app-owned `flags.enabled` helper instead of overwriting it
- add Sounding trials that lift a real temporary Sails app and load the packaged hook through `node_modules`
- document the helper-machine contract

## Verification

- `npm run lint`
- `npm run test:unit` — 257 passed
- focused real-Sails Sounding trial — 2 passed
- `npm pack --dry-run ./packages/hook` — includes `lib/helpers/flags/enabled.js`

Closes #314