### PR TITLE
fix(bridge): prevent mutation redirect loops

### DIFF
--- a/api/controllers/project/revoke-bridge-access.js
+++ b/api/controllers/project/revoke-bridge-access.js
@@ -9,9 +9,9 @@ module.exports = {
   },
 
   exits: {
-    success: { responseType: 'redirect' },
-    notFound: { responseType: 'redirect' },
-    forbidden: { responseType: 'redirect' }
+    success: { responseType: 'inertiaRedirect' },
+    notFound: { responseType: 'inertiaRedirect' },
+    forbidden: { responseType: 'inertiaRedirect' }
   },
 
   fn: async function ({ slug, envSlug, appSlug, accessId }) {

--- a/api/controllers/project/update-bridge-access.js
+++ b/api/controllers/project/update-bridge-access.js
@@ -14,9 +14,9 @@ module.exports = {
   },
 
   exits: {
-    success: { responseType: 'redirect' },
-    notFound: { responseType: 'redirect' },
-    forbidden: { responseType: 'redirect' }
+    success: { responseType: 'inertiaRedirect' },
+    notFound: { responseType: 'inertiaRedirect' },
+    forbidden: { responseType: 'inertiaRedirect' }
   },
 
   fn: async function ({ slug, envSlug, appSlug, accessId, role }) {

--- a/api/controllers/project/update-bridge-settings.js
+++ b/api/controllers/project/update-bridge-settings.js
@@ -11,9 +11,9 @@ module.exports = {
   },
 
   exits: {
-    success: { responseType: 'redirect' },
-    notFound: { responseType: 'redirect' },
-    forbidden: { responseType: 'redirect' }
+    success: { responseType: 'inertiaRedirect' },
+    notFound: { responseType: 'inertiaRedirect' },
+    forbidden: { responseType: 'inertiaRedirect' }
   },
 
   fn: async function ({ slug, envSlug, appSlug, enabled }) {

--- a/api/helpers/deploy/get-direct-access.js
+++ b/api/helpers/deploy/get-direct-access.js
@@ -78,9 +78,9 @@ module.exports = {
       return {
         url: null,
         attemptedUrl,
-        status: 'unavailable',
-        message: `Docker published host port ${hostPort} only on ${portBinding.host}, so it is intentionally private. Bind routable apps to 0.0.0.0 and redeploy before using a public direct URL.`,
-        firewallHint
+        status: 'private',
+        message: null,
+        firewallHint: null
       }
     }
 

--- a/tests/functional/pages/bridge-access.test.js
+++ b/tests/functional/pages/bridge-access.test.js
@@ -3,6 +3,60 @@ const { test } = require('sounding')
 const { withCsrfFromPage } = require('../../support/csrf-request')
 
 test(
+  'Bridge access mutations return one Inertia location instead of replaying the mutation',
+  { world: bridgeWorld('bridge-mutation-redirects', 'Bridge Redirects') },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const accessPath = bridgeAccessPath(project, environment, app)
+    const access = await world.create('bridgeaccess').with({
+      email: 'editor@host-app.example',
+      role: 'viewer',
+      status: 'active',
+      hostUserId: 'host-editor-1',
+      activatedAt: Date.now(),
+      app: app.id,
+      environment: environment.id,
+      project: project.id,
+      team: current.teams.genesisTeam.id,
+      invitedBy: current.users.genesisUser.id
+    })
+    const browser = await withCsrfFromPage(request, accessPath, 'genesisUser')
+
+    const enabled = await browser.request.patch(accessPath, { enabled: true })
+
+    expect(enabled).toHaveStatus(409)
+    expect(enabled).toHaveHeader('x-inertia-location', accessPath)
+    expect((await sails.models.app.findOne({ id: app.id })).bridgeEnabled).toBe(
+      true
+    )
+
+    const updated = await browser.request.patch(`${accessPath}/${access.id}`, {
+      role: 'editor'
+    })
+
+    expect(updated).toHaveStatus(409)
+    expect(updated).toHaveHeader('x-inertia-location', accessPath)
+    expect(
+      (await sails.models.bridgeaccess.findOne({ id: access.id })).role
+    ).toBe('editor')
+
+    const revoked = await browser.request.delete(
+      `${accessPath}/${access.id}`,
+      {}
+    )
+
+    expect(revoked).toHaveStatus(409)
+    expect(revoked).toHaveHeader('x-inertia-location', accessPath)
+    expect(
+      (await sails.models.bridgeaccess.findOne({ id: access.id })).status
+    ).toBe('revoked')
+  }
+)
+
+test(
   'owner invites a host-app account without granting Slipway team access',
   { world: bridgeWorld('host-bridge-invite', 'Host Bridge Invite') },
   async ({ sails, world, request, visit, mailbox, expect }) => {

--- a/tests/unit/helpers/docker/direct-access.test.js
+++ b/tests/unit/helpers/docker/direct-access.test.js
@@ -110,7 +110,7 @@ test('workers never receive a direct HTTP endpoint', async ({
   expect(directAccess.url).toBe(null)
 })
 
-test('an intentionally private loopback binding is explained instead of advertised', async ({
+test('an intentionally private loopback binding stays quiet and is not advertised', async ({
   sails,
   expect
 }) => {
@@ -127,7 +127,8 @@ test('an intentionally private loopback binding is explained instead of advertis
     }
   })
 
-  expect(directAccess.status).toBe('unavailable')
+  expect(directAccess.status).toBe('private')
   expect(directAccess.url).toBe(null)
-  expect(directAccess.message).toMatch(/intentionally private/)
+  expect(directAccess.message).toBe(null)
+  expect(directAccess.firewallHint).toBe(null)
 })


### PR DESCRIPTION
## Summary

- use mutation-safe Inertia redirects for Bridge enable, role update, and revoke actions
- classify the expected loopback Docker binding as a quiet private state
- retain actionable diagnostics for actual missing or invalid port mappings
- cover the regressions through public Sounding request and helper behavior

## Verification

- npm run lint
- npm run check:consistency
- npm test (259 unit, 95 functional, 42 e2e)

Closes #323