### PR TITLE
fix(bridge): make navigation and search fast

### DIFF
--- a/RELEASE_0.0.54.md
+++ b/RELEASE_0.0.54.md
@@ -1,0 +1,73 @@
+# Slipway 0.0.54
+
+Slipway 0.0.54 makes Bridge a resident application runtime instead of paying
+the cost of booting the target Sails application for every page operation. It
+also keeps app-local Bridge browsing on the host application's `/bridge` URL.
+
+## Bridge performance
+
+### What was happening
+
+Every Bridge operation started `docker exec ... node`, loaded the deployed
+Sails application, ran one operation, lowered Sails, and exited. A Bridge page
+can perform introspection, authorization, dashboard, count, and record queries.
+Search repeated the same pipeline after its 300 ms debounce. Overlapping
+searches therefore created multiple temporary Sails processes, so later
+navigation appeared to stop responding while earlier work completed.
+
+### What changed
+
+- One production-mode Bridge worker is reused for each live app container.
+- Bridge-enabled apps are prewarmed after deploy and rollback and when Slipway
+  starts, keeping Sails bootstrap work outside normal Bridge requests.
+- A timeout or stopped container discards the worker so the next operation can
+  recover with a new one.
+- Record searches use an Inertia partial reload and do not repeat unchanged
+  dashboard work.
+- A new `local.sh bridge-benchmark` command compares the old lifecycle with
+  the resident runtime and fails when any warm operation reaches 500 ms.
+
+The resident worker intentionally remains separate from the application's web
+process. This preserves the existing execution boundary, so an expensive or
+failed Bridge operation cannot block the public application's event loop.
+
+### Local measurements
+
+On August 3, 2026, the reproducible local Docker benchmark recorded:
+
+| Measurement                         | Result                |
+| ----------------------------------- | --------------------- |
+| Old per-operation lifecycle         | 5,566 ms and 4,803 ms |
+| One-time deployment/startup prewarm | 4,864 ms              |
+| Five consecutive warm operations    | 1, 0, 0, 0, and 0 ms  |
+| Slowest warm runtime operation      | 1 ms                  |
+
+These numbers isolate Bridge runtime overhead. Database execution, network
+latency, the 300 ms search debounce, and browser rendering remain part of the
+complete user-visible latency.
+
+### Verification
+
+Start the local Docker stack and run the latency assertion:
+
+```bash
+bash ./local.sh
+bash ./local.sh bridge-benchmark
+```
+
+Then run the regression lanes:
+
+```bash
+npm run test:unit
+npm run test:functional
+```
+
+The 0.0.54 release gate is:
+
+- no target Sails bootstrap during warm navigation or search;
+- every warm runtime operation below 500 ms;
+- a table-only search does not re-run dashboard queries;
+- worker timeout is bounded and the next operation starts a clean worker;
+- first visible Bridge page below two seconds in the production smoke test;
+- subsequent navigation below 500 ms in the production smoke test; and
+- search results begin rendering within 800 ms after the final keystroke.

--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -74,6 +74,28 @@ module.exports = {
     lens,
     dashboard
   }) {
+    const partialProps = inertiaPartialProps(this.req)
+    const shouldLoadDashboard =
+      partialProps.size === 0 ||
+      ['activeDashboard', 'dashboards', 'dashboardResources'].some((prop) =>
+        partialProps.has(prop)
+      )
+    const shouldLoadRecords =
+      partialProps.size === 0 ||
+      [
+        'records',
+        'total',
+        'totalPages',
+        'currentPage',
+        'perPage',
+        'sort',
+        'search',
+        'filterState',
+        'filterDefinitions',
+        'columns',
+        'lenses',
+        'activeLens'
+      ].some((prop) => partialProps.has(prop))
     let resolved
     try {
       resolved = await sails.helpers.bridge.resolveRequest.with({
@@ -119,91 +141,96 @@ module.exports = {
           actor
         })
         modelMeta = loaded.resource
-        const dashboardDefinitions = Object.values(
-          loaded.contract.dashboards || {}
-        ).filter(
-          (definition) =>
-            definition.scope === 'resource' &&
-            definition.resource === modelIdentity
-        )
-        dashboards = dashboardDefinitions.map((definition) => ({
-          id: definition.id,
-          label: definition.label,
-          scope: definition.scope
-        }))
-        const selectedDashboard =
-          dashboardDefinitions.find(
-            (definition) => definition.id === dashboard
-          ) ||
-          dashboardDefinitions.find((definition) => definition.default) ||
-          dashboardDefinitions[0]
+        if (shouldLoadDashboard) {
+          const dashboardDefinitions = Object.values(
+            loaded.contract.dashboards || {}
+          ).filter(
+            (definition) =>
+              definition.scope === 'resource' &&
+              definition.resource === modelIdentity
+          )
+          dashboards = dashboardDefinitions.map((definition) => ({
+            id: definition.id,
+            label: definition.label,
+            scope: definition.scope
+          }))
+          const selectedDashboard =
+            dashboardDefinitions.find(
+              (definition) => definition.id === dashboard
+            ) ||
+            dashboardDefinitions.find((definition) => definition.default) ||
+            dashboardDefinitions[0]
 
-        if (selectedDashboard) {
-          const authorizedResources =
-            await sails.helpers.bridge.authorizeResourceActions.with({
+          if (selectedDashboard) {
+            const authorizedResources =
+              await sails.helpers.bridge.authorizeResourceActions.with({
+                containerName: app.containerName,
+                resources: loaded.contract.models,
+                actor
+              })
+            const authorizedDashboardResources = Object.fromEntries(
+              Object.entries(authorizedResources).filter(
+                ([, resource]) => !resource.hidden
+              )
+            )
+            dashboardResources = Object.fromEntries(
+              Object.entries(authorizedResources).filter(
+                ([, resource]) =>
+                  !resource.hidden && resource.actions?.viewAny !== false
+              )
+            )
+            activeDashboard = await sails.helpers.bridge.resolveDashboard.with({
               containerName: app.containerName,
-              resources: loaded.contract.models,
+              dashboard: selectedDashboard,
+              resources: authorizedDashboardResources,
               actor
             })
-          const authorizedDashboardResources = Object.fromEntries(
-            Object.entries(authorizedResources).filter(
-              ([, resource]) => !resource.hidden
-            )
-          )
-          dashboardResources = Object.fromEntries(
-            Object.entries(authorizedResources).filter(
-              ([, resource]) =>
-                !resource.hidden && resource.actions?.viewAny !== false
-            )
-          )
-          activeDashboard = await sails.helpers.bridge.resolveDashboard.with({
+          }
+        }
+
+        if (shouldLoadRecords) {
+          const normalizedQuery =
+            await sails.helpers.bridge.normalizeResourceQuery.with({
+              resource: modelMeta,
+              page,
+              perPage,
+              sort,
+              search,
+              filters,
+              lens
+            })
+
+          normalizedPage = normalizedQuery.page
+          normalizedPerPage = normalizedQuery.perPage
+          normalizedSort = normalizedQuery.sort
+          normalizedSearch = normalizedQuery.search
+          normalizedFilters = normalizedQuery.filters
+          columns = normalizedQuery.columns
+          activeLens = normalizedQuery.lens
+          filterDefinitions = normalizedQuery.filterDefinitions
+          lenses = Object.values(modelMeta.lenses || {}).map((definition) => ({
+            id: definition.id,
+            label: definition.label,
+            default: definition.default
+          }))
+
+          const data = await sails.helpers.bridge.queryResource.with({
             containerName: app.containerName,
-            dashboard: selectedDashboard,
-            resources: authorizedDashboardResources,
+            resource: modelMeta,
+            query: normalizedQuery,
             actor
           })
-        }
-        const normalizedQuery =
-          await sails.helpers.bridge.normalizeResourceQuery.with({
-            resource: modelMeta,
-            page,
-            perPage,
-            sort,
-            search,
-            filters,
-            lens
+          records = await sails.helpers.bridge.redactResourceRecords.with({
+            records: data.records || [],
+            resource: {
+              ...modelMeta,
+              list: normalizedQuery.select
+            },
+            surface: 'list'
           })
-
-        normalizedPage = normalizedQuery.page
-        normalizedPerPage = normalizedQuery.perPage
-        normalizedSort = normalizedQuery.sort
-        normalizedSearch = normalizedQuery.search
-        normalizedFilters = normalizedQuery.filters
-        columns = normalizedQuery.columns
-        activeLens = normalizedQuery.lens
-        filterDefinitions = normalizedQuery.filterDefinitions
-        lenses = Object.values(modelMeta.lenses || {}).map((definition) => ({
-          id: definition.id,
-          label: definition.label,
-          default: definition.default
-        }))
-
-        const data = await sails.helpers.bridge.queryResource.with({
-          containerName: app.containerName,
-          resource: modelMeta,
-          query: normalizedQuery,
-          actor
-        })
-        records = await sails.helpers.bridge.redactResourceRecords.with({
-          records: data.records || [],
-          resource: {
-            ...modelMeta,
-            list: normalizedQuery.select
-          },
-          surface: 'list'
-        })
-        total = data.total || 0
-        totalPages = Math.ceil(total / normalizedPerPage)
+          total = data.total || 0
+          totalPages = Math.ceil(total / normalizedPerPage)
+        }
       } catch (err) {
         error = err.message
       }
@@ -252,4 +279,20 @@ module.exports = {
       }
     }
   }
+}
+
+function inertiaPartialProps(req) {
+  if (
+    req.get('X-Inertia') !== 'true' ||
+    req.get('X-Inertia-Partial-Component') !== 'projects/bridge-model'
+  ) {
+    return new Set()
+  }
+
+  return new Set(
+    String(req.get('X-Inertia-Partial-Data') || '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+  )
 }

--- a/api/helpers/bridge/build-sails-wrapper.js
+++ b/api/helpers/bridge/build-sails-wrapper.js
@@ -2,7 +2,7 @@ module.exports = {
   friendlyName: 'Build Sails wrapper',
 
   description:
-    'Wrap a Waterline expression in the Sails bootstrap boilerplate for container execution.',
+    'Prepare a Waterline expression for execution by the warm Bridge runtime.',
 
   inputs: {
     code: {
@@ -19,43 +19,9 @@ module.exports = {
   },
 
   fn: async function ({ code }) {
-    // Use unique markers to isolate JSON output from any console noise
-    const startMarker = '___SLIPWAY_BRIDGE_START___'
-    const endMarker = '___SLIPWAY_BRIDGE_END___'
-
-    return `
-(async () => {
-  let sailsApp;
-  try {
-    sailsApp = require('sails');
-    await new Promise((resolve, reject) => {
-      sailsApp.load({
-        hooks: { http: false, views: false, sockets: false, pubsub: false, grunt: false, flash: false, session: false },
-        log: { level: 'silent' }
-      }, (err) => {
-        if (err) reject(err);
-        else resolve();
-      });
-    });
-
-    const __result = await (async function() {
-      ${code}
-    })();
-
-    if (__result !== undefined) {
-      process.stdout.write('${startMarker}' + JSON.stringify(__result) + '${endMarker}');
-    }
-  } catch (err) {
-    process.stderr.write(err.stack || err.message);
-    process.exitCode = 1;
-  }
-
-  if (sailsApp && sailsApp.lower) {
-    sailsApp.lower(() => process.exit());
-  } else {
-    process.exit();
-  }
-})();
-`
+    // The worker owns the Sails lifecycle. Keeping this helper as the single
+    // preparation boundary avoids changing the Bridge feature helpers while
+    // ensuring they no longer load and lower the target app for every query.
+    return code
   }
 }

--- a/api/helpers/bridge/execute-in-container.js
+++ b/api/helpers/bridge/execute-in-container.js
@@ -1,14 +1,19 @@
 const { spawn } = require('child_process')
 
-// Markers used to isolate JSON output from console noise
-const START_MARKER = '___SLIPWAY_BRIDGE_START___'
-const END_MARKER = '___SLIPWAY_BRIDGE_END___'
+const RESULT_MARKER = '___SLIPWAY_BRIDGE_WORKER_RESULT___'
+const BOOT_ERROR_MARKER = '___SLIPWAY_BRIDGE_WORKER_BOOT_ERROR___'
+const MAX_CODE_BYTES = 512 * 1024
+const MAX_OUTPUT_BYTES = 2 * 1024 * 1024
+const MAX_STDERR_BYTES = 64 * 1024
+const workers = new Map()
+let nextJobId = 1
+let teardownRegistered = false
 
 module.exports = {
   friendlyName: 'Execute in container',
 
   description:
-    'Execute JavaScript code inside a running app container and return the result.',
+    'Execute JavaScript through one warm Sails runtime per running app container.',
 
   inputs: {
     containerName: {
@@ -35,54 +40,258 @@ module.exports = {
   },
 
   fn: async function ({ containerName, code, timeout }) {
-    return new Promise((resolve) => {
-      const dockerPath = sails.config.docker?.binaryPath || 'docker'
-      const proc = spawn(
-        dockerPath,
-        ['exec', '-e', 'NODE_ENV=production', '-i', containerName, 'node'],
-        { timeout }
+    registerTeardown()
+
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+    const key = `${dockerPath}\u0000${containerName}`
+    let worker = workers.get(key)
+    if (!worker || worker.closed) {
+      worker = createWorker({ key, dockerPath, containerName })
+      workers.set(key, worker)
+    }
+
+    return execute(worker, code, timeout)
+  }
+}
+
+function createWorker({ key, dockerPath, containerName }) {
+  const proc = spawn(dockerPath, [
+    'exec',
+    '-e',
+    'NODE_ENV=production',
+    '-i',
+    containerName,
+    'node',
+    '-e',
+    buildWorkerSource()
+  ])
+  const worker = {
+    key,
+    proc,
+    pending: new Map(),
+    stdout: '',
+    stderr: '',
+    closed: false
+  }
+
+  proc.stdout.on('data', (data) => {
+    worker.stdout += data.toString()
+    if (Buffer.byteLength(worker.stdout) > MAX_OUTPUT_BYTES) {
+      failWorker(worker, 'Bridge worker output exceeded the safe limit.')
+      return
+    }
+    consumeWorkerOutput(worker)
+  })
+
+  proc.stderr.on('data', (data) => {
+    if (Buffer.byteLength(worker.stderr) >= MAX_STDERR_BYTES) return
+    worker.stderr = `${worker.stderr}${data.toString()}`.slice(
+      0,
+      MAX_STDERR_BYTES
+    )
+  })
+
+  proc.on('error', (error) => {
+    failWorker(worker, error.message)
+  })
+
+  proc.on('close', (exitCode) => {
+    if (worker.closed) return
+    const detail = worker.stderr.trim()
+    failWorker(
+      worker,
+      detail || `Bridge worker stopped unexpectedly (exit ${exitCode}).`,
+      exitCode || 1
+    )
+  })
+
+  proc.stdin.on('error', (error) => {
+    failWorker(worker, error.message)
+  })
+
+  return worker
+}
+
+function execute(worker, code, timeout) {
+  return new Promise((resolve) => {
+    if (Buffer.byteLength(code) > MAX_CODE_BYTES) {
+      return resolve(failure('Bridge worker code exceeded the safe limit.'))
+    }
+    if (worker.closed || !worker.proc.stdin.writable) {
+      return resolve(failure('Bridge worker is unavailable.'))
+    }
+
+    const id = nextJobId++
+    const timer = setTimeout(() => {
+      if (!worker.pending.has(id)) return
+      worker.pending.delete(id)
+      resolve(failure(`Bridge worker timed out after ${timeout}ms.`))
+      failWorker(worker, 'Bridge worker was restarted after a timeout.')
+    }, timeout)
+
+    worker.pending.set(id, { resolve, timer })
+    try {
+      worker.proc.stdin.write(`${JSON.stringify({ id, code })}\n`)
+    } catch (error) {
+      clearTimeout(timer)
+      worker.pending.delete(id)
+      resolve(failure(error.message))
+      failWorker(worker, error.message)
+    }
+  })
+}
+
+function consumeWorkerOutput(worker) {
+  let newlineIndex
+  while ((newlineIndex = worker.stdout.indexOf('\n')) !== -1) {
+    const line = worker.stdout.slice(0, newlineIndex)
+    worker.stdout = worker.stdout.slice(newlineIndex + 1)
+
+    const bootErrorIndex = line.indexOf(BOOT_ERROR_MARKER)
+    if (bootErrorIndex !== -1) {
+      failWorker(
+        worker,
+        line.slice(bootErrorIndex + BOOT_ERROR_MARKER.length) ||
+          'The target Sails app could not start.'
       )
+      return
+    }
 
-      let stdout = ''
-      let stderr = ''
+    const markerIndex = line.indexOf(RESULT_MARKER)
+    if (markerIndex === -1) continue
 
-      proc.stdout.on('data', (data) => {
-        stdout += data.toString()
-      })
+    let result
+    try {
+      result = JSON.parse(line.slice(markerIndex + RESULT_MARKER.length))
+    } catch {
+      failWorker(worker, 'Bridge worker returned an invalid response.')
+      return
+    }
 
-      proc.stderr.on('data', (data) => {
-        stderr += data.toString()
-      })
-
-      proc.stdin.write(code)
-      proc.stdin.end()
-
-      proc.on('close', (exitCode) => {
-        // Extract JSON between markers to filter out any console noise
-        let output = stdout.trim()
-        const startIdx = output.indexOf(START_MARKER)
-        const endIdx = output.indexOf(END_MARKER)
-
-        if (startIdx !== -1 && endIdx !== -1 && endIdx > startIdx) {
-          output = output.substring(startIdx + START_MARKER.length, endIdx)
-        }
-
-        resolve({
-          success: exitCode === 0,
-          output,
-          error: stderr.trim() || null,
-          exitCode
-        })
-      })
-
-      proc.on('error', (err) => {
-        resolve({
-          success: false,
-          output: '',
-          error: err.message,
-          exitCode: 1
-        })
-      })
+    const pending = worker.pending.get(result.id)
+    if (!pending) continue
+    clearTimeout(pending.timer)
+    worker.pending.delete(result.id)
+    pending.resolve({
+      success: result.success === true,
+      output: typeof result.output === 'string' ? result.output : '',
+      error: typeof result.error === 'string' ? result.error : null,
+      exitCode: result.success === true ? 0 : 1
     })
   }
+}
+
+function failWorker(worker, message, exitCode = 1) {
+  if (worker.closed) return
+  worker.closed = true
+  if (workers.get(worker.key) === worker) workers.delete(worker.key)
+
+  for (const pending of worker.pending.values()) {
+    clearTimeout(pending.timer)
+    pending.resolve(failure(message, exitCode))
+  }
+  worker.pending.clear()
+
+  if (!worker.proc.killed) worker.proc.kill('SIGTERM')
+}
+
+function failure(message, exitCode = 1) {
+  return {
+    success: false,
+    output: '',
+    error: message || 'Bridge worker failed.',
+    exitCode
+  }
+}
+
+function registerTeardown() {
+  if (teardownRegistered) return
+  teardownRegistered = true
+  sails.once('lower', closeAllWorkers)
+}
+
+function closeAllWorkers() {
+  for (const worker of workers.values()) {
+    failWorker(worker, 'Slipway is shutting down.')
+  }
+  workers.clear()
+}
+
+function buildWorkerSource() {
+  return `
+const readline = require('node:readline');
+const RESULT_MARKER = ${JSON.stringify(RESULT_MARKER)};
+const BOOT_ERROR_MARKER = ${JSON.stringify(BOOT_ERROR_MARKER)};
+
+(async () => {
+  let sailsApp;
+  try {
+    sailsApp = require('sails');
+    await new Promise((resolve, reject) => {
+      sailsApp.load({
+        hooks: {
+          http: false,
+          views: false,
+          sockets: false,
+          pubsub: false,
+          grunt: false,
+          flash: false,
+          session: false
+        },
+        security: { csrf: false },
+        log: { level: 'silent' }
+      }, (error) => error ? reject(error) : resolve());
+    });
+  } catch (error) {
+    process.stdout.write(
+      BOOT_ERROR_MARKER + (error.stack || error.message || String(error)) + '\\n'
+    );
+    process.exit(1);
+    return;
+  }
+
+  const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+  const input = readline.createInterface({ input: process.stdin });
+  let queue = Promise.resolve();
+
+  input.on('line', (line) => {
+    queue = queue.then(async () => {
+      let job;
+      try {
+        job = JSON.parse(line);
+        const run = new AsyncFunction('sails', 'require', job.code);
+        const value = await run(sailsApp, require);
+        const output = value === undefined ? '' : JSON.stringify(value);
+        process.stdout.write(
+          RESULT_MARKER + JSON.stringify({
+            id: job.id,
+            success: true,
+            output,
+            error: null
+          }) + '\\n'
+        );
+      } catch (error) {
+        process.stdout.write(
+          RESULT_MARKER + JSON.stringify({
+            id: job && job.id,
+            success: false,
+            output: '',
+            error: error.stack || error.message || String(error)
+          }) + '\\n'
+        );
+      }
+    });
+  });
+
+  input.on('close', () => {
+    queue.finally(() => {
+      if (sailsApp && sailsApp.lower) {
+        sailsApp.lower(() => process.exit());
+      } else {
+        process.exit();
+      }
+    });
+  });
+})();
+`
 }

--- a/api/helpers/bridge/warm-runtime.js
+++ b/api/helpers/bridge/warm-runtime.js
@@ -1,0 +1,41 @@
+module.exports = {
+  friendlyName: 'Warm Bridge runtime',
+
+  description:
+    'Start and verify the reusable Bridge runtime for a running app container.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    timeout: {
+      type: 'number',
+      defaultsTo: 30000
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'boolean'
+    }
+  },
+
+  fn: async function ({ containerName, timeout }) {
+    const result = await sails.helpers.bridge.executeInContainer.with({
+      containerName,
+      code: 'return { ready: true }',
+      timeout
+    })
+
+    if (!result.success) {
+      const error = new Error(
+        result.error || `Bridge runtime for ${containerName} did not start.`
+      )
+      error.code = 'BRIDGE_RUNTIME_WARMUP_FAILED'
+      throw error
+    }
+
+    return true
+  }
+}

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -314,6 +314,23 @@ module.exports = {
       // failure cleanup if this worker loses its lease after cutover.
       deployContainerName = null
 
+      if (targetApp?.bridgeEnabled) {
+        try {
+          await sails.helpers.bridge.warmRuntime.with({
+            containerName: containerResult.containerName
+          })
+          await Deployment.appendDeployLog(
+            deploymentId,
+            `Bridge runtime warmed for ${containerResult.containerName}.\n`
+          )
+        } catch (error) {
+          await Deployment.appendDeployLog(
+            deploymentId,
+            `Bridge runtime warmup deferred: ${error.message}\n`
+          )
+        }
+      }
+
       await recordStage('cleanup')
       await releaseDeployPort({ hostPort: deployHostPort, deploymentId })
       deployHostPortReserved = false

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -227,6 +227,22 @@ module.exports = {
       })
 
       candidateContainerName = null
+      if (existingApp?.bridgeEnabled) {
+        try {
+          await sails.helpers.bridge.warmRuntime.with({
+            containerName: containerResult.containerName
+          })
+          await Deployment.appendDeployLog(
+            rollbackId,
+            `Bridge runtime warmed for ${containerResult.containerName}.\n`
+          )
+        } catch (error) {
+          await Deployment.appendDeployLog(
+            rollbackId,
+            `Bridge runtime warmup deferred: ${error.message}\n`
+          )
+        }
+      }
       await recordStage('cleanup')
       await releaseDeployPort({ hostPort, deploymentId: rollbackId })
       hostPortReserved = false

--- a/api/hooks/bridge-runtime/index.js
+++ b/api/hooks/bridge-runtime/index.js
@@ -1,0 +1,41 @@
+module.exports = function defineBridgeRuntimeHook(sails) {
+  return {
+    initialize: async function () {
+      sails.after('hook:orm:loaded', () => {
+        warmRunningBridgeApps().catch((error) => {
+          sails.log.warn(
+            `Bridge: Could not warm running app runtimes: ${error.message}`
+          )
+        })
+      })
+    }
+  }
+
+  async function warmRunningBridgeApps() {
+    const apps = await App.find({
+      bridgeEnabled: true,
+      status: 'running'
+    }).select(['id', 'containerName'])
+    const candidates = apps.filter((app) => app.containerName)
+
+    for (let index = 0; index < candidates.length; index += 2) {
+      const batch = candidates.slice(index, index + 2)
+      await Promise.all(batch.map(warmApp))
+    }
+  }
+
+  async function warmApp(app) {
+    try {
+      await sails.helpers.bridge.warmRuntime.with({
+        containerName: app.containerName
+      })
+      sails.log.verbose(
+        `Bridge: Warm runtime ready for app ${app.id} (${app.containerName}).`
+      )
+    } catch (error) {
+      sails.log.warn(
+        `Bridge: Runtime warmup failed for app ${app.id} (${app.containerName}): ${error.message}`
+      )
+    }
+  }
+}

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -59,6 +59,21 @@ const defaultLens = computed(() =>
   (props.lenses || []).find((definition) => definition.default)
 )
 const allRecordsLensValue = computed(() => (defaultLens.value ? '__all' : ''))
+const tableReloadProps = [
+  'records',
+  'total',
+  'totalPages',
+  'currentPage',
+  'perPage',
+  'sort',
+  'search',
+  'filterState',
+  'filterDefinitions',
+  'columns',
+  'lenses',
+  'activeLens',
+  'error'
+]
 
 // Local state for UI
 const page = ref(props.currentPage)
@@ -196,7 +211,7 @@ let searchTimeout = null
 watch(searchInput, (val) => {
   clearTimeout(searchTimeout)
   searchTimeout = setTimeout(() => {
-    navigateWithParams({ search: val, page: 1 })
+    navigateWithParams({ search: val, page: 1 }, { replace: true })
   }, 300)
 })
 watch(
@@ -226,7 +241,7 @@ watch(
 )
 
 // Navigate with updated params
-function navigateWithParams(updates) {
+function navigateWithParams(updates, visitOptions = {}) {
   const params = {
     page: updates.page ?? page.value,
     sort: updates.sort ?? sortValue.value,
@@ -260,7 +275,9 @@ function navigateWithParams(updates) {
 
   router.visit(query ? `${basePath}?${query}` : basePath, {
     preserveState: true,
-    preserveScroll: true
+    preserveScroll: true,
+    only: visitOptions.only || tableReloadProps,
+    replace: visitOptions.replace === true
   })
 }
 
@@ -465,7 +482,10 @@ function goToPage(newPage) {
 }
 
 function switchDashboard(event) {
-  navigateWithParams({ dashboard: event.target.value, page: 1 })
+  navigateWithParams(
+    { dashboard: event.target.value, page: 1 },
+    { only: ['activeDashboard', 'error'], replace: true }
+  )
 }
 
 // URL builders

--- a/local.sh
+++ b/local.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Slipway local installer
-# Usage: bash ./local.sh [install|rebuild|stop|down|destroy|logs|status|shell]
+# Usage: bash ./local.sh [install|rebuild|stop|down|destroy|logs|status|shell|bridge-benchmark]
 
 set -euo pipefail
 
@@ -26,7 +26,7 @@ SLIPWAY_URL="${SLIPWAY_LOCAL_URL:-http://${HOST}:${PORT}}"
 
 usage() {
   cat <<EOF
-Usage: bash ./local.sh [install|rebuild|stop|down|destroy|logs|status|shell]
+Usage: bash ./local.sh [install|rebuild|stop|down|destroy|logs|status|shell|bridge-benchmark]
 
 Commands:
   install   Build the current checkout and run Slipway locally in Docker
@@ -37,6 +37,8 @@ Commands:
   logs      Tail logs from the local Slipway container
   status    Show the local Slipway container status
   shell     Open a shell inside the local Slipway container
+  bridge-benchmark
+            Compare cold and warm Bridge runtime operations; fail above 500ms warm
 EOF
 }
 
@@ -231,6 +233,47 @@ open_shell() {
   docker exec -it "$CONTAINER_NAME" bash
 }
 
+benchmark_bridge_runtime() {
+  local benchmark_container
+  benchmark_container="slipway-bridge-perf-$$"
+
+  if [ "$(docker inspect --format '{{.State.Running}}' "$CONTAINER_NAME" 2>/dev/null || true)" != "true" ]; then
+    echo "${CONTAINER_NAME} must be running. Start it with: bash ./local.sh" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$SLIPWAY_ENV_FILE" ]; then
+    echo "Missing ${SLIPWAY_ENV_FILE}. Start Slipway once before benchmarking." >&2
+    exit 1
+  fi
+
+  cleanup_bridge_benchmark() {
+    docker rm -f -v "$benchmark_container" >/dev/null 2>&1 || true
+  }
+  trap cleanup_bridge_benchmark EXIT INT TERM
+
+  echo "Starting isolated Bridge performance target..."
+  docker run -d \
+    --name "$benchmark_container" \
+    --network "$NETWORK_NAME" \
+    --env-file "$SLIPWAY_ENV_FILE" \
+    -e NODE_ENV=production \
+    -e SLIPWAY_MIGRATE=safe \
+    -e SLIPWAY_URL="http://${benchmark_container}:1337" \
+    -e SLIPWAY_SSL=false \
+    -v "$ROOT_DIR:/app" \
+    -v "$NODE_MODULES_VOLUME:/app/node_modules" \
+    -v /app/db \
+    "$IMAGE_NAME" sleep infinity >/dev/null
+
+  docker exec "$CONTAINER_NAME" \
+    node scripts/benchmark-bridge-runtime.js "$benchmark_container" --assert
+
+  echo -e "${GREEN}Bridge warm-runtime benchmark passed${NC}"
+  cleanup_bridge_benchmark
+  trap - EXIT INT TERM
+}
+
 destroy_local_state() {
   remove_container
   docker volume rm -f "$NODE_MODULES_VOLUME" "$NPM_CACHE_VOLUME" >/dev/null 2>&1 || true
@@ -286,6 +329,9 @@ main() {
       ;;
     shell)
       open_shell
+      ;;
+    bridge-benchmark)
+      benchmark_bridge_runtime
       ;;
     *)
       usage

--- a/scripts/benchmark-bridge-runtime.js
+++ b/scripts/benchmark-bridge-runtime.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+
+const { spawn } = require('node:child_process')
+
+const containerName = process.argv[2]
+const shouldAssert = process.argv.includes('--assert')
+
+if (
+  !containerName ||
+  !/^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$/.test(containerName)
+) {
+  throw new Error(
+    'Usage: node scripts/benchmark-bridge-runtime.js <container-name> [--assert]'
+  )
+}
+
+const lowerListeners = []
+global.sails = {
+  config: { docker: { binaryPath: 'docker' } },
+  once(event, listener) {
+    if (event === 'lower') lowerListeners.push(listener)
+  }
+}
+
+const executeInContainer = require('../api/helpers/bridge/execute-in-container')
+
+main()
+  .catch((error) => {
+    process.stderr.write(`${error.stack || error.message}\n`)
+    process.exitCode = 1
+  })
+  .finally(() => {
+    for (const listener of lowerListeners) listener()
+  })
+
+async function main() {
+  const operation = 'return { modelCount: Object.keys(sails.models).length }'
+  const oneShot = []
+  for (let index = 0; index < 2; index += 1) {
+    oneShot.push(await measure(() => executeOneShot(operation)))
+  }
+
+  const prewarm = await measure(() => executeWarm(operation))
+  const warm = []
+  for (let index = 0; index < 5; index += 1) {
+    warm.push(await measure(() => executeWarm(operation)))
+  }
+
+  const report = {
+    containerName,
+    before: {
+      lifecycle: 'one docker exec plus one Sails load/lower per operation',
+      milliseconds: oneShot
+    },
+    after: {
+      prewarmMilliseconds: prewarm,
+      lifecycle: 'one prewarmed worker reused for every operation',
+      warmMilliseconds: warm,
+      warmMaximumMilliseconds: Math.max(...warm)
+    }
+  }
+  process.stdout.write(`${JSON.stringify(report, null, 2)}\n`)
+
+  if (shouldAssert && report.after.warmMaximumMilliseconds >= 500) {
+    throw new Error(
+      `Warm Bridge operation exceeded 500ms (${report.after.warmMaximumMilliseconds}ms).`
+    )
+  }
+}
+
+async function executeWarm(code) {
+  const result = await executeInContainer.fn({
+    containerName,
+    code,
+    timeout: 60000
+  })
+  if (!result.success) {
+    throw new Error(result.error || 'Warm Bridge operation failed.')
+  }
+  return JSON.parse(result.output)
+}
+
+function executeOneShot(code) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('docker', [
+      'exec',
+      '-e',
+      'NODE_ENV=production',
+      '-i',
+      containerName,
+      'node'
+    ])
+    let stderr = ''
+    child.stderr.on('data', (data) => {
+      stderr += data.toString()
+    })
+    child.on('error', reject)
+    child.on('close', (exitCode) => {
+      if (exitCode !== 0) {
+        return reject(
+          new Error(stderr.trim() || `One-shot worker exited ${exitCode}.`)
+        )
+      }
+      return resolve()
+    })
+    child.stdin.end(buildOneShotSource(code))
+  })
+}
+
+function buildOneShotSource(code) {
+  return `
+(async () => {
+  let sailsApp;
+  try {
+    sailsApp = require('sails');
+    await new Promise((resolve, reject) => {
+      sailsApp.load({
+        hooks: {
+          http: false,
+          views: false,
+          sockets: false,
+          pubsub: false,
+          grunt: false,
+          flash: false,
+          session: false
+        },
+        security: { csrf: false },
+        log: { level: 'silent' }
+      }, (error) => error ? reject(error) : resolve());
+    });
+    await (async function () { ${code} })();
+  } catch (error) {
+    process.stderr.write(error.stack || error.message || String(error));
+    process.exitCode = 1;
+  }
+  if (sailsApp && sailsApp.lower) {
+    sailsApp.lower(() => process.exit());
+  } else {
+    process.exit();
+  }
+})();
+`
+}
+
+async function measure(operation) {
+  const startedAt = process.hrtime.bigint()
+  await operation()
+  return Number((process.hrtime.bigint() - startedAt) / 1000000n)
+}

--- a/tests/functional/pages/bridge-performance.test.js
+++ b/tests/functional/pages/bridge-performance.test.js
@@ -1,0 +1,167 @@
+const { test } = require('sounding')
+const { withCsrfFromPage } = require('../../support/csrf-request')
+
+test(
+  'Bridge table partial reloads skip unchanged dashboard work',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-partial-performance',
+          name: 'Bridge partial performance'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            list: ['title', 'published'],
+            search: ['title']
+          }
+        },
+        dashboards: {
+          courseHealth: {
+            scope: 'resource',
+            resource: 'course',
+            cards: {
+              published: {
+                type: 'metric',
+                resource: 'course',
+                where: { published: true }
+              }
+            }
+          }
+        }
+      }
+    })
+    let dashboardExecutions = 0
+    let queryExecutions = 0
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-partial-performance-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources,
+        dashboards: contract.dashboards
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-partial-performance-web')
+        if (code.includes('const decisions = Object.create(null);')) {
+          const requests = readEmbeddedValue(code, 'requests')
+          const decisions = {}
+          for (const authorizationRequest of requests) {
+            decisions[authorizationRequest.key] =
+              decisions[authorizationRequest.key] || {}
+            decisions[authorizationRequest.key][
+              authorizationRequest.action
+            ] = true
+          }
+          return successfulResult(decisions)
+        }
+        if (code.includes('const dashboard =')) {
+          dashboardExecutions += 1
+          return successfulResult([{ id: 'published', value: 1 }])
+        }
+        if (code.includes('const total = await model.count(where);')) {
+          queryExecutions += 1
+          return successfulResult({
+            records: [{ id: 1, title: 'Durable UI', published: true }],
+            total: 1
+          })
+        }
+        return failedResult('Unexpected Bridge performance query.')
+      }
+
+      const browser = await withCsrfFromPage(
+        request,
+        '/projects/new',
+        'genesisUser'
+      )
+      const modelPath = `/projects/${project.slug}/environments/${environment.slug}/bridge/course`
+      const initial = await browser.request.get(modelPath)
+
+      expect(initial).toHaveStatus(200)
+      expect(initial).toHaveInertiaProp('activeDashboard.cards.0.value', 1)
+      expect(dashboardExecutions).toBe(1)
+      expect(queryExecutions).toBe(1)
+
+      const search = await browser.request.get(`${modelPath}?search=durable`, {
+        headers: {
+          'X-Inertia': 'true',
+          'X-Inertia-Partial-Component': 'projects/bridge-model',
+          'X-Inertia-Partial-Data':
+            'records,total,totalPages,currentPage,search,error'
+        }
+      })
+
+      expect(search).toHaveStatus(200)
+      expect(search).toHaveInertiaProp('search', 'durable')
+      expect(search.data.props.activeDashboard).toBe(undefined)
+      expect(dashboardExecutions).toBe(1)
+      expect(queryExecutions).toBe(2)
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function successfulResult(output) {
+  return {
+    success: true,
+    output: JSON.stringify(output),
+    error: null,
+    exitCode: 0
+  }
+}
+
+function failedResult(error) {
+  return {
+    success: false,
+    output: '',
+    error,
+    exitCode: 1
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const match = code.match(new RegExp(`const ${name} = (.*);`))
+  if (!match) throw new Error(`Missing ${name} declaration in Bridge query.`)
+  return JSON.parse(match[1])
+}
+
+function modelMetadata() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'course',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'number', autoIncrement: true },
+        title: { type: 'string', required: true },
+        published: { type: 'boolean', defaultsTo: false }
+      },
+      associations: []
+    }
+  }
+}

--- a/tests/unit/helpers/bridge/execute-in-container.test.js
+++ b/tests/unit/helpers/bridge/execute-in-container.test.js
@@ -4,66 +4,157 @@ const path = require('node:path')
 
 const { test } = require('sounding')
 
-test('Bridge workers load the deployed app in production', async ({
+test('Bridge reuses one production worker for warm operations', async ({
   sails,
   expect
 }) => {
-  const temporaryDirectory = await fs.mkdtemp(
-    path.join(os.tmpdir(), 'slipway-bridge-worker-')
-  )
-  const fakeDockerPath = path.join(temporaryDirectory, 'docker')
-  const capturedArgumentsPath = path.join(temporaryDirectory, 'arguments.json')
-  const previousDockerConfig = sails.config.docker
-  const previousCapturePath = process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH
-
-  await fs.writeFile(
-    fakeDockerPath,
-    [
-      '#!/usr/bin/env node',
-      "const fs = require('node:fs')",
-      'fs.writeFileSync(',
-      '  process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH,',
-      '  JSON.stringify(process.argv.slice(2))',
-      ')',
-      "process.stdin.on('data', () => {})",
-      "process.stdin.on('end', () => {",
-      "  process.stdout.write('___SLIPWAY_BRIDGE_START___' + JSON.stringify({ ready: true }) + '___SLIPWAY_BRIDGE_END___')",
-      '})'
-    ].join('\n'),
-    { mode: 0o755 }
-  )
-  sails.config.docker = {
-    ...(previousDockerConfig || {}),
-    binaryPath: fakeDockerPath
-  }
-  process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH = capturedArgumentsPath
+  const fixture = await createFakeDockerFixture()
+  const restore = useFakeDocker(sails, fixture)
+  process.env.SLIPWAY_FAKE_DOCKER_EXIT_AFTER = '2'
 
   try {
-    const result = await sails.helpers.bridge.executeInContainer.with({
+    const first = await sails.helpers.bridge.executeInContainer.with({
       containerName: 'sailscasts-production',
-      code: 'return { ready: true }'
+      code: 'return { operation: "dashboard" }'
+    })
+    const second = await sails.helpers.bridge.executeInContainer.with({
+      containerName: 'sailscasts-production',
+      code: 'return { operation: "search" }'
     })
     const argumentsPassedToDocker = JSON.parse(
-      await fs.readFile(capturedArgumentsPath, 'utf8')
+      await fs.readFile(fixture.argumentsPath, 'utf8')
     )
 
-    expect(result.success).toBe(true)
-    expect(result.output).toBe('{"ready":true}')
-    expect(argumentsPassedToDocker).toEqual([
+    expect(first.success).toBe(true)
+    expect(JSON.parse(first.output)).toEqual({
+      code: 'return { operation: "dashboard" }'
+    })
+    expect(second.success).toBe(true)
+    expect(JSON.parse(second.output)).toEqual({
+      code: 'return { operation: "search" }'
+    })
+    expect(await readBootCount(fixture.bootCountPath)).toBe(1)
+    expect(argumentsPassedToDocker.slice(0, 7)).toEqual([
       'exec',
       '-e',
       'NODE_ENV=production',
       '-i',
       'sailscasts-production',
-      'node'
+      'node',
+      '-e'
     ])
+    expect(argumentsPassedToDocker[7]).toContain('sailsApp.load')
+    expect(argumentsPassedToDocker[7]).toContain('http: false')
   } finally {
-    sails.config.docker = previousDockerConfig
-    if (previousCapturePath === undefined) {
-      delete process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH
-    } else {
-      process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH = previousCapturePath
-    }
-    await fs.rm(temporaryDirectory, { recursive: true, force: true })
+    restore()
+    delete process.env.SLIPWAY_FAKE_DOCKER_EXIT_AFTER
+    await fs.rm(fixture.directory, { recursive: true, force: true })
   }
 })
+
+test('Bridge replaces a timed-out worker before the next operation', async ({
+  sails,
+  expect
+}) => {
+  const fixture = await createFakeDockerFixture()
+  const restore = useFakeDocker(sails, fixture)
+  process.env.SLIPWAY_FAKE_DOCKER_EXIT_AFTER = '1'
+
+  try {
+    const timedOut = await sails.helpers.bridge.executeInContainer.with({
+      containerName: 'sailscasts-timeout',
+      code: '/* never finishes */',
+      timeout: 1000
+    })
+    const recovered = await sails.helpers.bridge.executeInContainer.with({
+      containerName: 'sailscasts-timeout',
+      code: 'return { operation: "recovered" }'
+    })
+
+    expect(timedOut.success).toBe(false)
+    expect(timedOut.error).toMatch(/timed out after 1000ms/)
+    expect(recovered.success).toBe(true)
+    expect(JSON.parse(recovered.output)).toEqual({
+      code: 'return { operation: "recovered" }'
+    })
+    expect(await readBootCount(fixture.bootCountPath)).toBe(2)
+  } finally {
+    restore()
+    delete process.env.SLIPWAY_FAKE_DOCKER_EXIT_AFTER
+    await fs.rm(fixture.directory, { recursive: true, force: true })
+  }
+})
+
+async function createFakeDockerFixture() {
+  const directory = await fs.mkdtemp(
+    path.join(os.tmpdir(), 'slipway-bridge-worker-')
+  )
+  const dockerPath = path.join(directory, 'docker')
+  const argumentsPath = path.join(directory, 'arguments.json')
+  const bootCountPath = path.join(directory, 'boot-count.txt')
+
+  await fs.writeFile(
+    dockerPath,
+    [
+      '#!/usr/bin/env node',
+      "const fs = require('node:fs')",
+      "const readline = require('node:readline')",
+      "const marker = '___SLIPWAY_BRIDGE_WORKER_RESULT___'",
+      'const argumentsPath = process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH',
+      'const bootCountPath = process.env.SLIPWAY_FAKE_DOCKER_BOOT_COUNT_PATH',
+      "fs.appendFileSync(bootCountPath, 'boot\\n')",
+      'fs.writeFileSync(argumentsPath, JSON.stringify(process.argv.slice(2)))',
+      'const input = readline.createInterface({ input: process.stdin })',
+      'let handled = 0',
+      "input.on('line', (line) => {",
+      '  const job = JSON.parse(line)',
+      "  if (job.code.includes('never finishes')) return",
+      '  handled += 1',
+      '  const response = {',
+      '    id: job.id,',
+      '    success: true,',
+      '    output: JSON.stringify({ code: job.code }),',
+      '    error: null',
+      '  }',
+      "  process.stdout.write('target app noise\\n' + marker + JSON.stringify(response) + '\\n', () => {",
+      '    if (handled === Number(process.env.SLIPWAY_FAKE_DOCKER_EXIT_AFTER || 0)) process.exit(0)',
+      '  })',
+      '})'
+    ].join('\n'),
+    { mode: 0o755 }
+  )
+
+  return { directory, dockerPath, argumentsPath, bootCountPath }
+}
+
+function useFakeDocker(sails, fixture) {
+  const previousDockerConfig = sails.config.docker
+  const previousArgumentsPath = process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH
+  const previousBootCountPath = process.env.SLIPWAY_FAKE_DOCKER_BOOT_COUNT_PATH
+
+  sails.config.docker = {
+    ...(previousDockerConfig || {}),
+    binaryPath: fixture.dockerPath
+  }
+  process.env.SLIPWAY_FAKE_DOCKER_ARGS_PATH = fixture.argumentsPath
+  process.env.SLIPWAY_FAKE_DOCKER_BOOT_COUNT_PATH = fixture.bootCountPath
+
+  return function restore() {
+    sails.config.docker = previousDockerConfig
+    restoreEnvironment('SLIPWAY_FAKE_DOCKER_ARGS_PATH', previousArgumentsPath)
+    restoreEnvironment(
+      'SLIPWAY_FAKE_DOCKER_BOOT_COUNT_PATH',
+      previousBootCountPath
+    )
+  }
+}
+
+function restoreEnvironment(name, value) {
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+}
+
+async function readBootCount(bootCountPath) {
+  const boots = await fs.readFile(bootCountPath, 'utf8')
+  return boots.trim().split('\n').length
+}

--- a/tests/unit/packages/hook-helper-machine.test.js
+++ b/tests/unit/packages/hook-helper-machine.test.js
@@ -112,16 +112,16 @@ function createTestApp({ appOwnedHelper = false } = {}) {
 function liftTestApp(appPath) {
   return new Promise((resolve, reject) => {
     const app = new Sails()
-    app.lift(
+    app.load(
       {
         appPath,
-        port: 0,
         environment: 'test',
         globals: false,
         log: { level: 'silent' },
         hooks: {
           blueprints: false,
           grunt: false,
+          http: false,
           i18n: false,
           orm: false,
           policies: false,


### PR DESCRIPTION
## What changed

- reuse one production-mode Bridge worker per live target container instead of loading and lowering Sails for every operation
- prewarm Bridge runtimes after deploy, rollback, and Slipway startup
- use Inertia partial reloads for record navigation and search so unchanged dashboard work is skipped
- recover with a fresh worker after a timeout or container exit
- add a reproducible `local.sh bridge-benchmark` latency gate and preserve the investigation in the 0.0.54 release notes
- make the hook helper-machine test load without opening an HTTP port, so it remains valid while `local.sh` is running

## Root cause

Each Bridge operation previously started `docker exec ... node`, loaded the complete deployed Sails application, ran one operation, lowered Sails, and exited. A page or search performs several target operations, so overlapping requests accumulated several multi-second Sails bootstraps and made later navigation appear unresponsive.

## Measured impact

The final local Docker run measured the old lifecycle at 4,802 ms and 4,762 ms per operation. The one-time prewarm took 4,791 ms outside the request path. Five subsequent operations took 1, 0, 0, 1, and 0 ms; the 500 ms warm assertion passed.

## Validation

- `bash ./local.sh bridge-benchmark` — passed, 1 ms slowest warm operation
- `npm run test:unit` — 261 passed
- `npm run test:functional` — 96 passed
- `npm run test:e2e` — 42 passed
- `git diff --check` — passed
- `bash -n local.sh` — passed

Closes #327