### PR TITLE
fix(bridge): keep app-local navigation on the host origin

### DIFF
--- a/RELEASE_0.0.54.md
+++ b/RELEASE_0.0.54.md
@@ -31,14 +31,54 @@ The resident worker intentionally remains separate from the application's web
 process. This preserves the existing execution boundary, so an expensive or
 failed Bridge operation cannot block the public application's event loop.
 
+## Same-origin Bridge
+
+### What was happening
+
+The host app's `/bridge` hook authenticated the app user, exchanged that
+identity for a one-time launch code, and then redirected the browser to the
+Slipway control-plane hostname. Every Bridge link was consequently built as a
+Slipway dashboard path. That produced two different browsing models and made a
+host-app launch unexpectedly leave the host origin.
+
+A simple reverse proxy alone would not be safe for two Sails applications:
+both default to a cookie named `sails.sid`, so the proxied Slipway session could
+overwrite the host application's session on the same origin. Absolute asset,
+API, redirect, and Inertia page URLs would also escape the proxy after the
+first page.
+
+### What changed
+
+- Caddy gives each Bridge-enabled app three routes before the app catch-all:
+  the one-time launch endpoint, a namespaced asset endpoint, and the app's
+  `/bridge` subtree.
+- The host app authenticates through a private `/_slipway/bridge` callback;
+  direct `/bridge` exchange remains available for deployments without the new
+  ingress route.
+- Host-origin exchange returns a launch URL on the app's public hostname and
+  sets the same revocable, app-scoped Bridge session used by direct Slipway
+  access.
+- Slipway sessions now use `slipway.sid`, keeping them separate from a host
+  Sails app's `sails.sid` while retaining normal session-backed CSRF.
+- Server redirects, relationship APIs, Inertia page URLs, initial assets, and
+  lazy-loaded chunks use the public Bridge base path. Direct
+  `slipway.sailscasts.com/projects/.../bridge` navigation is unchanged.
+- The Bridge Access screen and app menu expose both entry points explicitly:
+  the public `https://<app-host>/bridge` URL and the operator
+  `https://<slipway-host>/projects/<project>/environments/<environment>/apps/<app>/bridge`
+  URL.
+
+Changing the Slipway session cookie name requires operators to sign in to the
+Slipway dashboard once after upgrading. Host-app sessions are not affected.
+
 ### Local measurements
 
 On August 3, 2026, the reproducible local Docker benchmark recorded:
 
 | Measurement                         | Result                |
 | ----------------------------------- | --------------------- |
-| Old per-operation lifecycle         | 5,566 ms and 4,803 ms |
-| One-time deployment/startup prewarm | 4,864 ms              |
+| Old per-operation lifecycle         | 5,026 ms and 4,953 ms |
+| One-time deployment/startup prewarm | 4,917 ms              |
 | Five consecutive warm operations    | 1, 0, 0, 0, and 0 ms  |
 | Slowest warm runtime operation      | 1 ms                  |
 
@@ -71,3 +111,12 @@ The 0.0.54 release gate is:
 - first visible Bridge page below two seconds in the production smoke test;
 - subsequent navigation below 500 ms in the production smoke test; and
 - search results begin rendering within 800 ms after the final keystroke.
+
+The same-origin gate additionally requires:
+
+- an app-origin `/bridge` request never changes the browser hostname;
+- a non-root app keeps launch, assets, navigation, search, API calls, and
+  mutation redirects under its own `<app-path>/bridge` prefix;
+- host and Slipway session cookies cannot overwrite each other;
+- revocation and Bridge-secret rotation invalidate both URL modes; and
+- Caddy accepts the generated ordered handlers before deployment cutover.

--- a/api/controllers/api/v1/bridge/exchange.js
+++ b/api/controllers/api/v1/bridge/exchange.js
@@ -17,6 +17,10 @@ module.exports = {
     },
     inviteToken: {
       type: 'string'
+    },
+    hostOrigin: {
+      type: 'boolean',
+      defaultsTo: false
     }
   },
 
@@ -35,7 +39,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ appId, hostUser, inviteToken }) {
+  fn: async function ({ appId, hostUser, inviteToken, hostOrigin }) {
     const presentedSecret = bearerToken(this.req)
     const app = await App.findOne({ id: appId }).decrypt()
 
@@ -124,6 +128,31 @@ module.exports = {
       appId: app.id
     })
     const instanceUrl = await sails.helpers.getInstanceUrl()
+    let launchBaseUrl = instanceUrl.replace(/\/$/, '')
+
+    if (hostOrigin) {
+      const environment = await Environment.findOne({ id: app.environment })
+      const project = environment
+        ? await Project.findOne({ id: environment.project })
+        : null
+      const appUrl =
+        environment && project
+          ? await sails.helpers.bridge.getAppUrl.with({
+              app,
+              environment,
+              project
+            })
+          : ''
+
+      if (!appUrl) {
+        throw {
+          badRequest: {
+            error: 'Bridge does not have a public app URL for this deployment.'
+          }
+        }
+      }
+      launchBaseUrl = appUrl.replace(/\/$/, '')
+    }
 
     await sails.helpers.audit.log.with({
       action: activated ? 'bridge.access.activated' : 'bridge.access.exchanged',
@@ -139,10 +168,15 @@ module.exports = {
     })
 
     return {
-      launchUrl: `${instanceUrl.replace(
-        /\/$/,
-        ''
-      )}/bridge/launch?code=${encodeURIComponent(code)}`
+      launchUrl: `${launchBaseUrl}/bridge/launch?code=${encodeURIComponent(
+        code
+      )}${
+        hostOrigin
+          ? `&hostOrigin=true&hostRoutePath=${encodeURIComponent(
+              app.routePath || '/'
+            )}`
+          : ''
+      }`
     }
   }
 }

--- a/api/controllers/bridge/launch.js
+++ b/api/controllers/bridge/launch.js
@@ -1,4 +1,10 @@
 const crypto = require('crypto')
+const {
+  isHostOriginRequest,
+  normalizeRoutePath,
+  publicBridgeBasePath,
+  publicBridgeCallbackPath
+} = require('../../lib/bridge-paths')
 
 module.exports = {
   friendlyName: 'Launch Bridge',
@@ -10,6 +16,14 @@ module.exports = {
     code: {
       type: 'string',
       required: true
+    },
+    hostOrigin: {
+      type: 'boolean',
+      defaultsTo: false
+    },
+    hostRoutePath: {
+      type: 'string',
+      defaultsTo: '/'
     }
   },
 
@@ -22,11 +36,21 @@ module.exports = {
     }
   },
 
-  fn: async function ({ code }) {
+  fn: async function ({ code, hostOrigin, hostRoutePath }) {
+    const instanceUrl = await sails.helpers.getInstanceUrl()
+    const useHostOrigin =
+      hostOrigin && isHostOriginRequest(this.req, instanceUrl)
+    const fallbackHostCallback = `${safeRoutePrefix(
+      hostRoutePath
+    )}/_slipway/bridge`
     const tokenHash = crypto.createHash('sha256').update(code).digest('hex')
     const launchCode = await sails.helpers.bridge.consumeLaunchCode(tokenHash)
     if (!launchCode) {
-      throw { forbidden: '/login?error=bridge_link_expired' }
+      throw {
+        forbidden: useHostOrigin
+          ? `${fallbackHostCallback}?error=bridge_link_expired`
+          : '/login?error=bridge_link_expired'
+      }
     }
 
     const access = await BridgeAccess.findOne({
@@ -48,7 +72,13 @@ module.exports = {
       : null
 
     if (!access || !app || !environment || !project) {
-      throw { forbidden: '/login?error=bridge_access_denied' }
+      throw {
+        forbidden: useHostOrigin
+          ? `${
+              app ? publicBridgeCallbackPath(app) : fallbackHostCallback
+            }?error=bridge_access_denied`
+          : '/login?error=bridge_access_denied'
+      }
     }
 
     const existingUserId = this.req.session.userId
@@ -60,9 +90,19 @@ module.exports = {
     this.req.session.bridgeAppId = app.id
     this.req.session.bridgeAuthenticatedAt = Date.now()
     this.req.session.bridgeCredentialHash = hashCredential(app.bridgeSecret)
+    this.req.session.bridgeHostOrigin = useHostOrigin
+
+    if (useHostOrigin) {
+      return publicBridgeBasePath(app)
+    }
 
     return `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
   }
+}
+
+function safeRoutePrefix(value) {
+  const prefix = normalizeRoutePath(value)
+  return /^\/[A-Za-z0-9._~/-]*$/.test(prefix) ? prefix : ''
 }
 
 function regenerateSession(req) {

--- a/api/controllers/project/bridge-bulk-delete.js
+++ b/api/controllers/project/bridge-bulk-delete.js
@@ -57,7 +57,7 @@ module.exports = {
       if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
-    const { project, environment, app, actor } = resolved
+    const { project, environment, app, actor, bridgeBasePath } = resolved
 
     if (!Array.isArray(ids) || ids.length === 0) {
       throw { badRequest: { error: 'No records selected' } }
@@ -132,9 +132,6 @@ module.exports = {
     }
 
     // Redirect back to model list
-    const bridgeBasePath = appSlug
-      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
-      : `/projects/${slug}/environments/${envSlug}/bridge`
     return `${bridgeBasePath}/${modelIdentity}`
   }
 }

--- a/api/controllers/project/bridge-create-record.js
+++ b/api/controllers/project/bridge-create-record.js
@@ -60,7 +60,8 @@ module.exports = {
       if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
-    const { project, environment, app, actor, actorId } = resolved
+    const { project, environment, app, actor, actorId, bridgeBasePath } =
+      resolved
     const validateOnly = bridgeValidateOnly(this.req)
 
     let loaded
@@ -112,9 +113,6 @@ module.exports = {
       })
       const recordId = record?.[loaded.resource.primaryKey]
 
-      const bridgeBasePath = appSlug
-        ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
-        : `/projects/${slug}/environments/${envSlug}/bridge`
       if (recordId !== undefined && recordId !== null) {
         return `${bridgeBasePath}/${
           loaded.resource.identity

--- a/api/controllers/project/bridge-delete-record.js
+++ b/api/controllers/project/bridge-delete-record.js
@@ -56,7 +56,7 @@ module.exports = {
       if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
-    const { project, environment, app, actor } = resolved
+    const { project, environment, app, actor, bridgeBasePath } = resolved
 
     let resource
     let normalizedRecordId
@@ -98,9 +98,6 @@ module.exports = {
     }
 
     // Redirect back to model list
-    const bridgeBasePath = appSlug
-      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
-      : `/projects/${slug}/environments/${envSlug}/bridge`
     return `${bridgeBasePath}/${modelIdentity}`
   }
 }

--- a/api/controllers/project/bridge-execute-action.js
+++ b/api/controllers/project/bridge-execute-action.js
@@ -76,7 +76,8 @@ module.exports = {
       if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
-    const { project, environment, app, actor, auditUserId } = resolved
+    const { project, environment, app, actor, auditUserId, bridgeBasePath } =
+      resolved
 
     let loaded
     let allowedValues
@@ -171,19 +172,14 @@ module.exports = {
       outcome.message || action.success || `${action.label} completed.`
     )
     return actionRedirect({
-      slug,
-      envSlug,
-      appSlug: appSlug ? app.slug : null,
+      bridgeBasePath,
       resource: loaded.resource,
       loaded
     })
   }
 }
 
-function actionRedirect({ slug, envSlug, appSlug, resource, loaded }) {
-  const bridgeBasePath = appSlug
-    ? `/projects/${slug}/environments/${envSlug}/apps/${appSlug}/bridge`
-    : `/projects/${slug}/environments/${envSlug}/bridge`
+function actionRedirect({ bridgeBasePath, resource, loaded }) {
   const modelPath = `${bridgeBasePath}/${resource.identity}`
   if (loaded.actionDefinition.scope !== 'record') return modelPath
   return `${modelPath}/${encodeURIComponent(String(loaded.recordId))}`

--- a/api/controllers/project/bridge-update-record.js
+++ b/api/controllers/project/bridge-update-record.js
@@ -71,7 +71,8 @@ module.exports = {
       if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
-    const { project, environment, app, actor, actorId } = resolved
+    const { project, environment, app, actor, actorId, bridgeBasePath } =
+      resolved
     const validateOnly = bridgeValidateOnly(this.req)
 
     let loaded
@@ -141,9 +142,6 @@ module.exports = {
     }
 
     // Redirect back to record view
-    const bridgeBasePath = appSlug
-      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
-      : `/projects/${slug}/environments/${envSlug}/bridge`
     return `${bridgeBasePath}/${modelIdentity}/${encodeURIComponent(
       String(recordId)
     )}`

--- a/api/controllers/project/bridge-update-relationship.js
+++ b/api/controllers/project/bridge-update-relationship.js
@@ -79,7 +79,7 @@ module.exports = {
       if (error.code === 'notFound') throw { notFound: '/' }
       throw { badRequest: { error: 'App is not running' } }
     }
-    const { environment, app, actor } = resolved
+    const { environment, app, actor, bridgeBasePath } = resolved
 
     try {
       const loaded = await sails.helpers.bridge.loadResource.with({
@@ -175,9 +175,6 @@ module.exports = {
       throw { badRequest: { error: error.message } }
     }
 
-    const bridgeBasePath = appSlug
-      ? `/projects/${slug}/environments/${envSlug}/apps/${app.slug}/bridge`
-      : `/projects/${slug}/environments/${envSlug}/bridge`
     return `${bridgeBasePath}/${modelIdentity}/${encodeURIComponent(
       String(recordId)
     )}`

--- a/api/controllers/project/view-bridge-access.js
+++ b/api/controllers/project/view-bridge-access.js
@@ -38,6 +38,8 @@ module.exports = {
       environment,
       project
     })
+    const slipwayBridgePath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
+    const instanceUrl = await sails.helpers.getInstanceUrl()
 
     return {
       page: 'projects/bridge-access',
@@ -60,7 +62,11 @@ module.exports = {
             'bridgeEnabled'
           ]),
           appUrl,
-          bridgeUrl: appUrl ? `${appUrl}/bridge` : null
+          bridgeUrl: appUrl ? `${appUrl}/bridge` : null,
+          slipwayBridgeUrl: `${instanceUrl.replace(
+            /\/$/,
+            ''
+          )}${slipwayBridgePath}`
         },
         access: access.map((grant) => ({
           id: grant.id,

--- a/api/controllers/project/view-bridge-create.js
+++ b/api/controllers/project/view-bridge-create.js
@@ -47,7 +47,16 @@ module.exports = {
       if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-    const { project, environment, app, actor } = resolved
+    const {
+      project,
+      environment,
+      app,
+      actor,
+      bridgeBasePath,
+      bridgeApiBasePath,
+      bridgeAssetBasePath,
+      bridgeHostOrigin
+    } = resolved
     const appRunning = app && app.status === 'running'
 
     let modelMeta = null
@@ -119,6 +128,10 @@ module.exports = {
         },
         app: { id: app.id, name: app.name, slug: app.slug },
         appScoped: Boolean(appSlug),
+        bridgeRequestBasePath: bridgeBasePath,
+        bridgeRequestApiBasePath: bridgeApiBasePath,
+        hostBridgeAssetBasePath: bridgeAssetBasePath,
+        hostBridgeOrigin: bridgeHostOrigin,
         mode: 'create',
         modelIdentity,
         recordId: null,

--- a/api/controllers/project/view-bridge-edit.js
+++ b/api/controllers/project/view-bridge-edit.js
@@ -51,7 +51,16 @@ module.exports = {
       if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-    const { project, environment, app, actor } = resolved
+    const {
+      project,
+      environment,
+      app,
+      actor,
+      bridgeBasePath,
+      bridgeApiBasePath,
+      bridgeAssetBasePath,
+      bridgeHostOrigin
+    } = resolved
     const appRunning = app && app.status === 'running'
 
     let modelMeta = null
@@ -178,6 +187,10 @@ module.exports = {
         },
         app: { id: app.id, name: app.name, slug: app.slug },
         appScoped: Boolean(appSlug),
+        bridgeRequestBasePath: bridgeBasePath,
+        bridgeRequestApiBasePath: bridgeApiBasePath,
+        hostBridgeAssetBasePath: bridgeAssetBasePath,
+        hostBridgeOrigin: bridgeHostOrigin,
         mode: 'edit',
         modelIdentity,
         recordId,

--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -109,7 +109,16 @@ module.exports = {
       if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-    const { project, environment, app, actor } = resolved
+    const {
+      project,
+      environment,
+      app,
+      actor,
+      bridgeBasePath,
+      bridgeApiBasePath,
+      bridgeAssetBasePath,
+      bridgeHostOrigin
+    } = resolved
     const appRunning = app && app.status === 'running'
 
     // Load model metadata and records server-side
@@ -251,6 +260,10 @@ module.exports = {
         },
         app: { id: app.id, name: app.name, slug: app.slug },
         appScoped: Boolean(appSlug),
+        bridgeRequestBasePath: bridgeBasePath,
+        bridgeRequestApiBasePath: bridgeApiBasePath,
+        hostBridgeAssetBasePath: bridgeAssetBasePath,
+        hostBridgeOrigin: bridgeHostOrigin,
         modelIdentity,
         appRunning,
         modelMeta,

--- a/api/controllers/project/view-bridge-record.js
+++ b/api/controllers/project/view-bridge-record.js
@@ -51,7 +51,16 @@ module.exports = {
       if (error.code === 'forbidden') throw 'forbidden'
       throw { notFound: '/login' }
     }
-    const { project, environment, app, actor } = resolved
+    const {
+      project,
+      environment,
+      app,
+      actor,
+      bridgeBasePath,
+      bridgeApiBasePath,
+      bridgeAssetBasePath,
+      bridgeHostOrigin
+    } = resolved
     const appRunning = app && app.status === 'running'
 
     let modelMeta = null
@@ -159,6 +168,10 @@ module.exports = {
         },
         app: { id: app.id, name: app.name, slug: app.slug },
         appScoped: Boolean(appSlug),
+        bridgeRequestBasePath: bridgeBasePath,
+        bridgeRequestApiBasePath: bridgeApiBasePath,
+        hostBridgeAssetBasePath: bridgeAssetBasePath,
+        hostBridgeOrigin: bridgeHostOrigin,
         modelIdentity,
         recordId,
         appRunning,

--- a/api/controllers/project/view-bridge.js
+++ b/api/controllers/project/view-bridge.js
@@ -58,7 +58,16 @@ module.exports = {
           : '/login'
       }
     }
-    const { project, environment, app, actor } = resolved
+    const {
+      project,
+      environment,
+      app,
+      actor,
+      bridgeBasePath,
+      bridgeApiBasePath,
+      bridgeAssetBasePath,
+      bridgeHostOrigin
+    } = resolved
     const appRunning = app && app.status === 'running'
 
     // Load models server-side if app is running
@@ -182,6 +191,10 @@ module.exports = {
           slug: app.slug
         },
         appScoped: Boolean(appSlug),
+        bridgeRequestBasePath: bridgeBasePath,
+        bridgeRequestApiBasePath: bridgeApiBasePath,
+        hostBridgeAssetBasePath: bridgeAssetBasePath,
+        hostBridgeOrigin: bridgeHostOrigin,
         appRunning,
         models,
         modelsError,

--- a/api/helpers/bridge/resolve-request.js
+++ b/api/helpers/bridge/resolve-request.js
@@ -1,4 +1,9 @@
 const crypto = require('crypto')
+const {
+  internalBridgeApiBasePath,
+  internalBridgeBasePath,
+  publicBridgeBasePath
+} = require('../../lib/bridge-paths')
 
 const ROLE_RANK = {
   viewer: 1,
@@ -82,7 +87,14 @@ module.exports = {
         actor,
         actorId: String(resolved.user.id),
         auditUserId: String(resolved.user.id),
-        access: null
+        access: null,
+        ...requestPaths({
+          req,
+          project: resolved.project,
+          environment: resolved.environment,
+          app: resolved.app,
+          appScoped: Boolean(appSlug)
+        })
       }
     }
 
@@ -106,7 +118,14 @@ module.exports = {
       actor,
       actorId: actor.id,
       auditUserId: String(resolved.user.id),
-      access
+      access,
+      ...requestPaths({
+        req,
+        project: resolved.project,
+        environment: resolved.environment,
+        app: resolved.app,
+        appScoped: Boolean(appSlug)
+      })
     }
   }
 }
@@ -189,8 +208,49 @@ async function resolveHostSession({
     actor,
     actorId: actor.id,
     auditUserId: null,
-    access
+    access,
+    ...requestPaths({
+      req,
+      project,
+      environment,
+      app,
+      appScoped: Boolean(appSlug)
+    })
   }
+}
+
+function requestPaths({ req, project, environment, app, appScoped }) {
+  const hostOrigin = req.session.bridgeHostOrigin === true
+  const internalBasePath = internalBridgeBasePath(
+    project,
+    environment,
+    app,
+    appScoped
+  )
+  const bridgeBasePath = hostOrigin
+    ? publicBridgeBasePath(app)
+    : internalBasePath
+
+  if (hostOrigin && typeof req.url === 'string') {
+    req.url = replacePathPrefix(req.url, internalBasePath, bridgeBasePath)
+  }
+
+  return {
+    bridgeBasePath,
+    bridgeApiBasePath: hostOrigin
+      ? bridgeBasePath
+      : internalBridgeApiBasePath(project, environment, app, appScoped),
+    bridgeAssetBasePath: hostOrigin ? `${bridgeBasePath}/_assets` : '',
+    bridgeHostOrigin: hostOrigin
+  }
+}
+
+function replacePathPrefix(url, currentPrefix, publicPrefix) {
+  return url === currentPrefix ||
+    url.startsWith(`${currentPrefix}/`) ||
+    url.startsWith(`${currentPrefix}?`)
+    ? `${publicPrefix}${url.slice(currentPrefix.length)}`
+    : url
 }
 
 function roleAllows(actual, required) {
@@ -202,6 +262,7 @@ function clearBridgeSession(req) {
   delete req.session.bridgeAppId
   delete req.session.bridgeAuthenticatedAt
   delete req.session.bridgeCredentialHash
+  delete req.session.bridgeHostOrigin
 }
 
 function hashCredential(value) {

--- a/api/helpers/caddy/generate-route-config.js
+++ b/api/helpers/caddy/generate-route-config.js
@@ -66,8 +66,12 @@ module.exports = {
       }
     }
 
-    // Single app with root path — identical config to original (backward compat)
-    if (routableApps.length === 1 && routableApps[0].routePath === '/') {
+    // Single non-Bridge app with a root path — retain the minimal route.
+    if (
+      routableApps.length === 1 &&
+      routableApps[0].routePath === '/' &&
+      !routableApps[0].bridgeEnabled
+    ) {
       const app = routableApps[0]
       return {
         domain: fullDomain,
@@ -99,6 +103,20 @@ module.exports = {
     })
 
     const handlers = []
+
+    for (const app of sorted) {
+      if (!app.bridgeEnabled) continue
+      handlers.push(
+        ...bridgeHandlers({
+          app,
+          projectSlug: environment.project.slug,
+          environmentSlug: environment.slug,
+          controlPlaneUpstream: `${
+            sails.config.custom.slipwayContainerName || 'slipway'
+          }:1337`
+        })
+      )
+    }
 
     for (const app of sorted) {
       if (app.routePath === '/') {
@@ -141,3 +159,49 @@ module.exports = {
     }
   }
 }
+
+function bridgeHandlers({
+  app,
+  projectSlug,
+  environmentSlug,
+  controlPlaneUpstream
+}) {
+  const routePrefix =
+    !app.routePath || app.routePath === '/'
+      ? ''
+      : `/${String(app.routePath).replace(/^\/+|\/+$/g, '')}`
+  const publicBasePath = `${routePrefix}/bridge`
+  const internalBasePath = `/projects/${projectSlug}/environments/${environmentSlug}/apps/${app.slug}/bridge`
+  const reverseProxy = {
+    handler: 'reverse_proxy',
+    upstreams: [{ dial: controlPlaneUpstream }]
+  }
+
+  return [
+    subroute(`${publicBasePath}/launch`, [
+      { handler: 'rewrite', uri: '/bridge/launch' },
+      reverseProxy
+    ]),
+    subroute(`${publicBasePath}/_assets/*`, [
+      { handler: 'rewrite', strip_path_prefix: `${publicBasePath}/_assets` },
+      reverseProxy
+    ]),
+    subroute(`${publicBasePath}*`, [
+      { handler: 'rewrite', strip_path_prefix: publicBasePath },
+      {
+        handler: 'rewrite',
+        uri: `${internalBasePath}{http.request.uri.path}`
+      },
+      reverseProxy
+    ])
+  ]
+}
+
+function subroute(path, handle) {
+  return {
+    handler: 'subroute',
+    routes: [{ match: [{ path: [path] }], handle }]
+  }
+}
+
+module.exports._private = { bridgeHandlers }

--- a/api/helpers/caddy/update-route.js
+++ b/api/helpers/caddy/update-route.js
@@ -99,12 +99,14 @@ module.exports = {
     const routableApps = environmentApps.filter(
       (app) => app.hostPort && app.routePath !== null
     )
-    const expectedUpstreams = routableApps.map(
-      (app) => `${app.containerName}:${app.port}`
+    const controlPlaneUpstream = `${
+      sails.config.custom.slipwayContainerName || 'slipway'
+    }:1337`
+    const expectedUpstreams = routeUpstreams(routableApps, controlPlaneUpstream)
+    const previousUpstreams = routeUpstreams(
+      previousApps.filter((app) => app.hostPort && app.routePath !== null),
+      controlPlaneUpstream
     )
-    const previousUpstreams = previousApps
-      .filter((app) => app.hostPort && app.routePath !== null)
-      .map((app) => `${app.containerName}:${app.port}`)
     const suffix = normalizeContainerSuffix(routeVersion || String(Date.now()))
     const candidateName = `${routeContainerName}-candidate-${suffix}`
     const previousName = `${routeContainerName}-previous-${suffix}`
@@ -207,32 +209,16 @@ async function buildCreateArgs({
     '--label',
     `caddy=${siteLabel}`
   ]
-
-  if (routableApps.length === 1) {
-    const app = routableApps[0]
-    args.push('--label', `caddy.reverse_proxy=${app.containerName}:${app.port}`)
-  } else {
-    const sorted = [...routableApps].sort((a, b) => {
-      if (a.routePath === '/') return 1
-      if (b.routePath === '/') return -1
-      return b.routePath.length - a.routePath.length
-    })
-
-    sorted.forEach((app, index) => {
-      if (app.routePath === '/') {
-        args.push(
-          '--label',
-          `caddy.reverse_proxy=${app.containerName}:${app.port}`
-        )
-      } else {
-        args.push('--label', `caddy.handle_path_${index}=${app.routePath}*`)
-        args.push(
-          '--label',
-          `caddy.handle_path_${index}.reverse_proxy=${app.containerName}:${app.port}`
-        )
-      }
-    })
-  }
+  const controlPlaneUpstream = `${
+    sails.config.custom.slipwayContainerName || 'slipway'
+  }:1337`
+  const labels = buildRouteLabels({
+    projectSlug: config.projectSlug,
+    environmentSlug: config.environmentSlug,
+    routableApps,
+    controlPlaneUpstream
+  })
+  for (const label of labels) args.push('--label', label)
 
   const acmeEmail = await sails.helpers.setting.get('acmeEmail')
   if (acmeEmail && sails.config.custom.slipwayIngress !== 'cloudflare-tunnel') {
@@ -241,6 +227,84 @@ async function buildCreateArgs({
 
   args.push('alpine', 'sleep', 'infinity')
   return args
+}
+
+function buildRouteLabels({
+  projectSlug,
+  environmentSlug,
+  routableApps,
+  controlPlaneUpstream
+}) {
+  const labels = []
+  let handleIndex = 0
+  const sorted = [...routableApps].sort((a, b) => {
+    if (a.routePath === '/') return 1
+    if (b.routePath === '/') return -1
+    return b.routePath.length - a.routePath.length
+  })
+
+  for (const app of sorted) {
+    if (!app.bridgeEnabled) continue
+
+    const routePrefix = normalizeRoutePrefix(app.routePath)
+    const publicBasePath = `${routePrefix}/bridge`
+    const internalBasePath = `/projects/${projectSlug}/environments/${environmentSlug}/apps/${app.slug}/bridge`
+
+    addHandle({
+      labels,
+      index: handleIndex++,
+      matcher: `${publicBasePath}/launch`,
+      uri: `replace ${publicBasePath}/launch /bridge/launch`,
+      upstream: controlPlaneUpstream
+    })
+    addHandle({
+      labels,
+      index: handleIndex++,
+      matcher: `${publicBasePath}/_assets/*`,
+      uri: `strip_prefix ${publicBasePath}/_assets`,
+      upstream: controlPlaneUpstream
+    })
+    addHandle({
+      labels,
+      index: handleIndex++,
+      matcher: `${publicBasePath}*`,
+      uri: `replace ${publicBasePath} ${internalBasePath}`,
+      upstream: controlPlaneUpstream
+    })
+  }
+
+  for (const app of sorted) {
+    const routePrefix = normalizeRoutePrefix(app.routePath)
+    addHandle({
+      labels,
+      index: handleIndex++,
+      matcher: routePrefix ? `${routePrefix}*` : '/*',
+      ...(routePrefix ? { uri: `strip_prefix ${routePrefix}` } : {}),
+      upstream: `${app.containerName}:${app.port}`
+    })
+  }
+
+  return labels
+}
+
+function addHandle({ labels, index, matcher, uri, upstream }) {
+  const key = `caddy.handle_${index}`
+  labels.push(`${key}=${matcher}`)
+  if (uri) labels.push(`${key}.0_uri=${uri}`)
+  labels.push(`${key}.1_reverse_proxy=${upstream}`)
+}
+
+function normalizeRoutePrefix(routePath) {
+  if (!routePath || routePath === '/') return ''
+  return `/${String(routePath).replace(/^\/+|\/+$/g, '')}`
+}
+
+function routeUpstreams(apps, controlPlaneUpstream) {
+  const upstreams = apps.map((app) => `${app.containerName}:${app.port}`)
+  if (apps.some((app) => app.bridgeEnabled)) {
+    upstreams.push(controlPlaneUpstream)
+  }
+  return [...new Set(upstreams)]
 }
 
 async function getContainerState(dockerPath, containerName) {
@@ -273,4 +337,9 @@ function normalizeContainerSuffix(value) {
     .slice(0, 64)
 }
 
-module.exports._private = { buildCreateArgs, normalizeContainerSuffix }
+module.exports._private = {
+  buildCreateArgs,
+  buildRouteLabels,
+  normalizeContainerSuffix,
+  routeUpstreams
+}

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -226,6 +226,7 @@ module.exports = {
         envVars.SLIPWAY_BRIDGE_ENABLED = 'true'
         envVars.SLIPWAY_BRIDGE_EXCHANGE_URL = `http://${bridgeHost}:1337/api/v1/bridge/exchange`
         envVars.SLIPWAY_BRIDGE_APP_ID = String(targetApp.id)
+        envVars.SLIPWAY_BRIDGE_ROUTE_PATH = targetApp.routePath || '/'
         envVars.SLIPWAY_BRIDGE_SECRET =
           await sails.helpers.bridge.ensureAppSecret(String(targetApp.id))
       }

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -164,6 +164,7 @@ module.exports = {
         envVars.SLIPWAY_BRIDGE_ENABLED = 'true'
         envVars.SLIPWAY_BRIDGE_EXCHANGE_URL = `http://${bridgeHost}:1337/api/v1/bridge/exchange`
         envVars.SLIPWAY_BRIDGE_APP_ID = String(existingApp.id)
+        envVars.SLIPWAY_BRIDGE_ROUTE_PATH = existingApp.routePath || '/'
         envVars.SLIPWAY_BRIDGE_SECRET =
           await sails.helpers.bridge.ensureAppSecret(String(existingApp.id))
       }

--- a/api/lib/bridge-paths.js
+++ b/api/lib/bridge-paths.js
@@ -1,0 +1,70 @@
+function normalizeRoutePath(routePath) {
+  if (!routePath || routePath === '/') return ''
+  return `/${String(routePath).replace(/^\/+|\/+$/g, '')}`
+}
+
+function publicBridgeBasePath(app) {
+  return `${normalizeRoutePath(app?.routePath)}/bridge`
+}
+
+function publicBridgeCallbackPath(app) {
+  return `${normalizeRoutePath(app?.routePath)}/_slipway/bridge`
+}
+
+function internalBridgeBasePath(project, environment, app, appScoped = true) {
+  const environmentPath = `/projects/${project.slug}/environments/${environment.slug}`
+  return appScoped
+    ? `${environmentPath}/apps/${app.slug}/bridge`
+    : `${environmentPath}/bridge`
+}
+
+function internalBridgeApiBasePath(
+  project,
+  environment,
+  app,
+  appScoped = true
+) {
+  const environmentPath = `/api/v1/projects/${project.slug}/environments/${environment.slug}`
+  return appScoped
+    ? `${environmentPath}/apps/${app.slug}/bridge`
+    : `${environmentPath}/bridge`
+}
+
+function isHostOriginRequest(req, instanceUrl) {
+  const requestHost = normalizeHostname(
+    req?.get?.('x-forwarded-host') || req?.get?.('host') || req?.hostname
+  )
+  const instanceHost = hostnameFromUrl(instanceUrl)
+  return Boolean(requestHost && instanceHost && requestHost !== instanceHost)
+}
+
+function hostnameFromUrl(value) {
+  try {
+    return new URL(value).hostname.toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+function normalizeHostname(value) {
+  const first = String(value || '')
+    .split(',')[0]
+    .trim()
+    .toLowerCase()
+  if (!first) return ''
+
+  try {
+    return new URL(`http://${first}`).hostname.toLowerCase()
+  } catch {
+    return ''
+  }
+}
+
+module.exports = {
+  internalBridgeApiBasePath,
+  internalBridgeBasePath,
+  isHostOriginRequest,
+  normalizeRoutePath,
+  publicBridgeBasePath,
+  publicBridgeCallbackPath
+}

--- a/api/policies/is-bridge-authenticated.js
+++ b/api/policies/is-bridge-authenticated.js
@@ -1,6 +1,31 @@
+const {
+  isHostOriginRequest,
+  publicBridgeCallbackPath
+} = require('../lib/bridge-paths')
+
 module.exports = async function (req, res, proceed) {
   if (req.session.userId || req.session.bridgeAccessId) {
     return proceed()
+  }
+
+  const instanceUrl = await sails.helpers.getInstanceUrl()
+  if (isHostOriginRequest(req, instanceUrl)) {
+    const app = await resolveProxiedApp(req.allParams())
+    if (app) {
+      const invitation =
+        typeof req.query?.invite === 'string'
+          ? `?invite=${encodeURIComponent(req.query.invite)}`
+          : ''
+      const callback = `${publicBridgeCallbackPath(app)}${invitation}`
+
+      if (req.get('X-Inertia') === 'true') {
+        return res.status(409).set('X-Inertia-Location', callback).send('')
+      }
+
+      if (acceptsHtml(req)) {
+        return res.redirect(callback)
+      }
+    }
   }
 
   if (req.wantsJSON && req.get('X-Inertia') !== 'true') {
@@ -11,4 +36,27 @@ module.exports = async function (req, res, proceed) {
   }
 
   return res.redirect('/login')
+}
+
+function acceptsHtml(req) {
+  return String(req.get('accept') || '').includes('text/html')
+}
+
+async function resolveProxiedApp(params) {
+  if (!params?.slug || !params?.envSlug || !params?.appSlug) return null
+
+  const project = await Project.findOne({ slug: params.slug })
+  const environment = project
+    ? await Environment.findOne({
+        project: project.id,
+        slug: params.envSlug
+      })
+    : null
+  return environment
+    ? App.findOne({
+        environment: environment.id,
+        slug: params.appSlug,
+        bridgeEnabled: true
+      })
+    : null
 }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -2,6 +2,14 @@ import { createApp, h } from 'vue'
 import { createInertiaApp, router } from '@inertiajs/vue3'
 import '~/css/app.css'
 
+/* global __webpack_public_path__ */
+if (typeof window !== 'undefined' && window.__SLIPWAY_ASSET_PREFIX__) {
+  __webpack_public_path__ = `${window.__SLIPWAY_ASSET_PREFIX__.replace(
+    /\/$/,
+    ''
+  )}/`
+}
+
 const UNSAFE_METHODS = new Set(['POST', 'PUT', 'PATCH', 'DELETE'])
 
 function setCsrfToken(token) {

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -1160,6 +1160,25 @@ onBeforeUnmount(() => {
                       </svg>
                       Helm
                     </Link>
+                    <Link
+                      :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`"
+                      class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+                    >
+                      <svg
+                        class="h-4 w-4 text-gray-400"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+                        />
+                      </svg>
+                      Bridge in Slipway
+                    </Link>
                     <a
                       v-if="app.bridgeEnabled && app.bridgeUrl"
                       :href="app.bridgeUrl"
@@ -1180,28 +1199,8 @@ onBeforeUnmount(() => {
                           d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
                         />
                       </svg>
-                      Bridge
+                      Public Bridge
                     </a>
-                    <Link
-                      v-else
-                      :href="`/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`"
-                      class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
-                    >
-                      <svg
-                        class="h-4 w-4 text-gray-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-                        />
-                      </svg>
-                      Bridge
-                    </Link>
                     <Link
                       v-if="hasDatabaseService"
                       :href="`/projects/${project.slug}/environments/${

--- a/assets/js/pages/projects/bridge-access.vue
+++ b/assets/js/pages/projects/bridge-access.vue
@@ -253,8 +253,15 @@ function timeAgo(timestamp) {
               rel="noopener"
               class="min-h-9 inline-flex items-center rounded-lg bg-gray-950 px-3.5 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100"
             >
-              Open Bridge
+              Open public Bridge
             </a>
+            <Link
+              v-if="app.bridgeEnabled"
+              :href="bridgePath"
+              class="min-h-9 inline-flex items-center rounded-lg border border-gray-200 px-3.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-800 dark:text-gray-300 dark:hover:bg-gray-900"
+            >
+              Open in Slipway
+            </Link>
             <button
               v-if="!app.bridgeEnabled"
               type="button"
@@ -300,6 +307,47 @@ function timeAgo(timestamp) {
               scoped exchange credential.
             </p>
           </div>
+        </section>
+
+        <section
+          v-if="app.bridgeEnabled"
+          class="mt-6 grid gap-3 sm:grid-cols-2"
+          aria-label="Bridge URLs"
+          data-test="bridge-urls"
+        >
+          <a
+            v-if="app.bridgeUrl"
+            :href="app.bridgeUrl"
+            target="_blank"
+            rel="noopener"
+            class="min-w-0 rounded-lg border border-gray-200 px-4 py-3 hover:border-gray-300 dark:border-gray-800 dark:hover:border-gray-700"
+          >
+            <span
+              class="block text-xs font-medium text-gray-500 dark:text-gray-400"
+            >
+              Public app URL
+            </span>
+            <code
+              class="mt-1 block truncate text-sm text-gray-900 dark:text-gray-100"
+            >
+              {{ app.bridgeUrl }}
+            </code>
+          </a>
+          <a
+            :href="app.slipwayBridgeUrl"
+            class="min-w-0 rounded-lg border border-gray-200 px-4 py-3 hover:border-gray-300 dark:border-gray-800 dark:hover:border-gray-700"
+          >
+            <span
+              class="block text-xs font-medium text-gray-500 dark:text-gray-400"
+            >
+              Slipway instance URL
+            </span>
+            <code
+              class="mt-1 block truncate text-sm text-gray-900 dark:text-gray-100"
+            >
+              {{ app.slipwayBridgeUrl }}
+            </code>
+          </a>
         </section>
 
         <section class="mt-10" aria-labelledby="invite-title">

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -23,6 +23,9 @@ const props = defineProps({
   environment: Object,
   app: Object,
   appScoped: Boolean,
+  bridgeRequestBasePath: String,
+  bridgeRequestApiBasePath: String,
+  hostBridgeOrigin: Boolean,
   mode: String,
   modelIdentity: String,
   recordId: String,
@@ -37,15 +40,19 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const { toasts, toast, dismiss } = createToast()
-const bridgeBasePath = computed(() =>
-  props.appScoped && props.app?.slug
-    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
-    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+const bridgeBasePath = computed(
+  () =>
+    props.bridgeRequestBasePath ||
+    (props.appScoped && props.app?.slug
+      ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+      : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`)
 )
-const bridgeApiBasePath = computed(() =>
-  props.appScoped && props.app?.slug
-    ? `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
-    : `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+const bridgeApiBasePath = computed(
+  () =>
+    props.bridgeRequestApiBasePath ||
+    (props.appScoped && props.app?.slug
+      ? `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+      : `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`)
 )
 
 const isEdit = computed(() => props.mode === 'edit')
@@ -368,19 +375,21 @@ function recordUrl() {
           }}</span>
         </nav>
         <nav class="hidden items-center space-x-2 text-sm sm:flex">
-          <Link
-            href="/"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >projects</Link
-          >
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
+          <template v-if="!hostBridgeOrigin">
+            <Link
+              href="/"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+              >projects</Link
+            >
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+            <Link
+              :href="`/projects/${project.slug}`"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              {{ project.name.toLowerCase() }}
+            </Link>
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+          </template>
           <Link
             :href="bridgeUrl()"
             class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -20,6 +20,9 @@ const props = defineProps({
   environment: Object,
   app: Object,
   appScoped: Boolean,
+  bridgeRequestBasePath: String,
+  bridgeRequestApiBasePath: String,
+  hostBridgeOrigin: Boolean,
   modelIdentity: String,
   appRunning: Boolean,
   modelMeta: Object,
@@ -45,12 +48,17 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const { toasts, toast, dismiss } = createToast()
-const bridgeBasePath = computed(() =>
-  props.appScoped && props.app?.slug
-    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
-    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+const bridgeBasePath = computed(
+  () =>
+    props.bridgeRequestBasePath ||
+    (props.appScoped && props.app?.slug
+      ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+      : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`)
 )
 const relationshipBaseUrl = computed(() => {
+  if (props.bridgeRequestApiBasePath) {
+    return `${props.bridgeRequestApiBasePath}/${props.modelIdentity}/relationships`
+  }
   const appPath =
     props.appScoped && props.app?.slug ? `/apps/${props.app.slug}` : ''
   return `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}${appPath}/bridge/${props.modelIdentity}/relationships`
@@ -620,26 +628,28 @@ function createUrl() {
           }}</span>
         </nav>
         <nav class="hidden items-center space-x-2 text-sm sm:flex">
-          <Link
-            href="/"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >projects</Link
-          >
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.slug }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
+          <template v-if="!hostBridgeOrigin">
+            <Link
+              href="/"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+              >projects</Link
+            >
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+            <Link
+              :href="`/projects/${project.slug}`"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              {{ project.name.toLowerCase() }}
+            </Link>
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+            <Link
+              :href="`/projects/${project.slug}/environments/${environment.slug}`"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              {{ environment.slug }}
+            </Link>
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+          </template>
           <Link
             :href="bridgeUrl()"
             class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -19,6 +19,9 @@ const props = defineProps({
   environment: Object,
   app: Object,
   appScoped: Boolean,
+  bridgeRequestBasePath: String,
+  bridgeRequestApiBasePath: String,
+  hostBridgeOrigin: Boolean,
   modelIdentity: String,
   recordId: String,
   appRunning: Boolean,
@@ -32,15 +35,19 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const { toasts, toast, dismiss } = createToast()
-const bridgeBasePath = computed(() =>
-  props.appScoped && props.app?.slug
-    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
-    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+const bridgeBasePath = computed(
+  () =>
+    props.bridgeRequestBasePath ||
+    (props.appScoped && props.app?.slug
+      ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+      : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`)
 )
-const bridgeApiBasePath = computed(() =>
-  props.appScoped && props.app?.slug
-    ? `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
-    : `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+const bridgeApiBasePath = computed(
+  () =>
+    props.bridgeRequestApiBasePath ||
+    (props.appScoped && props.app?.slug
+      ? `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+      : `/api/v1/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`)
 )
 
 const deleteModal = ref({ show: false })
@@ -325,19 +332,21 @@ function relationshipMutationBaseUrl(relationship) {
           >
         </nav>
         <nav class="hidden items-center space-x-2 text-sm sm:flex">
-          <Link
-            href="/"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >projects</Link
-          >
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
+          <template v-if="!hostBridgeOrigin">
+            <Link
+              href="/"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+              >projects</Link
+            >
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+            <Link
+              :href="`/projects/${project.slug}`"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              {{ project.name.toLowerCase() }}
+            </Link>
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+          </template>
           <Link
             :href="bridgeUrl()"
             class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -13,6 +13,8 @@ const props = defineProps({
   environment: Object,
   app: Object,
   appScoped: Boolean,
+  bridgeRequestBasePath: String,
+  hostBridgeOrigin: Boolean,
   appRunning: Boolean,
   models: Object,
   modelsError: String,
@@ -23,10 +25,12 @@ const props = defineProps({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
-const bridgeBasePath = computed(() =>
-  props.appScoped && props.app?.slug
-    ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
-    : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
+const bridgeBasePath = computed(
+  () =>
+    props.bridgeRequestBasePath ||
+    (props.appScoped && props.app?.slug
+      ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
+      : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`)
 )
 
 // Search
@@ -179,7 +183,14 @@ function switchDashboard(event) {
           </svg>
         </button>
         <nav class="flex items-center space-x-2 text-sm sm:hidden">
+          <span
+            v-if="hostBridgeOrigin"
+            class="text-gray-500 dark:text-gray-400"
+          >
+            {{ app.name.toLowerCase() }}
+          </span>
           <Link
+            v-else
             :href="`/projects/${project.slug}/environments/${environment.slug}`"
             class="text-gray-500 dark:text-gray-400"
           >
@@ -189,25 +200,30 @@ function switchDashboard(event) {
           <span class="font-medium text-gray-900 dark:text-white">bridge</span>
         </nav>
         <nav class="hidden items-center space-x-2 text-sm sm:flex">
-          <Link
-            href="/"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >projects</Link
-          >
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <Link
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-          >
-            {{ environment.slug }}
-          </Link>
+          <template v-if="!hostBridgeOrigin">
+            <Link
+              href="/"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+              >projects</Link
+            >
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+            <Link
+              :href="`/projects/${project.slug}`"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              {{ project.name.toLowerCase() }}
+            </Link>
+            <span class="text-gray-400 dark:text-gray-600">/</span>
+            <Link
+              :href="`/projects/${project.slug}/environments/${environment.slug}`"
+              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >
+              {{ environment.slug }}
+            </Link>
+          </template>
+          <span v-else class="text-gray-500 dark:text-gray-400">
+            {{ app.name.toLowerCase() }}
+          </span>
           <span class="text-gray-400 dark:text-gray-600">/</span>
           <span class="font-medium text-gray-900 dark:text-white">bridge</span>
         </nav>
@@ -281,6 +297,7 @@ function switchDashboard(event) {
             Deploy your app to start using Bridge.
           </p>
           <Link
+            v-if="!hostBridgeOrigin"
             :href="`/projects/${project.slug}/environments/${environment.slug}`"
             class="mt-4 inline-flex items-center rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
           >

--- a/config/custom.js
+++ b/config/custom.js
@@ -54,6 +54,9 @@ module.exports.custom = {
   // Docker network name for app containers
   slipwayNetwork: 'slipway',
 
+  // Stable control-plane upstream used by same-origin Bridge ingress routes.
+  slipwayContainerName: 'slipway',
+
   // Directory where app source code is stored
   slipwayAppsDir: '/var/slipway/apps',
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -391,6 +391,8 @@ module.exports.routes = {
     'project/view-bridge',
   'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity':
     'project/view-bridge-model',
+  'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/relationships/:relationshipAlias/options':
+    'project/bridge-relationship-options',
   'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/new':
     'project/view-bridge-create',
   'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/:recordId':

--- a/config/session.js
+++ b/config/session.js
@@ -10,6 +10,11 @@
  */
 
 module.exports.session = {
+  // Slipway can serve Bridge through another Sails app's origin. Use a
+  // product-specific cookie name so the two apps never overwrite each
+  // other's `sails.sid` while still retaining normal session-backed CSRF.
+  name: 'slipway.sid',
+
   /***************************************************************************
    *                                                                          *
    * Session secret is automatically generated when your new app is created   *

--- a/packages/hook/index.js
+++ b/packages/hook/index.js
@@ -108,6 +108,10 @@ module.exports = function defineSlipwayHook(sails) {
       if (process.env.SLIPWAY_BRIDGE_SECRET) {
         sails.config.slipway.bridge.secret = process.env.SLIPWAY_BRIDGE_SECRET
       }
+      if (process.env.SLIPWAY_BRIDGE_ROUTE_PATH) {
+        sails.config.slipway.bridge.routePath =
+          process.env.SLIPWAY_BRIDGE_ROUTE_PATH
+      }
     },
 
     initialize: function (done) {
@@ -229,88 +233,8 @@ module.exports = function defineSlipwayHook(sails) {
         }
       },
       after: {
-        'GET /bridge': async function (req, res) {
-          if (!bridgeConfig.enabled) {
-            return res.notFound()
-          }
-
-          if (
-            !bridgeConfig.exchangeUrl ||
-            !bridgeConfig.appId ||
-            !bridgeConfig.secret
-          ) {
-            sails.log.warn(
-              'sails-hook-slipway: Bridge is enabled but its Slipway exchange credentials are unavailable.'
-            )
-            return res.serverError(
-              'Bridge is not configured for this deployment. Redeploy the app from Slipway.'
-            )
-          }
-
-          let identity
-          try {
-            identity = await resolveBridgeIdentity(req)
-          } catch (error) {
-            sails.log.warn(
-              `sails-hook-slipway: Could not resolve the Bridge user: ${
-                error.message || error
-              }`
-            )
-            return res.forbidden(
-              'Bridge could not verify your host-app account.'
-            )
-          }
-
-          if (!identity) {
-            const loginPath = safeLocalPath(bridgeConfig.loginPath, '/login')
-            const returnUrl = safeLocalPath(req.originalUrl, '/bridge')
-            return res.redirect(
-              `${loginPath}?redirect=${encodeURIComponent(returnUrl)}`
-            )
-          }
-
-          if (!identity.emailVerified) {
-            return res.forbidden(
-              'Verify your host-app email address before opening Bridge.'
-            )
-          }
-
-          try {
-            const response = await requestJson({
-              url: bridgeConfig.exchangeUrl,
-              token: bridgeConfig.secret,
-              body: {
-                appId: String(bridgeConfig.appId),
-                hostUser: identity,
-                inviteToken:
-                  typeof req.query?.invite === 'string'
-                    ? req.query.invite
-                    : undefined
-              }
-            })
-
-            if (!response.launchUrl) {
-              throw new Error('Slipway did not return a Bridge launch URL.')
-            }
-
-            return res.redirect(response.launchUrl)
-          } catch (error) {
-            if (error.statusCode === 403) {
-              return res.forbidden(
-                `Your host-app account (${identity.email}) has not been invited to Bridge.`
-              )
-            }
-
-            sails.log.warn(
-              `sails-hook-slipway: Bridge exchange failed: ${
-                error.message || error
-              }`
-            )
-            return res.serverError(
-              'Bridge could not contact Slipway. Try again in a moment.'
-            )
-          }
-        }
+        'GET /bridge': createBridgeRoute(false),
+        'GET /_slipway/bridge': createBridgeRoute(true)
       }
     },
 
@@ -322,6 +246,110 @@ module.exports = function defineSlipwayHook(sails) {
       flush()
       return done()
     }
+  }
+
+  function createBridgeRoute(hostOrigin) {
+    return async function openBridge(req, res) {
+      if (!bridgeConfig.enabled) {
+        return res.notFound()
+      }
+
+      if (
+        !bridgeConfig.exchangeUrl ||
+        !bridgeConfig.appId ||
+        !bridgeConfig.secret
+      ) {
+        sails.log.warn(
+          'sails-hook-slipway: Bridge is enabled but its Slipway exchange credentials are unavailable.'
+        )
+        return res.serverError(
+          'Bridge is not configured for this deployment. Redeploy the app from Slipway.'
+        )
+      }
+
+      let identity
+      try {
+        identity = await resolveBridgeIdentity(req)
+      } catch (error) {
+        sails.log.warn(
+          `sails-hook-slipway: Could not resolve the Bridge user: ${
+            error.message || error
+          }`
+        )
+        return res.forbidden('Bridge could not verify your host-app account.')
+      }
+
+      if (!identity) {
+        const loginPath = safeLocalPath(bridgeConfig.loginPath, '/login')
+        let returnUrl = hostOrigin
+          ? withBridgeRoutePrefix('/_slipway/bridge')
+          : safeLocalPath(req.originalUrl, '/bridge')
+        if (hostOrigin && typeof req.query?.invite === 'string') {
+          returnUrl += `?invite=${encodeURIComponent(req.query.invite)}`
+        }
+        return res.redirect(
+          `${
+            hostOrigin ? withBridgeRoutePrefix(loginPath) : loginPath
+          }?redirect=${encodeURIComponent(returnUrl)}`
+        )
+      }
+
+      if (!identity.emailVerified) {
+        return res.forbidden(
+          'Verify your host-app email address before opening Bridge.'
+        )
+      }
+
+      try {
+        const response = await requestJson({
+          url: bridgeConfig.exchangeUrl,
+          token: bridgeConfig.secret,
+          body: {
+            appId: String(bridgeConfig.appId),
+            hostUser: identity,
+            inviteToken:
+              typeof req.query?.invite === 'string'
+                ? req.query.invite
+                : undefined,
+            hostOrigin
+          }
+        })
+
+        if (!response.launchUrl) {
+          throw new Error('Slipway did not return a Bridge launch URL.')
+        }
+
+        return res.redirect(response.launchUrl)
+      } catch (error) {
+        if (error.statusCode === 403) {
+          return res.forbidden(
+            `Your host-app account (${identity.email}) has not been invited to Bridge.`
+          )
+        }
+
+        sails.log.warn(
+          `sails-hook-slipway: Bridge exchange failed: ${
+            error.message || error
+          }`
+        )
+        return res.serverError(
+          'Bridge could not contact Slipway. Try again in a moment.'
+        )
+      }
+    }
+  }
+
+  function withBridgeRoutePrefix(path) {
+    const routePath = String(bridgeConfig.routePath || '').replace(
+      /^\/+|\/+$/g,
+      ''
+    )
+    const normalizedPath = safeLocalPath(path, '/')
+    if (!routePath) return normalizedPath
+    const prefix = `/${routePath}`
+    return normalizedPath === prefix || normalizedPath.startsWith(`${prefix}/`)
+      ? normalizedPath
+      : `${prefix}${normalizedPath}`
   }
 
   function initializeTelemetry(done) {

--- a/tests/functional/pages/bridge-access.test.js
+++ b/tests/functional/pages/bridge-access.test.js
@@ -84,6 +84,11 @@ test(
     expect(page).toHaveInertiaProps({
       'app.bridgeEnabled': true,
       'app.bridgeUrl': 'https://host-app.example/bridge',
+      'app.slipwayBridgeUrl': `${await sails.helpers.getInstanceUrl()}${bridgeAppPath(
+        project,
+        environment,
+        app
+      )}`,
       hookDetected: true
     })
 
@@ -334,6 +339,120 @@ test(
       .withSession(launch.session)
       .get(bridgePath)
     expect(staleSession).toHaveStatus(403)
+  }
+)
+
+test(
+  'host-origin Bridge keeps launch, navigation, APIs, and assets under the app route',
+  { world: bridgeWorld('host-origin-bridge', 'Host Origin Bridge') },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const app = await sails.models.app
+      .updateOne({ id: current.apps.web.id })
+      .set({
+        routePath: '/',
+        bridgeEnabled: true
+      })
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      domain: 'host-app.example'
+    })
+    const secret = await sails.helpers.bridge.ensureAppSecret.with({
+      appId: String(app.id),
+      rotate: true
+    })
+    const access = await world.create('bridgeaccess').with({
+      email: 'host-origin@host-app.example',
+      role: 'viewer',
+      status: 'active',
+      hostUserId: 'host-origin-user',
+      activatedAt: Date.now(),
+      app: app.id,
+      environment: environment.id,
+      project: project.id,
+      team: current.teams.genesisTeam.id,
+      invitedBy: current.users.genesisUser.id
+    })
+    const appClient = request.withHeaders({
+      authorization: `Bearer ${secret}`,
+      accept: 'application/json'
+    })
+    const exchange = await appClient.post('/api/v1/bridge/exchange', {
+      appId: String(app.id),
+      hostOrigin: true,
+      hostUser: {
+        id: access.hostUserId,
+        email: access.email,
+        fullName: 'Host Origin User',
+        emailVerified: true
+      }
+    })
+
+    expect(exchange).toHaveStatus(201)
+    const publicLaunchUrl = new URL(exchange.data.launchUrl)
+    expect(publicLaunchUrl.origin).toBe('https://host-app.example')
+    expect(publicLaunchUrl.pathname).toBe('/bridge/launch')
+    expect(publicLaunchUrl.searchParams.get('hostOrigin')).toBe('true')
+    expect(publicLaunchUrl.searchParams.get('hostRoutePath')).toBe('/')
+
+    const internalBridgePath = bridgeAppPath(project, environment, app)
+    const unauthenticated = await request.get(internalBridgePath, {
+      headers: {
+        host: 'host-app.example',
+        'x-forwarded-host': 'host-app.example',
+        accept: 'text/html, application/xhtml+xml'
+      }
+    })
+    expect(unauthenticated).toHaveStatus(302)
+    expect(unauthenticated).toRedirectTo('/_slipway/bridge')
+
+    const launch = await request.get(
+      `/bridge/launch${publicLaunchUrl.search}`,
+      {
+        headers: {
+          host: 'host-app.example',
+          'x-forwarded-host': 'host-app.example'
+        }
+      }
+    )
+    expect(launch).toHaveStatus(302)
+    expect(launch).toRedirectTo('/bridge')
+    expect(launch.session.bridgeAccessId).toBe(access.id)
+    expect(launch.session.bridgeHostOrigin).toBe(true)
+
+    const bridge = await request
+      .withSession(launch.session)
+      .get(internalBridgePath, {
+        headers: {
+          host: 'host-app.example',
+          'x-forwarded-host': 'host-app.example',
+          'x-inertia': 'true',
+          accept: 'text/html, application/xhtml+xml'
+        }
+      })
+    expect(bridge).toHaveStatus(200)
+    expect(bridge).toBeInertiaPage('projects/bridge')
+    expect(bridge.data.url).toBe('/bridge')
+    expect(bridge).toHaveInertiaProps({
+      bridgeRequestBasePath: '/bridge',
+      bridgeRequestApiBasePath: '/bridge',
+      hostBridgeAssetBasePath: '/bridge/_assets',
+      hostBridgeOrigin: true
+    })
+
+    const search = await request
+      .withSession(launch.session)
+      .get(`${internalBridgePath}/user?search=ada`, {
+        headers: {
+          host: 'host-app.example',
+          'x-forwarded-host': 'host-app.example',
+          'x-inertia': 'true',
+          accept: 'text/html, application/xhtml+xml'
+        }
+      })
+    expect(search).toHaveStatus(200)
+    expect(search.data.url).toBe('/bridge/user?search=ada')
   }
 )
 

--- a/tests/unit/config/routes.test.js
+++ b/tests/unit/config/routes.test.js
@@ -34,6 +34,11 @@ test('browser actions and JSON transports have explicit route contracts', ({
   ).toBe('project/bridge-relationship-options')
   expect(
     routes[
+      'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/:modelIdentity/relationships/:relationshipAlias/options'
+    ]
+  ).toBe('project/bridge-relationship-options')
+  expect(
+    routes[
       'POST /projects/:slug/environments/:envSlug/bridge/:modelIdentity/:recordId/relationships/:relationshipAlias/:operation'
     ]
   ).toBe('project/bridge-update-relationship')

--- a/tests/unit/config/session.test.js
+++ b/tests/unit/config/session.test.js
@@ -1,0 +1,9 @@
+const { test } = require('sounding')
+
+const { session } = require('../../../config/session')
+
+test('Slipway sessions never collide with a proxied host Sails app', ({
+  expect
+}) => {
+  expect(session.name).toBe('slipway.sid')
+})

--- a/tests/unit/helpers/caddy/generate-route-config.test.js
+++ b/tests/unit/helpers/caddy/generate-route-config.test.js
@@ -1,0 +1,28 @@
+const { test } = require('sounding')
+
+const generateRouteConfig = require('../../../../api/helpers/caddy/generate-route-config')
+
+test('generated Caddy config rewrites host Bridge paths to the control plane', ({
+  expect
+}) => {
+  const handlers = generateRouteConfig._private.bridgeHandlers({
+    app: { slug: 'web', routePath: '/academy' },
+    projectSlug: 'durable-ui',
+    environmentSlug: 'production',
+    controlPlaneUpstream: 'slipway:1337'
+  })
+
+  expect(handlers[0].routes[0].match[0].path).toEqual([
+    '/academy/bridge/launch'
+  ])
+  expect(handlers[0].routes[0].handle[0].uri).toBe('/bridge/launch')
+  expect(handlers[1].routes[0].handle[0].strip_path_prefix).toBe(
+    '/academy/bridge/_assets'
+  )
+  expect(handlers[2].routes[0].handle[1].uri).toBe(
+    '/projects/durable-ui/environments/production/apps/web/bridge{http.request.uri.path}'
+  )
+  expect(handlers[2].routes[0].handle[2].upstreams).toEqual([
+    { dial: 'slipway:1337' }
+  ])
+})

--- a/tests/unit/helpers/caddy/update-route.test.js
+++ b/tests/unit/helpers/caddy/update-route.test.js
@@ -76,6 +76,62 @@ test('Cloudflare Tunnel routes keep TLS at the edge', async ({
   }
 })
 
+test('Bridge routes stay on the app origin and precede the app catch-all', ({
+  expect
+}) => {
+  const helper = require(helperPath)
+  const labels = helper._private.buildRouteLabels({
+    projectSlug: 'durable-ui',
+    environmentSlug: 'production',
+    controlPlaneUpstream: 'slipway:1337',
+    routableApps: [
+      {
+        slug: 'admin',
+        routePath: '/admin',
+        bridgeEnabled: true,
+        containerName: 'durable-ui-admin',
+        port: 1337
+      },
+      {
+        slug: 'web',
+        routePath: '/',
+        bridgeEnabled: false,
+        containerName: 'durable-ui-web',
+        port: 1337
+      }
+    ]
+  })
+
+  expect(labels).toEqual([
+    'caddy.handle_0=/admin/bridge/launch',
+    'caddy.handle_0.0_uri=replace /admin/bridge/launch /bridge/launch',
+    'caddy.handle_0.1_reverse_proxy=slipway:1337',
+    'caddy.handle_1=/admin/bridge/_assets/*',
+    'caddy.handle_1.0_uri=strip_prefix /admin/bridge/_assets',
+    'caddy.handle_1.1_reverse_proxy=slipway:1337',
+    'caddy.handle_2=/admin/bridge*',
+    'caddy.handle_2.0_uri=replace /admin/bridge /projects/durable-ui/environments/production/apps/admin/bridge',
+    'caddy.handle_2.1_reverse_proxy=slipway:1337',
+    'caddy.handle_3=/admin*',
+    'caddy.handle_3.0_uri=strip_prefix /admin',
+    'caddy.handle_3.1_reverse_proxy=durable-ui-admin:1337',
+    'caddy.handle_4=/*',
+    'caddy.handle_4.1_reverse_proxy=durable-ui-web:1337'
+  ])
+  expect(
+    helper._private.routeUpstreams(
+      [
+        {
+          bridgeEnabled: true,
+          containerName: 'durable-ui-admin',
+          port: 1337
+        }
+      ],
+      'slipway:1337'
+    )
+  ).toEqual(['durable-ui-admin:1337', 'slipway:1337'])
+})
+
 test(
   'candidate route verification failure removes the candidate and verifies the still-active previous route',
   { world: routeWorld('route-restoration') },

--- a/tests/unit/packages/hook-bridge.test.js
+++ b/tests/unit/packages/hook-bridge.test.js
@@ -82,6 +82,77 @@ test('host Bridge preserves the invitation while sending a guest through app log
   )
 })
 
+test('proxied Bridge exchanges on the host origin with its routed app prefix', async ({
+  expect
+}) => {
+  const exchange = await startExchangeServer()
+  const { hostRoute } = await createBridgeRoute({
+    bridge: {
+      enabled: true,
+      exchangeUrl: exchange.url,
+      appId: '42',
+      secret: 'slb_app-secret',
+      loginPath: '/sign-in',
+      routePath: '/academy',
+      identity: defaultIdentityConfig()
+    },
+    user: {
+      id: 'host-user-7',
+      email: 'editor@example.com',
+      fullName: 'Host Editor',
+      emailStatus: 'verified'
+    }
+  })
+  const response = createResponse()
+
+  try {
+    await hostRoute(
+      {
+        session: { userId: 'host-user-7' },
+        originalUrl: '/_slipway/bridge',
+        query: {}
+      },
+      response
+    )
+
+    expect(response.status).toBe('redirect')
+    expect(exchange.request.body.hostOrigin).toBe(true)
+  } finally {
+    await exchange.close()
+  }
+})
+
+test('proxied Bridge prefixes host login and preserves its invitation callback', async ({
+  expect
+}) => {
+  const { hostRoute } = await createBridgeRoute({
+    bridge: {
+      enabled: true,
+      exchangeUrl: 'http://127.0.0.1:1/exchange',
+      appId: '42',
+      secret: 'slb_app-secret',
+      loginPath: '/sign-in',
+      routePath: '/academy',
+      identity: defaultIdentityConfig()
+    }
+  })
+  const response = createResponse()
+
+  await hostRoute(
+    {
+      session: {},
+      originalUrl: '/_slipway/bridge?invite=bli_invitation',
+      query: { invite: 'bli_invitation' }
+    },
+    response
+  )
+
+  expect(response.status).toBe('redirect')
+  expect(response.value).toBe(
+    '/academy/sign-in?redirect=%2Facademy%2F_slipway%2Fbridge%3Finvite%3Dbli_invitation'
+  )
+})
+
 test('host Bridge fails closed when the app cannot prove email verification', async ({
   expect
 }) => {
@@ -169,7 +240,8 @@ async function createBridgeRoute({
   })
 
   return {
-    route: hook.routes.after['GET /bridge']
+    route: hook.routes.after['GET /bridge'],
+    hostRoute: hook.routes.after['GET /_slipway/bridge']
   }
 }
 

--- a/tests/unit/views/bridge-assets.test.js
+++ b/tests/unit/views/bridge-assets.test.js
@@ -1,0 +1,48 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const ejs = require('ejs')
+const { test } = require('sounding')
+
+const template = fs.readFileSync(
+  path.resolve(__dirname, '../../../views/app.ejs'),
+  'utf8'
+)
+
+test('host-origin Bridge loads every Slipway asset through its public prefix', ({
+  expect
+}) => {
+  const html = ejs.render(template, {
+    page: {
+      component: 'projects/bridge',
+      props: {
+        hostBridgeAssetBasePath: '/academy/bridge/_assets'
+      }
+    },
+    shipwright: {
+      styles: () => '<link rel="stylesheet" href="/css/app.css">',
+      scripts: () => '<script src="/js/app.js"></script>'
+    }
+  })
+
+  expect(html).toContain(
+    'window.__SLIPWAY_ASSET_PREFIX__ = "/academy/bridge/_assets"'
+  )
+  expect(html).toContain('href="/academy/bridge/_assets/images/favicon.svg"')
+  expect(html).toContain('href="/academy/bridge/_assets/css/app.css"')
+  expect(html).toContain('src="/academy/bridge/_assets/js/app.js"')
+})
+
+test('direct Slipway pages retain their ordinary asset paths', ({ expect }) => {
+  const html = ejs.render(template, {
+    page: { component: 'projects/bridge', props: {} },
+    shipwright: {
+      styles: () => '<link rel="stylesheet" href="/css/app.css">',
+      scripts: () => '<script src="/js/app.js"></script>'
+    }
+  })
+
+  expect(html).toContain('href="/images/favicon.svg"')
+  expect(html).toContain('href="/css/app.css"')
+  expect(html).toContain('src="/js/app.js"')
+  expect(html.includes('__SLIPWAY_ASSET_PREFIX__')).toBe(false)
+})

--- a/views/app.ejs
+++ b/views/app.ejs
@@ -1,5 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+  <%
+    const bridgeAssetBasePath = page?.props?.hostBridgeAssetBasePath || ''
+    const prefixBridgeAssets = (tags) =>
+      bridgeAssetBasePath
+        ? tags.replace(/(src|href)="\//g, `$1="${bridgeAssetBasePath}/`)
+        : tags
+  %>
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -11,16 +18,21 @@
       rel="icon"
       type="image/svg+xml"
       sizes="any"
-      href="/images/favicon.svg"
+      href="<%= bridgeAssetBasePath %>/images/favicon.svg"
       data-deployment-state="idle"
     />
-    <%- shipwright.styles() %>
+    <%- prefixBridgeAssets(shipwright.styles()) %>
   </head>
   <body>
     <div id="app"></div>
     <script type="application/json" data-page="app">
       <%- JSON.stringify(page).replace(/</g, '\\u003c') %>
     </script>
-    <%- shipwright.scripts() %>
+    <% if (bridgeAssetBasePath) { %>
+      <script>
+        window.__SLIPWAY_ASSET_PREFIX__ = <%- JSON.stringify(bridgeAssetBasePath) %>
+      </script>
+    <% } %>
+    <%- prefixBridgeAssets(shipwright.scripts()) %>
   </body>
 </html>


### PR DESCRIPTION
## Summary

- proxy app-local Bridge launch, assets, navigation, search, APIs, and mutations through the host application's `/bridge` subtree
- keep the existing app-scoped Slipway operator URL available and show both URLs in the UI
- isolate Slipway's session cookie from the host Sails app and preserve revocable Bridge access semantics
- document the performance architecture and final local latency measurements for 0.0.54

## Verification

- `npm run test:unit` — 268 passed
- `npm run test:functional` — 97 passed
- `npm run test:e2e` — 42 passed
- `npm run lint`
- `npm run check:consistency`
- real caddy-docker-proxy label adaptation
- `bash ./local.sh rebuild` — healthy image `04223017…`
- `bash ./local.sh bridge-benchmark` — old 4,953–5,026ms; warm 0–1ms

Fixes #328