### PR TITLE
fix(config): accept unchanged legacy managed metadata

### DIFF
--- a/api/controllers/api/v1/environment/update-environment.js
+++ b/api/controllers/api/v1/environment/update-environment.js
@@ -112,6 +112,24 @@ module.exports = {
     const managedKeys = services
       .map((service) => service.envVarKey)
       .filter(Boolean)
+    const currentEnvVarMetadata =
+      sails.helpers.configuration.normalizeEnvVarMetadata.with({
+        values: environment.envVars || {},
+        metadata: environment.envVarMetadata || {},
+        currentValues: environment.envVars || {},
+        currentMetadata: environment.envVarMetadata || {},
+        managedKeys,
+        recordChanges: false
+      })
+    const requestedEnvVarMetadata =
+      sails.helpers.configuration.normalizeEnvVarMetadata.with({
+        values: nextEnvVars,
+        metadata: envVarMetadata || currentEnvVarMetadata,
+        currentValues: environment.envVars || {},
+        currentMetadata: currentEnvVarMetadata,
+        managedKeys,
+        recordChanges: false
+      })
     if (envVars !== undefined) {
       for (const key of managedKeys) {
         if (envVars[key] !== (environment.envVars || {})[key]) {
@@ -124,13 +142,11 @@ module.exports = {
     }
     if (envVarMetadata !== undefined) {
       for (const key of managedKeys) {
-        const previous = environment.envVarMetadata?.[key] || {}
-        const requested = envVarMetadata?.[key]
+        const previous = currentEnvVarMetadata[key] || {}
+        const requested = requestedEnvVarMetadata[key]
         if (!requested) continue
         const changed = ['kind', 'previewPolicy', 'description'].some(
-          (field) =>
-            requested[field] !== undefined &&
-            requested[field] !== previous[field]
+          (field) => requested[field] !== previous[field]
         )
         if (changed) {
           problems.push({
@@ -152,14 +168,14 @@ module.exports = {
     if (name !== undefined) updates.name = name
     if (isProduction !== undefined) updates.isProduction = isProduction
     if (domain !== undefined) updates.domain = domain
-    let normalizedMetadata = environment.envVarMetadata || {}
+    let normalizedMetadata = currentEnvVarMetadata
     if (envVars !== undefined || envVarMetadata !== undefined) {
       normalizedMetadata =
         sails.helpers.configuration.normalizeEnvVarMetadata.with({
           values: nextEnvVars,
-          metadata: envVarMetadata || environment.envVarMetadata || {},
+          metadata: requestedEnvVarMetadata,
           currentValues: environment.envVars || {},
-          currentMetadata: environment.envVarMetadata || {},
+          currentMetadata: currentEnvVarMetadata,
           managedKeys,
           changedBy: String(user.id),
           changedByName: user.fullName
@@ -174,7 +190,7 @@ module.exports = {
       await sails.helpers.configuration.recordEnvVarChanges.with({
         before: environment.envVars || {},
         after: nextEnvVars,
-        beforeMetadata: environment.envVarMetadata || {},
+        beforeMetadata: currentEnvVarMetadata,
         afterMetadata: normalizedMetadata,
         scope: 'environment',
         resourceType: 'environment',

--- a/api/helpers/configuration/normalize-env-var-metadata.js
+++ b/api/helpers/configuration/normalize-env-var-metadata.js
@@ -14,7 +14,13 @@ module.exports = {
     managedKeys: { type: 'ref', defaultsTo: [] },
     changedBy: { type: 'string', allowNull: true },
     changedByName: { type: 'string', allowNull: true },
-    now: { type: 'number', defaultsTo: 0 }
+    now: { type: 'number', defaultsTo: 0 },
+    recordChanges: {
+      type: 'boolean',
+      defaultsTo: true,
+      description:
+        'Whether policy defaulting may create per-variable change history.'
+    }
   },
 
   exits: {
@@ -29,7 +35,8 @@ module.exports = {
     managedKeys,
     changedBy,
     changedByName,
-    now
+    now,
+    recordChanges
   }) {
     const normalized = {}
     const managed = new Set((managedKeys || []).map(String))
@@ -66,6 +73,12 @@ module.exports = {
       }
       if (description) next.description = description
 
+      if (!recordChanges) {
+        preserveHistory(next, previous)
+        normalized[key] = next
+        continue
+      }
+
       const changed =
         !Object.prototype.hasOwnProperty.call(currentValues || {}, key) ||
         currentValues[key] !== values[key] ||
@@ -74,11 +87,13 @@ module.exports = {
         previous.previewPolicy !== next.previewPolicy ||
         String(previous.description || '') !== description
 
-      next.changedAt = changed ? changedAt : previous.changedAt || changedAt
-      next.changedBy = changed ? changedBy || null : previous.changedBy || null
-      next.changedByName = changed
-        ? changedByName || null
-        : previous.changedByName || null
+      if (changed) {
+        next.changedAt = changedAt
+        next.changedBy = changedBy || null
+        next.changedByName = changedByName || null
+      } else {
+        preserveHistory(next, previous)
+      }
       normalized[key] = next
     }
 
@@ -88,4 +103,10 @@ module.exports = {
 
 function allowed(value, values) {
   return values.includes(value)
+}
+
+function preserveHistory(target, source) {
+  for (const field of ['changedAt', 'changedBy', 'changedByName']) {
+    if (source[field] !== undefined) target[field] = source[field]
+  }
 }

--- a/tests/functional/api/configuration-secrets.test.js
+++ b/tests/functional/api/configuration-secrets.test.js
@@ -124,6 +124,120 @@ test(
 )
 
 test(
+  'unrelated variables can change alongside unchanged legacy managed metadata',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'legacy-managed-environment-secrets',
+          name: 'Legacy managed environment secrets'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const environment = world.current.environments.production
+    const managedValue = 'postgresql://legacy-managed'
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      envVars: { DATABASE_URL: managedValue },
+      envVarMetadata: {}
+    })
+    await world.create('service').with({
+      name: 'legacy-main-db',
+      environment: environment.id,
+      envVarKey: 'DATABASE_URL'
+    })
+    const dashboard = await withCsrfFromPage(
+      request,
+      '/projects/legacy-managed-environment-secrets/environments/production',
+      'genesisUser'
+    )
+    const path =
+      '/api/v1/projects/legacy-managed-environment-secrets/environments/production'
+    const normalizedPageMetadata = {
+      DATABASE_URL: {
+        kind: 'secret',
+        managed: true,
+        previewPolicy: 'omit'
+      },
+      SENTRY_DSN: {
+        kind: 'secret',
+        previewPolicy: 'omit'
+      }
+    }
+
+    const response = await dashboard.request.patch(path, {
+      envVars: {
+        DATABASE_URL: managedValue,
+        SENTRY_DSN: 'https://sentry.example/123'
+      },
+      envVarMetadata: normalizedPageMetadata
+    })
+
+    expect(response).toHaveStatus(200)
+    let persisted = await sails.models.environment
+      .findOne({ id: environment.id })
+      .decrypt()
+    expect(persisted.envVars.DATABASE_URL).toBe(managedValue)
+    expect(persisted.envVarMetadata.DATABASE_URL).toEqual({
+      kind: 'secret',
+      managed: true,
+      previewPolicy: 'omit'
+    })
+    expect(persisted.envVarMetadata.SENTRY_DSN.changedAt > 0).toBe(true)
+
+    const configurationAudits = await sails.models.auditlog.find({
+      resourceType: 'environment',
+      resourceId: String(environment.id),
+      action: { startsWith: 'configuration.' }
+    })
+    expect(configurationAudits.map((audit) => audit.details.key)).toEqual([
+      'SENTRY_DSN'
+    ])
+    expect(JSON.stringify(configurationAudits).includes(managedValue)).toBe(
+      false
+    )
+
+    const valueChange = await dashboard.request.patch(path, {
+      envVars: {
+        DATABASE_URL: 'postgresql://forbidden-change',
+        SENTRY_DSN: 'https://sentry.example/123'
+      },
+      envVarMetadata: normalizedPageMetadata
+    })
+    const policyChange = await dashboard.request.patch(path, {
+      envVars: {
+        DATABASE_URL: managedValue,
+        SENTRY_DSN: 'https://sentry.example/123'
+      },
+      envVarMetadata: {
+        ...normalizedPageMetadata,
+        DATABASE_URL: {
+          ...normalizedPageMetadata.DATABASE_URL,
+          kind: 'plain'
+        }
+      }
+    })
+
+    expect(valueChange).toHaveStatus(303)
+    expect(policyChange).toHaveStatus(303)
+    persisted = await sails.models.environment
+      .findOne({ id: environment.id })
+      .decrypt()
+    expect(persisted.envVars.DATABASE_URL).toBe(managedValue)
+    expect(persisted.envVarMetadata.DATABASE_URL.kind).toBe('secret')
+    expect(
+      await sails.models.auditlog.count({
+        resourceType: 'environment',
+        resourceId: String(environment.id),
+        action: { startsWith: 'configuration.' }
+      })
+    ).toBe(1)
+  }
+)
+
+test(
   'global configuration changes retain metadata and write value-free audits',
   { world: 'configured-slipway' },
   async ({ sails, request, expect }) => {

--- a/tests/unit/helpers/configuration/runtime-config.test.js
+++ b/tests/unit/helpers/configuration/runtime-config.test.js
@@ -23,6 +23,58 @@ test('config metadata defaults secrets to omit and keeps plain config inheritabl
   expect(metadata.API_SECRET.changedByName).toBe('Builder')
 })
 
+test('read-only metadata normalization resolves legacy policy without inventing history', async ({
+  sails,
+  expect
+}) => {
+  const missing = sails.helpers.configuration.normalizeEnvVarMetadata.with({
+    values: { DATABASE_URL: 'postgresql://managed' },
+    metadata: {},
+    currentValues: { DATABASE_URL: 'postgresql://managed' },
+    currentMetadata: {},
+    managedKeys: ['DATABASE_URL'],
+    now: 999,
+    recordChanges: false
+  })
+  const partial = sails.helpers.configuration.normalizeEnvVarMetadata.with({
+    values: { DATABASE_URL: 'postgresql://managed' },
+    metadata: {
+      DATABASE_URL: {
+        kind: 'secret',
+        changedAt: 123,
+        changedBy: '7',
+        changedByName: 'Builder'
+      }
+    },
+    currentValues: { DATABASE_URL: 'postgresql://managed' },
+    currentMetadata: {
+      DATABASE_URL: {
+        kind: 'secret',
+        changedAt: 123,
+        changedBy: '7',
+        changedByName: 'Builder'
+      }
+    },
+    managedKeys: ['DATABASE_URL'],
+    now: 999,
+    recordChanges: false
+  })
+
+  expect(missing.DATABASE_URL).toEqual({
+    kind: 'secret',
+    managed: true,
+    previewPolicy: 'omit'
+  })
+  expect(partial.DATABASE_URL).toEqual({
+    kind: 'secret',
+    managed: true,
+    previewPolicy: 'omit',
+    changedAt: 123,
+    changedBy: '7',
+    changedByName: 'Builder'
+  })
+})
+
 test('preview policy omits production secrets and regenerates selected values', async ({
   sails,
   expect


### PR DESCRIPTION
## Summary

- compare managed variable policy using one canonical effective metadata snapshot instead of raw legacy storage
- persist and audit accepted updates from that same baseline, so unrelated env changes do not fabricate managed-variable changes
- add an explicit read-only normalization mode that resolves defaults without creating history
- preserve rejection of genuine managed value and protected-policy changes

## Verification

- `npx sounding test --file tests/unit/helpers/configuration/runtime-config.test.js` — 4 passed
- `npx sounding test --file tests/functional/api/configuration-secrets.test.js` — 5 passed
- `npx sounding test --file tests/e2e/pages/projects/configuration-secrets.test.js --test-concurrency=1` — passed
- `git diff --check`

Fixes #356