### PR TITLE
fix(config-ui): show only recorded variable history

### DIFF
--- a/api/controllers/project/view-app.js
+++ b/api/controllers/project/view-app.js
@@ -238,7 +238,7 @@ module.exports = {
             currentValues:
               decryptedApp.secureEnvVars || decryptedApp.envVars || {},
             currentMetadata: decryptedApp.envVarMetadata || {},
-            now: decryptedApp.updatedAt
+            recordChanges: false
           }),
         inheritedVars,
         deploymentHistory,

--- a/api/controllers/project/view-environment.js
+++ b/api/controllers/project/view-environment.js
@@ -173,7 +173,7 @@ module.exports = {
         currentValues: environment.envVars || {},
         currentMetadata: environment.envVarMetadata || {},
         managedKeys: managedEnvVarKeys,
-        now: environment.updatedAt
+        recordChanges: false
       })
 
     // Check if GitHub is connected for this team

--- a/api/controllers/setting/view-global-env.js
+++ b/api/controllers/setting/view-global-env.js
@@ -34,6 +34,14 @@ module.exports = {
       globalEnvVars.R2_SECRET_KEY &&
       globalEnvVars.R2_BUCKET
     )
+    globalEnvVarMetadata =
+      sails.helpers.configuration.normalizeEnvVarMetadata.with({
+        values: globalEnvVars,
+        metadata: globalEnvVarMetadata,
+        currentValues: globalEnvVars,
+        currentMetadata: globalEnvVarMetadata,
+        recordChanges: false
+      })
 
     return {
       page: 'settings/global-env',

--- a/assets/js/components/ConfigVariableMenu.vue
+++ b/assets/js/components/ConfigVariableMenu.vue
@@ -12,12 +12,26 @@ function update(field, value) {
     [field]: value
   })
 }
+
+function previewPolicyDescription(policy) {
+  return {
+    omit: 'Not copied to preview environments.',
+    inherit: 'Copied to preview environments.',
+    randomize: 'A fresh value is generated for each preview environment.'
+  }[policy]
+}
+
+function toggleDetails(event) {
+  const details = event.currentTarget.closest('details')
+  details.open = !details.open
+}
 </script>
 
 <template>
   <details :data-test="`config-menu-${variableKey}`" class="relative">
     <summary
       :aria-label="`Configure ${variableKey}`"
+      @keydown.enter.prevent="toggleDetails"
       class="flex cursor-pointer list-none rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700 [&::-webkit-details-marker]:hidden"
     >
       <svg
@@ -41,6 +55,18 @@ function update(field, value) {
       >
         Managed by Slipway. Change or remove the service that owns this value.
       </p>
+
+      <div v-if="metadata.managed">
+        <p class="text-xs font-medium text-gray-700 dark:text-gray-300">
+          Preview environments
+        </p>
+        <p
+          data-test="config-preview-policy-description"
+          class="mt-1 text-xs leading-5 text-gray-500 dark:text-gray-400"
+        >
+          {{ previewPolicyDescription(metadata.previewPolicy) }}
+        </p>
+      </div>
 
       <template v-else>
         <label class="block">
@@ -70,6 +96,12 @@ function update(field, value) {
             <option value="inherit">Inherit</option>
             <option value="randomize">Generate a new value</option>
           </select>
+          <span
+            data-test="config-preview-policy-description"
+            class="mt-1 block text-xs leading-5 text-gray-500 dark:text-gray-400"
+          >
+            {{ previewPolicyDescription(metadata.previewPolicy) }}
+          </span>
         </label>
 
         <label class="block">

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -462,13 +462,7 @@ function isSensitive(key) {
 
 function metadataSummary(key) {
   const metadata = metadataFor(key)
-  const type = metadata.kind === 'secret' ? 'Secret' : 'Plain config'
-  const preview = {
-    omit: 'omitted from previews',
-    inherit: 'inherited by previews',
-    randomize: 'regenerated for previews'
-  }[metadata.previewPolicy]
-  return `${type} · ${preview}`
+  return metadata.kind === 'secret' ? 'Secret' : 'Plain config'
 }
 
 function changeSummary(key) {
@@ -1705,7 +1699,7 @@ onBeforeUnmount(() => {
                         class="min-w-0 flex-1 border-b border-dashed border-transparent bg-transparent font-mono text-sm font-medium text-gray-900 focus:border-gray-300 focus:outline-none dark:text-white dark:focus:border-gray-600"
                       />
                       <div
-                        class="has-[details[open]]:visible invisible flex items-center space-x-1 focus-within:visible group-hover:visible"
+                        class="has-[details[open]]:opacity-100 flex items-center space-x-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
                       >
                         <button
                           v-if="isSensitive(key)"
@@ -1768,7 +1762,10 @@ onBeforeUnmount(() => {
                       spellcheck="false"
                       class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                     />
-                    <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                    <p
+                      :data-test="`config-variable-summary-${key}`"
+                      class="mt-1 text-xs text-gray-400 dark:text-gray-500"
+                    >
                       {{ metadataSummary(key) }}
                       <template v-if="changeSummary(key)">
                         · {{ changeSummary(key) }}

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -445,17 +445,11 @@ function isSensitive(key) {
 
 function metadataSummary(key) {
   const metadata = metadataFor(key)
-  const type = metadata.managed
+  return metadata.managed
     ? 'Managed secret'
     : metadata.kind === 'secret'
     ? 'Secret'
     : 'Plain config'
-  const preview = {
-    omit: 'omitted from previews',
-    inherit: 'inherited by previews',
-    randomize: 'regenerated for previews'
-  }[metadata.previewPolicy]
-  return `${type} · ${preview}`
 }
 
 function changeSummary(key) {
@@ -2644,7 +2638,7 @@ onBeforeUnmount(() => {
                         class="min-w-0 flex-1 border-b border-dashed border-transparent bg-transparent font-mono text-sm font-medium text-gray-900 focus:border-gray-300 focus:outline-none dark:text-white dark:focus:border-gray-600"
                       />
                       <div
-                        class="has-[details[open]]:visible invisible flex items-center space-x-1 focus-within:visible group-hover:visible"
+                        class="has-[details[open]]:opacity-100 flex items-center space-x-1 opacity-0 transition-opacity focus-within:opacity-100 group-hover:opacity-100"
                       >
                         <button
                           v-if="isSensitive(key)"
@@ -2708,7 +2702,10 @@ onBeforeUnmount(() => {
                       spellcheck="false"
                       class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                     />
-                    <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                    <p
+                      :data-test="`config-variable-summary-${key}`"
+                      class="mt-1 text-xs text-gray-400 dark:text-gray-500"
+                    >
                       {{ metadataSummary(key) }}
                       <template v-if="changeSummary(key)">
                         · {{ changeSummary(key) }}

--- a/assets/js/pages/settings/global-env.vue
+++ b/assets/js/pages/settings/global-env.vue
@@ -52,17 +52,11 @@ function isSensitive(key) {
 
 function metadataSummary(key) {
   const metadata = metadataFor(key)
-  const type = metadata.managed
+  return metadata.managed
     ? 'Managed secret'
     : metadata.kind === 'secret'
     ? 'Secret'
     : 'Plain config'
-  const preview = {
-    omit: 'omitted from previews',
-    inherit: 'inherited by previews',
-    randomize: 'regenerated for previews'
-  }[metadata.previewPolicy]
-  return `${type} · ${preview}`
 }
 
 function changeSummary(key) {
@@ -709,7 +703,10 @@ onMounted(() => {
                   spellcheck="false"
                   class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                 />
-                <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                <p
+                  :data-test="`config-variable-summary-${key}`"
+                  class="mt-1 text-xs text-gray-400 dark:text-gray-500"
+                >
                   {{ metadataSummary(key) }}
                   <template v-if="changeSummary(key)">
                     · {{ changeSummary(key) }}

--- a/tests/e2e/pages/projects/configuration-secrets.test.js
+++ b/tests/e2e/pages/projects/configuration-secrets.test.js
@@ -41,6 +41,7 @@ test(
       .set({
         envVars: {
           DATABASE_URL: 'postgresql://managed',
+          LEGACY_SECRET: 'legacy-environment-secret',
           RELEASE_CHANNEL: 'stable'
         },
         envVarMetadata: {
@@ -70,7 +71,10 @@ test(
       status: 'stopped'
     })
     await sails.models.app.updateOne({ id: current.apps.web.id }).set({
-      secureEnvVars: { APP_SIGNING_SECRET: 'app-secret' },
+      secureEnvVars: {
+        APP_SIGNING_SECRET: 'app-secret',
+        LEGACY_APP_SECRET: 'legacy-app-secret'
+      },
       envVars: {},
       envVarMetadata: {
         APP_SIGNING_SECRET: {
@@ -86,7 +90,10 @@ test(
     })
     await sails.helpers.setting.set(
       'globalEnvVars',
-      JSON.stringify({ GLOBAL_REGION: 'eu-central' })
+      JSON.stringify({
+        GLOBAL_REGION: 'eu-central',
+        LEGACY_GLOBAL_SECRET: 'legacy-global-secret'
+      })
     )
     await sails.helpers.setting.set(
       'globalEnvVarMetadata',
@@ -138,30 +145,59 @@ test(
       '/projects/configuration-secrets-ui/environments/production?env=1'
     )
     await page.wait('@environment-config')
-    await page.raw.locator('input[value="DATABASE_URL"]').hover()
-    await page.raw
-      .locator('[data-test="config-menu-DATABASE_URL"] summary')
-      .click()
+    const legacyEnvironmentSummary = page.raw.locator(
+      '[data-test="config-variable-summary-LEGACY_SECRET"]'
+    )
+    expect((await legacyEnvironmentSummary.textContent()).trim()).toBe('Secret')
+    const managedEnvironmentSummary = page.raw.locator(
+      '[data-test="config-variable-summary-DATABASE_URL"]'
+    )
+    expect(
+      (await managedEnvironmentSummary.textContent()).includes('ago')
+    ).toBe(true)
+    const managedMenu = page.raw.locator(
+      '[data-test="config-menu-DATABASE_URL"] summary'
+    )
+    await managedMenu.focus()
+    await managedMenu.press('Enter')
+    expect(
+      await managedMenu.evaluate((summary) => summary.parentElement.open)
+    ).toBe(true)
     await expect(page).toSee(
       'Managed by Slipway. Change or remove the service that owns this value.'
     )
+    await expect(page).toSee('Not copied to preview environments.')
     await screenshotConfig(
       page,
       'environment-config',
       '.tmp/issue-200-environment-secrets-light.png'
     )
+    await page.resize(390, 844)
+    await screenshotConfig(
+      page,
+      'environment-config',
+      '.tmp/issue-357-environment-secrets-narrow.png'
+    )
 
     await page.inDarkMode()
+    await page.resize(1440, 1000)
     await navigateAfterUpdateCheck(
       page,
       '/projects/configuration-secrets-ui/environments/production/apps/web?env=1'
     )
     await page.wait('@app-config')
+    const legacyAppSummary = page.raw.locator(
+      '[data-test="config-variable-summary-LEGACY_APP_SECRET"]'
+    )
+    expect((await legacyAppSummary.textContent()).trim()).toBe('Secret')
     await page.raw.locator('input[value="APP_SIGNING_SECRET"]').hover()
     await page.raw
       .locator('[data-test="config-menu-APP_SIGNING_SECRET"] summary')
       .click()
     await expect(page).toSee('Generate a new value')
+    await expect(page).toSee(
+      'A fresh value is generated for each preview environment.'
+    )
     await screenshotConfig(
       page,
       'app-config',
@@ -171,9 +207,14 @@ test(
     await page.inLightMode()
     await navigateAfterUpdateCheck(page, '/settings/global-env')
     await page.wait('@global-config')
+    const legacyGlobalSummary = page.raw.locator(
+      '[data-test="config-variable-summary-LEGACY_GLOBAL_SECRET"]'
+    )
+    expect((await legacyGlobalSummary.textContent()).trim()).toBe('Secret')
     await page.raw
       .locator('[data-test="config-menu-GLOBAL_REGION"] summary')
       .click()
+    await expect(page).toSee('Copied to preview environments.')
     await screenshotConfig(
       page,
       'global-config',

--- a/tests/functional/api/configuration-secrets.test.js
+++ b/tests/functional/api/configuration-secrets.test.js
@@ -166,6 +166,11 @@ test(
         previewPolicy: 'omit'
       }
     }
+    expect(dashboard.page.data.props.envVarMetadata.DATABASE_URL).toEqual({
+      kind: 'secret',
+      managed: true,
+      previewPolicy: 'omit'
+    })
 
     const response = await dashboard.request.patch(path, {
       envVars: {
@@ -186,6 +191,22 @@ test(
       previewPolicy: 'omit'
     })
     expect(persisted.envVarMetadata.SENTRY_DSN.changedAt > 0).toBe(true)
+    expect(persisted.envVarMetadata.SENTRY_DSN.changedBy).toBe(
+      String(world.current.users.genesisUser.id)
+    )
+    expect(persisted.envVarMetadata.SENTRY_DSN.changedByName).toBe(
+      world.current.users.genesisUser.fullName
+    )
+    const metadataAfterVariableUpdate = persisted.envVarMetadata
+
+    const unrelatedUpdate = await dashboard.request.patch(path, {
+      name: 'Production launch'
+    })
+    expect(unrelatedUpdate).toHaveStatus(200)
+    persisted = await sails.models.environment
+      .findOne({ id: environment.id })
+      .decrypt()
+    expect(persisted.envVarMetadata).toEqual(metadataAfterVariableUpdate)
 
     const configurationAudits = await sails.models.auditlog.find({
       resourceType: 'environment',

--- a/tests/unit/helpers/configuration/runtime-config.test.js
+++ b/tests/unit/helpers/configuration/runtime-config.test.js
@@ -59,6 +59,15 @@ test('read-only metadata normalization resolves legacy policy without inventing 
     now: 999,
     recordChanges: false
   })
+  const reread = sails.helpers.configuration.normalizeEnvVarMetadata.with({
+    values: { DATABASE_URL: 'postgresql://managed' },
+    metadata: missing,
+    currentValues: { DATABASE_URL: 'postgresql://managed' },
+    currentMetadata: missing,
+    managedKeys: ['DATABASE_URL'],
+    now: 1000,
+    recordChanges: false
+  })
 
   expect(missing.DATABASE_URL).toEqual({
     kind: 'secret',
@@ -70,6 +79,35 @@ test('read-only metadata normalization resolves legacy policy without inventing 
     managed: true,
     previewPolicy: 'omit',
     changedAt: 123,
+    changedBy: '7',
+    changedByName: 'Builder'
+  })
+  expect(reread).toEqual(missing)
+})
+
+test('accepted metadata mutations record the supplied actor and time', async ({
+  sails,
+  expect
+}) => {
+  const metadata = sails.helpers.configuration.normalizeEnvVarMetadata.with({
+    values: { API_SECRET: 'new-value' },
+    metadata: {
+      API_SECRET: { kind: 'secret', previewPolicy: 'randomize' }
+    },
+    currentValues: { API_SECRET: 'old-value' },
+    currentMetadata: {
+      API_SECRET: { kind: 'secret', previewPolicy: 'omit' }
+    },
+    changedBy: '7',
+    changedByName: 'Builder',
+    now: 456
+  })
+
+  expect(metadata.API_SECRET).toEqual({
+    kind: 'secret',
+    managed: false,
+    previewPolicy: 'randomize',
+    changedAt: 456,
     changedBy: '7',
     changedByName: 'Builder'
   })


### PR DESCRIPTION
## Summary

- resolve effective environment-variable policy on environment, app, and global reads without synthesizing actor/time history
- keep variable rows scannable while explaining preview behavior inside the existing variable menu
- make row controls keyboard-focusable and support opening the menu with Enter
- preserve real recorded history and verify legacy metadata remains history-free

## Verification

- `npx sounding test --file tests/unit/helpers/configuration/runtime-config.test.js` (5 passed)
- `npx sounding test --file tests/functional/api/configuration-secrets.test.js` (5 passed)
- `npx sounding test --file tests/e2e/pages/projects/configuration-secrets.test.js --test-concurrency=1` (1 passed)
- `npm run lint`
- visually checked environment, app, and global configuration in light/dark mode plus the environment view at 390px

Fixes #357