### PR TITLE
feat(bridge): remove host adapter requirements

### DIFF
--- a/api/helpers/bridge/authorize-resource-actions.js
+++ b/api/helpers/bridge/authorize-resource-actions.js
@@ -42,8 +42,10 @@ module.exports = {
 
     for (const [key, resource] of Object.entries(effectiveResources)) {
       const helperIdentity = resource.authorization?.helper
-      if (!helperIdentity) continue
-      if (!isSafeHelperIdentity(helperIdentity)) {
+      const roleAuthorization =
+        resource.authorization?.mode === 'roles' ? resource.authorization : null
+      if (!helperIdentity && !roleAuthorization) continue
+      if (helperIdentity && !isSafeHelperIdentity(helperIdentity)) {
         const error = new Error(
           `Bridge resource "${
             resource.identity || key
@@ -67,7 +69,8 @@ module.exports = {
         requests.push({
           key,
           action,
-          helperIdentity,
+          ...(helperIdentity ? { helperIdentity } : {}),
+          ...(roleAuthorization ? { roleAuthorization } : {}),
           scope: resource.actionDefinitions?.[action]?.scope || null,
           resource: {
             identity: resource.identity,
@@ -94,6 +97,10 @@ module.exports = {
       const recordId = ${JSON.stringify(recordId)};
       const recordIds = ${JSON.stringify(recordIds)};
       const decisions = Object.create(null);
+      const actorId =
+        actor && actor.id !== undefined && actor.id !== null
+          ? String(actor.id)
+          : '';
 
       function resolveHelper(identity) {
         let helper = sails.helpers;
@@ -110,7 +117,61 @@ module.exports = {
         return helper;
       }
 
+      const roleRecords = Object.create(null);
       for (const request of requests) {
+        if (!request.roleAuthorization) continue;
+        if (!actorId) {
+          throw new Error(
+            'Declarative Bridge authorization requires a stable host user ID.'
+          );
+        }
+        const authorization = request.roleAuthorization;
+        const cacheKey = [
+          authorization.model,
+          authorization.primaryKey,
+          authorization.roleAttribute
+        ].join(':');
+        if (Object.prototype.hasOwnProperty.call(roleRecords, cacheKey)) {
+          continue;
+        }
+        const model = sails.models[authorization.model];
+        if (!model || typeof model.findOne !== 'function') {
+          throw new Error(
+            'Configured Bridge authorization model "' +
+              authorization.model +
+              '" is unavailable.'
+          );
+        }
+        roleRecords[cacheKey] = await model.findOne({
+          [authorization.primaryKey]: actorId
+        });
+      }
+
+      for (const request of requests) {
+        if (request.roleAuthorization) {
+          const authorization = request.roleAuthorization;
+          const cacheKey = [
+            authorization.model,
+            authorization.primaryKey,
+            authorization.roleAttribute
+          ].join(':');
+          const record = roleRecords[cacheKey];
+          const role = record
+            ? String(record[authorization.roleAttribute] || '')
+            : '';
+          const allowedActions = Object.prototype.hasOwnProperty.call(
+            authorization.roles,
+            role
+          )
+            ? authorization.roles[role]
+            : [];
+          decisions[request.key] = decisions[request.key] || {};
+          decisions[request.key][request.action] =
+            allowedActions.includes('*') ||
+            allowedActions.includes(request.action);
+          continue;
+        }
+
         const helper = resolveHelper(request.helperIdentity);
         const inputs = {
           actor,

--- a/api/helpers/bridge/execute-custom-action.js
+++ b/api/helpers/bridge/execute-custom-action.js
@@ -57,7 +57,8 @@ module.exports = {
 
     const actionCode = `
       const helperIdentity = ${JSON.stringify(action.helper)};
-      const inputs = {
+      const invocation = ${JSON.stringify(action.invocation || null)};
+      const envelope = {
         actor: ${JSON.stringify(actor)},
         resource: ${JSON.stringify({
           identity: resource.identity,
@@ -83,14 +84,51 @@ module.exports = {
       }
 
       if (recordId !== undefined && recordId !== null) {
-        inputs.recordId = recordId;
+        envelope.recordId = recordId;
       }
       if (Array.isArray(recordIds)) {
-        inputs.recordIds = recordIds;
+        envelope.recordIds = recordIds;
+      }
+
+      const inputs =
+        invocation && invocation.inputs === 'values'
+          ? { ...envelope.values }
+          : envelope;
+      if (invocation && invocation.inputs === 'values') {
+        for (const key of invocation.context || []) {
+          if (Object.prototype.hasOwnProperty.call(envelope, key)) {
+            inputs[key] = envelope[key];
+          }
+        }
       }
 
       const result = await helper.with(inputs);
       if (result === undefined || result === null) return {};
+      if (invocation && invocation.result && invocation.result.message) {
+        if (typeof result !== 'object' || Array.isArray(result)) {
+          throw new Error('Configured Bridge action result must be an object.');
+        }
+        const message = invocation.result.message.replace(
+          /{{\\s*([^{}]+?)\\s*}}/g,
+          function (_placeholder, path) {
+            let value = result;
+            for (const segment of path.split('.')) {
+              value = value && value[segment];
+            }
+            if (
+              value === undefined ||
+              value === null ||
+              !['string', 'number', 'boolean'].includes(typeof value)
+            ) {
+              throw new Error(
+                'Configured Bridge action result is missing "' + path + '".'
+              );
+            }
+            return String(value);
+          }
+        );
+        return { message };
+      }
       if (typeof result === 'string') return { message: result };
       if (typeof result !== 'object' || Array.isArray(result)) return {};
       return {
@@ -108,7 +146,9 @@ module.exports = {
 
     if (!result.success) {
       throw bridgeActionError(
-        result.error || `${action.label || action.name} failed.`,
+        action.invocation
+          ? `${action.label || action.name} failed.`
+          : result.error || `${action.label || action.name} failed.`,
         'BRIDGE_ACTION_EXECUTION_FAILED'
       )
     }

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -89,6 +89,19 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'destructive',
     'fields'
   ]
+  const CUSTOM_ACTION_HELPER_OPTION_KEYS = [
+    'identity',
+    'inputs',
+    'context',
+    'result'
+  ]
+  const CUSTOM_ACTION_RESULT_OPTION_KEYS = ['message']
+  const CUSTOM_ACTION_CONTEXT_KEYS = [
+    'actor',
+    'resource',
+    'recordId',
+    'recordIds'
+  ]
   const CUSTOM_ACTION_FIELD_OPTION_KEYS = [
     'type',
     'label',
@@ -238,6 +251,21 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       model,
       rawResource === false ? { hidden: true } : rawResource || {},
       rawResource !== undefined
+    )
+  }
+
+  const globalAuthorization = normalizeGlobalAuthorization(
+    config.authorization,
+    config.identity,
+    resources
+  )
+  for (const [identity, resource] of Object.entries(resources)) {
+    const rawResource = configuredResources[identity]
+    resource.authorization = normalizeAuthorization(
+      identity,
+      isPlainObject(rawResource) ? rawResource.authorization : undefined,
+      globalAuthorization,
+      resource
     )
   }
 
@@ -416,7 +444,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       configured,
       actions: normalizedActions.permissions,
       actionDefinitions: normalizedActions.definitions,
-      authorization: normalizeAuthorization(identity, raw.authorization),
+      authorization: null,
       attributes,
       associations
     }
@@ -992,9 +1020,11 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         `${path}.scope must be one of: ${CUSTOM_ACTION_SCOPES.join(', ')}.`
       )
     }
-    if (!isSafeHelperIdentity(rawAction.helper)) {
-      throw new Error(`${path}.helper must be a safe Sails helper identity.`)
-    }
+    const normalizedHelper = normalizeCustomActionHelper(
+      path,
+      rawAction.helper,
+      rawAction.fields
+    )
     for (const option of ['label', 'description', 'confirm', 'success']) {
       assertOptionalString(rawAction[option], `${path}.${option}`)
     }
@@ -1026,7 +1056,10 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     return {
       name,
       scope: rawAction.scope,
-      helper: rawAction.helper,
+      helper: normalizedHelper.identity,
+      ...(normalizedHelper.invocation
+        ? { invocation: normalizedHelper.invocation }
+        : {}),
       label,
       description: readString(rawAction.description),
       confirm:
@@ -1304,29 +1337,258 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     }
   }
 
-  function normalizeAuthorization(identity, rawAuthorization) {
+  function normalizeGlobalAuthorization(
+    rawAuthorization,
+    identityConfig,
+    normalizedResources
+  ) {
     if (rawAuthorization === undefined) return null
+    const path = 'sails.config.slipway.bridge.authorization'
+    if (!isPlainObject(rawAuthorization)) {
+      throw new Error(`${path} must be an object.`)
+    }
+    rejectUnknownKeys(
+      rawAuthorization,
+      ['model', 'roleAttribute', 'roles', 'default'],
+      path
+    )
+
+    const modelIdentity = String(
+      rawAuthorization.model || identityConfig?.model || 'user'
+    ).toLowerCase()
+    if (!isSafeIdentifier(modelIdentity) || !models[modelIdentity]) {
+      throw new Error(
+        `${path}.model must name an introspected Waterline model.`
+      )
+    }
+    const model = models[modelIdentity]
+    const primaryKey = model.primaryKey || 'id'
+    const roleAttribute = rawAuthorization.roleAttribute || 'role'
+    if (
+      !isSafeIdentifier(roleAttribute) ||
+      !model.attributes?.[roleAttribute]
+    ) {
+      throw new Error(
+        `${path}.roleAttribute must name an attribute on "${modelIdentity}".`
+      )
+    }
+
+    const knownActions = new Set()
+    for (const resource of Object.values(normalizedResources)) {
+      for (const action of Object.keys(resource.actions || {})) {
+        knownActions.add(action)
+      }
+    }
+    return {
+      mode: 'roles',
+      model: modelIdentity,
+      primaryKey,
+      roleAttribute,
+      roles: normalizeAuthorizationRoles({
+        roles: rawAuthorization.roles,
+        defaultActions: rawAuthorization.default,
+        path,
+        knownActions,
+        knownRoles: readKnownRoleValues(model.attributes[roleAttribute])
+      }),
+      default: []
+    }
+  }
+
+  function normalizeAuthorization(
+    identity,
+    rawAuthorization,
+    globalAuthorization,
+    resource
+  ) {
+    if (rawAuthorization === undefined) {
+      return globalAuthorization
+        ? cloneSerializable(globalAuthorization, `${identity}.authorization`)
+        : null
+    }
 
     const authorization =
       typeof rawAuthorization === 'string'
         ? { helper: rawAuthorization }
         : rawAuthorization
+    const path = `Bridge resource "${identity}".authorization`
     if (!isPlainObject(authorization)) {
+      throw new Error(`${path} must be a helper identity or an object.`)
+    }
+
+    if (Object.prototype.hasOwnProperty.call(authorization, 'helper')) {
+      rejectUnknownKeys(authorization, ['helper'], path)
+      if (!isSafeHelperIdentity(authorization.helper)) {
+        throw new Error(`${path}.helper must be a safe Sails helper identity.`)
+      }
+      return { helper: authorization.helper }
+    }
+
+    rejectUnknownKeys(authorization, ['roles', 'default'], path)
+    if (!globalAuthorization) {
       throw new Error(
-        `Bridge resource "${identity}".authorization must be a helper identity or an object.`
+        `${path}.roles requires sails.config.slipway.bridge.authorization.`
+      )
+    }
+    const model = models[globalAuthorization.model]
+    return {
+      ...cloneSerializable(globalAuthorization, path),
+      roles: normalizeAuthorizationRoles({
+        roles: authorization.roles,
+        defaultActions: authorization.default,
+        path,
+        knownActions: new Set(Object.keys(resource.actions || {})),
+        knownRoles: readKnownRoleValues(
+          model.attributes[globalAuthorization.roleAttribute]
+        )
+      }),
+      default: []
+    }
+  }
+
+  function normalizeAuthorizationRoles({
+    roles,
+    defaultActions,
+    path,
+    knownActions,
+    knownRoles
+  }) {
+    if (!isPlainObject(roles) || Object.keys(roles).length === 0) {
+      throw new Error(`${path}.roles must be a non-empty object.`)
+    }
+    if (
+      defaultActions !== undefined &&
+      (!Array.isArray(defaultActions) || defaultActions.length !== 0)
+    ) {
+      throw new Error(`${path}.default must be an empty deny-by-default array.`)
+    }
+
+    const normalized = {}
+    for (const [role, actions] of Object.entries(roles)) {
+      if (!isSafeIdentifier(role)) {
+        throw new Error(`${path}.roles contains an invalid role "${role}".`)
+      }
+      if (knownRoles && !knownRoles.has(role)) {
+        throw new Error(`${path}.roles references unknown role "${role}".`)
+      }
+      if (!Array.isArray(actions)) {
+        throw new Error(`${path}.roles.${role} must be an array.`)
+      }
+      const unique = Array.from(new Set(actions))
+      for (const action of unique) {
+        if (
+          action !== '*' &&
+          (!isSafeIdentifier(action) || !knownActions.has(action))
+        ) {
+          throw new Error(
+            `${path}.roles.${role} references unknown action "${action}".`
+          )
+        }
+      }
+      normalized[role] = unique
+    }
+    return normalized
+  }
+
+  function readKnownRoleValues(attribute) {
+    const values = attribute?.isIn || attribute?.validations?.isIn
+    return Array.isArray(values) ? new Set(values.map(String)) : null
+  }
+
+  function normalizeCustomActionHelper(path, rawHelper, rawFields) {
+    if (typeof rawHelper === 'string') {
+      if (!isSafeHelperIdentity(rawHelper)) {
+        throw new Error(`${path}.helper must be a safe Sails helper identity.`)
+      }
+      return { identity: rawHelper, invocation: null }
+    }
+    if (!isPlainObject(rawHelper)) {
+      throw new Error(
+        `${path}.helper must be a safe helper identity or an invocation object.`
       )
     }
     rejectUnknownKeys(
-      authorization,
-      ['helper'],
-      `Bridge resource "${identity}".authorization`
+      rawHelper,
+      CUSTOM_ACTION_HELPER_OPTION_KEYS,
+      `${path}.helper`
     )
-    if (!isSafeHelperIdentity(authorization.helper)) {
+    if (!isSafeHelperIdentity(rawHelper.identity)) {
       throw new Error(
-        `Bridge resource "${identity}".authorization.helper must be a safe Sails helper identity.`
+        `${path}.helper.identity must be a safe Sails helper identity.`
       )
     }
-    return { helper: authorization.helper }
+    const inputMode = rawHelper.inputs || 'values'
+    if (!['values', 'envelope'].includes(inputMode)) {
+      throw new Error(`${path}.helper.inputs must be "values" or "envelope".`)
+    }
+    const context = rawHelper.context || []
+    if (
+      !Array.isArray(context) ||
+      context.some((key) => !CUSTOM_ACTION_CONTEXT_KEYS.includes(key))
+    ) {
+      throw new Error(
+        `${path}.helper.context may contain only: ${CUSTOM_ACTION_CONTEXT_KEYS.join(
+          ', '
+        )}.`
+      )
+    }
+    const uniqueContext = Array.from(new Set(context))
+    if (
+      inputMode === 'values' &&
+      uniqueContext.some((key) =>
+        Object.prototype.hasOwnProperty.call(rawFields || {}, key)
+      )
+    ) {
+      throw new Error(
+        `${path}.helper.context cannot overwrite an action field with the same name.`
+      )
+    }
+
+    let result = null
+    if (rawHelper.result !== undefined) {
+      if (!isPlainObject(rawHelper.result)) {
+        throw new Error(`${path}.helper.result must be an object.`)
+      }
+      rejectUnknownKeys(
+        rawHelper.result,
+        CUSTOM_ACTION_RESULT_OPTION_KEYS,
+        `${path}.helper.result`
+      )
+      if (
+        typeof rawHelper.result.message !== 'string' ||
+        !rawHelper.result.message.trim() ||
+        rawHelper.result.message.length > 500
+      ) {
+        throw new Error(
+          `${path}.helper.result.message must be a non-empty string of at most 500 characters.`
+        )
+      }
+      for (const placeholder of rawHelper.result.message.matchAll(
+        /{{\s*([^{}]+?)\s*}}/g
+      )) {
+        if (!isSafeResultPath(placeholder[1])) {
+          throw new Error(
+            `${path}.helper.result.message contains an invalid result placeholder.`
+          )
+        }
+      }
+      result = { message: rawHelper.result.message.trim() }
+    }
+
+    return {
+      identity: rawHelper.identity,
+      invocation: {
+        inputs: inputMode,
+        context: uniqueContext,
+        ...(result ? { result } : {})
+      }
+    }
+  }
+
+  function isSafeResultPath(value) {
+    return String(value)
+      .split('.')
+      .every((part) => isSafeIdentifier(part))
   }
 
   function validateFieldVisibility(identity, name, visibility) {

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -463,18 +463,57 @@ surface. Protected values are never readable through Bridge.
 
 ## Target app authorization
 
-Static `actions` remain useful for permanently disabling operations. Add an
-authorization helper when the decision depends on the signed-in actor:
+Static `actions` remain useful for permanently disabling operations. For the
+common host-role boundary, configure a deny-by-default role matrix once:
 
 ```js
-course: {
+bridge: {
   authorization: {
-    helper: 'bridge.authorize'
+    roleAttribute: 'role',
+    roles: {
+      admin: ['*'],
+      editor: ['viewAny', 'view', 'create']
+    },
+    default: []
+  },
+  resources: {
+    coursePurchase: {
+      authorization: {
+        roles: {
+          admin: ['viewAny', 'view'],
+          editor: []
+        }
+      }
+    }
   }
 }
 ```
 
-The helper runs inside the target Sails application. It receives `actor`,
+The authorization model defaults to the Bridge identity model (`User`) and its
+primary key. Slipway loads that host user by the stable host ID bound during
+the app-local exchange, reads `roleAttribute` once per authorization pass, and
+intersects the configured actions with the Bridge invitation-role ceiling.
+The browser-supplied email is never used to find the user. `'*'` applies only
+to actions already enabled on configured resources. Unknown users, roles, and
+actions are denied; invalid models, attributes, roles, or action names reject
+the resource contract.
+
+A resource `roles` object replaces the global matrix for that resource, which
+allows a sensitive resource to be narrower. `default` may only be `[]`; an
+unlisted host role can never acquire access.
+
+Keep an authorization helper only for genuinely record-specific domain
+decisions that a role matrix cannot express:
+
+```js
+course: {
+  authorization: {
+    helper: 'course.authorizeBridgeRecord'
+  }
+}
+```
+
+That helper runs inside the target Sails application. It receives `actor`,
 `action`, `resource`, and `recordId` when a record is in scope. It must return
 `true` (or `{ allowed: true }`) to allow the action; falsey values, missing
 helpers, malformed results, and helper errors fail closed.
@@ -510,11 +549,9 @@ module.exports = {
 }
 ```
 
-This matches the current Nexus split: editors can discover, read, and create;
-admins can also update and delete. The actor contains a small Slipway identity
-context (`id`, `email`, `fullName`, team role, and current project/environment
-identifiers). The target app remains responsible for mapping that identity to
-its own user and roles.
+The actor contains a small Slipway identity context (`id`, `email`, `fullName`,
+Bridge role, and current project/environment identifiers). Declarative
+authorization treats only `id` as the stable host identity.
 
 Custom actions use the same authorization helper. A denied action is removed
 from the effective contract sent to the UI and the execution endpoint repeats
@@ -533,13 +570,15 @@ cannot cross the Bridge boundary.
 
 ```js
 course: {
-  authorization: 'bridge.authorize',
   actions: {
     bulkDelete: false,
 
     syncCatalog: {
       scope: 'resource',
-      helper: 'bridge.syncCatalog',
+      helper: {
+        identity: 'catalog.sync',
+        inputs: 'values'
+      },
       label: 'Sync catalog',
       success: 'Catalog synchronized.'
     },
@@ -590,6 +629,33 @@ course: {
 }
 ```
 
+The object helper form invokes ordinary application domain behavior. With
+`inputs: 'values'`, validated action fields become named Sails helper inputs,
+so the helper's own input contract is enforced normally. `context` may
+explicitly add `actor`, `resource`, `recordId`, or `recordIds`; none are passed
+implicitly. The helper identity comes only from trusted server configuration.
+The client cannot select or override it.
+
+An action that returns structured data can map scalar fields into one bounded,
+one-time result message:
+
+```js
+helper: {
+  identity: 'license.createLicense',
+  inputs: 'values',
+  result: {
+    message: 'License issued for {{email}}. Copy this key now: {{key}}'
+  }
+}
+```
+
+The template is rendered inside the target app. Only the normalized message
+leaves the container, appears in the one-time flash, and is limited to 500
+characters. Raw structured output, submitted values, and plaintext secrets are
+not stored in the resource contract or audit log. Direct-domain-helper errors
+are replaced with a generic action failure so exception text cannot leak a
+secret.
+
 The three scopes determine where the action appears and which identifiers the
 helper receives:
 
@@ -623,7 +689,8 @@ normalized. Rich text supports the explicit Markdown format and repeats the
 raw-HTML denial on the server. Relationship and upload fields are not action
 inputs; use record forms for those workflows.
 
-The configured helper runs inside the target Sails application:
+The legacy string helper form remains available for Bridge-envelope adapters
+and runs inside the target Sails application:
 
 ```js
 // api/helpers/bridge/publish-course.js

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -27,11 +27,17 @@ Enable Bridge for an app from **App → Bridge access** in Slipway, then redeplo
 the app. Slipway injects a dedicated, app-scoped exchange credential into that
 deployment.
 
-People open:
+People can enter Bridge through either URL without changing origin mid-session:
 
 ```text
 https://your-app.example.com/bridge
+https://slipway.example.com/projects/<project>/environments/<environment>/apps/<app>/bridge
 ```
+
+The public URL keeps navigation, search, actions, and assets under the app's
+own `/bridge` path. The Slipway URL is the operator entry point. If the app is
+mounted below a route prefix, that prefix comes before `/bridge`; a root app
+uses exactly `/bridge`.
 
 The hook uses the app's existing authenticated user as the identity. Slipway
 only activates an invitation when the signed-in user's verified email exactly
@@ -47,10 +53,98 @@ The default Boring Stack conventions work without app code:
 - name: `fullName`
 - verification: `emailStatus` is `verified` or `confirmed`
 
-### Custom authentication
+Persist that provider-neutral verification state when Wish, a redeemed magic
+link, or another authentication flow proves ownership of the exact email
+stored on the user. A provider that verifies a different candidate email must
+not confirm the current address. Opening `/bridge` must never call GitHub,
+Google, or another identity provider, and Bridge does not need stored OAuth
+access tokens.
 
-Configure one identity helper when the app uses different authentication
-conventions:
+### Declarative identity mapping
+
+For conventional model-backed sessions with different names, map the
+attributes instead:
+
+```js
+module.exports.slipway = {
+  bridge: {
+    loginPath: '/login',
+    identity: {
+      model: 'member',
+      sessionKey: 'memberId',
+      emailAttribute: 'emailAddress',
+      nameAttribute: 'name',
+      emailVerifiedAttribute: 'hasVerifiedEmail'
+    }
+  }
+}
+```
+
+### Declarative host authorization
+
+Bridge invitation roles are a ceiling. Narrow them with the host user's
+persisted role without an application authorization helper:
+
+```js
+module.exports.slipway = {
+  bridge: {
+    authorization: {
+      roleAttribute: 'role',
+      roles: {
+        admin: ['*'],
+        editor: ['viewAny', 'view', 'create']
+      },
+      default: []
+    },
+    resources: {
+      purchase: {
+        authorization: {
+          roles: {
+            admin: ['viewAny', 'view'],
+            editor: []
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Slipway resolves the host user by the stable ID established during the Bridge
+exchange and reads the configured role once per authorization pass. Unknown
+users, roles, actions, and invalid configuration fail closed.
+
+### Direct domain actions
+
+An action can invoke an explicitly allowlisted application domain helper with
+validated fields as named inputs:
+
+```js
+issueLicense: {
+  scope: 'resource',
+  helper: {
+    identity: 'license.createLicense',
+    inputs: 'values',
+    result: {
+      message: 'License issued for {{email}}. Copy this key now: {{key}}'
+    }
+  },
+  fields: {
+    email: { type: 'email', required: true },
+    maxUses: { type: 'number', required: true, min: 1, max: 2 }
+  }
+}
+```
+
+Sails still validates the domain helper's declared inputs. The result template
+is rendered inside the target app and only the bounded message crosses into a
+one-time Bridge flash. Add `context: ['actor', 'recordId']` only when the domain
+helper explicitly declares those inputs. The browser can never choose a helper
+identity.
+
+### Custom authentication escape hatch
+
+Use an identity helper only when authentication is not model-backed:
 
 ```js
 // config/slipway.js
@@ -94,26 +188,6 @@ module.exports = {
 The helper must return `emailVerified: true`. Bridge fails closed when it cannot
 prove email verification.
 
-### Declarative identity mapping
-
-For conventional model-backed sessions with different names, map the
-attributes instead:
-
-```js
-module.exports.slipway = {
-  bridge: {
-    loginPath: '/login',
-    identity: {
-      model: 'member',
-      sessionKey: 'memberId',
-      emailAttribute: 'emailAddress',
-      nameAttribute: 'name',
-      emailVerifiedAttribute: 'hasVerifiedEmail'
-    }
-  }
-}
-```
-
 ## Security model
 
 - Bridge is disabled per app by default.
@@ -129,6 +203,10 @@ module.exports.slipway = {
   the eight-hour Bridge session lifetime invalidates access server-side.
 - Bridge roles (`viewer`, `editor`, and `administrator`) are a ceiling. The
   target app's configured resource authorization can only narrow that access.
+- Declarative host authorization loads the host user by its server-established
+  ID, never by a client-supplied email.
+- OAuth provider tokens stay inside authentication and are not required by
+  Bridge.
 
 ## Lookout telemetry
 

--- a/tests/functional/pages/bridge-performance.test.js
+++ b/tests/functional/pages/bridge-performance.test.js
@@ -25,6 +25,15 @@ test(
     const contract = await sails.helpers.bridge.normalizeResourceContract.with({
       models: modelMetadata(),
       config: {
+        discover: false,
+        authorization: {
+          roleAttribute: 'role',
+          roles: {
+            admin: ['*'],
+            editor: ['viewAny', 'view', 'create']
+          },
+          default: []
+        },
         resources: {
           course: {
             list: ['title', 'published'],
@@ -48,6 +57,9 @@ test(
     })
     let dashboardExecutions = 0
     let queryExecutions = 0
+    let authorizationExecutions = 0
+    let roleQueries = 0
+    const authorizationRequestCounts = []
 
     try {
       await sails.models.app.updateOne({ id: app.id }).set({
@@ -65,15 +77,21 @@ test(
       sails.helpers.bridge.executeInContainer = async (containerName, code) => {
         expect(containerName).toBe('bridge-partial-performance-web')
         if (code.includes('const decisions = Object.create(null);')) {
+          authorizationExecutions += 1
           const requests = readEmbeddedValue(code, 'requests')
-          const decisions = {}
-          for (const authorizationRequest of requests) {
-            decisions[authorizationRequest.key] =
-              decisions[authorizationRequest.key] || {}
-            decisions[authorizationRequest.key][
-              authorizationRequest.action
-            ] = true
-          }
+          authorizationRequestCounts.push(requests.length)
+          const run = new Function('sails', `return (async () => {${code}})();`)
+          const decisions = await run({
+            models: {
+              user: {
+                findOne: async () => {
+                  roleQueries += 1
+                  return { id: 'host-user', role: 'editor' }
+                }
+              }
+            },
+            helpers: {}
+          })
           return successfulResult(decisions)
         }
         if (code.includes('const dashboard =')) {
@@ -102,6 +120,8 @@ test(
       expect(initial).toHaveInertiaProp('activeDashboard.cards.0.value', 1)
       expect(dashboardExecutions).toBe(1)
       expect(queryExecutions).toBe(1)
+      expect(roleQueries).toBe(authorizationExecutions)
+      expect(authorizationRequestCounts.some((count) => count > 3)).toBe(true)
 
       const search = await browser.request.get(`${modelPath}?search=durable`, {
         headers: {
@@ -117,6 +137,7 @@ test(
       expect(search.data.props.activeDashboard).toBe(undefined)
       expect(dashboardExecutions).toBe(1)
       expect(queryExecutions).toBe(2)
+      expect(roleQueries).toBe(authorizationExecutions)
     } finally {
       sails.helpers.bridge.introspectModels = originalIntrospectModels
       sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
@@ -160,6 +181,20 @@ function modelMetadata() {
         id: { type: 'number', autoIncrement: true },
         title: { type: 'string', required: true },
         published: { type: 'boolean', defaultsTo: false }
+      },
+      associations: []
+    },
+    user: {
+      identity: 'user',
+      globalId: 'User',
+      tableName: 'user',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true },
+        role: {
+          type: 'string',
+          isIn: ['user', 'editor', 'admin']
+        }
       },
       associations: []
     }

--- a/tests/unit/helpers/bridge/custom-actions.test.js
+++ b/tests/unit/helpers/bridge/custom-actions.test.js
@@ -266,6 +266,130 @@ test('Bridge custom actions expose only bounded helper feedback', async ({
   }
 })
 
+test('Bridge invokes an allowlisted domain helper with named values and maps its one-time result', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: courseMetadata(),
+    config: {
+      resources: {
+        course: {
+          actions: {
+            issueLicense: {
+              scope: 'resource',
+              helper: {
+                identity: 'license.createLicense',
+                inputs: 'values',
+                result: {
+                  message:
+                    'License issued for {{ email }}. Copy this key now: {{key}}'
+                }
+              },
+              fields: {
+                email: { type: 'email', required: true },
+                maxUses: { type: 'number', required: true }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+  const action = contract.resources.course.actionDefinitions.issueLicense
+  expect(action.helper).toBe('license.createLicense')
+  expect(action.invocation).toEqual({
+    inputs: 'values',
+    context: [],
+    result: {
+      message: 'License issued for {{ email }}. Copy this key now: {{key}}'
+    }
+  })
+
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  let helperInputs
+  let shouldFail = false
+  const createLicense = async (inputs) => {
+    helperInputs = inputs
+    if (shouldFail) {
+      throw new Error(
+        'provider failure containing plaintext secret sk_live_nope'
+      )
+    }
+    return {
+      email: inputs.email,
+      key: 'license-key-shown-once',
+      internalReceipt: 'must not leave the target app'
+    }
+  }
+  createLicense.with = createLicense
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-app-web')
+      try {
+        const run = new Function('sails', `return (async () => {${code}})();`)
+        const output = await run({
+          helpers: {
+            license: { createLicense }
+          }
+        })
+        return successfulResult(output)
+      } catch (error) {
+        return {
+          success: false,
+          output: '',
+          error: error.message,
+          exitCode: 1
+        }
+      }
+    }
+
+    const result = await sails.helpers.bridge.executeCustomAction.with({
+      containerName: 'bridge-app-web',
+      resource: contract.resources.course,
+      action,
+      actor: { id: '7', email: 'admin@example.com' },
+      values: {
+        email: 'customer@example.com',
+        maxUses: 2
+      }
+    })
+    expect(helperInputs).toEqual({
+      email: 'customer@example.com',
+      maxUses: 2
+    })
+    expect(result).toEqual({
+      message:
+        'License issued for customer@example.com. Copy this key now: license-key-shown-once'
+    })
+
+    shouldFail = true
+    let normalizedError
+    try {
+      await sails.helpers.bridge.executeCustomAction.with({
+        containerName: 'bridge-app-web',
+        resource: contract.resources.course,
+        action,
+        actor: { id: '7', email: 'admin@example.com' },
+        values: {
+          email: 'customer@example.com',
+          maxUses: 2
+        }
+      })
+    } catch (error) {
+      normalizedError = error
+    }
+    expect(normalizedError.message).toBe('Issue License failed.')
+    expect(normalizedError.message.includes('sk_live_nope')).toBe(false)
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
 function actionConfig() {
   return {
     resources: {

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -1332,6 +1332,117 @@ test('Bridge resolves target app action authorization and fails closed', async (
   }
 })
 
+test('Bridge declarative roles use one stable-ID lookup and deny unknown roles', async ({
+  sails,
+  expect
+}) => {
+  const models = modelMetadata()
+  models.user.attributes.role = {
+    type: 'string',
+    isIn: ['user', 'editor', 'admin']
+  }
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models,
+    config: {
+      discover: false,
+      authorization: {
+        roleAttribute: 'role',
+        roles: {
+          admin: ['*'],
+          editor: ['viewAny', 'view', 'create']
+        },
+        default: []
+      },
+      resources: {
+        course: {
+          actions: { publish: true }
+        },
+        user: {
+          authorization: {
+            roles: {
+              admin: ['viewAny'],
+              editor: []
+            }
+          }
+        }
+      }
+    }
+  })
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  let role = 'editor'
+  let queryCount = 0
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+      expect(containerName).toBe('bridge-app-web')
+      const run = new Function('sails', `return (async () => {${code}})();`)
+      const output = await run({
+        models: {
+          user: {
+            findOne: async (criteria) => {
+              queryCount += 1
+              expect(criteria).toEqual({ id: '7' })
+              return { id: 7, role }
+            }
+          }
+        },
+        helpers: {}
+      })
+      return successfulResult(output)
+    }
+
+    const editorResources =
+      await sails.helpers.bridge.authorizeResourceActions.with({
+        containerName: 'bridge-app-web',
+        resources: contract.resources,
+        actor: {
+          id: '7',
+          email: 'forged-address-does-not-drive-authorization@example.com'
+        }
+      })
+    expect(queryCount).toBe(1)
+    expect(editorResources.course.actions.viewAny).toBe(true)
+    expect(editorResources.course.actions.create).toBe(true)
+    expect(editorResources.course.actions.update).toBe(false)
+    expect(editorResources.course.actions.publish).toBe(false)
+    expect(editorResources.user.actions.viewAny).toBe(false)
+
+    role = 'unknown'
+    queryCount = 0
+    const unknownResources =
+      await sails.helpers.bridge.authorizeResourceActions.with({
+        containerName: 'bridge-app-web',
+        resources: contract.resources,
+        actor: { id: '7', email: 'editor@example.com' }
+      })
+    expect(queryCount).toBe(1)
+    expect(unknownResources.course.actions.viewAny).toBe(false)
+    expect(unknownResources.course.actions.create).toBe(false)
+  } finally {
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+
+  let invalidConfiguration
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models,
+      config: {
+        authorization: {
+          roles: {
+            editor: ['publsih']
+          }
+        }
+      }
+    })
+  } catch (error) {
+    invalidConfiguration = error
+  }
+  expect(invalidConfiguration.message).toContain('unknown action "publsih"')
+})
+
 test('Bridge denies raw HTML in Markdown fields by default', async ({
   sails,
   expect


### PR DESCRIPTION
## Summary

- add a deny-by-default, model-backed host-role matrix with per-resource narrowing
- resolve the host user by the stable exchange-bound ID once per authorization pass
- add direct allowlisted domain-helper actions with named values and explicit context
- map structured action output into a bounded one-time message
- keep existing helper contracts backward compatible
- document the zero-Bridge-helper path and both Bridge URL modes

This changes Sailscasts authorization from one target helper invocation and one email lookup per enabled action to one stable-ID user lookup for the entire authorization pass.

## Security

- unknown users, roles, operations, models, attributes, and malformed mappings fail closed
- invitation roles remain a separate platform ceiling
- the browser never selects a helper identity
- direct helpers receive only validated values plus explicitly declared context
- direct-helper errors are normalized so exception text cannot leak secrets
- structured output remains inside the target app except for the bounded one-time message

## Verification

- focused contract tests: 30/30
- full unit lane: 272/272
- full functional lane: 98/98
- full E2E lane: 42/42
- focused Bridge performance integration: 1/1
- `npm run lint`
- `npm run check:consistency`
- downstream Sailscasts: 40/40 plus lint
- public docs: Prettier plus VitePress production build

Fixes #361
Part of #329