### PR TITLE
fix(bridge): separate operator and public access flows

### DIFF
--- a/api/controllers/project/view-bridge-access.js
+++ b/api/controllers/project/view-bridge-access.js
@@ -38,8 +38,6 @@ module.exports = {
       environment,
       project
     })
-    const slipwayBridgePath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
-    const instanceUrl = await sails.helpers.getInstanceUrl()
 
     return {
       page: 'projects/bridge-access',
@@ -62,11 +60,7 @@ module.exports = {
             'bridgeEnabled'
           ]),
           appUrl,
-          bridgeUrl: appUrl ? `${appUrl}/bridge` : null,
-          slipwayBridgeUrl: `${instanceUrl.replace(
-            /\/$/,
-            ''
-          )}${slipwayBridgePath}`
+          bridgeUrl: appUrl ? `${appUrl}/bridge` : null
         },
         access: access.map((grant) => ({
           id: grant.id,

--- a/api/helpers/bridge/resolve-request.js
+++ b/api/helpers/bridge/resolve-request.js
@@ -73,52 +73,20 @@ module.exports = {
       .intercept('notFound', 'notFound')
       .intercept('appNotRunning', 'appNotRunning')
 
-    // Existing dashboard Bridge remains available to the team until app-local
-    // Bridge is enabled. Once enabled, every person must first prove a matching
-    // host-app account through /bridge.
-    if (!resolved.app.bridgeEnabled) {
-      const actor = await sails.helpers.bridge.buildActor.with({
-        user: resolved.user,
-        project: resolved.project,
-        environment: resolved.environment
-      })
-      return {
-        ...resolved,
-        actor,
-        actorId: String(resolved.user.id),
-        auditUserId: String(resolved.user.id),
-        access: null,
-        ...requestPaths({
-          req,
-          project: resolved.project,
-          environment: resolved.environment,
-          app: resolved.app,
-          appScoped: Boolean(appSlug)
-        })
-      }
-    }
-
-    const access = await BridgeAccess.findOne({
-      app: resolved.app.id,
-      email: resolved.user.email.toLowerCase(),
-      status: 'active'
-    })
-    if (!access || !roleAllows(access.role, requiredRole)) {
-      throw 'forbidden'
-    }
-
-    const actor = await sails.helpers.bridge.buildAccessActor.with({
-      access,
+    // A Slipway operator enters Bridge with their existing project/team
+    // authorization. App-local invitations are a separate public-host flow
+    // and are resolved above through the dedicated Bridge session.
+    const actor = await sails.helpers.bridge.buildActor.with({
+      user: resolved.user,
       project: resolved.project,
-      environment: resolved.environment,
-      app: resolved.app
+      environment: resolved.environment
     })
     return {
       ...resolved,
       actor,
-      actorId: actor.id,
+      actorId: String(resolved.user.id),
       auditUserId: String(resolved.user.id),
-      access,
+      access: null,
       ...requestPaths({
         req,
         project: resolved.project,

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -1106,7 +1106,11 @@ onBeforeUnmount(() => {
             <!-- More menu -->
             <div class="relative">
               <button
+                type="button"
                 data-test="app-more-menu"
+                aria-label="Open app actions"
+                aria-haspopup="true"
+                :aria-expanded="moreMenuOpen"
                 @click.stop="moreMenuOpen = !moreMenuOpen"
                 class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
               >
@@ -1171,30 +1175,8 @@ onBeforeUnmount(() => {
                           d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
                         />
                       </svg>
-                      Bridge in Slipway
+                      Bridge
                     </Link>
-                    <a
-                      v-if="app.bridgeEnabled && app.bridgeUrl"
-                      :href="app.bridgeUrl"
-                      target="_blank"
-                      rel="noopener"
-                      class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
-                    >
-                      <svg
-                        class="h-4 w-4 text-gray-400"
-                        fill="none"
-                        stroke="currentColor"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          stroke-linecap="round"
-                          stroke-linejoin="round"
-                          stroke-width="2"
-                          d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
-                        />
-                      </svg>
-                      Public Bridge
-                    </a>
                     <Link
                       v-if="hasDatabaseService"
                       :href="`/projects/${project.slug}/environments/${

--- a/assets/js/pages/projects/bridge-access.vue
+++ b/assets/js/pages/projects/bridge-access.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { Head, Link, router, useForm } from '@inertiajs/vue3'
+import { Head, router, useForm } from '@inertiajs/vue3'
 import { computed, inject, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
@@ -245,7 +245,7 @@ function timeAgo(timestamp) {
               in to {{ app.name }} with that verified address.
             </p>
           </div>
-          <div class="flex shrink-0 items-center gap-2">
+          <div class="flex shrink-0 items-center">
             <a
               v-if="app.bridgeEnabled && app.bridgeUrl"
               :href="app.bridgeUrl"
@@ -255,13 +255,6 @@ function timeAgo(timestamp) {
             >
               Open public Bridge
             </a>
-            <Link
-              v-if="app.bridgeEnabled"
-              :href="bridgePath"
-              class="min-h-9 inline-flex items-center rounded-lg border border-gray-200 px-3.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-800 dark:text-gray-300 dark:hover:bg-gray-900"
-            >
-              Open in Slipway
-            </Link>
             <button
               v-if="!app.bridgeEnabled"
               type="button"
@@ -311,8 +304,8 @@ function timeAgo(timestamp) {
 
         <section
           v-if="app.bridgeEnabled"
-          class="mt-6 grid gap-3 sm:grid-cols-2"
-          aria-label="Bridge URLs"
+          class="mt-6"
+          aria-label="Public Bridge URL"
           data-test="bridge-urls"
         >
           <a
@@ -320,32 +313,18 @@ function timeAgo(timestamp) {
             :href="app.bridgeUrl"
             target="_blank"
             rel="noopener"
-            class="min-w-0 rounded-lg border border-gray-200 px-4 py-3 hover:border-gray-300 dark:border-gray-800 dark:hover:border-gray-700"
+            data-test="public-bridge-url"
+            class="block min-w-0 rounded-lg border border-gray-200 px-4 py-3 hover:border-gray-300 dark:border-gray-800 dark:hover:border-gray-700"
           >
             <span
               class="block text-xs font-medium text-gray-500 dark:text-gray-400"
             >
-              Public app URL
+              Public Bridge URL
             </span>
             <code
               class="mt-1 block truncate text-sm text-gray-900 dark:text-gray-100"
             >
               {{ app.bridgeUrl }}
-            </code>
-          </a>
-          <a
-            :href="app.slipwayBridgeUrl"
-            class="min-w-0 rounded-lg border border-gray-200 px-4 py-3 hover:border-gray-300 dark:border-gray-800 dark:hover:border-gray-700"
-          >
-            <span
-              class="block text-xs font-medium text-gray-500 dark:text-gray-400"
-            >
-              Slipway instance URL
-            </span>
-            <code
-              class="mt-1 block truncate text-sm text-gray-900 dark:text-gray-100"
-            >
-              {{ app.slipwayBridgeUrl }}
             </code>
           </a>
         </section>

--- a/tests/e2e/pages/projects/bridge-access.test.js
+++ b/tests/e2e/pages/projects/bridge-access.test.js
@@ -3,6 +3,60 @@ const path = require('node:path')
 const { test } = require('sounding')
 
 test(
+  'app actions expose one internal Bridge entry',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-app-menu',
+          name: 'Bridge App Menu'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalGetContainerStatus = sails.helpers.docker.getContainerStatus
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        bridgeEnabled: true,
+        status: 'running',
+        containerName: 'bridge-app-menu-web'
+      })
+      sails.helpers.docker.getContainerStatus = async () => ({
+        running: true,
+        health: 'healthy'
+      })
+
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      const appPath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`
+      await page.goto(appPath)
+      await page.click('@app-more-menu')
+
+      const bridgeLink = page.raw.getByRole('link', {
+        name: 'Bridge',
+        exact: true
+      })
+      await bridgeLink.waitFor({ state: 'visible' })
+      expect(await bridgeLink.getAttribute('href')).toBe(`${appPath}/bridge`)
+      await expect(page).not.toSee('Bridge in Slipway')
+      await expect(page).not.toSee('Public Bridge')
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.helpers.docker.getContainerStatus = originalGetContainerStatus
+    }
+  }
+)
+
+test(
   'Bridge access manager stays minimal and legible in light and dark mode',
   {
     browser: true,
@@ -75,6 +129,17 @@ test(
     await expect(page).toSee('Ada Lovelace')
     await expect(page).toSee('grace@example.com')
     await expect(page).toSee('App-local Bridge is enabled')
+    await expect(page).toSee('Public Bridge URL')
+    await expect(page).not.toSee('Open in Slipway')
+    await expect(page).not.toSee('Slipway instance URL')
+    expect(
+      await page.script(
+        () =>
+          window.getComputedStyle(
+            document.querySelector('[data-test="public-bridge-url"]')
+          ).display
+      )
+    ).toBe('block')
     expect(page).toHaveNoJavascriptErrors()
 
     await page.screenshot(path.join(screenshotRoot, 'light.png'), {

--- a/tests/functional/pages/bridge-access.test.js
+++ b/tests/functional/pages/bridge-access.test.js
@@ -84,11 +84,6 @@ test(
     expect(page).toHaveInertiaProps({
       'app.bridgeEnabled': true,
       'app.bridgeUrl': 'https://host-app.example/bridge',
-      'app.slipwayBridgeUrl': `${await sails.helpers.getInstanceUrl()}${bridgeAppPath(
-        project,
-        environment,
-        app
-      )}`,
       hookDetected: true
     })
 
@@ -145,6 +140,34 @@ test(
     } finally {
       sails.config.sounding.mail = previousMailConfig
     }
+  }
+)
+
+test(
+  'Slipway operator opens internal Bridge without a public Bridge invitation',
+  { world: bridgeWorld('operator-bridge', 'Operator Bridge') },
+  async ({ sails, world, visit, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const bridgePath = bridgeAppPath(project, environment, app)
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      bridgeEnabled: true,
+      status: 'stopped',
+      containerName: null
+    })
+    await sails.models.bridgeaccess.destroy({ app: app.id })
+
+    const page = await visit.as('genesisUser')(bridgePath)
+
+    expect(page).toHaveStatus(200)
+    expect(page).toBeInertiaPage('projects/bridge')
+    expect(page).toHaveInertiaProps({
+      bridgeRequestBasePath: bridgePath,
+      hostBridgeOrigin: false
+    })
   }
 )
 


### PR DESCRIPTION
## Summary

- separate authenticated Slipway operator access from public app Bridge invitations
- keep `/projects/.../bridge` on the internal Slipway route without requiring a matching `BridgeAccess` row
- simplify app actions to one internal `Bridge` entry and keep public sharing on Bridge Access
- show only the public app `/bridge` URL on the access-management page
- fix the single public URL card layout after removing the two-column grid

## Verification

- `npm run lint`
- `npm run test:unit` — 272 passed
- `npm run test:functional` — 99 passed
- `npx sounding test --file tests/e2e/pages/projects/bridge-access.test.js --test-concurrency=1` — 2 passed

Fixes #363
