### PR TITLE
Give app-domain Bridge its own workspace navigation shell

### DIFF
--- a/api/controllers/project/view-bridge-create.js
+++ b/api/controllers/project/view-bridge-create.js
@@ -68,6 +68,13 @@ module.exports = {
     let modelMeta = null
     let assocOptions = {}
     let error = null
+    let bridgeWorkspace = bridgeHostOrigin
+      ? await sails.helpers.bridge.buildWorkspaceNavigation.with({
+          actor,
+          contract: { models: {}, dashboards: {} },
+          authorizedResources: {}
+        })
+      : null
 
     if (appRunning) {
       try {
@@ -79,6 +86,21 @@ module.exports = {
           actor
         })
         modelMeta = loaded.resource
+        if (bridgeHostOrigin) {
+          try {
+            bridgeWorkspace =
+              await sails.helpers.bridge.buildWorkspaceNavigation.with({
+                containerName: app.containerName,
+                environmentId: environment.id,
+                actor,
+                contract: loaded.contract
+              })
+          } catch (navigationError) {
+            sails.log.warn(
+              `Bridge workspace navigation could not be loaded: ${navigationError.message}`
+            )
+          }
+        }
         const authorizedResources = {
           [modelMeta.identity]: modelMeta
         }
@@ -138,6 +160,7 @@ module.exports = {
         bridgeRequestApiBasePath: bridgeApiBasePath,
         hostBridgeAssetBasePath: bridgeAssetBasePath,
         hostBridgeOrigin: bridgeHostOrigin,
+        bridgeWorkspace,
         mode: 'create',
         modelIdentity,
         recordId: null,

--- a/api/controllers/project/view-bridge-edit.js
+++ b/api/controllers/project/view-bridge-edit.js
@@ -73,6 +73,13 @@ module.exports = {
     let record = null
     let assocOptions = {}
     let error = null
+    let bridgeWorkspace = bridgeHostOrigin
+      ? await sails.helpers.bridge.buildWorkspaceNavigation.with({
+          actor,
+          contract: { models: {}, dashboards: {} },
+          authorizedResources: {}
+        })
+      : null
 
     if (appRunning) {
       try {
@@ -85,6 +92,21 @@ module.exports = {
           recordId
         })
         modelMeta = loaded.resource
+        if (bridgeHostOrigin) {
+          try {
+            bridgeWorkspace =
+              await sails.helpers.bridge.buildWorkspaceNavigation.with({
+                containerName: app.containerName,
+                environmentId: environment.id,
+                actor,
+                contract: loaded.contract
+              })
+          } catch (navigationError) {
+            sails.log.warn(
+              `Bridge workspace navigation could not be loaded: ${navigationError.message}`
+            )
+          }
+        }
 
         const criteria = {
           [modelMeta.primaryKey]: loaded.recordId
@@ -197,6 +219,7 @@ module.exports = {
         bridgeRequestApiBasePath: bridgeApiBasePath,
         hostBridgeAssetBasePath: bridgeAssetBasePath,
         hostBridgeOrigin: bridgeHostOrigin,
+        bridgeWorkspace,
         mode: 'edit',
         modelIdentity,
         recordId,

--- a/api/controllers/project/view-bridge-model.js
+++ b/api/controllers/project/view-bridge-model.js
@@ -145,6 +145,13 @@ module.exports = {
     let dashboards = []
     let dashboardResources = {}
     let activeDashboard = null
+    let bridgeWorkspace = bridgeHostOrigin
+      ? await sails.helpers.bridge.buildWorkspaceNavigation.with({
+          actor,
+          contract: { models: {}, dashboards: {} },
+          authorizedResources: {}
+        })
+      : null
 
     if (appRunning) {
       try {
@@ -156,6 +163,21 @@ module.exports = {
           actor
         })
         modelMeta = loaded.resource
+        if (bridgeHostOrigin) {
+          try {
+            bridgeWorkspace =
+              await sails.helpers.bridge.buildWorkspaceNavigation.with({
+                containerName: app.containerName,
+                environmentId: environment.id,
+                actor,
+                contract: loaded.contract
+              })
+          } catch (navigationError) {
+            sails.log.warn(
+              `Bridge workspace navigation could not be loaded: ${navigationError.message}`
+            )
+          }
+        }
         if (shouldLoadDashboard) {
           const dashboardDefinitions = Object.values(
             loaded.contract.dashboards || {}
@@ -270,6 +292,7 @@ module.exports = {
         bridgeRequestApiBasePath: bridgeApiBasePath,
         hostBridgeAssetBasePath: bridgeAssetBasePath,
         hostBridgeOrigin: bridgeHostOrigin,
+        bridgeWorkspace,
         modelIdentity,
         appRunning,
         modelMeta,

--- a/api/controllers/project/view-bridge-record.js
+++ b/api/controllers/project/view-bridge-record.js
@@ -73,6 +73,13 @@ module.exports = {
     let record = null
     let relationships = {}
     let error = null
+    let bridgeWorkspace = bridgeHostOrigin
+      ? await sails.helpers.bridge.buildWorkspaceNavigation.with({
+          actor,
+          contract: { models: {}, dashboards: {} },
+          authorizedResources: {}
+        })
+      : null
 
     if (appRunning) {
       try {
@@ -85,6 +92,21 @@ module.exports = {
           recordId
         })
         modelMeta = loaded.resource
+        if (bridgeHostOrigin) {
+          try {
+            bridgeWorkspace =
+              await sails.helpers.bridge.buildWorkspaceNavigation.with({
+                containerName: app.containerName,
+                environmentId: environment.id,
+                actor,
+                contract: loaded.contract
+              })
+          } catch (navigationError) {
+            sails.log.warn(
+              `Bridge workspace navigation could not be loaded: ${navigationError.message}`
+            )
+          }
+        }
 
         const criteria = {
           [modelMeta.primaryKey]: loaded.recordId
@@ -178,6 +200,7 @@ module.exports = {
         bridgeRequestApiBasePath: bridgeApiBasePath,
         hostBridgeAssetBasePath: bridgeAssetBasePath,
         hostBridgeOrigin: bridgeHostOrigin,
+        bridgeWorkspace,
         modelIdentity,
         recordId,
         appRunning,

--- a/api/controllers/project/view-bridge.js
+++ b/api/controllers/project/view-bridge.js
@@ -81,6 +81,13 @@ module.exports = {
     let modelsError = null
     let dashboards = []
     let activeDashboard = null
+    let bridgeWorkspace = bridgeHostOrigin
+      ? await sails.helpers.bridge.buildWorkspaceNavigation.with({
+          actor,
+          contract: { models: {}, dashboards: {} },
+          authorizedResources: {}
+        })
+      : null
 
     if (appRunning) {
       try {
@@ -109,6 +116,15 @@ module.exports = {
                 !resource.hidden && resource.actions?.viewAny !== false
             )
           )
+
+          if (bridgeHostOrigin) {
+            bridgeWorkspace =
+              await sails.helpers.bridge.buildWorkspaceNavigation.with({
+                actor,
+                contract: introspection,
+                authorizedResources: authorizedModels
+              })
+          }
 
           const dashboardDefinitions = Object.values(
             introspection.dashboards || {}
@@ -201,6 +217,7 @@ module.exports = {
         bridgeRequestApiBasePath: bridgeApiBasePath,
         hostBridgeAssetBasePath: bridgeAssetBasePath,
         hostBridgeOrigin: bridgeHostOrigin,
+        bridgeWorkspace,
         appRunning,
         models,
         modelsError,

--- a/api/helpers/bridge/build-workspace-navigation.js
+++ b/api/helpers/bridge/build-workspace-navigation.js
@@ -1,0 +1,78 @@
+module.exports = {
+  friendlyName: 'Build Bridge workspace navigation',
+
+  description:
+    'Build the small, authorized navigation contract used by app-domain Bridge pages.',
+
+  inputs: {
+    containerName: { type: 'string' },
+    environmentId: { type: 'number' },
+    actor: { type: 'ref', required: true },
+    contract: { type: 'ref' },
+    authorizedResources: { type: 'ref' }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: async function ({
+    containerName,
+    environmentId,
+    actor,
+    contract,
+    authorizedResources
+  }) {
+    let resourceContract = contract
+    let resources = authorizedResources
+
+    if (!resourceContract && containerName && environmentId) {
+      resourceContract = await sails.helpers.bridge.introspectModels(
+        containerName,
+        environmentId
+      )
+    }
+
+    if (resourceContract?.error) {
+      resourceContract = { models: {}, dashboards: {} }
+    }
+
+    if (resources === undefined && resourceContract && containerName) {
+      resources = await sails.helpers.bridge.authorizeResourceActions.with({
+        containerName,
+        resources: resourceContract.models || {},
+        actor
+      })
+    }
+
+    const visibleResources = Object.values(resources || {})
+      .filter(
+        (resource) => !resource.hidden && resource.actions?.viewAny !== false
+      )
+      .map((resource) => ({
+        identity: resource.identity,
+        label: resource.label,
+        singularLabel: resource.singularLabel
+      }))
+      .sort((left, right) => left.label.localeCompare(right.label))
+
+    const dashboards = Object.values(resourceContract?.dashboards || {})
+      .filter((dashboard) => dashboard.scope !== 'resource')
+      .map((dashboard) => ({
+        id: dashboard.id,
+        label: dashboard.label,
+        default: dashboard.default === true
+      }))
+
+    return {
+      actor: {
+        id: actor.id,
+        email: actor.email,
+        fullName: actor.fullName || '',
+        role: actor.bridgeRole || actor.role || 'viewer'
+      },
+      dashboards,
+      resources: visibleResources
+    }
+  }
+}

--- a/assets/js/components/bridge/BridgePageHeader.vue
+++ b/assets/js/components/bridge/BridgePageHeader.vue
@@ -1,0 +1,182 @@
+<script setup>
+import { Link } from '@inertiajs/vue3'
+import { computed, inject } from 'vue'
+
+const props = defineProps({
+  project: Object,
+  environment: Object,
+  app: Object,
+  hostBridgeOrigin: Boolean,
+  breadcrumbs: {
+    type: Array,
+    default: () => []
+  }
+})
+
+const toggleMobileMenu = inject('toggleMobileMenu')
+const toggleSidebar = inject('toggleSidebar')
+const sidebarCollapsed = inject('sidebarCollapsed')
+const mobileBreadcrumbs = computed(() => props.breadcrumbs.slice(-2))
+</script>
+
+<template>
+  <header
+    class="min-h-14 flex items-center justify-between gap-3 border-b border-gray-200 bg-white px-4 py-3 dark:border-gray-800 dark:bg-gray-950 sm:px-6"
+    data-test="bridge-page-header"
+  >
+    <div class="flex min-w-0 items-center gap-3">
+      <button
+        type="button"
+        class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
+        aria-label="Open Bridge navigation"
+        @click="toggleMobileMenu"
+      >
+        <svg
+          class="h-5 w-5"
+          viewBox="-0.5 -0.5 16 16"
+          fill="none"
+          stroke="currentColor"
+        >
+          <path
+            d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+          />
+          <path
+            d="M5.615 14.285V.715M2.6 5.992 3.919 7.5 2.6 9.008"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+          />
+        </svg>
+      </button>
+      <button
+        type="button"
+        class="hidden rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-900 dark:hover:text-gray-200 md:block"
+        :aria-label="sidebarCollapsed ? 'Show navigation' : 'Hide navigation'"
+        @click="toggleSidebar"
+      >
+        <svg
+          class="h-5 w-5"
+          viewBox="-0.5 -0.5 16 16"
+          fill="none"
+          stroke="currentColor"
+        >
+          <path
+            d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+          />
+          <path
+            d="M5.615 14.285V.715"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+          />
+          <path
+            :d="
+              sidebarCollapsed
+                ? 'M2.6 5.992 3.919 7.5 2.6 9.008'
+                : 'M3.919 5.992 2.6 7.5l1.319 1.508'
+            "
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="1"
+          />
+        </svg>
+      </button>
+
+      <nav
+        aria-label="Breadcrumb"
+        class="flex min-w-0 items-center gap-2 text-sm sm:hidden"
+      >
+        <template
+          v-for="(crumb, index) in mobileBreadcrumbs"
+          :key="`${crumb.label}-${index}`"
+        >
+          <span v-if="index" class="text-gray-300 dark:text-gray-700">/</span>
+          <Link
+            v-if="crumb.href && index < mobileBreadcrumbs.length - 1"
+            :href="crumb.href"
+            class="max-w-32 truncate text-gray-500 dark:text-gray-400"
+          >
+            {{ crumb.label }}
+          </Link>
+          <span
+            v-else
+            class="max-w-40 truncate font-medium text-gray-900 dark:text-white"
+            :title="crumb.title || crumb.label"
+          >
+            {{ crumb.label }}
+          </span>
+        </template>
+      </nav>
+
+      <nav
+        aria-label="Breadcrumb"
+        class="hidden min-w-0 items-center gap-2 text-sm sm:flex"
+      >
+        <template v-if="!hostBridgeOrigin">
+          <Link
+            href="/"
+            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+            >projects</Link
+          >
+          <span class="text-gray-300 dark:text-gray-700">/</span>
+          <Link
+            :href="`/projects/${project.slug}`"
+            class="max-w-32 truncate text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          >
+            {{ project.name.toLowerCase() }}
+          </Link>
+          <span class="text-gray-300 dark:text-gray-700">/</span>
+          <Link
+            :href="`/projects/${project.slug}/environments/${environment.slug}`"
+            class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          >
+            {{ environment.slug }}
+          </Link>
+        </template>
+        <span v-else class="max-w-32 truncate text-gray-500 dark:text-gray-400">
+          {{ app?.name }}
+        </span>
+        <template
+          v-for="(crumb, index) in breadcrumbs"
+          :key="`${crumb.label}-${index}`"
+        >
+          <span class="text-gray-300 dark:text-gray-700">/</span>
+          <Link
+            v-if="crumb.href"
+            :href="crumb.href"
+            class="max-w-40 truncate text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+          >
+            {{ crumb.label }}
+          </Link>
+          <span
+            v-else
+            class="max-w-48 truncate font-medium text-gray-900 dark:text-white"
+            :title="crumb.title || crumb.label"
+          >
+            {{ crumb.label }}
+          </span>
+        </template>
+      </nav>
+    </div>
+
+    <div class="flex shrink-0 items-center gap-2 sm:gap-3">
+      <a
+        v-if="hostBridgeOrigin"
+        href="https://docs.sailscasts.com/slipway/bridge"
+        target="_blank"
+        rel="noreferrer"
+        class="text-sm text-gray-500 transition-colors hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+        data-test="bridge-docs-link"
+      >
+        Docs <span aria-hidden="true">↗</span>
+      </a>
+      <slot name="actions" />
+    </div>
+  </header>
+</template>

--- a/assets/js/components/bridge/BridgeWorkspaceSidebar.vue
+++ b/assets/js/components/bridge/BridgeWorkspaceSidebar.vue
@@ -1,0 +1,357 @@
+<script setup>
+import { Link, usePage } from '@inertiajs/vue3'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+
+const props = defineProps({
+  app: Object,
+  basePath: String,
+  workspace: Object
+})
+
+defineEmits(['navigate'])
+
+const page = usePage()
+const search = ref('')
+const actorMenuOpen = ref(false)
+const normalizedBasePath = computed(() => props.basePath || '/bridge')
+const currentUrl = computed(() => page.url || normalizedBasePath.value)
+const currentPath = computed(() => currentUrl.value.split('?')[0])
+const selectedDashboard = computed(() =>
+  new URLSearchParams(currentUrl.value.split('?')[1] || '').get('dashboard')
+)
+const visibleDashboards = computed(() =>
+  (props.workspace?.dashboards || []).filter((dashboard) => !dashboard.default)
+)
+const actor = computed(() => props.workspace?.actor || {})
+const actorName = computed(
+  () => actor.value.fullName || actor.value.email || 'Bridge user'
+)
+const actorInitials = computed(() => {
+  const source = actor.value.fullName || actor.value.email || 'B'
+  return source
+    .split(/[\s@._-]+/)
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((part) => part.charAt(0).toUpperCase())
+    .join('')
+})
+const roleLabel = computed(() => {
+  const role = actor.value.role || 'viewer'
+  return role.charAt(0).toUpperCase() + role.slice(1)
+})
+const appInitial = computed(
+  () => props.app?.name?.trim().charAt(0).toUpperCase() || 'A'
+)
+const resources = computed(() => props.workspace?.resources || [])
+const showSearch = computed(() => resources.value.length > 8)
+const filteredResources = computed(() => {
+  const query = search.value.trim().toLowerCase()
+  if (!query) return resources.value
+  return resources.value.filter((resource) =>
+    [resource.label, resource.singularLabel, resource.identity]
+      .filter(Boolean)
+      .some((value) => value.toLowerCase().includes(query))
+  )
+})
+
+function resourceUrl(identity) {
+  return `${normalizedBasePath.value}/${identity}`
+}
+
+function isResourceActive(identity) {
+  const path = resourceUrl(identity)
+  return currentPath.value === path || currentPath.value.startsWith(`${path}/`)
+}
+
+function closeActorMenu() {
+  actorMenuOpen.value = false
+}
+
+function handleEscapeKey(event) {
+  if (event.key === 'Escape') closeActorMenu()
+}
+
+onMounted(() => {
+  document.addEventListener('click', closeActorMenu)
+  document.addEventListener('keydown', handleEscapeKey)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('click', closeActorMenu)
+  document.removeEventListener('keydown', handleEscapeKey)
+})
+</script>
+
+<template>
+  <aside
+    class="flex h-full flex-col border-r border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-950"
+    data-test="bridge-workspace-sidebar"
+  >
+    <div class="flex items-center justify-between px-3 py-4">
+      <div
+        class="flex w-full min-w-0 items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 dark:text-gray-200"
+      >
+        <span
+          class="bg-brand flex h-6 w-6 shrink-0 items-center justify-center rounded text-xs font-medium text-white"
+          aria-hidden="true"
+        >
+          {{ appInitial }}
+        </span>
+        <div class="min-w-0 flex-1">
+          <p class="truncate font-medium" :title="app?.name || 'App'">
+            {{ app?.name || 'App' }}
+          </p>
+          <p class="truncate text-[11px] text-gray-400 dark:text-gray-500">
+            Bridge
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <nav
+      class="min-h-0 flex-1 overflow-y-auto px-3 py-4"
+      aria-label="Bridge workspace"
+    >
+      <ul class="space-y-1">
+        <li>
+          <Link
+            :href="normalizedBasePath"
+            :class="[
+              'flex items-center space-x-3 rounded-md px-2 py-2 text-sm transition-colors',
+              currentPath === normalizedBasePath && !selectedDashboard
+                ? 'font-medium text-gray-900 dark:text-white'
+                : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+            ]"
+            @click="$emit('navigate')"
+          >
+            <svg
+              class="h-4 w-4 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M4 5.5A1.5 1.5 0 0 1 5.5 4h13A1.5 1.5 0 0 1 20 5.5v13a1.5 1.5 0 0 1-1.5 1.5h-13A1.5 1.5 0 0 1 4 18.5v-13Z M8 9h8M8 13h5"
+              />
+            </svg>
+            <span>Overview</span>
+          </Link>
+        </li>
+        <li v-for="dashboard in visibleDashboards" :key="dashboard.id">
+          <Link
+            :href="`${normalizedBasePath}?dashboard=${encodeURIComponent(
+              dashboard.id
+            )}`"
+            :class="[
+              'flex items-center space-x-3 rounded-md px-2 py-2 text-sm transition-colors',
+              selectedDashboard === dashboard.id
+                ? 'font-medium text-gray-900 dark:text-white'
+                : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+            ]"
+            @click="$emit('navigate')"
+          >
+            <svg
+              class="h-4 w-4 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M4 19V9m5 10V5m5 14v-7m5 7V8"
+              />
+            </svg>
+            <span class="truncate">{{ dashboard.label }}</span>
+          </Link>
+        </li>
+
+        <li v-if="showSearch" class="px-2 pb-2">
+          <div class="relative">
+            <svg
+              class="pointer-events-none absolute left-0 top-2 h-3.5 w-3.5 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="m21 21-4.35-4.35m1.35-5.65a7 7 0 1 1-14 0 7 7 0 0 1 14 0Z"
+              />
+            </svg>
+            <input
+              v-model="search"
+              type="search"
+              aria-label="Search Bridge resources"
+              placeholder="Find a resource"
+              class="focus:border-brand w-full border-b border-dashed border-gray-300 bg-transparent py-1.5 pl-5 pr-1 text-xs text-gray-800 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-gray-200 dark:placeholder-gray-600"
+            />
+          </div>
+        </li>
+        <li v-for="resource in filteredResources" :key="resource.identity">
+          <Link
+            :href="resourceUrl(resource.identity)"
+            :data-resource="resource.identity"
+            data-test="bridge-resource-link"
+            :class="[
+              'flex items-center space-x-3 rounded-md px-2 py-2 text-sm transition-colors',
+              isResourceActive(resource.identity)
+                ? 'font-medium text-gray-900 dark:text-white'
+                : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200'
+            ]"
+            @click="$emit('navigate')"
+          >
+            <svg
+              class="h-4 w-4 shrink-0"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M5 7.5C5 5.567 8.134 4 12 4s7 1.567 7 3.5S15.866 11 12 11 5 9.433 5 7.5Zm0 0v4c0 1.933 3.134 3.5 7 3.5s7-1.567 7-3.5v-4m-14 4v4C5 17.433 8.134 19 12 19s7-1.567 7-3.5v-4"
+              />
+            </svg>
+            <span class="truncate">{{ resource.label }}</span>
+          </Link>
+        </li>
+        <li
+          v-if="resources.length && filteredResources.length === 0"
+          class="px-2 py-4 text-xs text-gray-400 dark:text-gray-500"
+        >
+          No matching resources
+        </li>
+      </ul>
+    </nav>
+
+    <div class="relative px-3 py-3">
+      <Transition
+        enter-active-class="transition ease-out duration-100"
+        enter-from-class="transform opacity-0 scale-95"
+        enter-to-class="transform opacity-100 scale-100"
+        leave-active-class="transition ease-in duration-75"
+        leave-from-class="transform opacity-100 scale-100"
+        leave-to-class="transform opacity-0 scale-95"
+      >
+        <div
+          v-if="actorMenuOpen"
+          id="bridge-actor-menu"
+          class="absolute bottom-full left-3 right-3 z-20 mb-1 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+          data-test="bridge-actor-menu"
+          @click.stop
+        >
+          <div
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 dark:text-gray-300"
+          >
+            <svg
+              class="h-4 w-4 shrink-0 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M9 12.75 11.25 15 15 9.75m6-1.5c0 5.25-3.44 9.95-9 11.25-5.56-1.3-9-6-9-11.25V5.8L12 2.25l9 3.55v2.45Z"
+              />
+            </svg>
+            <span class="min-w-0 flex-1 truncate" data-test="bridge-actor-role">
+              {{ roleLabel }}
+            </span>
+            <span
+              class="shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:bg-gray-800 dark:text-gray-500"
+            >
+              Role
+            </span>
+          </div>
+          <div class="my-1 border-t border-gray-100 dark:border-gray-800"></div>
+          <a
+            href="https://docs.sailscasts.com/slipway/bridge"
+            target="_blank"
+            rel="noreferrer"
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            <svg
+              class="h-4 w-4 text-gray-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253"
+              />
+            </svg>
+            <span>Docs</span>
+          </a>
+          <a
+            href="https://github.com/sponsors/DominusKelvin"
+            target="_blank"
+            rel="noreferrer"
+            class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
+          >
+            <svg
+              class="h-4 w-4 text-pink-400"
+              fill="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z"
+              />
+            </svg>
+            <span>Sponsor Slipway</span>
+          </a>
+        </div>
+      </Transition>
+
+      <button
+        type="button"
+        class="flex w-full items-center space-x-3 rounded-md px-2 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-200/50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-200"
+        aria-controls="bridge-actor-menu"
+        :aria-expanded="actorMenuOpen"
+        data-test="bridge-actor-menu-button"
+        @click.stop="actorMenuOpen = !actorMenuOpen"
+      >
+        <span
+          class="bg-brand flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
+        >
+          {{ actorInitials }}
+        </span>
+        <span
+          class="min-w-0 flex-1 truncate text-left"
+          :title="actor.email || actorName"
+        >
+          {{ actor.email || actorName }}
+        </span>
+        <svg
+          :class="[
+            'h-4 w-4 shrink-0 text-gray-400 transition-transform duration-150',
+            actorMenuOpen ? 'rotate-180' : ''
+          ]"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="m19 9-7 7-7-7"
+          />
+        </svg>
+      </button>
+    </div>
+  </aside>
+</template>

--- a/assets/js/layouts/BridgePageLayout.vue
+++ b/assets/js/layouts/BridgePageLayout.vue
@@ -1,0 +1,18 @@
+<script setup>
+import { usePage } from '@inertiajs/vue3'
+import { computed } from 'vue'
+import AppLayout from '@/layouts/AppLayout.vue'
+import BridgeWorkspaceLayout from '@/layouts/BridgeWorkspaceLayout.vue'
+
+const page = usePage()
+const isHostBridge = computed(() => page.props.hostBridgeOrigin === true)
+</script>
+
+<template>
+  <BridgeWorkspaceLayout v-if="isHostBridge">
+    <slot />
+  </BridgeWorkspaceLayout>
+  <AppLayout v-else>
+    <slot />
+  </AppLayout>
+</template>

--- a/assets/js/layouts/BridgeWorkspaceLayout.vue
+++ b/assets/js/layouts/BridgeWorkspaceLayout.vue
@@ -1,0 +1,96 @@
+<script setup>
+import { usePage } from '@inertiajs/vue3'
+import { onMounted, onUnmounted, provide, ref } from 'vue'
+import BridgeWorkspaceSidebar from '@/components/bridge/BridgeWorkspaceSidebar.vue'
+
+const STORAGE_KEY = 'slipway:bridge-sidebar-collapsed'
+const page = usePage()
+const mobileMenuOpen = ref(false)
+const sidebarCollapsed = ref(false)
+
+function toggleMobileMenu() {
+  mobileMenuOpen.value = !mobileMenuOpen.value
+}
+
+function closeMobileMenu() {
+  mobileMenuOpen.value = false
+}
+
+function toggleSidebar() {
+  sidebarCollapsed.value = !sidebarCollapsed.value
+  localStorage.setItem(STORAGE_KEY, String(sidebarCollapsed.value))
+}
+
+function handleKeydown(event) {
+  if (event.key === 'Escape') closeMobileMenu()
+}
+
+provide('toggleMobileMenu', toggleMobileMenu)
+provide('toggleSidebar', toggleSidebar)
+provide('sidebarCollapsed', sidebarCollapsed)
+
+onMounted(() => {
+  sidebarCollapsed.value = localStorage.getItem(STORAGE_KEY) === 'true'
+  document.addEventListener('keydown', handleKeydown)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('keydown', handleKeydown)
+})
+</script>
+
+<template>
+  <div
+    class="flex h-screen min-h-0 overflow-hidden bg-white text-gray-900 dark:bg-gray-950 dark:text-white"
+    data-test="bridge-workspace"
+  >
+    <Transition
+      enter-active-class="transition-opacity duration-300"
+      enter-from-class="opacity-0"
+      enter-to-class="opacity-100"
+      leave-active-class="transition-opacity duration-300"
+      leave-from-class="opacity-100"
+      leave-to-class="opacity-0"
+    >
+      <button
+        v-if="mobileMenuOpen"
+        type="button"
+        class="fixed inset-0 z-40 bg-black/50 md:hidden"
+        aria-label="Close Bridge navigation"
+        @click="closeMobileMenu"
+      ></button>
+    </Transition>
+
+    <Transition
+      enter-active-class="transition-transform duration-300 ease-out"
+      enter-from-class="-translate-x-full"
+      enter-to-class="translate-x-0"
+      leave-active-class="transition-transform duration-300 ease-in"
+      leave-from-class="translate-x-0"
+      leave-to-class="-translate-x-full"
+    >
+      <BridgeWorkspaceSidebar
+        v-if="mobileMenuOpen"
+        :app="page.props.app"
+        :base-path="page.props.bridgeRequestBasePath"
+        :workspace="page.props.bridgeWorkspace"
+        class="fixed inset-y-0 left-0 z-50 w-72 shadow-2xl md:hidden"
+        @navigate="closeMobileMenu"
+      />
+    </Transition>
+
+    <BridgeWorkspaceSidebar
+      :app="page.props.app"
+      :base-path="page.props.bridgeRequestBasePath"
+      :workspace="page.props.bridgeWorkspace"
+      :class="[
+        'hidden shrink-0 transition-[width,border] duration-200 ease-out md:flex',
+        sidebarCollapsed ? 'w-0 overflow-hidden border-r-0' : 'w-56'
+      ]"
+    />
+
+    <main class="min-w-0 flex-1 overflow-hidden">
+      <slot />
+    </main>
+  </div>
+</template>

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, onMounted } from 'vue'
-import AppLayout from '@/layouts/AppLayout.vue'
+import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
@@ -13,9 +13,10 @@ import {
 } from '@/lib/bridge/fields.mjs'
 import { containsRawHtml } from '@/lib/content/markdown.mjs'
 import { usePrecognitionValidation } from '@/composables/precognition'
+import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 
 defineOptions({
-  layout: AppLayout
+  layout: BridgePageLayout
 })
 
 const props = defineProps({
@@ -26,6 +27,7 @@ const props = defineProps({
   bridgeRequestBasePath: String,
   bridgeRequestApiBasePath: String,
   hostBridgeOrigin: Boolean,
+  bridgeWorkspace: Object,
   mode: String,
   modelIdentity: String,
   recordId: String,
@@ -273,8 +275,25 @@ function recordUrl() {
   <ToastContainer :toasts="toasts" @dismiss="dismiss" />
 
   <div class="flex h-full flex-col">
-    <!-- Header -->
+    <BridgePageHeader
+      v-if="hostBridgeOrigin"
+      :project="project"
+      :environment="environment"
+      :app="app"
+      :host-bridge-origin="true"
+      :breadcrumbs="[
+        { label: 'bridge', href: bridgeUrl() },
+        { label: modelMeta?.label || modelIdentity, href: modelUrl() },
+        {
+          label: isEdit ? displayIdentifier(recordId) : 'new',
+          title: isEdit ? String(recordId) : 'New record'
+        }
+      ]"
+    />
+
+    <!-- Operator header -->
     <div
+      v-else
       class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6"
     >
       <div class="flex items-center space-x-3">

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, watch } from 'vue'
-import AppLayout from '@/layouts/AppLayout.vue'
+import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
@@ -10,9 +10,10 @@ import ActionMenu from '@/components/ActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
+import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 
 defineOptions({
-  layout: AppLayout
+  layout: BridgePageLayout
 })
 
 const props = defineProps({
@@ -23,6 +24,7 @@ const props = defineProps({
   bridgeRequestBasePath: String,
   bridgeRequestApiBasePath: String,
   hostBridgeOrigin: Boolean,
+  bridgeWorkspace: Object,
   modelIdentity: String,
   appRunning: Boolean,
   modelMeta: Object,
@@ -526,8 +528,21 @@ function createUrl() {
     @click="closeActionMenu"
     @keydown.esc="closeActionMenu"
   >
-    <!-- Header -->
+    <BridgePageHeader
+      v-if="hostBridgeOrigin"
+      :project="project"
+      :environment="environment"
+      :app="app"
+      :host-bridge-origin="true"
+      :breadcrumbs="[
+        { label: 'bridge', href: bridgeUrl() },
+        { label: modelMeta?.label || modelIdentity }
+      ]"
+    />
+
+    <!-- Operator header -->
     <div
+      v-else
       class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6"
     >
       <div class="flex items-center space-x-3">

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -1,7 +1,7 @@
 <script setup>
 import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
-import AppLayout from '@/layouts/AppLayout.vue'
+import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import { createToast } from '@/composables/toast'
@@ -9,9 +9,10 @@ import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 import BridgeCollectionManager from '@/components/bridge/BridgeCollectionManager.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
+import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 
 defineOptions({
-  layout: AppLayout
+  layout: BridgePageLayout
 })
 
 const props = defineProps({
@@ -22,6 +23,7 @@ const props = defineProps({
   bridgeRequestBasePath: String,
   bridgeRequestApiBasePath: String,
   hostBridgeOrigin: Boolean,
+  bridgeWorkspace: Object,
   modelIdentity: String,
   recordId: String,
   appRunning: Boolean,
@@ -228,8 +230,37 @@ function relationshipMutationBaseUrl(relationship) {
   <ToastContainer :toasts="toasts" @dismiss="dismiss" />
 
   <div class="flex h-full flex-col">
-    <!-- Header -->
+    <BridgePageHeader
+      v-if="hostBridgeOrigin"
+      :project="project"
+      :environment="environment"
+      :app="app"
+      :host-bridge-origin="true"
+      :breadcrumbs="[
+        { label: 'bridge', href: bridgeUrl() },
+        { label: modelMeta?.label || modelIdentity, href: modelUrl() },
+        { label: displayIdentifier(recordId), title: String(recordId) }
+      ]"
+    >
+      <template #actions>
+        <ActionMenu
+          v-if="record"
+          :items="recordMenuItems"
+          :disabled="quickActionForm.processing"
+          :label="`Actions for ${
+            record[modelMeta?.title] ||
+            modelMeta?.singularLabel ||
+            modelIdentity
+          }`"
+          test-id="bridge-record-action-menu"
+          @select="handleRecordAction"
+        />
+      </template>
+    </BridgePageHeader>
+
+    <!-- Operator header -->
     <div
+      v-else
       class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6"
     >
       <div class="flex items-center space-x-3">

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -1,11 +1,12 @@
 <script setup>
 import { Link, Head, router } from '@inertiajs/vue3'
-import { inject, computed, ref } from 'vue'
-import AppLayout from '@/layouts/AppLayout.vue'
+import { computed, ref } from 'vue'
+import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
+import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 
 defineOptions({
-  layout: AppLayout
+  layout: BridgePageLayout
 })
 
 const props = defineProps({
@@ -15,6 +16,7 @@ const props = defineProps({
   appScoped: Boolean,
   bridgeRequestBasePath: String,
   hostBridgeOrigin: Boolean,
+  bridgeWorkspace: Object,
   appRunning: Boolean,
   models: Object,
   modelsError: String,
@@ -22,9 +24,6 @@ const props = defineProps({
   activeDashboard: Object
 })
 
-const toggleMobileMenu = inject('toggleMobileMenu')
-const toggleSidebar = inject('toggleSidebar')
-const sidebarCollapsed = inject('sidebarCollapsed')
 const bridgeBasePath = computed(
   () =>
     props.bridgeRequestBasePath ||
@@ -90,145 +89,14 @@ function switchDashboard(event) {
 <template>
   <Head :title="`Bridge - ${project.name} | Slipway`"></Head>
   <div class="flex h-full flex-col">
-    <!-- Header -->
-    <div
-      class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6"
+    <BridgePageHeader
+      :project="project"
+      :environment="environment"
+      :app="app"
+      :host-bridge-origin="hostBridgeOrigin"
+      :breadcrumbs="[{ label: 'bridge' }]"
     >
-      <div class="flex items-center space-x-3">
-        <button
-          @click="toggleMobileMenu"
-          class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
-        >
-          <svg
-            class="h-5 w-5"
-            viewBox="-0.5 -0.5 16 16"
-            fill="none"
-            stroke="currentColor"
-          >
-            <path
-              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M5.615 14.285V.715"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M2.6 5.992 3.919 7.5 2.6 9.008"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-          </svg>
-        </button>
-        <button
-          @click="toggleSidebar"
-          class="hidden text-gray-400 dark:text-gray-500 md:block"
-        >
-          <svg
-            v-if="sidebarCollapsed"
-            class="h-5 w-5"
-            viewBox="-0.5 -0.5 16 16"
-            fill="none"
-            stroke="currentColor"
-          >
-            <path
-              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M5.615 14.285V.715"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M2.6 5.992 3.919 7.5 2.6 9.008"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-          </svg>
-          <svg
-            v-else
-            class="h-5 w-5"
-            viewBox="-0.5 -0.5 16 16"
-            fill="none"
-            stroke="currentColor"
-          >
-            <path
-              d="M12.777 14.285H2.223c-.833 0-1.508-.675-1.508-1.508V2.223c0-.833.675-1.508 1.508-1.508h10.554c.833 0 1.508.675 1.508 1.508v10.554c0 .833-.675 1.508-1.508 1.508Z"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M5.615 14.285V.715"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-            <path
-              d="M3.919 5.992 2.6 7.5l1.319 1.508"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="1"
-            />
-          </svg>
-        </button>
-        <nav class="flex items-center space-x-2 text-sm sm:hidden">
-          <span
-            v-if="hostBridgeOrigin"
-            class="text-gray-500 dark:text-gray-400"
-          >
-            {{ app.name.toLowerCase() }}
-          </span>
-          <Link
-            v-else
-            :href="`/projects/${project.slug}/environments/${environment.slug}`"
-            class="text-gray-500 dark:text-gray-400"
-          >
-            {{ project.name.toLowerCase() }}
-          </Link>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">bridge</span>
-        </nav>
-        <nav class="hidden items-center space-x-2 text-sm sm:flex">
-          <template v-if="!hostBridgeOrigin">
-            <Link
-              href="/"
-              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-              >projects</Link
-            >
-            <span class="text-gray-400 dark:text-gray-600">/</span>
-            <Link
-              :href="`/projects/${project.slug}`"
-              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              {{ project.name.toLowerCase() }}
-            </Link>
-            <span class="text-gray-400 dark:text-gray-600">/</span>
-            <Link
-              :href="`/projects/${project.slug}/environments/${environment.slug}`"
-              class="text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
-            >
-              {{ environment.slug }}
-            </Link>
-          </template>
-          <span v-else class="text-gray-500 dark:text-gray-400">
-            {{ app.name.toLowerCase() }}
-          </span>
-          <span class="text-gray-400 dark:text-gray-600">/</span>
-          <span class="font-medium text-gray-900 dark:text-white">bridge</span>
-        </nav>
-      </div>
-      <div class="flex items-center gap-2">
+      <template #actions>
         <select
           v-if="dashboards?.length > 1"
           :value="activeDashboard?.id"
@@ -265,8 +133,8 @@ function switchDashboard(event) {
             />
           </svg>
         </button>
-      </div>
-    </div>
+      </template>
+    </BridgePageHeader>
 
     <!-- Content -->
     <div class="flex-1 overflow-y-auto">
@@ -446,7 +314,7 @@ function switchDashboard(event) {
             <div
               v-for="model in filteredModels"
               :key="model.identity"
-              class="group grid grid-cols-12 items-center gap-4 px-6 py-4"
+              class="group grid grid-cols-12 items-center gap-4 px-6 py-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-900/40"
             >
               <div class="col-span-5">
                 <Link
@@ -473,7 +341,7 @@ function switchDashboard(event) {
                   </div>
                   <div class="min-w-0">
                     <div
-                      class="font-medium text-gray-900 underline decoration-gray-300 decoration-dashed underline-offset-2 hover:text-gray-700 dark:text-white dark:decoration-gray-600 dark:hover:text-gray-300"
+                      class="font-medium text-gray-900 transition-colors group-hover:text-gray-700 dark:text-white dark:group-hover:text-gray-300"
                     >
                       {{ model.label }}
                     </div>

--- a/tests/e2e/pages/projects/bridge-workspace.test.js
+++ b/tests/e2e/pages/projects/bridge-workspace.test.js
@@ -1,0 +1,288 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('sounding')
+
+test(
+  'app-domain Bridge renders its own responsive workspace shell',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-workspace-ui',
+          name: 'Bridge Workspace UI'
+        }
+      }
+    }
+  },
+  async ({ sails, world, page, expect }) => {
+    const current = world.current
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const app = current.apps.web
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const screenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-390-bridge-workspace'
+    )
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: workspaceModels(),
+      config: workspaceConfig()
+    })
+
+    try {
+      await sails.models.environment.updateOne({ id: environment.id }).set({
+        domain: 'academy.example.com'
+      })
+      await sails.models.app.updateOne({ id: app.id }).set({
+        name: 'Sailscasts',
+        routePath: '/',
+        bridgeEnabled: true,
+        status: 'running',
+        containerName: 'bridge-workspace-ui-web'
+      })
+      const secret = await sails.helpers.bridge.ensureAppSecret.with({
+        appId: String(app.id),
+        rotate: true
+      })
+      expect(Boolean(secret)).toBe(true)
+
+      const access = await world.create('bridgeaccess').with({
+        email: 'kevin@sailscasts.com',
+        role: 'administrator',
+        status: 'active',
+        hostUserId: 'sailscasts-admin',
+        hostUserName: 'Kevin Omereshone',
+        activatedAt: Date.now(),
+        app: app.id,
+        environment: environment.id,
+        project: project.id,
+        team: current.teams.genesisTeam.id,
+        invitedBy: current.users.genesisUser.id
+      })
+
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources,
+        dashboards: contract.dashboards
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-workspace-ui-web')
+        if (code.includes('const decisions = Object.create(null);')) {
+          const requests = readEmbeddedValue(code, 'requests')
+          const decisions = {}
+          for (const request of requests) {
+            decisions[request.key] ||= {}
+            decisions[request.key][request.action] = true
+          }
+          return successfulResult(decisions)
+        }
+        if (code.includes('const dashboard =')) {
+          return successfulResult([
+            { id: 'users', value: 61 },
+            { id: 'courses', value: 5 },
+            { id: 'chapters', value: 24 },
+            { id: 'lessons', value: 88 },
+            { id: 'sales', value: 1, detail: 'Completed purchases' }
+          ])
+        }
+        if (code.includes('const counts = {};')) {
+          return successfulResult({
+            user: 61,
+            course: 5,
+            chapter: 24,
+            lesson: 88,
+            purchase: 1
+          })
+        }
+        return successfulResult({})
+      }
+
+      const launchCode = await sails.helpers.bridge.issueLaunchCode.with({
+        accessId: String(access.id),
+        appId: String(app.id)
+      })
+      await page.raw.route('**/bridge/_assets/**', async (route) => {
+        const assetUrl = new URL(route.request().url())
+        assetUrl.pathname = assetUrl.pathname.replace('/bridge/_assets', '')
+        await route.continue({ url: assetUrl.toString() })
+      })
+      await page.raw.context().setExtraHTTPHeaders({
+        'x-forwarded-host': 'academy.example.com'
+      })
+      await page.goto(
+        `/bridge/launch?code=${encodeURIComponent(
+          launchCode
+        )}&hostOrigin=true&hostRoutePath=/`
+      )
+
+      const internalBridgePath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
+      await page.resize(1440, 960)
+      await page.goto(internalBridgePath)
+      await page.wait('@bridge-workspace')
+
+      await expect(page).toSee('Sailscasts')
+      await expect(page).toSee('Bridge')
+      await expect(page).toSee('Content overview')
+      await expect(page).toSee('Courses')
+      await expect(page).toSee('Lessons')
+      const desktopSidebar = page.raw
+        .locator('[data-test="bridge-workspace-sidebar"]')
+        .last()
+      expect(
+        await desktopSidebar
+          .locator('[data-test="bridge-resource-link"]')
+          .count()
+      ).toBe(5)
+      expect(
+        await desktopSidebar
+          .locator('[data-test="bridge-resource-link"][data-resource="course"]')
+          .getAttribute('href')
+      ).toBe('/bridge/course')
+      expect(
+        await desktopSidebar.getByText('Content', { exact: true }).count()
+      ).toBe(0)
+      expect(
+        await desktopSidebar.getByText('People', { exact: true }).count()
+      ).toBe(0)
+      expect(
+        await page.raw.locator('[data-test="desktop-team-selector"]').count()
+      ).toBe(0)
+      expect(
+        await page.raw
+          .locator('[data-test="bridge-docs-link"]')
+          .getAttribute('href')
+      ).toBe('https://docs.sailscasts.com/slipway/bridge')
+      expect(
+        await page.raw
+          .locator('[data-test="bridge-page-header"]')
+          .getByText('Administrator', { exact: true })
+          .count()
+      ).toBe(0)
+
+      const actorButton = desktopSidebar.locator(
+        '[data-test="bridge-actor-menu-button"]'
+      )
+      expect(
+        (await actorButton.textContent()).includes('kevin@sailscasts.com')
+      ).toBe(true)
+      await actorButton.click()
+      const actorMenu = desktopSidebar.locator(
+        '[data-test="bridge-actor-menu"]'
+      )
+      await actorMenu.waitFor({ state: 'visible' })
+      const actorMenuText = await actorMenu.textContent()
+      expect(actorMenuText.includes('Role')).toBe(true)
+      expect(
+        (
+          await actorMenu
+            .locator('[data-test="bridge-actor-role"]')
+            .textContent()
+        ).includes('Administrator')
+      ).toBe(true)
+      expect(
+        await actorMenu.getByRole('link', { name: 'Docs' }).getAttribute('href')
+      ).toBe('https://docs.sailscasts.com/slipway/bridge')
+      expect(
+        await actorMenu
+          .getByRole('link', { name: 'Sponsor Slipway' })
+          .getAttribute('href')
+      ).toBe('https://github.com/sponsors/DominusKelvin')
+      expect(page).toHaveNoJavascriptErrors()
+
+      await page.screenshot(path.join(screenshotRoot, 'actor-menu.png'), {
+        fullPage: true
+      })
+      await page.raw.locator('[data-test="bridge-page-header"]').click()
+      await actorMenu.waitFor({ state: 'hidden' })
+
+      await page.screenshot(path.join(screenshotRoot, 'desktop.png'), {
+        fullPage: true
+      })
+
+      await page.resize(390, 844)
+      await page.raw
+        .getByRole('button', { name: 'Open Bridge navigation' })
+        .click()
+      await page.raw
+        .locator('[data-test="bridge-workspace-sidebar"]')
+        .first()
+        .waitFor({ state: 'visible' })
+      await page.raw.waitForTimeout(250)
+      await page.screenshot(path.join(screenshotRoot, 'mobile.png'), {
+        fullPage: true
+      })
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
+function workspaceModels() {
+  return Object.fromEntries(
+    ['user', 'course', 'chapter', 'lesson', 'purchase'].map((identity) => [
+      identity,
+      {
+        identity,
+        globalId: identity.charAt(0).toUpperCase() + identity.slice(1),
+        tableName: `${identity}s`,
+        primaryKey: 'id',
+        attributes: {
+          id: { type: 'number', autoIncrement: true },
+          title: { type: 'string' },
+          createdAt: { type: 'number', autoCreatedAt: true }
+        },
+        associations: []
+      }
+    ])
+  )
+}
+
+function workspaceConfig() {
+  return {
+    resources: {
+      user: { label: 'Users' },
+      course: { label: 'Courses' },
+      chapter: { label: 'Chapters' },
+      lesson: { label: 'Lessons' },
+      purchase: { label: 'Sales' }
+    },
+    dashboard: {
+      label: 'Content overview',
+      default: true,
+      cards: {
+        users: { type: 'metric', label: 'Total users', resource: 'user' },
+        courses: { type: 'metric', label: 'Courses', resource: 'course' },
+        chapters: { type: 'metric', label: 'Chapters', resource: 'chapter' },
+        lessons: { type: 'metric', label: 'Lessons', resource: 'lesson' },
+        sales: { type: 'metric', label: 'Sales', resource: 'purchase' }
+      }
+    }
+  }
+}
+
+function readEmbeddedValue(code, name) {
+  const marker = `const ${name} = `
+  const start = code.indexOf(marker)
+  const end = code.indexOf(';', start)
+  return JSON.parse(code.slice(start + marker.length, end))
+}
+
+function successfulResult(value) {
+  return {
+    success: true,
+    output: JSON.stringify(value),
+    error: null,
+    exitCode: 0
+  }
+}

--- a/tests/functional/pages/bridge-access.test.js
+++ b/tests/functional/pages/bridge-access.test.js
@@ -461,7 +461,17 @@ test(
       bridgeRequestBasePath: '/bridge',
       bridgeRequestApiBasePath: '/bridge',
       hostBridgeAssetBasePath: '/bridge/_assets',
-      hostBridgeOrigin: true
+      hostBridgeOrigin: true,
+      bridgeWorkspace: {
+        actor: {
+          id: 'host-origin-user',
+          email: 'host-origin@host-app.example',
+          fullName: 'Host Origin User',
+          role: 'viewer'
+        },
+        dashboards: [],
+        resources: []
+      }
     })
 
     const search = await request

--- a/tests/unit/helpers/bridge/workspace-navigation.test.js
+++ b/tests/unit/helpers/bridge/workspace-navigation.test.js
@@ -1,0 +1,82 @@
+const { test } = require('sounding')
+
+test('Bridge workspace navigation exposes only authorized resources and global dashboards', async ({
+  sails,
+  expect
+}) => {
+  const navigation = await sails.helpers.bridge.buildWorkspaceNavigation.with({
+    actor: {
+      id: 'host-user-7',
+      email: 'ada@example.com',
+      fullName: 'Ada Lovelace',
+      role: 'administrator',
+      bridgeRole: 'administrator',
+      teamId: 'private-team-id'
+    },
+    contract: {
+      dashboards: {
+        overview: {
+          id: 'overview',
+          label: 'Content overview',
+          scope: 'environment',
+          default: true
+        },
+        courseHealth: {
+          id: 'courseHealth',
+          label: 'Course health',
+          scope: 'resource',
+          resource: 'course'
+        }
+      }
+    },
+    authorizedResources: {
+      lesson: {
+        identity: 'lesson',
+        label: 'Lessons',
+        singularLabel: 'Lesson',
+        actions: { viewAny: true }
+      },
+      course: {
+        identity: 'course',
+        label: 'Courses',
+        singularLabel: 'Course',
+        actions: { viewAny: true }
+      },
+      secret: {
+        identity: 'secret',
+        label: 'Secrets',
+        singularLabel: 'Secret',
+        hidden: true,
+        actions: { viewAny: true }
+      },
+      audit: {
+        identity: 'audit',
+        label: 'Audit entries',
+        singularLabel: 'Audit entry',
+        actions: { viewAny: false }
+      }
+    }
+  })
+
+  expect(navigation).toEqual({
+    actor: {
+      id: 'host-user-7',
+      email: 'ada@example.com',
+      fullName: 'Ada Lovelace',
+      role: 'administrator'
+    },
+    dashboards: [{ id: 'overview', label: 'Content overview', default: true }],
+    resources: [
+      {
+        identity: 'course',
+        label: 'Courses',
+        singularLabel: 'Course'
+      },
+      {
+        identity: 'lesson',
+        label: 'Lessons',
+        singularLabel: 'Lesson'
+      }
+    ]
+  })
+})


### PR DESCRIPTION
## Summary
- give app-domain Bridge a responsive Slipway-native workspace shell
- expose only authorized resources in a flat navigation list while keeping /bridge as the all-resources overview
- add Bridge-specific breadcrumbs, Docs access, actor role menu, and host-safe layouts without changing the internal operator flow

## Testing
- npx sounding test --file tests/unit/helpers/bridge/workspace-navigation.test.js --test-concurrency=1 --compact
- npx sounding test --file tests/functional/pages/bridge-access.test.js --test-concurrency=1 --compact
- npx sounding test --file tests/e2e/pages/projects/bridge-workspace.test.js --test-concurrency=1 --compact
- npm run lint
- git diff --check

Closes #390