### PR TITLE
fix(bridge): accept equivalent Markdown round trips

### DIFF
--- a/assets/js/components/content/MarkdownEditor.vue
+++ b/assets/js/components/content/MarkdownEditor.vue
@@ -308,7 +308,11 @@ function loadMarkdown(markdown, currentEditor = editor.value) {
     currentEditor.getMarkdown(),
     markdown
   )
-  if (!roundTripMatches(markdown, serialized)) {
+  if (
+    !roundTripMatches(markdown, serialized, (value) =>
+      currentEditor.markdown.parse(value)
+    )
+  ) {
     setCompatibility({
       supported: false,
       issues: [{ code: 'round-trip', label: 'syntax Visual mode cannot keep' }],

--- a/assets/js/lib/content/markdown.mjs
+++ b/assets/js/lib/content/markdown.mjs
@@ -75,10 +75,22 @@ export function normalizeMarkdownBoundary(markdown = '') {
     .replace(/\n+$/, '')
 }
 
-export function roundTripMatches(source, serialized) {
-  return (
+export function roundTripMatches(source, serialized, parseMarkdown) {
+  if (
     normalizeMarkdownBoundary(source) === normalizeMarkdownBoundary(serialized)
-  )
+  ) {
+    return true
+  }
+  if (typeof parseMarkdown !== 'function') return false
+
+  try {
+    return (
+      JSON.stringify(parseMarkdown(source)) ===
+      JSON.stringify(parseMarkdown(serialized))
+    )
+  } catch {
+    return false
+  }
 }
 
 export function preserveMarkdownEnvelope(serialized, source = '') {

--- a/tests/unit/content/markdown-editor.test.js
+++ b/tests/unit/content/markdown-editor.test.js
@@ -50,6 +50,44 @@ test('Content Manager keeps unsupported Markdown in source mode', async ({
   }
 })
 
+test('Content Manager accepts harmless prose whitespace normalization', async ({
+  expect
+}) => {
+  const { preserveMarkdownEnvelope, roundTripMatches } = await import(
+    '../../../assets/js/lib/content/markdown.mjs'
+  )
+  const markdown =
+    'First plain paragraph.\n\n\nSecond paragraph that is\nsoft wrapped across lines.\n'
+  const editor = createMarkdownEditor(markdown)
+  const serialized = preserveMarkdownEnvelope(editor.getMarkdown(), markdown)
+
+  expect(serialized).toBe(
+    'First plain paragraph.\n\nSecond paragraph that is\nsoft wrapped across lines.\n'
+  )
+  expect(
+    roundTripMatches(markdown, serialized, (value) =>
+      editor.markdown.parse(value)
+    )
+  ).toBe(true)
+  editor.destroy()
+})
+
+test('Content Manager does not normalize meaningful code-block whitespace', async ({
+  expect
+}) => {
+  const { roundTripMatches } = await import(
+    '../../../assets/js/lib/content/markdown.mjs'
+  )
+  const source = '```js\nconst first = true;\n\nconst second = true;\n```\n'
+  const rewritten = '```js\nconst first = true;\nconst second = true;\n```\n'
+  const editor = createMarkdownEditor(source)
+
+  expect(
+    roundTripMatches(source, rewritten, (value) => editor.markdown.parse(value))
+  ).toBe(false)
+  editor.destroy()
+})
+
 test('Content Manager rejects unsafe links and image sources', async ({
   expect
 }) => {


### PR DESCRIPTION
Closes #382

## Summary

- retain the exact Markdown comparison as the fast path
- when serialization changes only formatting, parse both versions through the same Tiptap Markdown manager and compare their document structure
- keep Visual mode available for ordinary prose with redundant blank lines and soft wrapping
- continue failing closed for unsupported Markdown and meaningful changes inside code blocks

## Root cause

Bridge compared the source and Tiptap serialization almost byte-for-byte. Three newlines between plain paragraphs serialize as the canonical two-newline boundary, so harmless prose was treated as a destructive rewrite.

## Verification

- regression fixture reproduces redundant blank lines in plain lesson prose
- semantic comparison confirms that the source and serialized documents are equivalent
- a removed blank line inside a fenced code block remains incompatible
- unsupported HTML, comments, tables, task lists, footnotes, reference links, directives, and MDX remain blocked by the existing inspection path
- focused Markdown suite: 5 passed
- MarkdownEditor Vue script and template compiled successfully
- Prettier passed

The local full unit lane reached 285 passing tests; eight unrelated tests could not bind localhost ports in the sandbox. GitHub CI is the unrestricted full-suite authority for this PR.
