### PR TITLE
fix(config): remove redundant secret labels

### DIFF
--- a/assets/js/lib/config-variables.mjs
+++ b/assets/js/lib/config-variables.mjs
@@ -1,0 +1,13 @@
+export function configVariableSummary(metadata = {}, changeSummary = '') {
+  const context = []
+
+  if (metadata.managed === true) {
+    context.push('Managed by Slipway')
+  } else if (metadata.kind === 'plain') {
+    context.push('Plain config')
+  }
+
+  if (changeSummary) context.push(changeSummary)
+
+  return context.join(' · ')
+}

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -22,6 +22,7 @@ import { useToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
 import { highlightLogLine } from '@/lib/highlightLog'
+import { configVariableSummary } from '@/lib/config-variables.mjs'
 
 defineOptions({
   layout: AppLayout
@@ -460,11 +461,6 @@ function isSensitive(key) {
   return metadataFor(key).kind === 'secret'
 }
 
-function metadataSummary(key) {
-  const metadata = metadataFor(key)
-  return metadata.kind === 'secret' ? 'Secret' : 'Plain config'
-}
-
 function changeSummary(key) {
   const metadata = metadataFor(key)
   return [
@@ -473,6 +469,10 @@ function changeSummary(key) {
   ]
     .filter(Boolean)
     .join(' · ')
+}
+
+function variableSummary(key) {
+  return configVariableSummary(metadataFor(key), changeSummary(key))
 }
 
 function toggleReveal(key) {
@@ -1745,13 +1745,11 @@ onBeforeUnmount(() => {
                       class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                     />
                     <p
+                      v-if="variableSummary(key)"
                       :data-test="`config-variable-summary-${key}`"
                       class="mt-1 text-xs text-gray-400 dark:text-gray-500"
                     >
-                      {{ metadataSummary(key) }}
-                      <template v-if="changeSummary(key)">
-                        · {{ changeSummary(key) }}
-                      </template>
+                      {{ variableSummary(key) }}
                     </p>
                   </div>
                 </div>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -21,6 +21,7 @@ import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
 import { useEventSource } from '@/composables/sse'
 import { usePrecognitionValidation } from '@/composables/precognition'
+import { configVariableSummary } from '@/lib/config-variables.mjs'
 
 defineOptions({
   layout: AppLayout
@@ -443,15 +444,6 @@ function isSensitive(key) {
   return metadataFor(key).kind === 'secret'
 }
 
-function metadataSummary(key) {
-  const metadata = metadataFor(key)
-  return metadata.managed
-    ? 'Managed secret'
-    : metadata.kind === 'secret'
-    ? 'Secret'
-    : 'Plain config'
-}
-
 function changeSummary(key) {
   const metadata = metadataFor(key)
   return [
@@ -460,6 +452,10 @@ function changeSummary(key) {
   ]
     .filter(Boolean)
     .join(' · ')
+}
+
+function variableSummary(key) {
+  return configVariableSummary(metadataFor(key), changeSummary(key))
 }
 
 function toggleReveal(key) {
@@ -2703,13 +2699,11 @@ onBeforeUnmount(() => {
                       class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                     />
                     <p
+                      v-if="variableSummary(key)"
                       :data-test="`config-variable-summary-${key}`"
                       class="mt-1 text-xs text-gray-400 dark:text-gray-500"
                     >
-                      {{ metadataSummary(key) }}
-                      <template v-if="changeSummary(key)">
-                        · {{ changeSummary(key) }}
-                      </template>
+                      {{ variableSummary(key) }}
                     </p>
                   </div>
                 </div>

--- a/assets/js/pages/settings/global-env.vue
+++ b/assets/js/pages/settings/global-env.vue
@@ -7,6 +7,7 @@ import CodeEditor from '@/components/CodeEditor.vue'
 import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
 import { useToast } from '@/composables/toast'
 import { usePrecognitionValidation } from '@/composables/precognition'
+import { configVariableSummary } from '@/lib/config-variables.mjs'
 
 defineOptions({
   layout: AppLayout
@@ -50,15 +51,6 @@ function isSensitive(key) {
   return metadataFor(key).kind === 'secret'
 }
 
-function metadataSummary(key) {
-  const metadata = metadataFor(key)
-  return metadata.managed
-    ? 'Managed secret'
-    : metadata.kind === 'secret'
-    ? 'Secret'
-    : 'Plain config'
-}
-
 function changeSummary(key) {
   const metadata = metadataFor(key)
   return [
@@ -67,6 +59,10 @@ function changeSummary(key) {
   ]
     .filter(Boolean)
     .join(' · ')
+}
+
+function variableSummary(key) {
+  return configVariableSummary(metadataFor(key), changeSummary(key))
 }
 
 function timeAgo(timestamp) {
@@ -704,13 +700,11 @@ onMounted(() => {
                   class="mt-1 w-full border-b border-dashed border-transparent bg-transparent font-mono text-sm text-gray-500 focus:border-gray-300 focus:outline-none dark:text-gray-400 dark:focus:border-gray-600"
                 />
                 <p
+                  v-if="variableSummary(key)"
                   :data-test="`config-variable-summary-${key}`"
                   class="mt-1 text-xs text-gray-400 dark:text-gray-500"
                 >
-                  {{ metadataSummary(key) }}
-                  <template v-if="changeSummary(key)">
-                    · {{ changeSummary(key) }}
-                  </template>
+                  {{ variableSummary(key) }}
                 </p>
               </div>
             </div>

--- a/tests/e2e/pages/projects/configuration-secrets.test.js
+++ b/tests/e2e/pages/projects/configuration-secrets.test.js
@@ -148,13 +148,17 @@ test(
     const legacyEnvironmentSummary = page.raw.locator(
       '[data-test="config-variable-summary-LEGACY_SECRET"]'
     )
-    expect((await legacyEnvironmentSummary.textContent()).trim()).toBe('Secret')
+    expect(await legacyEnvironmentSummary.count()).toBe(0)
     const managedEnvironmentSummary = page.raw.locator(
       '[data-test="config-variable-summary-DATABASE_URL"]'
     )
-    expect(
-      (await managedEnvironmentSummary.textContent()).includes('ago')
-    ).toBe(true)
+    const managedEnvironmentText = await managedEnvironmentSummary.textContent()
+    expect(managedEnvironmentText.includes('Managed by Slipway')).toBe(true)
+    expect(managedEnvironmentText.includes('ago')).toBe(true)
+    const plainEnvironmentText = await page.raw
+      .locator('[data-test="config-variable-summary-RELEASE_CHANNEL"]')
+      .textContent()
+    expect(plainEnvironmentText.startsWith('Plain config · ')).toBe(true)
     const managedMenu = page.raw.locator(
       '[data-test="config-menu-DATABASE_URL"] summary'
     )
@@ -189,7 +193,12 @@ test(
     const legacyAppSummary = page.raw.locator(
       '[data-test="config-variable-summary-LEGACY_APP_SECRET"]'
     )
-    expect((await legacyAppSummary.textContent()).trim()).toBe('Secret')
+    expect(await legacyAppSummary.count()).toBe(0)
+    const attributedAppText = await page.raw
+      .locator('[data-test="config-variable-summary-APP_SIGNING_SECRET"]')
+      .textContent()
+    expect(attributedAppText.includes(changedByName)).toBe(true)
+    expect(attributedAppText.includes('Secret')).toBe(false)
     await page.raw.locator('input[value="APP_SIGNING_SECRET"]').hover()
     await page.raw
       .locator('[data-test="config-menu-APP_SIGNING_SECRET"] summary')
@@ -210,7 +219,11 @@ test(
     const legacyGlobalSummary = page.raw.locator(
       '[data-test="config-variable-summary-LEGACY_GLOBAL_SECRET"]'
     )
-    expect((await legacyGlobalSummary.textContent()).trim()).toBe('Secret')
+    expect(await legacyGlobalSummary.count()).toBe(0)
+    const plainGlobalText = await page.raw
+      .locator('[data-test="config-variable-summary-GLOBAL_REGION"]')
+      .textContent()
+    expect(plainGlobalText.startsWith('Plain config · ')).toBe(true)
     await page.raw
       .locator('[data-test="config-menu-GLOBAL_REGION"] summary')
       .click()

--- a/tests/unit/config-variable-summary.test.js
+++ b/tests/unit/config-variable-summary.test.js
@@ -1,0 +1,31 @@
+const { test } = require('sounding')
+
+test('configuration summaries keep the secure default quiet', async ({
+  expect
+}) => {
+  const { configVariableSummary } = await import(
+    '../../assets/js/lib/config-variables.mjs'
+  )
+
+  expect(configVariableSummary({ kind: 'secret' })).toBe('')
+  expect(configVariableSummary({})).toBe('')
+})
+
+test('configuration summaries retain useful exceptional context', async ({
+  expect
+}) => {
+  const { configVariableSummary } = await import(
+    '../../assets/js/lib/config-variables.mjs'
+  )
+
+  expect(configVariableSummary({ kind: 'plain' })).toBe('Plain config')
+  expect(
+    configVariableSummary({ kind: 'secret' }, 'Kelvin · 2 minutes ago')
+  ).toBe('Kelvin · 2 minutes ago')
+  expect(
+    configVariableSummary(
+      { kind: 'secret', managed: true },
+      'Slipway · just now'
+    )
+  ).toBe('Managed by Slipway · Slipway · just now')
+})


### PR DESCRIPTION
## Summary

- remove the repeated Secret caption from default masked environment variables
- keep managed ownership, plain-config warnings, and change attribution visible
- share the presentation rule across project, app, and global configuration views

## Verification

- `npx sounding test --file tests/unit/config-variable-summary.test.js`
- `npx sounding test --file tests/e2e/pages/projects/configuration-secrets.test.js --test-concurrency=1`
- Vue SFC compilation for all three changed pages
- Prettier and `git diff --check`

Closes #385