### PR TITLE
fix(bridge): hide numeric input steppers

### DIFF
--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -788,7 +788,7 @@ function defaultPlaceholder(fieldType) {
           :aria-invalid="visibleError ? 'true' : undefined"
           :aria-describedby="describedBy"
           :data-test="`${fieldId}-input`"
-          class="h-11 w-full bg-transparent px-2 text-sm tabular-nums text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:text-white dark:placeholder-gray-500"
+          class="bridge-number-input h-11 w-full bg-transparent px-2 text-sm tabular-nums text-gray-900 placeholder-gray-400 focus:outline-none disabled:cursor-not-allowed disabled:text-gray-400 dark:text-white dark:placeholder-gray-500"
           @input="update($event.target.value)"
           @blur="handleBlur"
         />
@@ -809,7 +809,7 @@ function defaultPlaceholder(fieldType) {
         :aria-invalid="visibleError ? 'true' : undefined"
         :aria-describedby="describedBy"
         :data-test="`${fieldId}-input`"
-        :class="`${inputClass} tabular-nums`"
+        :class="`${inputClass} bridge-number-input tabular-nums`"
         @input="update($event.target.value)"
         @blur="handleBlur"
       />
@@ -1085,3 +1085,16 @@ function defaultPlaceholder(fieldType) {
     </p>
   </div>
 </template>
+
+<style scoped>
+.bridge-number-input {
+  appearance: textfield;
+  -moz-appearance: textfield;
+}
+
+.bridge-number-input::-webkit-outer-spin-button,
+.bridge-number-input::-webkit-inner-spin-button {
+  margin: 0;
+  -webkit-appearance: none;
+}
+</style>

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -632,6 +632,7 @@ test(
       await expect(page).toSee('Course description')
       await expect(page).toSee('Thumbnail')
       await expect(page).toSee('Price')
+      await expect(page).toSee('Order')
       await expect(page).toSee('Website')
       await expect(page).toSee('Metadata')
       await expect(page).toSee('Creator')
@@ -673,7 +674,27 @@ test(
       await page.raw
         .getByText('Course title is already in use', { exact: false })
         .waitFor({ state: 'hidden' })
-      await page.raw.getByLabel('Price').fill('49')
+      const priceInput = page.raw.getByLabel('Price')
+      const orderInput = page.raw.getByLabel('Order')
+      for (const numericInput of [priceInput, orderInput]) {
+        expect(await numericInput.getAttribute('type')).toBe('number')
+        expect(await numericInput.getAttribute('inputmode')).toBe('decimal')
+        expect(await numericInput.getAttribute('step')).toBe('any')
+        expect(
+          (await numericInput.getAttribute('class')).includes(
+            'bridge-number-input'
+          )
+        ).toBe(true)
+        expect(
+          await numericInput.evaluate(
+            (element) => getComputedStyle(element).appearance
+          )
+        ).toBe('textfield')
+      }
+      expect(await orderInput.getAttribute('min')).toBe('0')
+      expect(await orderInput.getAttribute('max')).toBe('999')
+      await priceInput.fill('49')
+      await orderInput.fill('5')
       await page.raw.setViewportSize({ width: 1440, height: 1100 })
       const creatorRelationshipSelect = page.raw.getByRole('combobox', {
         name: 'Creator'
@@ -874,6 +895,7 @@ test(
       expect(createdValues.id).toBe(createdCourseRecordId)
       expect(createdValues.creator).toBe(creatorId)
       expect(createdValues.price).toBe(49)
+      expect(createdValues.order).toBe(5)
       await expect(page).toSee('Ship a durable course')
 
       await page.goto(`${coursePath}/${createdCourseRecordId}/edit`)
@@ -1108,6 +1130,7 @@ function resourceConfig() {
           'description',
           'thumbnailUrl',
           'price',
+          'order',
           'website',
           'metadata',
           'published',
@@ -1269,6 +1292,11 @@ function resourceConfig() {
               submit: 'major'
             }
           },
+          order: {
+            label: 'Order',
+            type: 'number',
+            help: 'Lower numbers appear first.'
+          },
           website: {
             label: 'Website',
             type: 'url',
@@ -1346,6 +1374,11 @@ function resourceMetadata() {
         price: {
           type: 'number',
           required: true
+        },
+        order: {
+          type: 'number',
+          min: 0,
+          max: 999
         },
         website: {
           type: 'string',


### PR DESCRIPTION
## Summary

- hide native number steppers for Bridge number and currency inputs in Chromium, WebKit, and Firefox
- preserve semantic `type="number"`, decimal keyboards, constraints, and validation
- cover an Order-style number field and a currency field in the Bridge browser contract

## Verification

- `npx sounding test --file tests/e2e/pages/projects/bridge-resource-contract.test.js --test-concurrency=1`
- Vue SFC template and scoped-style compilation
- Prettier and `git diff --check`

Closes #366