### PR TITLE
fix(bridge): simplify relationship searches

### DIFF
--- a/assets/js/components/bridge/BridgeCollectionManager.vue
+++ b/assets/js/components/bridge/BridgeCollectionManager.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { router } from '@inertiajs/vue3'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import BridgeSearchInput from '@/components/bridge/BridgeSearchInput.vue'
 
 const props = defineProps({
   relationship: {
@@ -206,20 +207,18 @@ onBeforeUnmount(() => {
           </button>
         </header>
 
-        <div class="border-b border-gray-100 p-4 dark:border-gray-800">
+        <div class="px-5 py-3">
           <label
             :for="`bridge-${relationship.alias}-manager-search`"
             class="sr-only"
             >Search {{ relationship.label.toLowerCase() }}</label
           >
-          <input
+          <BridgeSearchInput
             :id="`bridge-${relationship.alias}-manager-search`"
             ref="searchInput"
             v-model="query"
-            type="search"
-            autocomplete="off"
+            :label="`Search ${relationship.label.toLowerCase()}`"
             :placeholder="`Search ${relationship.label.toLowerCase()}…`"
-            class="h-10 w-full rounded-md bg-gray-50 px-3 text-sm text-gray-900 outline-none ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-700 dark:focus:ring-gray-500"
           />
         </div>
 

--- a/assets/js/components/bridge/BridgeRelationshipSelect.vue
+++ b/assets/js/components/bridge/BridgeRelationshipSelect.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import BridgeSearchInput from '@/components/bridge/BridgeSearchInput.vue'
 
 const props = defineProps({
   id: {
@@ -203,21 +204,16 @@ onBeforeUnmount(() => {
         openAbove ? 'bottom-full mb-2' : 'mt-2'
       ]"
     >
-      <div
-        v-if="searchable && searchUrl"
-        class="border-b border-gray-100 p-2 dark:border-gray-800"
-      >
+      <div v-if="searchable && searchUrl" class="px-3 py-2">
         <label :for="`${id}-search`" class="sr-only"
           >Search {{ label.toLowerCase() }}</label
         >
-        <input
+        <BridgeSearchInput
           :id="`${id}-search`"
           ref="searchInput"
           v-model="query"
-          type="search"
-          autocomplete="off"
+          :label="`Search ${label.toLowerCase()}`"
           :placeholder="`Search ${label.toLowerCase()}…`"
-          class="h-9 w-full rounded-md bg-gray-50 px-3 text-sm text-gray-900 outline-none ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-700 dark:focus:ring-gray-500"
           @keydown.esc.prevent="hideOptions"
         />
       </div>

--- a/assets/js/components/bridge/BridgeSearchInput.vue
+++ b/assets/js/components/bridge/BridgeSearchInput.vue
@@ -1,0 +1,43 @@
+<script setup>
+import { ref } from 'vue'
+
+defineProps({
+  id: {
+    type: String,
+    required: true
+  },
+  label: {
+    type: String,
+    required: true
+  },
+  placeholder: {
+    type: String,
+    default: ''
+  }
+})
+
+const model = defineModel({
+  type: String,
+  default: ''
+})
+const input = ref(null)
+
+defineExpose({
+  focus() {
+    input.value?.focus()
+  }
+})
+</script>
+
+<template>
+  <input
+    :id="id"
+    ref="input"
+    v-model="model"
+    type="search"
+    autocomplete="off"
+    :aria-label="label"
+    :placeholder="placeholder"
+    class="focus:border-brand h-10 w-full border-b border-dashed border-gray-200 bg-transparent px-1 text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-0 dark:border-gray-700 dark:bg-transparent dark:text-white dark:placeholder-gray-500"
+  />
+</template>

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -704,6 +704,22 @@ test(
       })
       await creatorRelationshipSelect.click()
       await page.wait('text=Ada Lovelace')
+      const creatorSearch = page.raw.getByRole('searchbox', {
+        name: 'Search creator'
+      })
+      const creatorSearchClass = await creatorSearch.getAttribute('class')
+      expect(creatorSearchClass.includes('border-b')).toBe(true)
+      expect(creatorSearchClass.includes('border-dashed')).toBe(true)
+      expect(creatorSearchClass.includes('bg-transparent')).toBe(true)
+      expect(creatorSearchClass.includes('rounded')).toBe(false)
+      expect(creatorSearchClass.includes('ring-1')).toBe(false)
+      expect(
+        await creatorSearch.evaluate(
+          (element) => getComputedStyle(element).borderBottomStyle
+        )
+      ).toBe('dashed')
+      await creatorSearch.fill('Ada')
+      await page.wait('text=Ada Lovelace')
       await page.screenshot(
         path.join(
           relationshipScreenshotRoot,
@@ -1033,6 +1049,17 @@ test(
       await page.raw
         .getByRole('button', { name: 'Manage lessons', exact: true })
         .click()
+      await page.wait('text=Operate the boring path')
+      const collectionSearch = page.raw.getByRole('searchbox', {
+        name: 'Search lessons'
+      })
+      const collectionSearchClass = await collectionSearch.getAttribute('class')
+      expect(collectionSearchClass.includes('border-b')).toBe(true)
+      expect(collectionSearchClass.includes('border-dashed')).toBe(true)
+      expect(collectionSearchClass.includes('bg-transparent')).toBe(true)
+      expect(collectionSearchClass.includes('rounded')).toBe(false)
+      expect(collectionSearchClass.includes('ring-1')).toBe(false)
+      await collectionSearch.fill('Operate')
       await page.wait('text=Operate the boring path')
       await expect(page).toSee('Remove')
       await expect(page).toSee('Attach')


### PR DESCRIPTION
## Summary

- replace nested boxed relationship searches with a shared transparent dashed-bottom input
- use the same control for belongs-to dropdowns, relationship filters, and collection managers
- retain focus, async search, selection, accessible labels, and dark/light behavior

## Verification

- `npx sounding test --file tests/e2e/pages/projects/bridge-resource-contract.test.js --test-concurrency=1`
- Vue SFC compilation for the shared input and both consumers
- light and dark Creator dropdown screenshots
- collection-manager screenshot and search assertion
- Prettier and `git diff --check`

Closes #367