### PR TITLE
Bridge: scope dependent relationship fields

### DIFF
--- a/api/controllers/project/bridge-relationship-options.js
+++ b/api/controllers/project/bridge-relationship-options.js
@@ -39,6 +39,11 @@ module.exports = {
     page: {
       type: 'number',
       defaultsTo: 1
+    },
+    dependencies: {
+      type: 'string',
+      defaultsTo: '',
+      maxLength: 2000
     }
   },
 
@@ -69,7 +74,8 @@ module.exports = {
     surface,
     recordId,
     q,
-    page
+    page,
+    dependencies
   }) {
     let resolved
     try {
@@ -99,6 +105,7 @@ module.exports = {
     }
 
     try {
+      const dependencyValues = parseDependencyValues(dependencies)
       const loaded = await sails.helpers.bridge.loadResource.with({
         containerName: app.containerName,
         environmentId: environment.id,
@@ -156,6 +163,7 @@ module.exports = {
         relationshipAlias,
         search: q,
         page,
+        values: dependencyValues,
         ...(loaded.recordId !== undefined ? { recordId: loaded.recordId } : {})
       })
     } catch (error) {
@@ -168,4 +176,33 @@ function relationshipError(message) {
   const error = new Error(message)
   error.code = 'BRIDGE_RELATIONSHIP_NOT_ALLOWED'
   return error
+}
+
+function parseDependencyValues(value) {
+  if (!value) return {}
+
+  let parsed
+  try {
+    parsed = JSON.parse(value)
+  } catch {
+    throw relationshipError('Bridge relationship dependencies are invalid.')
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    Array.isArray(parsed) ||
+    ![Object.prototype, null].includes(Object.getPrototypeOf(parsed))
+  ) {
+    throw relationshipError('Bridge relationship dependencies are invalid.')
+  }
+
+  for (const key of Object.keys(parsed)) {
+    if (
+      !/^[A-Za-z][A-Za-z0-9]*$/.test(key) ||
+      ['__proto__', 'constructor', 'prototype'].includes(key)
+    ) {
+      throw relationshipError('Bridge relationship dependencies are invalid.')
+    }
+  }
+  return parsed
 }

--- a/api/helpers/bridge/allow-resource-values.js
+++ b/api/helpers/bridge/allow-resource-values.js
@@ -74,8 +74,18 @@ module.exports = {
     const requestedFields = validateOnly.length
       ? Array.from(new Set(validateOnly))
       : Object.keys(values)
+    const fieldsToNormalize = Array.from(
+      new Set([
+        ...requestedFields,
+        ...requestedFields.flatMap((field) =>
+          Object.values(resource.relationships?.[field]?.where || {})
+            .map((constraint) => constraint?.fromField)
+            .filter(Boolean)
+        )
+      ])
+    )
 
-    for (const key of requestedFields) {
+    for (const key of fieldsToNormalize) {
       if (
         !allowedFields.has(key) ||
         ['__proto__', 'constructor', 'prototype'].includes(key)

--- a/api/helpers/bridge/authorize-relationship-values.js
+++ b/api/helpers/bridge/authorize-relationship-values.js
@@ -41,6 +41,7 @@ module.exports = {
     values
   }) {
     const definitions = []
+    const unresolved = {}
 
     for (const association of resource.associations || []) {
       if (
@@ -57,6 +58,19 @@ module.exports = {
         throw relationshipError(
           `Bridge relationship "${resource.identity}.${association.alias}" is unavailable.`
         )
+      }
+
+      const scope = await sails.helpers.bridge.resolveRelationshipScope.with({
+        resource,
+        relationship,
+        values
+      })
+      if (!scope.ready) {
+        const sourceField = scope.missing[0]
+        unresolved[association.alias] = `Choose ${
+          resource.attributes?.[sourceField]?.label || sourceField
+        } before ${relationship.label}.`
+        continue
       }
 
       let related
@@ -78,8 +92,22 @@ module.exports = {
         alias: association.alias,
         identity: related.resource.identity,
         primaryKey: related.resource.primaryKey,
-        id: values[association.alias]
+        id: values[association.alias],
+        where: scope.where,
+        invalidMessage: relationshipScopeMessage({
+          resource,
+          relationship
+        })
       })
+    }
+
+    if (Object.keys(unresolved).length > 0) {
+      const error = relationshipError(
+        'Some selected Bridge relationships need more context.'
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_SCOPE_REQUIRED'
+      error.fieldErrors = unresolved
+      throw error
     }
 
     if (definitions.length === 0) return values
@@ -93,8 +121,12 @@ module.exports = {
         if (!model) {
           throw new Error('Configured Bridge relationship model is unavailable.');
         }
+        const identity = { [definition.primaryKey]: definition.id };
+        const criteria = Object.keys(definition.where).length > 0
+          ? { and: [definition.where, identity] }
+          : identity;
         const record = await model
-          .findOne({ [definition.primaryKey]: definition.id })
+          .findOne(criteria)
           .select([definition.primaryKey]);
         if (!record) missing.push(definition.alias);
       }
@@ -133,10 +165,14 @@ module.exports = {
         'Some selected Bridge relationships no longer exist.'
       )
       error.code = 'BRIDGE_RELATIONSHIP_NOT_FOUND'
+      const definitionsByAlias = new Map(
+        definitions.map((definition) => [definition.alias, definition])
+      )
       error.fieldErrors = Object.fromEntries(
         data.missing.map((alias) => [
           alias,
-          `${resource.attributes?.[alias]?.label || alias} no longer exists.`
+          definitionsByAlias.get(alias)?.invalidMessage ||
+            `${resource.attributes?.[alias]?.label || alias} is unavailable.`
         ])
       )
       throw error
@@ -150,4 +186,20 @@ function relationshipError(message) {
   const error = new Error(message)
   error.code = 'BRIDGE_RELATIONSHIP_NOT_ALLOWED'
   return error
+}
+
+function relationshipScopeMessage({ resource, relationship }) {
+  const dependency = Object.values(relationship.where || {}).find(
+    (constraint) => constraint?.fromField
+  )
+  if (dependency) {
+    const source = resource.attributes?.[dependency.fromField]
+    return `${relationship.label} is not available for the selected ${(
+      source?.label || dependency.fromField
+    ).toLowerCase()}.`
+  }
+  if (Object.keys(relationship.where || {}).length > 0) {
+    return `${relationship.label} is not eligible for this field.`
+  }
+  return `${relationship.label} no longer exists.`
 }

--- a/api/helpers/bridge/load-association-options.js
+++ b/api/helpers/bridge/load-association-options.js
@@ -55,6 +55,11 @@ module.exports = {
       if (!relatedResource || relatedResource.hidden) continue
       const relationship = resource.relationships?.[association.alias]
       if (!relationship) continue
+      const scope = await sails.helpers.bridge.resolveRelationshipScope.with({
+        resource,
+        relationship,
+        values
+      })
 
       definitions.push({
         alias: association.alias,
@@ -62,6 +67,8 @@ module.exports = {
         primaryKey: relatedResource.primaryKey,
         title: relatedResource.title,
         limit: relationship.limit,
+        where: scope.where,
+        scopeReady: scope.ready,
         selectedId: values?.[association.alias]
       })
     }
@@ -83,12 +90,15 @@ module.exports = {
           definition.primaryKey,
           definition.title
         ].filter(Boolean)));
-        const records = await model
-          .find({
-            sort: definition.title + ' ASC',
-            limit: definition.limit
-          })
-          .select(fields);
+        const records = definition.scopeReady
+          ? await model
+              .find({
+                where: definition.where,
+                sort: definition.title + ' ASC',
+                limit: definition.limit
+              })
+              .select(fields)
+          : [];
         if (
           definition.selectedId !== undefined &&
           definition.selectedId !== null &&
@@ -98,18 +108,37 @@ module.exports = {
               String(definition.selectedId)
           )
         ) {
-          const selected = await model
+          const selectedCriteria = Object.keys(definition.where).length > 0
+            ? {
+                and: [
+                  definition.where,
+                  { [definition.primaryKey]: definition.selectedId }
+                ]
+              }
+            : { [definition.primaryKey]: definition.selectedId };
+          const selectedInScope = definition.scopeReady
+            ? await model
+                .findOne(selectedCriteria)
+                .select(fields)
+            : null;
+          const selected = selectedInScope || await model
             .findOne({
               [definition.primaryKey]: definition.selectedId
             })
             .select(fields);
-          if (selected) records.unshift(selected);
+          if (selected) {
+            records.unshift({
+              ...selected,
+              __bridgeOutOfScope: !selectedInScope
+            });
+          }
         }
         options[definition.alias] = records.map((record) => ({
           id: record[definition.primaryKey],
           label: record[definition.title] == null
             ? '#' + record[definition.primaryKey]
-            : String(record[definition.title])
+            : String(record[definition.title]),
+          ...(record.__bridgeOutOfScope ? { outOfScope: true } : {})
         }));
       }
 

--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -165,6 +165,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
     'search',
     'fields',
     'limit',
+    'where',
     'attach',
     'detach'
   ]
@@ -278,6 +279,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       resources
     )
   }
+  validateRelationshipDependencyCycles(resources)
   for (const [identity, resource] of Object.entries(resources)) {
     validateUploadTemplateReferences(identity, resource, resources)
   }
@@ -784,6 +786,14 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         : configuredFields
       const defaultLimit = association.type === 'model' ? 20 : 5
       const limit = raw?.limit ?? defaultLimit
+      const where = normalizeRelationshipWhere({
+        identity,
+        alias: association.alias,
+        association,
+        value: raw?.where,
+        resource,
+        relatedResource
+      })
       const showByDefault =
         association.type === 'collection'
           ? true
@@ -812,6 +822,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
         search: searchFields,
         fields,
         limit,
+        ...(where ? { where } : {}),
         attach:
           association.type === 'collection' &&
           !hidden &&
@@ -895,6 +906,201 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       throw new Error(
         `Bridge relationship "${identity}.${alias}" can enable attach or detach only for a collection association.`
       )
+    }
+    if (relation.where !== undefined && !isPlainObject(relation.where)) {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}".where must be an object.`
+      )
+    }
+  }
+
+  function normalizeRelationshipWhere({
+    identity,
+    alias,
+    association,
+    value,
+    resource,
+    relatedResource
+  }) {
+    if (value === undefined) return null
+    if (association.type !== 'model') {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}".where requires a belongs-to association.`
+      )
+    }
+    if (!isPlainObject(value)) {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}".where must be an object.`
+      )
+    }
+
+    const entries = Object.entries(value)
+    if (entries.length > 10) {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}".where may contain at most 10 fields.`
+      )
+    }
+
+    const where = {}
+    for (const [targetField, rawConstraint] of entries) {
+      if (
+        !/^[A-Za-z][A-Za-z0-9]*$/.test(targetField) ||
+        ['__proto__', 'constructor', 'prototype'].includes(targetField)
+      ) {
+        throw new Error(
+          `Bridge relationship "${identity}.${alias}".where references an invalid target field.`
+        )
+      }
+      const targetAttribute = relatedResource?.attributes?.[targetField]
+      if (!isRelationshipScopeAttribute(targetAttribute)) {
+        throw new Error(
+          `Bridge relationship "${identity}.${alias}".where references unavailable target field "${targetField}".`
+        )
+      }
+
+      if (isPlainObject(rawConstraint)) {
+        const keys = Object.keys(rawConstraint)
+        if (keys.length !== 1 || !['fromField', 'in'].includes(keys[0])) {
+          throw new Error(
+            `Bridge relationship "${identity}.${alias}".where.${targetField} must use only "fromField" or "in".`
+          )
+        }
+
+        if (keys[0] === 'fromField') {
+          const sourceField = readString(rawConstraint.fromField)
+          const sourceAttribute = sourceField
+            ? resource.attributes?.[sourceField]
+            : null
+          if (!sourceField || !isRelationshipScopeAttribute(sourceAttribute)) {
+            throw new Error(
+              `Bridge relationship "${identity}.${alias}".where.${targetField} references unavailable source field "${rawConstraint.fromField}".`
+            )
+          }
+          if (sourceAttribute.type !== targetAttribute.type) {
+            throw new Error(
+              `Bridge relationship "${identity}.${alias}".where.${targetField} cannot use "${sourceField}" because their field types are incompatible.`
+            )
+          }
+          for (const surface of ['create', 'edit']) {
+            if (
+              resource[surface].includes(alias) &&
+              !resource[surface].includes(sourceField)
+            ) {
+              throw new Error(
+                `Bridge relationship "${identity}.${alias}" depends on "${sourceField}", which is unavailable on the ${surface} form.`
+              )
+            }
+          }
+          where[targetField] = { fromField: sourceField }
+          continue
+        }
+
+        if (
+          !Array.isArray(rawConstraint.in) ||
+          rawConstraint.in.length === 0 ||
+          rawConstraint.in.length > 50
+        ) {
+          throw new Error(
+            `Bridge relationship "${identity}.${alias}".where.${targetField}.in must contain 1 to 50 values.`
+          )
+        }
+        where[targetField] = {
+          in: Array.from(
+            new Set(
+              rawConstraint.in.map((entry) =>
+                normalizeRelationshipScopeValue({
+                  identity,
+                  alias,
+                  targetField,
+                  attribute: targetAttribute,
+                  value: entry
+                })
+              )
+            )
+          )
+        }
+        continue
+      }
+
+      where[targetField] = normalizeRelationshipScopeValue({
+        identity,
+        alias,
+        targetField,
+        attribute: targetAttribute,
+        value: rawConstraint
+      })
+    }
+
+    return Object.keys(where).length > 0 ? where : null
+  }
+
+  function normalizeRelationshipScopeValue({
+    identity,
+    alias,
+    targetField,
+    attribute,
+    value
+  }) {
+    const valid =
+      (attribute.type === 'string' && typeof value === 'string') ||
+      (attribute.type === 'number' &&
+        typeof value === 'number' &&
+        Number.isFinite(value)) ||
+      (attribute.type === 'boolean' && typeof value === 'boolean')
+    if (!valid) {
+      throw new Error(
+        `Bridge relationship "${identity}.${alias}".where.${targetField} must use ${attribute.type} values.`
+      )
+    }
+    return value
+  }
+
+  function isRelationshipScopeAttribute(attribute) {
+    return Boolean(
+      attribute &&
+        !attribute.protect &&
+        !attribute.encrypt &&
+        attribute.sensitive !== true &&
+        ['string', 'number', 'boolean'].includes(attribute.type)
+    )
+  }
+
+  function validateRelationshipDependencyCycles(resources) {
+    for (const resource of Object.values(resources)) {
+      const graph = new Map()
+      for (const relationship of Object.values(resource.relationships || {})) {
+        if (relationship.type !== 'model') continue
+        graph.set(
+          relationship.alias,
+          Object.values(relationship.where || {})
+            .map((constraint) => constraint?.fromField)
+            .filter(
+              (field) => resource.relationships?.[field]?.type === 'model'
+            )
+        )
+      }
+
+      const visiting = new Set()
+      const visited = new Set()
+      const visit = (alias, path = []) => {
+        if (visiting.has(alias)) {
+          throw new Error(
+            `Bridge relationship dependencies contain a cycle: ${[
+              ...path,
+              alias
+            ].join(' -> ')}.`
+          )
+        }
+        if (visited.has(alias)) return
+        visiting.add(alias)
+        for (const dependency of graph.get(alias) || []) {
+          visit(dependency, [...path, alias])
+        }
+        visiting.delete(alias)
+        visited.add(alias)
+      }
+
+      for (const alias of graph.keys()) visit(alias)
     }
   }
 

--- a/api/helpers/bridge/resolve-relationship-scope.js
+++ b/api/helpers/bridge/resolve-relationship-scope.js
@@ -1,0 +1,101 @@
+module.exports = {
+  friendlyName: 'Resolve Bridge relationship scope',
+
+  description:
+    'Resolve a normalized relationship where contract using declared sibling field values only.',
+
+  inputs: {
+    resource: {
+      type: 'ref',
+      required: true
+    },
+    relationship: {
+      type: 'ref',
+      required: true
+    },
+    values: {
+      type: 'ref',
+      defaultsTo: {}
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ resource, relationship, values }) {
+    const safeValues =
+      values && typeof values === 'object' && !Array.isArray(values)
+        ? values
+        : {}
+    const where = {}
+    const missing = []
+
+    for (const [targetField, constraint] of Object.entries(
+      relationship.where || {}
+    )) {
+      if (!isFromFieldConstraint(constraint)) {
+        where[targetField] = constraint
+        continue
+      }
+
+      const sourceField = constraint.fromField
+      const value = safeValues[sourceField]
+      if (value === undefined || value === null || value === '') {
+        missing.push(sourceField)
+        continue
+      }
+
+      const attribute = resource.attributes?.[sourceField] || {}
+      where[targetField] = await normalizeValue({
+        value,
+        attribute,
+        label: resource.attributes?.[sourceField]?.label || sourceField
+      })
+    }
+
+    return {
+      ready: missing.length === 0,
+      missing,
+      where
+    }
+  }
+}
+
+function isFromFieldConstraint(value) {
+  return Boolean(
+    value &&
+      typeof value === 'object' &&
+      !Array.isArray(value) &&
+      typeof value.fromField === 'string'
+  )
+}
+
+async function normalizeValue({ value, attribute, label }) {
+  if (attribute.type === 'boolean') {
+    if (value === true || value === false) return value
+    if (value === 'true') return true
+    if (value === 'false') return false
+    throw invalid(`${label} must be true or false.`)
+  }
+
+  try {
+    return await sails.helpers.bridge.normalizeIdentifier.with({
+      value,
+      attribute,
+      label
+    })
+  } catch (cause) {
+    const error = invalid(cause.message)
+    error.cause = cause
+    throw error
+  }
+}
+
+function invalid(message) {
+  const error = new Error(message)
+  error.code = 'BRIDGE_RELATIONSHIP_SCOPE_INVALID'
+  return error
+}

--- a/api/helpers/bridge/search-relationship-options.js
+++ b/api/helpers/bridge/search-relationship-options.js
@@ -31,6 +31,10 @@ module.exports = {
     },
     recordId: {
       type: 'ref'
+    },
+    values: {
+      type: 'ref',
+      defaultsTo: {}
     }
   },
 
@@ -47,7 +51,8 @@ module.exports = {
     relationshipAlias,
     search,
     page,
-    recordId
+    recordId,
+    values
   }) {
     const relationship = resource.relationships?.[relationshipAlias]
     if (!relationship) {
@@ -68,6 +73,36 @@ module.exports = {
       .trim()
       .slice(0, 100)
     const limit = Math.min(Math.max(relationship.limit || 20, 1), 50)
+    const declaredDependencies = new Set(
+      Object.values(relationship.where || {})
+        .map((constraint) => constraint?.fromField)
+        .filter(Boolean)
+    )
+    const unknownDependency = Object.keys(values || {}).find(
+      (field) => !declaredDependencies.has(field)
+    )
+    if (unknownDependency) {
+      const error = relationshipError(
+        `Bridge relationship dependency "${unknownDependency}" is not declared.`
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_SCOPE_INVALID'
+      throw error
+    }
+    const scope = await sails.helpers.bridge.resolveRelationshipScope.with({
+      resource,
+      relationship,
+      values
+    })
+    if (!scope.ready) {
+      const sourceField = scope.missing[0]
+      const error = relationshipError(
+        `Choose ${
+          resource.attributes?.[sourceField]?.label || sourceField
+        } before loading ${relationship.label}.`
+      )
+      error.code = 'BRIDGE_RELATIONSHIP_SCOPE_REQUIRED'
+      throw error
+    }
     const definition = {
       alias: relationship.alias,
       type: relationship.type,
@@ -78,6 +113,7 @@ module.exports = {
       limit,
       page: normalizedPage,
       query: normalizedSearch,
+      where: scope.where,
       parentIdentity: resource.identity,
       parentPrimaryKey: resource.primaryKey,
       recordId
@@ -90,13 +126,16 @@ module.exports = {
         throw new Error('Configured Bridge relationship model is unavailable.');
       }
 
-      const where = definition.query && definition.search.length > 0
+      const textSearch = definition.query && definition.search.length > 0
         ? {
             or: definition.search.map((field) => ({
               [field]: { contains: definition.query }
             }))
           }
-        : {};
+        : null;
+      const where = textSearch && Object.keys(definition.where).length > 0
+        ? { and: [definition.where, textSearch] }
+        : textSearch || definition.where;
       const fields = Array.from(new Set([
         definition.primaryKey,
         definition.title

--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -45,6 +45,22 @@ const props = defineProps({
     type: String,
     default: ''
   },
+  associationDisabledReason: {
+    type: String,
+    default: ''
+  },
+  associationSearchPlaceholder: {
+    type: String,
+    default: ''
+  },
+  associationEmptyText: {
+    type: String,
+    default: ''
+  },
+  resourceRelationships: {
+    type: Object,
+    default: () => ({})
+  },
   uploadUrl: {
     type: String,
     default: ''
@@ -146,8 +162,13 @@ const uploadPathValues = computed(() => {
     ),
     (match) => match[1]
   )
+  const dependencyRoots = roots.flatMap((name) =>
+    Object.values(props.resourceRelationships?.[name]?.where || {})
+      .map((constraint) => constraint?.fromField)
+      .filter(Boolean)
+  )
   return Object.fromEntries(
-    Array.from(new Set(roots))
+    Array.from(new Set([...roots, ...dependencyRoots]))
       .filter((name) =>
         Object.prototype.hasOwnProperty.call(props.uploadValues, name)
       )
@@ -877,7 +898,10 @@ function defaultPlaceholder(fieldType) {
         :options="associationOptions"
         :search-url="associationSearchUrl"
         :searchable="attribute.field?.relation?.searchable !== false"
-        :disabled="field.readOnly"
+        :disabled="field.readOnly || Boolean(associationDisabledReason)"
+        :placeholder="associationDisabledReason"
+        :search-placeholder="associationSearchPlaceholder"
+        :empty-text="associationEmptyText"
         :required="attribute.required"
         :invalid="Boolean(visibleError)"
         :described-by="describedBy"

--- a/assets/js/components/bridge/BridgeRelationshipSelect.vue
+++ b/assets/js/components/bridge/BridgeRelationshipSelect.vue
@@ -26,6 +26,18 @@ const props = defineProps({
     type: Boolean,
     default: true
   },
+  placeholder: {
+    type: String,
+    default: ''
+  },
+  searchPlaceholder: {
+    type: String,
+    default: ''
+  },
+  emptyText: {
+    type: String,
+    default: ''
+  },
   required: Boolean,
   disabled: Boolean,
   invalid: Boolean,
@@ -49,6 +61,7 @@ const hasMore = ref(false)
 const openAbove = ref(false)
 let debounceTimer
 let requestController
+const optionCache = new Map()
 
 const allOptions = computed(() => {
   const merged = new Map()
@@ -77,6 +90,21 @@ watch(query, () => {
   clearTimeout(debounceTimer)
   debounceTimer = setTimeout(() => loadOptions(1), 180)
 })
+
+watch(
+  () => props.searchUrl,
+  (searchUrl, previousUrl) => {
+    if (searchUrl === previousUrl) return
+    clearTimeout(debounceTimer)
+    requestController?.abort()
+    query.value = ''
+    results.value = []
+    page.value = 1
+    hasMore.value = false
+    loadError.value = ''
+    if (searchUrl) void loadOptions(1)
+  }
+)
 
 async function showOptions() {
   if (props.disabled) return
@@ -112,6 +140,12 @@ async function loadOptions(nextPage, { append = false } = {}) {
     const url = new URL(props.searchUrl, window.location.origin)
     url.searchParams.set('q', query.value)
     url.searchParams.set('page', String(nextPage))
+    const cacheKey = url.toString()
+    if (optionCache.has(cacheKey)) {
+      applyOptions(optionCache.get(cacheKey), nextPage, append)
+      loading.value = false
+      return
+    }
     const response = await fetch(url, {
       headers: { Accept: 'application/json' },
       signal: controller.signal
@@ -120,11 +154,9 @@ async function loadOptions(nextPage, { append = false } = {}) {
     if (!response.ok) {
       throw new Error(data.error || 'Relationships could not be loaded.')
     }
-    results.value = append
-      ? [...results.value, ...(data.options || [])]
-      : data.options || []
-    page.value = data.page || nextPage
-    hasMore.value = data.hasMore === true
+    if (requestController !== controller) return
+    cacheOptions(cacheKey, data)
+    applyOptions(data, nextPage, append)
   } catch (error) {
     if (error.name !== 'AbortError') {
       loadError.value = error.message || 'Relationships could not be loaded.'
@@ -134,7 +166,22 @@ async function loadOptions(nextPage, { append = false } = {}) {
   }
 }
 
+function applyOptions(data, nextPage, append) {
+  results.value = append
+    ? [...results.value, ...(data.options || [])]
+    : data.options || []
+  page.value = data.page || nextPage
+  hasMore.value = data.hasMore === true
+}
+
+function cacheOptions(key, data) {
+  optionCache.set(key, data)
+  if (optionCache.size <= 100) return
+  optionCache.delete(optionCache.keys().next().value)
+}
+
 function choose(option) {
+  if (option?.outOfScope) return
   emit('update:modelValue', option ? option.id : '')
   hideOptions()
 }
@@ -180,7 +227,7 @@ onBeforeUnmount(() => {
           selected ? 'truncate' : 'truncate text-gray-400 dark:text-gray-500'
         "
       >
-        {{ selected?.label || (required ? 'Select…' : 'None') }}
+        {{ selected?.label || placeholder || (required ? 'Select…' : 'None') }}
       </span>
       <svg
         class="ml-3 h-4 w-4 shrink-0 text-gray-400 transition"
@@ -213,7 +260,7 @@ onBeforeUnmount(() => {
           ref="searchInput"
           v-model="query"
           :label="`Search ${label.toLowerCase()}`"
-          :placeholder="`Search ${label.toLowerCase()}…`"
+          :placeholder="searchPlaceholder || `Search ${label.toLowerCase()}…`"
           @keydown.esc.prevent="hideOptions"
         />
       </div>
@@ -242,7 +289,8 @@ onBeforeUnmount(() => {
           type="button"
           role="option"
           :aria-selected="String(option.id) === String(modelValue)"
-          class="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-900 hover:bg-gray-50 dark:text-white dark:hover:bg-gray-800"
+          :disabled="option.outOfScope"
+          class="flex w-full items-center justify-between gap-3 px-3 py-2 text-left text-sm text-gray-900 hover:bg-gray-50 disabled:cursor-not-allowed disabled:text-amber-700 dark:text-white dark:hover:bg-gray-800 dark:disabled:text-amber-300"
           @click="choose(option)"
         >
           <span class="truncate">{{ option.label }}</span>
@@ -265,7 +313,11 @@ onBeforeUnmount(() => {
           v-if="!loading && !loadError && results.length === 0"
           class="px-3 py-6 text-center text-sm text-gray-400 dark:text-gray-500"
         >
-          No matching records
+          {{
+            query
+              ? `No matching ${label.toLowerCase()}`
+              : emptyText || `No ${label.toLowerCase()} available`
+          }}
         </p>
         <p
           v-if="loadError"

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -164,6 +164,8 @@ function serverFieldName(field) {
 
 function validateField(field) {
   const attr = field.attr
+  const scopeError = relationshipScopeError(field)
+  if (scopeError) return scopeError
   if (
     attr.field?.type === 'richtext' &&
     attr.field?.format?.toLowerCase() === 'markdown' &&
@@ -176,6 +178,16 @@ function validateField(field) {
     value: formValues.value[field.name],
     isEdit: isEdit.value
   })
+}
+
+function relationshipScopeError(field) {
+  if (!field.attr.isBelongsTo) return ''
+  const value = formValues.value[field.name]
+  const selected = (props.assocOptions?.[field.name] || []).find(
+    (option) => String(option.id) === String(value)
+  )
+  if (!selected?.outOfScope) return ''
+  return `${field.attr.label || field.name} is outside the available choices.`
 }
 
 function validateAndRemember(field, validateOnServer = true) {
@@ -192,13 +204,51 @@ function validateAndRemember(field, validateOnServer = true) {
 }
 
 function updateField(field, value) {
+  const previous = formValues.value[field.name]
   formValues.value[field.name] = value
-  if (formErrors.value[field.name]) validateAndRemember(field, false)
+  if (!sameRelationshipValue(previous, value)) {
+    clearDependentRelationshipValues(field.name)
+  }
+  if (formErrors.value[serverFieldName(field)]) {
+    validateAndRemember(field, false)
+  }
   revalidateWhenInvalid(serverFieldName(field))
 }
 
+function clearDependentRelationshipValues(sourceField) {
+  const queue = [sourceField]
+  const cleared = new Set()
+
+  while (queue.length > 0) {
+    const source = queue.shift()
+    for (const candidate of editableFields.value) {
+      if (
+        cleared.has(candidate.name) ||
+        !relationshipDependencyFields(candidate).includes(source)
+      ) {
+        continue
+      }
+      cleared.add(candidate.name)
+      if (hasRelationshipValue(formValues.value[candidate.name])) {
+        formValues.value[candidate.name] = ''
+        clearFieldError(candidate)
+      }
+      queue.push(candidate.name)
+    }
+  }
+}
+
+function sameRelationshipValue(left, right) {
+  if (!hasRelationshipValue(left) && !hasRelationshipValue(right)) return true
+  return String(left) === String(right)
+}
+
+function hasRelationshipValue(value) {
+  return value !== undefined && value !== null && value !== ''
+}
+
 function clearFieldError(field) {
-  delete formErrors.value[field.name]
+  delete formErrors.value[serverFieldName(field)]
   form.clearErrors(serverFieldName(field))
 }
 
@@ -242,15 +292,60 @@ function uploadUrl(field) {
 
 function relationshipSearchUrl(field) {
   if (!field.attr.isBelongsTo) return ''
+  const dependencies = relationshipDependencyFields(field)
+  const dependencyValues = {}
+  for (const dependency of dependencies) {
+    const value = formValues.value[dependency]
+    if (!hasRelationshipValue(value)) return ''
+    dependencyValues[dependency] = value
+  }
   const params = new URLSearchParams({
     surface: isEdit.value ? 'edit' : 'create'
   })
+  if (dependencies.length > 0) {
+    params.set('dependencies', JSON.stringify(dependencyValues))
+  }
   if (isEdit.value && props.recordId !== null) {
     params.set('recordId', String(props.recordId))
   }
   return `${bridgeApiBasePath.value}/${
     props.modelIdentity
   }/relationships/${encodePathSegment(field.name)}/options?${params.toString()}`
+}
+
+function relationshipDependencyFields(field) {
+  return Object.values(field.attr.field?.relation?.where || {})
+    .map((constraint) => constraint?.fromField)
+    .filter(Boolean)
+}
+
+function relationshipDisabledReason(field) {
+  const dependency = relationshipDependencyFields(field).find(
+    (name) => !hasRelationshipValue(formValues.value[name])
+  )
+  if (!dependency) return ''
+  const label = props.modelMeta?.attributes?.[dependency]?.label || dependency
+  return `Choose ${label.toLowerCase()} first`
+}
+
+function relationshipSearchPlaceholder(field) {
+  const dependency = relationshipDependencyFields(field)[0]
+  if (!dependency) return ''
+  const sourceLabel =
+    props.modelMeta?.attributes?.[dependency]?.label || dependency
+  return `Search ${(
+    field.attr.label || field.name
+  ).toLowerCase()} in this ${sourceLabel.toLowerCase()}…`
+}
+
+function relationshipEmptyText(field) {
+  const dependency = relationshipDependencyFields(field)[0]
+  if (!dependency) return ''
+  const sourceLabel =
+    props.modelMeta?.attributes?.[dependency]?.label || dependency
+  return `No ${(
+    field.attr.label || field.name
+  ).toLowerCase()} available for this ${sourceLabel.toLowerCase()}`
 }
 
 function bridgeUrl() {
@@ -483,7 +578,8 @@ function recordUrl() {
               :field="field"
               :model-value="formValues[field.name]"
               :error="
-                formErrors[field.name] ||
+                relationshipScopeError(field) ||
+                formErrors[serverFieldName(field)] ||
                 form.errors[serverFieldName(field)] ||
                 ''
               "
@@ -492,6 +588,12 @@ function recordUrl() {
               :record-id="recordId"
               :association-options="assocOptions[field.name] || []"
               :association-search-url="relationshipSearchUrl(field)"
+              :association-disabled-reason="relationshipDisabledReason(field)"
+              :association-search-placeholder="
+                relationshipSearchPlaceholder(field)
+              "
+              :association-empty-text="relationshipEmptyText(field)"
+              :resource-relationships="modelMeta.relationships || {}"
               :upload-url="uploadUrl(field)"
               :upload-values="formValues"
               @update:model-value="updateField(field, $event)"

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -892,9 +892,67 @@ The form receives only the first bounded page. Its combobox searches through a
 dedicated JSON transport and loads additional pages on demand, so a large user
 or course table is never serialized into an Inertia page.
 
+Use `where` when a belongs-to field should expose only eligible records. A
+fixed value or bounded `in` list is owned entirely by the server contract:
+
+```js
+lesson: {
+  fields: {
+    creator: {
+      help: 'Only administrators can be creators.',
+      relation: {
+        search: ['fullName', 'email'],
+        where: {
+          role: { in: ['editor', 'admin'] }
+        }
+      }
+    }
+  }
+}
+```
+
+A relationship can also depend on a declared sibling form field. This keeps a
+Chapter selector empty until Course has a value, then scopes every initial,
+search, and paginated query to that course:
+
+```js
+lesson: {
+  fields: {
+    course: {
+      relation: {
+        search: ['title', 'slug']
+      }
+    },
+    chapter: {
+      relation: {
+        search: ['title', 'slug'],
+        where: {
+          course: { fromField: 'course' }
+        }
+      }
+    }
+  }
+}
+```
+
+Dependent selectors are disabled until their source fields are ready. Changing
+a source clears downstream selections, aborts stale option requests, and
+prefetches the first bounded page for the new scope. Edit forms keep the label
+of an existing out-of-scope value visible with a warning so it can be replaced;
+the value cannot be submitted as eligible.
+
+`where` accepts scalar string, number, or boolean equality, `{in: [...]}` with
+1 to 50 values, and `{fromField: 'fieldName'}`. Slipway rejects unknown target
+or source fields, unsupported operators, incompatible types, unavailable form
+dependencies, and dependency cycles while normalizing the contract. Browser
+query parameters can supply values only for declared `fromField` dependencies;
+they cannot alter fixed constraints.
+
 Create and update requests repeat the related resource's `viewAny`
-authorization and verify that every submitted belongs-to ID still exists.
-Hiding a selector therefore cannot be bypassed with a forged form payload.
+authorization and verify that every submitted belongs-to ID both exists and
+matches the identical normalized `where` scope. Relationship-backed upload
+paths repeat the same verification. Hiding or modifying a selector therefore
+cannot be bypassed with a forged form or upload payload.
 
 Collection associations appear as compact related-record lists on the detail
 page. Values are selected only from the related resource's safe `show` fields.

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -72,6 +72,8 @@ test(
     const creatorId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80213'
     const chapterId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80214'
     const lessonId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80215'
+    const otherCourseId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80217'
+    const otherChapterId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80218'
     const records = [
       {
         id: courseRecordId,
@@ -150,6 +152,17 @@ test(
         })
       }
       if (code.includes('const options = {};')) {
+        const definitions = readEmbeddedValue(code, 'definitions')
+        if (definitions.some((definition) => definition.alias === 'chapter')) {
+          return successfulResult({
+            course: [
+              { id: courseRecordId, label: 'Build a production Sails app' },
+              { id: otherCourseId, label: 'Durable UI' }
+            ],
+            chapter: [],
+            creator: [{ id: creatorId, label: 'Ada Lovelace' }]
+          })
+        }
         return successfulResult({
           creator: [{ id: creatorId, label: 'Ada Lovelace' }]
         })
@@ -166,15 +179,43 @@ test(
               : {}
         })
       }
-      if (code.includes('const where = definition.query')) {
+      if (code.includes('const textSearch = definition.query')) {
         const definition = readEmbeddedValue(code, 'definition')
         if (definition.identity === 'user') {
+          expect(definition.where).toEqual({ role: 'admin' })
           return successfulResult({
             options: [
               {
                 id: creatorId,
                 label: 'Ada Lovelace',
                 attached: false
+              }
+            ],
+            page: definition.page,
+            limit: definition.limit,
+            hasMore: false
+          })
+        }
+        if (definition.identity === 'course') {
+          return successfulResult({
+            options: [
+              { id: courseRecordId, label: 'Build a production Sails app' },
+              { id: otherCourseId, label: 'Durable UI' }
+            ],
+            page: definition.page,
+            limit: definition.limit,
+            hasMore: false
+          })
+        }
+        if (definition.identity === 'chapter') {
+          const scopedToOtherCourse = definition.where.course === otherCourseId
+          return successfulResult({
+            options: [
+              {
+                id: scopedToOtherCourse ? otherChapterId : chapterId,
+                label: scopedToOtherCourse
+                  ? 'Durable form state'
+                  : 'The deployment path'
               }
             ],
             page: definition.page,
@@ -1077,6 +1118,68 @@ test(
         .click()
 
       await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.goto(`${bridgePath}/lesson/new`)
+      await page.wait('text=Create Lesson')
+      const courseSelect = page.raw.getByRole('combobox', { name: 'Course' })
+      const chapterSelect = page.raw.getByRole('combobox', { name: 'Chapter' })
+      const lessonCreatorSelect = page.raw.getByRole('combobox', {
+        name: 'Creator'
+      })
+
+      expect(await chapterSelect.isDisabled()).toBe(true)
+      await expect(chapterSelect).toHaveText('Choose course first')
+
+      await courseSelect.click()
+      await page.raw
+        .getByRole('option', {
+          name: 'Build a production Sails app',
+          exact: true
+        })
+        .click()
+      expect(await chapterSelect.isEnabled()).toBe(true)
+      await chapterSelect.click()
+      await page.wait('text=The deployment path')
+      await page.raw
+        .getByRole('option', { name: 'The deployment path', exact: true })
+        .click()
+      await expect(chapterSelect).toHaveText('The deployment path')
+
+      await courseSelect.click()
+      await page.raw
+        .getByRole('option', { name: 'Durable UI', exact: true })
+        .click()
+      await expect(chapterSelect).toHaveText('Select…')
+      await chapterSelect.click()
+      await page.wait('text=Durable form state')
+      expect(
+        await page.raw
+          .getByRole('option', { name: 'The deployment path', exact: true })
+          .count()
+      ).toBe(0)
+      await page.screenshot(
+        path.join(
+          relationshipScreenshotRoot,
+          'dependent-relationship-fields-light.png'
+        ),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(
+          relationshipScreenshotRoot,
+          'dependent-relationship-fields-dark.png'
+        ),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw
+        .getByRole('option', { name: 'Durable form state', exact: true })
+        .click()
+
+      await lessonCreatorSelect.click()
+      await page.wait('text=Ada Lovelace')
+
+      await page.raw.emulateMedia({ colorScheme: 'light' })
       await page.goto(`${bridgePath}/user/${creatorId}`)
       await page.wait('text=Ada Lovelace')
       await expect(page).toSee('ada@example.com')
@@ -1335,7 +1438,10 @@ function resourceConfig() {
             help: 'Structured course metadata stored as JSON.'
           },
           creator: {
-            label: 'Creator'
+            label: 'Creator',
+            relation: {
+              where: { role: 'admin' }
+            }
           }
         }
       },
@@ -1367,7 +1473,23 @@ function resourceConfig() {
         group: 'Content',
         title: 'title',
         search: ['title'],
-        list: ['title']
+        list: ['title'],
+        create: ['title', 'course', 'chapter', 'creator'],
+        fields: {
+          chapter: {
+            relation: {
+              search: ['title'],
+              where: { course: { fromField: 'course' } }
+            }
+          },
+          creator: {
+            help: 'Only administrators can be creators.',
+            relation: {
+              search: ['fullName', 'email'],
+              where: { role: 'admin' }
+            }
+          }
+        }
       }
     }
   }
@@ -1471,6 +1593,11 @@ function resourceMetadata() {
           isEmail: true,
           required: true
         },
+        role: {
+          type: 'string',
+          isIn: ['student', 'admin'],
+          defaultsTo: 'student'
+        },
         githubAccessToken: {
           type: 'string'
         },
@@ -1535,7 +1662,18 @@ function resourceMetadata() {
         },
         course: {
           type: 'string',
-          model: 'course'
+          model: 'course',
+          required: true
+        },
+        chapter: {
+          type: 'string',
+          model: 'chapter',
+          required: true
+        },
+        creator: {
+          type: 'string',
+          model: 'user',
+          required: true
         }
       },
       associations: [
@@ -1543,6 +1681,16 @@ function resourceMetadata() {
           alias: 'course',
           type: 'model',
           model: 'course'
+        },
+        {
+          alias: 'chapter',
+          type: 'model',
+          model: 'chapter'
+        },
+        {
+          alias: 'creator',
+          type: 'model',
+          model: 'user'
         }
       ]
     }

--- a/tests/functional/pages/bridge-relationships.test.js
+++ b/tests/functional/pages/bridge-relationships.test.js
@@ -57,7 +57,7 @@ test(
           }
           return successfulResult(decisions)
         }
-        if (code.includes('const where = definition.query')) {
+        if (code.includes('const textSearch = definition.query')) {
           const definition = readEmbeddedValue(code, 'definition')
           expect(definition.page).toBe(2)
           expect(definition.query).toBe('deploy')
@@ -223,6 +223,91 @@ test(
   }
 )
 
+test(
+  'Bridge rejects forged belongs-to values outside fixed and dependent scopes',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-scoped-relationship-tampering',
+          name: 'Bridge scoped relationship tampering'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, expect }) => {
+    const current = world.current
+    const app = current.apps.web
+    const environment = current.environments.production
+    const project = current.projects.deploymentTarget
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+    const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+    const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+      models: scopedRelationshipModels(),
+      config: scopedRelationshipConfig()
+    })
+    let forgedField = 'chapter'
+
+    try {
+      await sails.models.app.updateOne({ id: app.id }).set({
+        status: 'running',
+        containerName: 'bridge-scoped-relationship-tampering-web'
+      })
+      sails.helpers.bridge.introspectModels = async () => ({
+        schemaVersion: contract.schemaVersion,
+        discover: contract.discover,
+        configured: contract.configured,
+        models: contract.resources
+      })
+      sails.helpers.bridge.buildSailsWrapper = async (code) => code
+      sails.helpers.bridge.executeInContainer = async (containerName, code) => {
+        expect(containerName).toBe('bridge-scoped-relationship-tampering-web')
+        const definitions = readEmbeddedValue(code, 'definitions')
+        expect(
+          definitions.find((definition) => definition.alias === 'chapter').where
+        ).toEqual({ course: 'course-1' })
+        expect(
+          definitions.find((definition) => definition.alias === 'creator').where
+        ).toEqual({ role: 'admin' })
+        return successfulResult({ missing: [forgedField] })
+      }
+
+      const createPath =
+        `/projects/${project.slug}/environments/${environment.slug}` +
+        '/bridge/lesson/new'
+      const createRecordPath =
+        `/projects/${project.slug}/environments/${environment.slug}` +
+        '/bridge/lesson/create'
+      const browser = await withCsrfFromPage(request, createPath, 'genesisUser')
+      const values = {
+        title: 'A forged lesson',
+        course: 'course-1',
+        chapter: 'chapter-from-course-2',
+        creator: 'student-1'
+      }
+
+      const chapterResponse = await browser.request.post(createRecordPath, {
+        values
+      })
+      expect(chapterResponse).toHaveStatus(303)
+      expect(chapterResponse).toHaveHeader('x-exit', 'badRequest')
+
+      forgedField = 'creator'
+      const creatorResponse = await browser.request.post(createRecordPath, {
+        values
+      })
+      expect(creatorResponse).toHaveStatus(303)
+      expect(creatorResponse).toHaveHeader('x-exit', 'badRequest')
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+      sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+      sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+    }
+  }
+)
+
 function relationshipConfig({ attach, detach }) {
   return {
     schemaVersion: 1,
@@ -286,6 +371,88 @@ function relationshipModels() {
           type: 'model',
           model: 'course'
         }
+      ]
+    }
+  }
+}
+
+function scopedRelationshipConfig() {
+  return {
+    schemaVersion: 1,
+    resources: {
+      lesson: {
+        fields: {
+          chapter: {
+            relation: {
+              search: ['title'],
+              where: { course: { fromField: 'course' } }
+            }
+          },
+          creator: {
+            relation: {
+              search: ['fullName'],
+              where: { role: 'admin' }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+function scopedRelationshipModels() {
+  return {
+    course: {
+      identity: 'course',
+      globalId: 'Course',
+      tableName: 'course',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true },
+        title: { type: 'string', required: true }
+      },
+      associations: []
+    },
+    chapter: {
+      identity: 'chapter',
+      globalId: 'Chapter',
+      tableName: 'chapter',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true },
+        title: { type: 'string', required: true },
+        course: { type: 'string', model: 'course' }
+      },
+      associations: [{ alias: 'course', type: 'model', model: 'course' }]
+    },
+    user: {
+      identity: 'user',
+      globalId: 'User',
+      tableName: 'user',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'string', required: true },
+        fullName: { type: 'string', required: true },
+        role: { type: 'string', defaultsTo: 'student' }
+      },
+      associations: []
+    },
+    lesson: {
+      identity: 'lesson',
+      globalId: 'Lesson',
+      tableName: 'lesson',
+      primaryKey: 'id',
+      attributes: {
+        id: { type: 'number', autoIncrement: true },
+        title: { type: 'string', required: true },
+        course: { type: 'string', model: 'course', required: true },
+        chapter: { type: 'string', model: 'chapter', required: true },
+        creator: { type: 'string', model: 'user', required: true }
+      },
+      associations: [
+        { alias: 'course', type: 'model', model: 'course' },
+        { alias: 'chapter', type: 'model', model: 'chapter' },
+        { alias: 'creator', type: 'model', model: 'user' }
       ]
     }
   }

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -574,6 +574,178 @@ test('Bridge rejects unsafe relationship configuration', async ({
   )
 })
 
+test('Bridge normalizes fixed and dependent relationship scopes', async ({
+  sails,
+  expect
+}) => {
+  const courseId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80251'
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: relationshipModelMetadata(),
+    config: {
+      resources: {
+        lesson: {
+          fields: {
+            chapter: {
+              relation: {
+                where: {
+                  course: { fromField: 'course' }
+                }
+              }
+            },
+            creator: {
+              relation: {
+                where: {
+                  role: { in: ['editor', 'admin'] }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  })
+
+  expect(contract.resources.lesson.relationships.chapter.where).toEqual({
+    course: { fromField: 'course' }
+  })
+  expect(contract.resources.lesson.relationships.creator.where).toEqual({
+    role: { in: ['editor', 'admin'] }
+  })
+
+  const resolved = await sails.helpers.bridge.resolveRelationshipScope.with({
+    resource: contract.resources.lesson,
+    relationship: contract.resources.lesson.relationships.chapter,
+    values: { course: courseId }
+  })
+  expect(resolved).toEqual({
+    ready: true,
+    missing: [],
+    where: { course: courseId }
+  })
+
+  const unresolved = await sails.helpers.bridge.resolveRelationshipScope.with({
+    resource: contract.resources.lesson,
+    relationship: contract.resources.lesson.relationships.chapter,
+    values: {}
+  })
+  expect(unresolved).toEqual({
+    ready: false,
+    missing: ['course'],
+    where: {}
+  })
+
+  const precognitionValues =
+    await sails.helpers.bridge.allowResourceValues.with({
+      values: { course: courseId, chapter: 'chapter-1' },
+      resource: contract.resources.lesson,
+      surface: 'create',
+      validateOnly: ['chapter']
+    })
+  expect(precognitionValues).toEqual({
+    chapter: 'chapter-1',
+    course: courseId
+  })
+})
+
+test('Bridge rejects unsafe relationship scopes and dependency cycles', async ({
+  sails,
+  expect
+}) => {
+  const cases = [
+    {
+      where: { missing: 'admin' },
+      message: 'references unavailable target field "missing"'
+    },
+    {
+      where: { role: { fromField: 'missing' } },
+      field: 'creator',
+      message: 'references unavailable source field "missing"'
+    },
+    {
+      where: { role: { not: 'admin' } },
+      field: 'creator',
+      message: 'must use only "fromField" or "in"'
+    },
+    {
+      where: { course: { fromField: 'published' } },
+      message: 'field types are incompatible'
+    }
+  ]
+
+  for (const testCase of cases) {
+    let error
+    try {
+      await sails.helpers.bridge.normalizeResourceContract.with({
+        models: relationshipModelMetadata(),
+        config: {
+          resources: {
+            lesson: {
+              fields: {
+                [testCase.field || 'chapter']: {
+                  relation: { where: testCase.where }
+                }
+              }
+            }
+          }
+        }
+      })
+    } catch (cause) {
+      error = cause
+    }
+    expect(error.message).toContain(testCase.message)
+  }
+
+  let unavailableError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: relationshipModelMetadata(),
+      config: {
+        resources: {
+          lesson: {
+            create: ['title', 'chapter'],
+            fields: {
+              chapter: {
+                relation: { where: { course: { fromField: 'course' } } }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (cause) {
+    unavailableError = cause
+  }
+  expect(unavailableError.message).toContain(
+    'depends on "course", which is unavailable on the create form'
+  )
+
+  let cycleError
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: relationshipModelMetadata(),
+      config: {
+        resources: {
+          lesson: {
+            fields: {
+              chapter: {
+                relation: { where: { course: { fromField: 'course' } } }
+              },
+              course: {
+                relation: { where: { id: { fromField: 'chapter' } } }
+              }
+            }
+          }
+        }
+      }
+    })
+  } catch (cause) {
+    cycleError = cause
+  }
+  expect(cycleError.message).toContain(
+    'relationship dependencies contain a cycle'
+  )
+})
+
 test('Bridge authorizes and verifies submitted belongs-to values', async ({
   sails,
   expect
@@ -605,7 +777,9 @@ test('Bridge authorizes and verifies submitted belongs-to values', async ({
           alias: 'chapter',
           identity: 'chapter',
           primaryKey: 'id',
-          id: chapterId
+          id: chapterId,
+          where: {},
+          invalidMessage: 'Chapter no longer exists.'
         }
       ])
       return successfulResult({ missing })
@@ -650,6 +824,179 @@ test('Bridge authorizes and verifies submitted belongs-to values', async ({
     })
   } finally {
     sails.helpers.bridge.introspectModels = originalIntrospectModels
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+test('Bridge reapplies relationship scopes when authorizing mutations', async ({
+  sails,
+  expect
+}) => {
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: relationshipModelMetadata(),
+    config: {
+      resources: {
+        lesson: {
+          fields: {
+            chapter: {
+              relation: { where: { course: { fromField: 'course' } } }
+            },
+            creator: {
+              relation: { where: { role: 'admin' } }
+            }
+          }
+        }
+      }
+    }
+  })
+  const originalIntrospectModels = sails.helpers.bridge.introspectModels
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  const values = {
+    course: 'course-1',
+    chapter: 'chapter-from-another-course',
+    creator: 'student-1'
+  }
+
+  try {
+    sails.helpers.bridge.introspectModels = async () => ({
+      schemaVersion: contract.schemaVersion,
+      discover: contract.discover,
+      configured: contract.configured,
+      models: contract.resources
+    })
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (_containerName, code) => {
+      const definitions = readEmbeddedValue(code, 'definitions')
+      expect(
+        definitions.find((definition) => definition.alias === 'chapter').where
+      ).toEqual({ course: 'course-1' })
+      expect(
+        definitions.find((definition) => definition.alias === 'creator').where
+      ).toEqual({ role: 'admin' })
+      expect(code).toContain('{ and: [definition.where, identity] }')
+      return successfulResult({ missing: ['chapter', 'creator'] })
+    }
+
+    let error
+    try {
+      await sails.helpers.bridge.authorizeRelationshipValues.with({
+        containerName: 'bridge-app-web',
+        environmentId: 220,
+        resource: contract.resources.lesson,
+        actor: { id: '7', email: 'editor@example.com' },
+        values
+      })
+    } catch (cause) {
+      error = cause
+    }
+
+    expect(error.code).toBe('BRIDGE_RELATIONSHIP_NOT_FOUND')
+    expect(error.fieldErrors).toEqual({
+      chapter: 'Chapter is not available for the selected course.',
+      creator: 'Creator is not eligible for this field.'
+    })
+  } finally {
+    sails.helpers.bridge.introspectModels = originalIntrospectModels
+    sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
+    sails.helpers.bridge.executeInContainer = originalExecuteInContainer
+  }
+})
+
+test('Bridge scopes initial and searched relationship options identically', async ({
+  sails,
+  expect
+}) => {
+  const courseId = '018f2a5c-7b34-7f8a-9c12-4a73b9d80261'
+  const contract = await sails.helpers.bridge.normalizeResourceContract.with({
+    models: relationshipModelMetadata(),
+    config: {
+      resources: {
+        lesson: {
+          fields: {
+            chapter: {
+              relation: {
+                search: ['title'],
+                where: { course: { fromField: 'course' } }
+              }
+            },
+            creator: {
+              relation: { where: { role: 'admin' } }
+            }
+          }
+        }
+      }
+    }
+  })
+  const originalBuildSailsWrapper = sails.helpers.bridge.buildSailsWrapper
+  const originalExecuteInContainer = sails.helpers.bridge.executeInContainer
+  let searchDefinition
+  let initialDefinitions
+
+  try {
+    sails.helpers.bridge.buildSailsWrapper = async (code) => code
+    sails.helpers.bridge.executeInContainer = async (_containerName, code) => {
+      if (code.includes('const definition = ')) {
+        searchDefinition = readEmbeddedValue(code, 'definition')
+        expect(code).toContain('{ and: [definition.where, textSearch] }')
+        return successfulResult({
+          options: [{ id: 'chapter-1', label: 'Scoped chapter' }],
+          page: 1,
+          limit: 20,
+          hasMore: false
+        })
+      }
+      initialDefinitions = readEmbeddedValue(code, 'definitions')
+      return successfulResult({
+        course: [],
+        chapter: [{ id: 'chapter-1', label: 'Scoped chapter' }],
+        creator: [{ id: 'admin-1', label: 'Ada Admin' }]
+      })
+    }
+
+    const searched = await sails.helpers.bridge.searchRelationshipOptions.with({
+      containerName: 'bridge-app-web',
+      resources: contract.resources,
+      resource: contract.resources.lesson,
+      relationshipAlias: 'chapter',
+      values: { course: courseId },
+      search: 'scope'
+    })
+    expect(searched.options[0].label).toBe('Scoped chapter')
+    expect(searchDefinition.where).toEqual({ course: courseId })
+
+    const initial = await sails.helpers.bridge.loadAssociationOptions.with({
+      containerName: 'bridge-app-web',
+      resources: contract.resources,
+      resource: contract.resources.lesson,
+      surface: 'create',
+      values: { course: courseId }
+    })
+    expect(initial.chapter[0].label).toBe('Scoped chapter')
+    expect(
+      initialDefinitions.find((definition) => definition.alias === 'chapter')
+        .where
+    ).toEqual({ course: courseId })
+    expect(
+      initialDefinitions.find((definition) => definition.alias === 'creator')
+        .where
+    ).toEqual({ role: 'admin' })
+
+    let overrideError
+    try {
+      await sails.helpers.bridge.searchRelationshipOptions.with({
+        containerName: 'bridge-app-web',
+        resources: contract.resources,
+        resource: contract.resources.lesson,
+        relationshipAlias: 'creator',
+        values: { role: 'student' }
+      })
+    } catch (cause) {
+      overrideError = cause
+    }
+    expect(overrideError.code).toBe('BRIDGE_RELATIONSHIP_SCOPE_INVALID')
+  } finally {
     sails.helpers.bridge.buildSailsWrapper = originalBuildSailsWrapper
     sails.helpers.bridge.executeInContainer = originalExecuteInContainer
   }
@@ -1769,7 +2116,8 @@ function relationshipModelMetadata() {
         title: { type: 'string', required: true },
         chapter: { type: 'string', model: 'chapter' },
         course: { type: 'string', model: 'course' },
-        creator: { type: 'string', model: 'user' }
+        creator: { type: 'string', model: 'user' },
+        published: { type: 'boolean', defaultsTo: false }
       },
       associations: [
         { alias: 'chapter', type: 'model', model: 'chapter' },
@@ -1784,7 +2132,12 @@ function relationshipModelMetadata() {
       primaryKey: 'id',
       attributes: {
         id: { type: 'string', required: true, isUUID: true },
-        fullName: { type: 'string', required: true }
+        fullName: { type: 'string', required: true },
+        role: {
+          type: 'string',
+          isIn: ['student', 'editor', 'admin'],
+          defaultsTo: 'student'
+        }
       },
       associations: []
     }


### PR DESCRIPTION
Adds a normalized, server-enforced where contract for fixed and dependent belongs-to choices.

- scopes initial options, search, pagination, edit hydration, mutations, and relationship-backed uploads
- disables unresolved dependent selectors, prefetches new scopes, aborts stale requests, and clears downstream selections
- preserves legacy out-of-scope labels while blocking invalid submission
- documents fixed equality, bounded in lists, and fromField dependencies
- covers contract validation, forged requests, fixed role scopes, and Course to Chapter browser behavior

Closes #365