### PR TITLE
Fix deployment history release outcomes

### DIFF
--- a/api/controllers/api/v1/deploy/get-active-deployments.js
+++ b/api/controllers/api/v1/deploy/get-active-deployments.js
@@ -49,6 +49,9 @@ module.exports = {
 
     // Get all apps for these environments (for app name enrichment)
     const apps = await App.find({ environment: environmentIds })
+    const currentDeploymentIds = apps
+      .map((app) => app.currentDeployment)
+      .filter(Boolean)
 
     // Enrich with project/environment/app info
     const enriched = []
@@ -67,9 +70,14 @@ module.exports = {
             apps.find((a) => a.environment === env.id)
         }
 
+        const outcome = sails.helpers.deployment.describeOutcome.with({
+          deployment,
+          currentDeploymentIds
+        })
+
         enriched.push({
           id: deployment.id,
-          status: deployment.status,
+          ...outcome,
           gitBranch: deployment.gitBranch,
           gitCommit: deployment.gitCommit
             ? deployment.gitCommit.slice(0, 7)

--- a/api/controllers/api/v1/deploy/get-deployment-status.js
+++ b/api/controllers/api/v1/deploy/get-deployment-status.js
@@ -49,11 +49,14 @@ module.exports = {
 
     const duration = Deployment.getDuration(deployment)
     const queuePosition = await DeploymentJob.getQueuePosition(deployment.id)
+    const outcome = await sails.helpers.deployment.resolveOutcome.with({
+      deployment
+    })
 
     return {
       deployment: {
         id: deployment.id,
-        status: deployment.status,
+        ...outcome,
         gitCommit: deployment.gitCommit,
         gitBranch: deployment.gitBranch,
         gitMessage: deployment.gitMessage,

--- a/api/controllers/api/v1/deploy/stream-active-deployments.js
+++ b/api/controllers/api/v1/deploy/stream-active-deployments.js
@@ -90,6 +90,9 @@ async function fetchActiveDeployments(teamId) {
   if (activeDeployments.length === 0) return []
 
   const apps = await App.find({ environment: environmentIds })
+  const currentDeploymentIds = apps
+    .map((app) => app.currentDeployment)
+    .filter(Boolean)
 
   const enriched = []
   for (const deployment of activeDeployments) {
@@ -106,9 +109,14 @@ async function fetchActiveDeployments(teamId) {
           apps.find((a) => a.environment === env.id)
       }
 
+      const outcome = sails.helpers.deployment.describeOutcome.with({
+        deployment,
+        currentDeploymentIds
+      })
+
       enriched.push({
         id: deployment.id,
-        status: deployment.status,
+        ...outcome,
         gitBranch: deployment.gitBranch,
         gitCommit: deployment.gitCommit
           ? deployment.gitCommit.slice(0, 7)

--- a/api/controllers/api/v1/deploy/stream-deployment.js
+++ b/api/controllers/api/v1/deploy/stream-deployment.js
@@ -41,11 +41,13 @@ module.exports = {
 
     const stream = res.sse()
 
-    // Send initial status
-    stream.send({ status: deployment.status })
+    // Send initial lifecycle state and user-facing release outcome.
+    stream.send(await deploymentState(deployment))
 
     // If deployment is already complete, end immediately
-    if (['running', 'failed', 'cancelled'].includes(deployment.status)) {
+    if (
+      ['running', 'stopped', 'failed', 'cancelled'].includes(deployment.status)
+    ) {
       stream.close()
       return
     }
@@ -58,7 +60,15 @@ module.exports = {
         const current = await Deployment.findOne(id)
 
         if (!current) {
-          stream.send({ status: 'failed', error: 'Deployment not found' })
+          stream.send({
+            status: 'failed',
+            outcome: 'failed',
+            outcomeLabel: 'Failed',
+            isCurrent: false,
+            isActive: false,
+            appId: null,
+            error: 'Deployment not found'
+          })
           clearInterval(checkInterval)
           stream.close()
           return
@@ -67,7 +77,7 @@ module.exports = {
         // Send status update if changed
         if (current.status !== lastStatus) {
           lastStatus = current.status
-          stream.send({ status: current.status })
+          stream.send(await deploymentState(current))
         }
 
         // Stream new build log output if available
@@ -82,7 +92,9 @@ module.exports = {
         }
 
         // End stream when deployment is complete
-        if (['running', 'failed', 'cancelled'].includes(current.status)) {
+        if (
+          ['running', 'stopped', 'failed', 'cancelled'].includes(current.status)
+        ) {
           clearInterval(checkInterval)
           stream.close()
         }
@@ -97,4 +109,8 @@ module.exports = {
 
     return stream.wait()
   }
+}
+
+async function deploymentState(deployment) {
+  return await sails.helpers.deployment.resolveOutcome.with({ deployment })
 }

--- a/api/controllers/api/v1/environment/get-environment.js
+++ b/api/controllers/api/v1/environment/get-environment.js
@@ -58,6 +58,26 @@ module.exports = {
 
     // Get Docker health status for all apps
     const apps = await App.find({ environment: environment.id })
+    const currentDeploymentIds = apps
+      .map((app) => app.currentDeployment)
+      .filter(Boolean)
+    const defaultApp = apps.find((app) => app.isDefault) || apps[0] || null
+    const deployments = (environment.deployments || []).map((deployment) => {
+      const deploymentApp = deployment.app
+        ? apps.find(
+            (app) =>
+              String(app.id) === String(deployment.app?.id || deployment.app)
+          )
+        : defaultApp
+      return {
+        ...deployment,
+        ...sails.helpers.deployment.describeOutcome.with({
+          deployment,
+          currentDeploymentIds
+        }),
+        appId: deploymentApp?.id || null
+      }
+    })
     const appsWithHealth = []
     for (const a of apps) {
       let containerHealth = null
@@ -85,6 +105,7 @@ module.exports = {
         generatedDomain,
         domains,
         app: appsWithHealth,
+        deployments,
         containerHealth: appsWithHealth[0]?.containerHealth || null
       }
     }

--- a/api/controllers/project/view-deployment.js
+++ b/api/controllers/project/view-deployment.js
@@ -55,13 +55,9 @@ module.exports = {
     const duration = Deployment.getDuration(deployment)
     const queuePosition = await DeploymentJob.getQueuePosition(deployment.id)
 
-    // Check if this is the currently active deployment
-    const app =
-      (await App.findOne({ environment: environment.id, isDefault: true })) ||
-      (await App.findOne({ environment: environment.id }))
-    const isCurrentDeployment = app
-      ? app.currentDeployment === deployment.id
-      : false
+    const outcome = await sails.helpers.deployment.resolveOutcome.with({
+      deployment
+    })
 
     return {
       page: 'projects/deployment',
@@ -72,7 +68,8 @@ module.exports = {
           ...deployment,
           duration,
           queuePosition,
-          isCurrentDeployment,
+          ...outcome,
+          isCurrentDeployment: outcome.isCurrent,
           triggeredBy: deployment.triggeredBy
             ? {
                 id: deployment.triggeredBy.id,

--- a/api/helpers/deployment/describe-outcome.js
+++ b/api/helpers/deployment/describe-outcome.js
@@ -1,0 +1,108 @@
+const ACTIVE_LABELS = {
+  pending: 'Queued',
+  building: 'Building',
+  pushing: 'Publishing',
+  deploying: 'Deploying'
+}
+const SUCCESS_STATUSES = ['running', 'stopped', 'success']
+
+module.exports = {
+  friendlyName: 'Describe deployment outcome',
+
+  description:
+    'Keep deployment lifecycle state separate from the release that currently owns traffic.',
+
+  sync: true,
+
+  inputs: {
+    deployment: {
+      type: 'ref',
+      required: true
+    },
+    currentDeploymentIds: {
+      type: 'ref',
+      defaultsTo: []
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: function ({ deployment, currentDeploymentIds }) {
+    const currentIds = new Set(
+      (Array.isArray(currentDeploymentIds) ? currentDeploymentIds : [])
+        .map(Number)
+        .filter(Number.isFinite)
+    )
+    const isCurrent = currentIds.has(Number(deployment.id))
+    const status = deployment.status
+
+    if (isCurrent) {
+      return {
+        status,
+        outcome: 'current',
+        outcomeLabel: 'Current',
+        isCurrent: true,
+        isActive: false
+      }
+    }
+
+    if (ACTIVE_LABELS[status]) {
+      return {
+        status,
+        outcome: 'in-progress',
+        outcomeLabel: ACTIVE_LABELS[status],
+        isCurrent: false,
+        isActive: true
+      }
+    }
+
+    if (SUCCESS_STATUSES.includes(status)) {
+      return {
+        status,
+        outcome: 'succeeded',
+        outcomeLabel: 'Succeeded',
+        isCurrent: false,
+        isActive: false
+      }
+    }
+
+    if (status === 'failed') {
+      return {
+        status,
+        outcome: 'failed',
+        outcomeLabel: 'Failed',
+        isCurrent: false,
+        isActive: false
+      }
+    }
+
+    if (status === 'cancelled') {
+      return {
+        status,
+        outcome: 'cancelled',
+        outcomeLabel: 'Cancelled',
+        isCurrent: false,
+        isActive: false
+      }
+    }
+
+    return {
+      status,
+      outcome: 'neutral',
+      outcomeLabel: humanize(status),
+      isCurrent: false,
+      isActive: false
+    }
+  }
+}
+
+function humanize(value) {
+  const text = String(value || 'Unknown').replace(/[-_]+/g, ' ')
+  return text.charAt(0).toUpperCase() + text.slice(1)
+}
+
+module.exports._private = { ACTIVE_LABELS, SUCCESS_STATUSES, humanize }

--- a/api/helpers/deployment/get-history.js
+++ b/api/helpers/deployment/get-history.js
@@ -32,32 +32,6 @@ function decodeCursor(cursor) {
   }
 }
 
-function outcomeFor(deployment, isCurrent) {
-  if (isCurrent) return { key: 'current', label: 'Current' }
-
-  const activeLabels = {
-    pending: 'Queued',
-    building: 'Building',
-    pushing: 'Publishing',
-    deploying: 'Deploying'
-  }
-
-  if (activeLabels[deployment.status]) {
-    return { key: 'in-progress', label: activeLabels[deployment.status] }
-  }
-  if (SUCCESS_STATUSES.includes(deployment.status)) {
-    return { key: 'succeeded', label: 'Succeeded' }
-  }
-  if (deployment.status === 'failed') {
-    return { key: 'failed', label: 'Failed' }
-  }
-  if (deployment.status === 'cancelled') {
-    return { key: 'cancelled', label: 'Cancelled' }
-  }
-
-  return { key: 'neutral', label: deployment.status }
-}
-
 function titleFor(deployment) {
   if (deployment.gitMessage) return deployment.gitMessage
   if (deployment.triggerType === 'webhook') return 'Git deployment'
@@ -98,18 +72,16 @@ function serializeDeployment({
     appById.get(appId) ||
     defaultAppByEnvironment.get(environmentId) ||
     null
-  const isCurrent = currentDeploymentIds.has(Number(deployment.id))
-  const outcome = outcomeFor(deployment, isCurrent)
+  const state = sails.helpers.deployment.describeOutcome.with({
+    deployment,
+    currentDeploymentIds: [...currentDeploymentIds]
+  })
   const duration = Deployment.getDuration(deployment)
 
   return {
     id: deployment.id,
     title: titleFor(deployment),
-    status: deployment.status,
-    outcome: outcome.key,
-    outcomeLabel: outcome.label,
-    isCurrent,
-    isActive: ACTIVE_STATUSES.includes(deployment.status),
+    ...state,
     gitCommit: deployment.gitCommit,
     gitBranch: deployment.gitBranch,
     source: deployment.triggerType,
@@ -336,10 +308,11 @@ module.exports = {
         health:
           currentApp?.containerHealth === 'unhealthy'
             ? 'Unhealthy'
-            : currentApp?.status === 'running'
+            : currentApp?.containerHealth === 'healthy' ||
+              currentApp?.containerRunning === true
             ? 'Healthy'
-            : currentApp?.status
-            ? currentApp.status[0].toUpperCase() + currentApp.status.slice(1)
+            : currentApp?.status === 'stopped'
+            ? 'Stopped'
             : 'Unknown',
         appHref:
           serialized.environment && serialized.app
@@ -395,7 +368,6 @@ module.exports = {
     ACTIVE_STATUSES,
     decodeCursor,
     encodeCursor,
-    outcomeFor,
     serializeDeployment
   }
 }

--- a/api/helpers/deployment/resolve-outcome.js
+++ b/api/helpers/deployment/resolve-outcome.js
@@ -1,0 +1,55 @@
+module.exports = {
+  friendlyName: 'Resolve deployment outcome',
+
+  description:
+    'Resolve the App traffic owner for a deployment and return its user-facing outcome.',
+
+  inputs: {
+    deployment: {
+      type: 'ref',
+      required: true
+    },
+    app: {
+      type: 'ref'
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ deployment, app }) {
+    const associatedAppId =
+      deployment.app && typeof deployment.app === 'object'
+        ? deployment.app.id
+        : deployment.app
+    const environmentId =
+      deployment.environment && typeof deployment.environment === 'object'
+        ? deployment.environment.id
+        : deployment.environment
+
+    let resolvedApp = app || null
+    if (!resolvedApp && associatedAppId) {
+      resolvedApp = await App.findOne({ id: associatedAppId })
+    }
+    if (!resolvedApp && environmentId) {
+      resolvedApp =
+        (await App.findOne({ environment: environmentId, isDefault: true })) ||
+        (await App.findOne({ environment: environmentId }))
+    }
+
+    const state = sails.helpers.deployment.describeOutcome.with({
+      deployment,
+      currentDeploymentIds: resolvedApp?.currentDeployment
+        ? [resolvedApp.currentDeployment]
+        : []
+    })
+
+    return {
+      ...state,
+      appId: resolvedApp?.id || associatedAppId || null
+    }
+  }
+}

--- a/api/helpers/notification/send-deployment-notification.js
+++ b/api/helpers/notification/send-deployment-notification.js
@@ -22,9 +22,11 @@ module.exports = {
   },
 
   fn: async function ({ deployment, project, environment }) {
-    const status = deployment.status
-    const isSuccess = status === 'running' || status === 'success'
-    const isFailure = status === 'failed'
+    const outcome = await sails.helpers.deployment.resolveOutcome.with({
+      deployment
+    })
+    const isSuccess = ['current', 'succeeded'].includes(outcome.outcome)
+    const isFailure = outcome.outcome === 'failed'
 
     // Check notification preferences
     const notifyOnSuccess = await sails.helpers.setting.get(
@@ -57,7 +59,7 @@ module.exports = {
     const appName = app ? app.name : project.name
 
     const emoji = isSuccess ? '\u2705' : '\u274C'
-    const statusText = isSuccess ? 'succeeded' : 'failed'
+    const statusText = outcome.outcomeLabel.toLowerCase()
     const slippyTitle = isSuccess
       ? 'Deployment successful'
       : 'Deployment failed'
@@ -209,6 +211,9 @@ module.exports = {
             deployment: {
               id: deployment.id,
               status: deployment.status,
+              outcome: outcome.outcome,
+              outcomeLabel: outcome.outcomeLabel,
+              isCurrent: outcome.isCurrent,
               gitBranch: deployment.gitBranch,
               gitCommitShort: deployment.gitCommitShort
             },

--- a/assets/js/components/DeploymentHistory.vue
+++ b/assets/js/components/DeploymentHistory.vue
@@ -73,9 +73,22 @@ function refreshHistory() {
   })
 }
 
-function patchStatus(deploymentId, status) {
-  const patch = (deployment) =>
-    deployment.id === deploymentId ? { ...deployment, status } : deployment
+function patchState(deploymentId, state) {
+  const patch = (deployment) => {
+    const sameApp =
+      state.appId && String(deployment.app?.id || '') === String(state.appId)
+    const demoted =
+      state.isCurrent && sameApp && deployment.id !== deploymentId
+        ? {
+            ...deployment,
+            isCurrent: false,
+            outcome: 'succeeded',
+            outcomeLabel: 'Succeeded'
+          }
+        : deployment
+
+    return deployment.id === deploymentId ? { ...demoted, ...state } : demoted
+  }
 
   deployments.value = deployments.value.map(patch)
   activeDeployments.value = activeDeployments.value.map(patch)
@@ -111,7 +124,14 @@ function connectActiveDeployments() {
         const data = JSON.parse(event.data)
         if (!data.status) return
 
-        patchStatus(deployment.id, data.status)
+        patchState(deployment.id, {
+          status: data.status,
+          outcome: data.outcome,
+          outcomeLabel: data.outcomeLabel,
+          isCurrent: data.isCurrent,
+          isActive: data.isActive,
+          appId: data.appId
+        })
 
         if (
           ['running', 'failed', 'cancelled', 'stopped'].includes(data.status)
@@ -154,68 +174,36 @@ onBeforeUnmount(() => {
   activeSources.clear()
 })
 
-function statusBadge(status) {
+function outcomeBadge(deployment) {
   const map = {
-    running: {
-      label: 'Running',
+    current: {
       classes:
-        'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+        'bg-emerald-100 text-emerald-800 ring-1 ring-inset ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-300 dark:ring-emerald-400/20'
     },
-    building: {
-      label: 'Building',
+    succeeded: {
       classes:
-        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+        'bg-gray-100 text-gray-700 ring-1 ring-inset ring-gray-500/15 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-400/20'
     },
-    pushing: {
-      label: 'Pushing',
+    'in-progress': {
       classes:
-        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-    },
-    deploying: {
-      label: 'Deploying',
-      classes:
-        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-    },
-    pending: {
-      label: 'Queued',
-      classes:
-        'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+        'bg-blue-100 text-blue-700 ring-1 ring-inset ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-400/20'
     },
     failed: {
-      label: 'Failed',
-      classes: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-    },
-    stopped: {
-      label: 'Stopped',
-      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+      classes:
+        'bg-red-100 text-red-700 ring-1 ring-inset ring-red-600/20 dark:bg-red-900/30 dark:text-red-300 dark:ring-red-400/20'
     },
     cancelled: {
-      label: 'Cancelled',
-      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-    },
-    creating: {
-      label: 'Creating',
       classes:
-        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+        'bg-gray-100 text-gray-600 ring-1 ring-inset ring-gray-500/15 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-400/20'
     }
   }
 
-  return (
-    map[status] || {
-      label: status,
-      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-    }
-  )
-}
-
-function statusDotClasses(status) {
-  if (status === 'running') return 'bg-green-500'
-  if (status === 'failed') return 'bg-red-500'
-  if (['building', 'pushing', 'deploying'].includes(status)) {
-    return 'bg-blue-500'
+  return {
+    label: deployment.outcomeLabel || deployment.status,
+    classes:
+      map[deployment.outcome]?.classes ||
+      'bg-gray-100 text-gray-600 ring-1 ring-inset ring-gray-500/15 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-400/20'
   }
-  if (['cancelled', 'stopped'].includes(status)) return 'bg-gray-400'
-  return 'bg-yellow-500'
 }
 
 function timeAgo(date) {
@@ -239,18 +227,17 @@ function timeAgo(date) {
 }
 
 function deploymentTestId(deployment) {
-  if (deployment.status === 'failed') return 'failed-deployment-row'
-  if (
-    ['pending', 'building', 'pushing', 'deploying'].includes(deployment.status)
-  ) {
-    return 'active-deployment-row'
-  }
+  if (deployment.outcome === 'failed') return 'failed-deployment-row'
+  if (deployment.isActive) return 'active-deployment-row'
   return 'deployment-history-row'
 }
 </script>
 
 <template>
-  <div v-if="deployments.length > 0 || !hideWhenEmpty">
+  <div
+    v-if="deployments.length > 0 || !hideWhenEmpty"
+    data-testid="deployment-history-section"
+  >
     <h2 class="mb-4 text-sm font-medium text-gray-900 dark:text-white">
       {{ title }}
     </h2>
@@ -276,12 +263,6 @@ function deploymentTestId(deployment) {
         >
           <div class="flex items-center space-x-3">
             <span
-              :class="[
-                'h-2 w-2 rounded-full',
-                statusDotClasses(deployment.status)
-              ]"
-            ></span>
-            <span
               v-if="showEnvironment"
               class="text-sm text-gray-900 dark:text-white"
             >
@@ -290,11 +271,11 @@ function deploymentTestId(deployment) {
             <span
               v-if="showStatus"
               :class="[
-                'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium',
-                statusBadge(deployment.status).classes
+                'inline-flex items-center whitespace-nowrap rounded-md px-2 py-0.5 text-xs font-medium',
+                outcomeBadge(deployment).classes
               ]"
             >
-              {{ statusBadge(deployment.status).label }}
+              {{ outcomeBadge(deployment).label }}
             </span>
             <span
               v-if="deployment.app?.name"

--- a/assets/js/components/DeploymentToast.vue
+++ b/assets/js/components/DeploymentToast.vue
@@ -11,6 +11,8 @@ const props = defineProps({
 const emit = defineEmits(['status-change', 'dismiss'])
 
 const status = ref(props.deployment.status)
+const outcome = ref(props.deployment.outcome)
+const outcomeLabel = ref(props.deployment.outcomeLabel)
 const startTime = ref(props.deployment.startedAt || Date.now())
 const elapsed = ref(0)
 const dismissed = ref(false)
@@ -121,12 +123,19 @@ const statusConfig = computed(() => {
       icon: 'x'
     }
   }
-  return configs[status.value] || configs.pending
+  const config = configs[status.value] || configs.pending
+  return {
+    ...config,
+    label: outcomeLabel.value || config.label
+  }
 })
 
 const isActive = computed(() => {
   return ['pending', 'building', 'pushing', 'deploying'].includes(status.value)
 })
+const isSuccessful = computed(() =>
+  ['current', 'succeeded'].includes(outcome.value)
+)
 
 const elapsedFormatted = computed(() => {
   const mins = Math.floor(elapsed.value / 60)
@@ -141,11 +150,15 @@ const { close: closeStream, connect: connectToStream } = useEventSource(
     onMessage(data) {
       if (data.status) {
         status.value = data.status
+        outcome.value = data.outcome
+        outcomeLabel.value = data.outcomeLabel
         emit('status-change', {
           deploymentId: props.deployment.id,
-          status: data.status
+          ...data
         })
-        if (['running', 'failed', 'cancelled'].includes(data.status)) {
+        if (
+          ['running', 'stopped', 'failed', 'cancelled'].includes(data.status)
+        ) {
           closeStream()
           setTimeout(() => dismiss(), 5000)
         }
@@ -190,6 +203,20 @@ watch(
   () => props.deployment.status,
   (newStatus) => {
     status.value = newStatus
+  }
+)
+
+watch(
+  () => props.deployment.outcome,
+  (newOutcome) => {
+    outcome.value = newOutcome
+  }
+)
+
+watch(
+  () => props.deployment.outcomeLabel,
+  (newLabel) => {
+    outcomeLabel.value = newLabel
   }
 )
 
@@ -241,7 +268,7 @@ watch(status, (newStatus) => {
               'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg',
               isActive
                 ? 'bg-gray-100 dark:bg-gray-800'
-                : status === 'running'
+                : isSuccessful
                 ? 'bg-emerald-500/20'
                 : 'bg-red-500/20'
             ]"
@@ -250,7 +277,7 @@ watch(status, (newStatus) => {
             <SlippyLoader v-if="isActive" class="text-brand dark:text-white" />
             <!-- Check for success -->
             <svg
-              v-else-if="status === 'running'"
+              v-else-if="isSuccessful"
               class="h-5 w-5 text-emerald-400"
               fill="none"
               stroke="currentColor"

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -211,13 +211,13 @@ const { close: disconnectDeploymentStream } = useEventSource(
   }
 )
 
-function updateDeploymentStatus({ deploymentId, status }) {
+function updateDeploymentStatus({ deploymentId, ...state }) {
   const deployment = activeDeployments.value.find(
     ({ id }) => String(id) === String(deploymentId)
   )
-  if (deployment) deployment.status = status
+  if (deployment) Object.assign(deployment, state)
 
-  deploymentFavicon.noteDeploymentStatus(deploymentId, status)
+  deploymentFavicon.noteDeploymentStatus(deploymentId, state.status)
 }
 
 function dismissDeployment(deploymentId) {

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -30,16 +30,20 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 const logContainer = ref(null)
 
 // SSE-powered real-time updates
-const sseStatus = ref(null)
+const sseState = ref(null)
 const sseLogs = ref('')
 
 const deployment = computed(() => ({
   ...props.deployment,
-  ...(sseStatus.value ? { status: sseStatus.value } : {})
+  ...(sseState.value || {})
 }))
 
-const isInProgress = computed(() =>
-  ['pending', 'building', 'deploying'].includes(deployment.value.status)
+const isInProgress = computed(
+  () =>
+    deployment.value.isActive ??
+    ['pending', 'building', 'pushing', 'deploying'].includes(
+      deployment.value.status
+    )
 )
 
 const allLogs = computed(() => {
@@ -135,8 +139,18 @@ const { close: disconnectDeploymentStream } = useEventSource(
     immediate: isInProgress.value,
     onMessage(data) {
       if (data.status) {
-        sseStatus.value = data.status
-        if (['running', 'failed', 'cancelled'].includes(data.status)) {
+        sseState.value = {
+          status: data.status,
+          outcome: data.outcome,
+          outcomeLabel: data.outcomeLabel,
+          isCurrent: data.isCurrent,
+          isCurrentDeployment: data.isCurrent,
+          isActive: data.isActive,
+          appId: data.appId
+        }
+        if (
+          ['running', 'stopped', 'failed', 'cancelled'].includes(data.status)
+        ) {
           disconnectDeploymentStream()
           router.reload()
         }
@@ -160,47 +174,33 @@ watch(
   { immediate: true }
 )
 
-function statusBadge(status) {
+function outcomeBadge(deployment) {
   const map = {
-    running: {
-      label: 'Running',
+    current: {
       classes:
-        'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
+        'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
     },
-    building: {
-      label: 'Building',
-      classes:
-        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
+    succeeded: {
+      classes: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
     },
-    deploying: {
-      label: 'Deploying',
+    'in-progress': {
       classes:
-        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'
-    },
-    pending: {
-      label: 'Queued',
-      classes:
-        'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/30 dark:text-yellow-400'
+        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
     },
     failed: {
-      label: 'Failed',
       classes: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
     },
-    stopped: {
-      label: 'Stopped',
-      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-    },
     cancelled: {
-      label: 'Cancelled',
       classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
     }
   }
-  return (
-    map[status] || {
-      label: status,
-      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-    }
-  )
+
+  return {
+    label: deployment.outcomeLabel || deployment.status,
+    classes:
+      map[deployment.outcome]?.classes ||
+      'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+  }
 }
 
 function formatDuration(seconds) {
@@ -234,7 +234,14 @@ async function cancelDeployment() {
 
     if (res.ok) {
       disconnectDeploymentStream()
-      sseStatus.value = 'cancelled'
+      sseState.value = {
+        status: 'cancelled',
+        outcome: 'cancelled',
+        outcomeLabel: 'Cancelled',
+        isCurrent: false,
+        isCurrentDeployment: false,
+        isActive: false
+      }
       router.reload()
     } else {
       const data = await res.json()
@@ -250,9 +257,9 @@ async function cancelDeployment() {
 // Rollback
 const canRollback = computed(
   () =>
-    props.deployment.status === 'running' &&
-    !props.deployment.isCurrentDeployment &&
-    props.deployment.imageName
+    deployment.value.outcome === 'succeeded' &&
+    !deployment.value.isCurrent &&
+    deployment.value.imageName
 )
 
 const rollingBack = ref(false)
@@ -496,16 +503,10 @@ function executeRollback() {
               <span
                 :class="[
                   'inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium',
-                  statusBadge(deployment.status).classes
+                  outcomeBadge(deployment).classes
                 ]"
               >
-                {{ statusBadge(deployment.status).label }}
-              </span>
-              <span
-                v-if="deployment.isCurrentDeployment"
-                class="bg-brand/10 text-brand inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium"
-              >
-                current
+                {{ outcomeBadge(deployment).label }}
               </span>
               <span
                 v-if="isInProgress"

--- a/packages/cli/src/commands/deployments.js
+++ b/packages/cli/src/commands/deployments.js
@@ -64,7 +64,7 @@ export default async function deployments(options) {
 
     const rows = limited.map((d) => [
       String(d.id),
-      statusColor(d.status),
+      statusColor(d.outcome || d.status, d.outcomeLabel || d.status),
       d.environment,
       d.gitBranch || '-',
       d.gitCommit ? d.gitCommit.substring(0, 7) : '-',

--- a/packages/cli/src/lib/utils.js
+++ b/packages/cli/src/lib/utils.js
@@ -54,18 +54,22 @@ export function formatDuration(seconds) {
   return `${minutes}m ${secs}s`
 }
 
-export function statusColor(status) {
+export function statusColor(status, label = status) {
   const colorMap = {
     running: c.success,
+    current: c.success,
+    succeeded: c.success,
     pending: c.warn,
     building: c.info,
+    pushing: c.info,
     deploying: c.info,
+    'in-progress': c.info,
     stopped: c.gray,
     failed: c.error,
     cancelled: c.gray
   }
   const colorFn = colorMap[status] || ((s) => s)
-  return colorFn(status)
+  return colorFn(label)
 }
 
 // Simple spinner using stdout

--- a/tests/e2e/pages/deployment-favicon.test.js
+++ b/tests/e2e/pages/deployment-favicon.test.js
@@ -34,7 +34,7 @@ test(
 
     await page.raw
       .locator('.pointer-events-none.fixed.bottom-4.right-4')
-      .getByText('Deployed', { exact: true })
+      .getByText('Succeeded', { exact: true })
       .first()
       .waitFor({ state: 'visible' })
     expect(await faviconState(page)).toBe('deploying')

--- a/tests/e2e/pages/projects/deployment-history.test.js
+++ b/tests/e2e/pages/projects/deployment-history.test.js
@@ -1,4 +1,5 @@
 const { test } = require('sounding')
+const path = require('node:path')
 
 async function seedHistory({ sails, world }) {
   const current = world.current
@@ -18,9 +19,9 @@ async function seedHistory({ sails, world }) {
     finishedAt: now - 90000,
     createdAt: now - 100000
   })
-  await world.create('deployment').with({
+  const previousRelease = await world.create('deployment').with({
     ...target,
-    status: 'stopped',
+    status: 'running',
     triggerType: 'webhook',
     gitMessage: 'Previous successful release',
     startedAt: now - 80000,
@@ -36,7 +37,7 @@ async function seedHistory({ sails, world }) {
     finishedAt: now - 45000,
     createdAt: now - 50000
   })
-  await world.create('deployment').with({
+  const buildingRelease = await world.create('deployment').with({
     ...target,
     status: 'building',
     triggerType: 'manual',
@@ -62,7 +63,11 @@ async function seedHistory({ sails, world }) {
   return {
     projectSlug: current.projects.deploymentTarget.slug,
     environmentSlug: current.environments.production.slug,
-    appSlug: current.apps.web.slug
+    appSlug: current.apps.web.slug,
+    currentReleaseId: currentRelease.id,
+    previousReleaseId: previousRelease.id,
+    buildingReleaseId: buildingRelease.id,
+    appId: current.apps.web.id
   }
 }
 
@@ -94,11 +99,11 @@ test(
     await page.wait('@active-deployment-row')
     await page.wait('@failed-deployment-row')
     await expect(page).toSee('Deployments')
-    await expect(page).toSee('Running')
+    await expect(page).toSee('Current')
     await expect(page).toSee('Building')
     await expect(page).toSee('Queued')
     await expect(page).toSee('Failed')
-    await expect(page).toSee('Stopped')
+    await expect(page).toSee('Succeeded')
     await expect(page).toSee('main')
     await expect(page).toSee('c0ffee1')
 
@@ -109,10 +114,12 @@ test(
     )
     expect(rows.length).toBe(5)
     expect(rows[0].includes('Building')).toBe(true)
-    expect(rows[1].includes('Running')).toBe(true)
+    expect(rows[1].includes('Current')).toBe(true)
     expect(rows[2].includes('Queued')).toBe(true)
     expect(rows[3].includes('Failed')).toBe(true)
-    expect(rows[4].includes('Stopped')).toBe(true)
+    expect(rows[4].includes('Succeeded')).toBe(true)
+    expect(rows.filter((row) => row.includes('Current')).length).toBe(1)
+    expect(rows.some((row) => row.includes('Running'))).toBe(false)
 
     const deploymentToasts = await page.raw
       .locator('.pointer-events-none.fixed.bottom-4.right-4')
@@ -121,8 +128,34 @@ test(
       deploymentToasts.indexOf('Building') < deploymentToasts.indexOf('Queued')
     ).toBe(true)
 
-    await page.screenshot('.tmp/deployment-queue-order.png', {
-      fullPage: true
+    await page.raw
+      .locator('.pointer-events-none.fixed.bottom-4.right-4')
+      .evaluate((element) => element.setAttribute('hidden', ''))
+    await page.raw
+      .locator('[data-testid="deployment-history-section"]')
+      .screenshot({
+        path: path.resolve('.tmp/issue-377-deployment-outcomes.png')
+      })
+
+    // A completed SSE transition must transfer the Current outcome without
+    // briefly leaving the previous traffic owner presented as Current.
+    await sails.models.app.updateOne({ id: target.appId }).set({
+      currentDeployment: target.buildingReleaseId,
+      lastDeployedAt: Date.now()
+    })
+    await sails.models.deployment
+      .updateOne({ id: target.buildingReleaseId })
+      .set({ status: 'running', finishedAt: Date.now() })
+
+    await page.raw.waitForFunction(() => {
+      const rows = [
+        ...document.querySelectorAll('[data-testid="deployment-row"]')
+      ].map((row) => row.textContent)
+      return (
+        rows.filter((row) => row.includes('Current')).length === 1 &&
+        rows.filter((row) => row.includes('Succeeded')).length >= 2 &&
+        rows.every((row) => !row.includes('Running'))
+      )
     })
     expect(page).toHaveNoJavascriptErrors()
   }
@@ -143,11 +176,11 @@ test(
     await page.wait('@deployment-history')
     await page.wait('@active-deployment-row')
     await expect(page).toSee('Deployments')
-    await expect(page).toSee('Running')
+    await expect(page).toSee('Current')
     await expect(page).toSee('Building')
     await expect(page).toSee('Queued')
     await expect(page).toSee('Failed')
-    await expect(page).toSee('Stopped')
+    await expect(page).toSee('Succeeded')
     expect(page).toHaveNoJavascriptErrors()
   }
 )

--- a/tests/functional/pages/projects.test.js
+++ b/tests/functional/pages/projects.test.js
@@ -249,7 +249,9 @@ test(
 
     const tiedAt = baseTime + 200000
     const firstTie = await world.create('deployment').with({
-      status: 'stopped',
+      // Legacy successful releases can remain `running` after traffic moves on.
+      // The App pointer, not this lifecycle value, owns the user-facing outcome.
+      status: 'running',
       environment: environment.id,
       app: app.id,
       gitMessage: 'Tie A',
@@ -291,8 +293,16 @@ test(
       'Current'
     )
     expect(firstPage).toHaveInertiaProp(
-      'deploymentHistory.items.2.outcomeLabel',
+      'deploymentHistory.items.1.outcomeLabel',
       'Succeeded'
+    )
+    expect(firstPage).toHaveInertiaProp(
+      'deploymentHistory.items.0.isCurrent',
+      true
+    )
+    expect(firstPage).toHaveInertiaProp(
+      'deploymentHistory.items.1.isCurrent',
+      false
     )
     expect(firstPage).toHaveInertiaProp(
       'deploymentHistory.currentReleases.0.id',

--- a/tests/unit/helpers/deployment/describe-outcome.test.js
+++ b/tests/unit/helpers/deployment/describe-outcome.test.js
@@ -1,0 +1,36 @@
+const { test } = require('sounding')
+
+test('deployment outcomes separate traffic ownership from lifecycle status', ({
+  sails,
+  expect
+}) => {
+  const describe = (deployment, currentDeploymentIds = []) =>
+    sails.helpers.deployment.describeOutcome.with({
+      deployment,
+      currentDeploymentIds
+    })
+
+  expect(describe({ id: 42, status: 'running' }, [42])).toEqual({
+    status: 'running',
+    outcome: 'current',
+    outcomeLabel: 'Current',
+    isCurrent: true,
+    isActive: false
+  })
+
+  expect(describe({ id: 41, status: 'running' }, [42])).toEqual({
+    status: 'running',
+    outcome: 'succeeded',
+    outcomeLabel: 'Succeeded',
+    isCurrent: false,
+    isActive: false
+  })
+
+  expect(describe({ id: 43, status: 'pushing' }, [42])).toEqual({
+    status: 'pushing',
+    outcome: 'in-progress',
+    outcomeLabel: 'Publishing',
+    isCurrent: false,
+    isActive: true
+  })
+})


### PR DESCRIPTION
## Summary

- Derive deployment outcomes from App traffic ownership instead of raw lifecycle status.
- Use the same Current, Succeeded, active, failed, and cancelled vocabulary across UI, APIs, CLI, notifications, and SSE.
- Cover two legacy running rows and the final live traffic handoff in browser tests.

## Why

Legacy successful deployment records can retain a raw running status after traffic moves to a newer release. The UI reinterpreted that persistence value and could therefore present two releases as Running even though only one owned production traffic.

The shared outcome contract now treats App.currentDeployment as traffic ownership while preserving the raw status for deployment machinery and backwards compatibility.

## Verification

- 300 unit tests
- 100 functional tests
- Desktop and mobile deployment-history browser trials
- npm run lint
- npm run check:consistency

Fixes #377
