### PR TITLE
fix: keep Bridge dashboard links on the active origin

### DIFF
--- a/assets/js/components/bridge/BridgeDashboard.vue
+++ b/assets/js/components/bridge/BridgeDashboard.vue
@@ -13,20 +13,9 @@ const props = defineProps({
     type: Object,
     required: true
   },
-  project: {
-    type: Object,
+  bridgeBasePath: {
+    type: String,
     required: true
-  },
-  environment: {
-    type: Object,
-    required: true
-  },
-  app: {
-    type: Object
-  },
-  appScoped: {
-    type: Boolean,
-    default: false
   }
 })
 
@@ -52,11 +41,7 @@ const detailCards = computed(() =>
 )
 
 function resourceUrl(identity) {
-  const base =
-    props.appScoped && props.app?.slug
-      ? `/projects/${props.project.slug}/environments/${props.environment.slug}/apps/${props.app.slug}/bridge`
-      : `/projects/${props.project.slug}/environments/${props.environment.slug}/bridge`
-  return `${base}/${identity}`
+  return `${props.bridgeBasePath}/${identity}`
 }
 
 function actionUrl(card) {

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -783,10 +783,7 @@ function createUrl() {
           v-if="activeDashboard"
           :dashboard="activeDashboard"
           :resources="dashboardResources"
-          :project="project"
-          :environment="environment"
-          :app="app"
-          :app-scoped="appScoped"
+          :bridge-base-path="bridgeBasePath"
           class="mb-10"
         />
 

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -263,10 +263,7 @@ function switchDashboard(event) {
           v-if="activeDashboard"
           :dashboard="activeDashboard"
           :resources="models"
-          :project="project"
-          :environment="environment"
-          :app="app"
-          :app-scoped="appScoped"
+          :bridge-base-path="bridgeBasePath"
         />
 
         <!-- Toolbar -->

--- a/tests/e2e/pages/projects/bridge-dashboard.test.js
+++ b/tests/e2e/pages/projects/bridge-dashboard.test.js
@@ -179,6 +179,36 @@ test(
       await expect(page).toSee('Completed purchases')
       await expect(page).toSee('Make production failures boring')
       await expect(page).toSee('Ada Lovelace')
+      const recentLessonLink = page.raw.getByRole('link', {
+        name: /Make production failures boring/
+      })
+      expect(await recentLessonLink.getAttribute('href')).toBe(
+        `${bridgePath}/lesson/91`
+      )
+      const viewAllLinks = page.raw.getByRole('link', { name: 'View all' })
+      expect(await viewAllLinks.nth(0).getAttribute('href')).toBe(
+        `${bridgePath}/lesson`
+      )
+      expect(await viewAllLinks.nth(1).getAttribute('href')).toBe(
+        `${bridgePath}/user`
+      )
+
+      await recentLessonLink.click()
+      await page.raw.waitForURL(
+        (url) => url.pathname === `${bridgePath}/lesson/91`
+      )
+      await expect(page).not.toSee('Not Found')
+      await page.goto(bridgePath)
+      await page.wait('text=Content overview')
+
+      await page.raw.getByRole('link', { name: 'View all' }).nth(0).click()
+      await page.raw.waitForURL(
+        (url) => url.pathname === `${bridgePath}/lesson`
+      )
+      await expect(page).not.toSee('Not Found')
+      await page.goto(bridgePath)
+      await page.wait('text=Content overview')
+
       const metricCards = page.raw.locator('[data-bridge-metric-card]')
       expect(await metricCards.count()).toBe(5)
       const metricCardBoxes = await metricCards.evaluateAll((cards) =>
@@ -233,6 +263,14 @@ test(
       await page.raw
         .getByRole('button', { name: 'Quick actions' })
         .evaluate((button) => button.blur())
+      await page.raw.getByRole('button', { name: 'Quick actions' }).click()
+      await page.raw.getByRole('menuitem', { name: 'New Lesson' }).click()
+      await page.raw.waitForURL(
+        (url) => url.pathname === `${bridgePath}/lesson/new`
+      )
+      await expect(page).not.toSee('Not Found')
+      await page.goto(bridgePath)
+      await page.wait('text=Content overview')
 
       await page.screenshot(path.join(screenshotRoot, 'dashboard-light.png'), {
         fullPage: true

--- a/tests/e2e/pages/projects/bridge-workspace.test.js
+++ b/tests/e2e/pages/projects/bridge-workspace.test.js
@@ -40,7 +40,7 @@ test(
       })
       await sails.models.app.updateOne({ id: app.id }).set({
         name: 'Sailscasts',
-        routePath: '/',
+        routePath: '/academy',
         bridgeEnabled: true,
         status: 'running',
         containerName: 'bridge-workspace-ui-web'
@@ -85,12 +85,27 @@ test(
           return successfulResult(decisions)
         }
         if (code.includes('const dashboard =')) {
+          const dashboard = readEmbeddedValue(code, 'dashboard')
+          if (dashboard.id === 'lessonActivity') {
+            return successfulResult([
+              {
+                id: 'recentLessons',
+                records: [{ id: 91, title: 'App-owned routes stay put' }]
+              },
+              { id: 'newLesson' }
+            ])
+          }
           return successfulResult([
             { id: 'users', value: 61 },
             { id: 'courses', value: 5 },
             { id: 'chapters', value: 24 },
             { id: 'lessons', value: 88 },
-            { id: 'sales', value: 1, detail: 'Completed purchases' }
+            { id: 'sales', value: 1, detail: 'Completed purchases' },
+            {
+              id: 'recentLessons',
+              records: [{ id: 91, title: 'App-owned routes stay put' }]
+            },
+            { id: 'newLesson' }
           ])
         }
         if (code.includes('const counts = {};')) {
@@ -109,9 +124,14 @@ test(
         accessId: String(access.id),
         appId: String(app.id)
       })
-      await page.raw.route('**/bridge/_assets/**', async (route) => {
+      const internalBridgePath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
+      const publicBridgePath = '/academy/bridge'
+      await page.raw.route('**/academy/bridge/_assets/**', async (route) => {
         const assetUrl = new URL(route.request().url())
-        assetUrl.pathname = assetUrl.pathname.replace('/bridge/_assets', '')
+        assetUrl.pathname = assetUrl.pathname.replace(
+          '/academy/bridge/_assets',
+          ''
+        )
         await route.continue({ url: assetUrl.toString() })
       })
       await page.raw.context().setExtraHTTPHeaders({
@@ -120,10 +140,9 @@ test(
       await page.goto(
         `/bridge/launch?code=${encodeURIComponent(
           launchCode
-        )}&hostOrigin=true&hostRoutePath=/`
+        )}&hostOrigin=true&hostRoutePath=/academy`
       )
 
-      const internalBridgePath = `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/bridge`
       await page.resize(1440, 960)
       await page.goto(internalBridgePath)
       await page.wait('@bridge-workspace')
@@ -145,7 +164,7 @@ test(
         await desktopSidebar
           .locator('[data-test="bridge-resource-link"][data-resource="course"]')
           .getAttribute('href')
-      ).toBe('/bridge/course')
+      ).toBe(`${publicBridgePath}/course`)
       expect(
         await desktopSidebar.getByText('Content', { exact: true }).count()
       ).toBe(0)
@@ -164,6 +183,31 @@ test(
         await page.raw
           .locator('[data-test="bridge-page-header"]')
           .getByText('Administrator', { exact: true })
+          .count()
+      ).toBe(0)
+      const recentLessonLink = page.raw.getByRole('link', {
+        name: /App-owned routes stay put/
+      })
+      expect(await recentLessonLink.getAttribute('href')).toBe(
+        `${publicBridgePath}/lesson/91`
+      )
+      expect(
+        await page.raw
+          .getByRole('link', { name: 'View all' })
+          .getAttribute('href')
+      ).toBe(`${publicBridgePath}/lesson`)
+      await page.raw.getByRole('button', { name: 'Quick actions' }).click()
+      expect(
+        await page.raw
+          .getByRole('menuitem', { name: 'New Lesson' })
+          .getAttribute('href')
+      ).toBe(`${publicBridgePath}/lesson/new`)
+      await page.raw.keyboard.press('Escape')
+      expect(
+        await page.raw
+          .locator('#bridge-dashboard-title')
+          .locator('xpath=ancestor::section[1]')
+          .locator('a[href*="/projects/"]')
           .count()
       ).toBe(0)
 
@@ -206,6 +250,26 @@ test(
       await page.screenshot(path.join(screenshotRoot, 'desktop.png'), {
         fullPage: true
       })
+
+      await page.goto(`${internalBridgePath}/lesson`)
+      await page.wait('text=Lesson activity')
+      expect(
+        await page.raw
+          .getByRole('link', { name: /App-owned routes stay put/ })
+          .getAttribute('href')
+      ).toBe(`${publicBridgePath}/lesson/91`)
+      expect(
+        await page.raw
+          .getByRole('link', { name: 'View all' })
+          .getAttribute('href')
+      ).toBe(`${publicBridgePath}/lesson`)
+      await page.raw.getByRole('button', { name: 'Quick actions' }).click()
+      expect(
+        await page.raw
+          .getByRole('menuitem', { name: 'New Lesson' })
+          .getAttribute('href')
+      ).toBe(`${publicBridgePath}/lesson/new`)
+      await page.raw.keyboard.press('Escape')
 
       await page.resize(390, 844)
       await page.raw
@@ -257,15 +321,46 @@ function workspaceConfig() {
       lesson: { label: 'Lessons' },
       purchase: { label: 'Sales' }
     },
-    dashboard: {
-      label: 'Content overview',
-      default: true,
-      cards: {
-        users: { type: 'metric', label: 'Total users', resource: 'user' },
-        courses: { type: 'metric', label: 'Courses', resource: 'course' },
-        chapters: { type: 'metric', label: 'Chapters', resource: 'chapter' },
-        lessons: { type: 'metric', label: 'Lessons', resource: 'lesson' },
-        sales: { type: 'metric', label: 'Sales', resource: 'purchase' }
+    dashboards: {
+      overview: {
+        label: 'Content overview',
+        default: true,
+        cards: {
+          users: { type: 'metric', label: 'Total users', resource: 'user' },
+          courses: { type: 'metric', label: 'Courses', resource: 'course' },
+          chapters: { type: 'metric', label: 'Chapters', resource: 'chapter' },
+          lessons: { type: 'metric', label: 'Lessons', resource: 'lesson' },
+          sales: { type: 'metric', label: 'Sales', resource: 'purchase' },
+          recentLessons: {
+            type: 'recent',
+            label: 'Recent lessons',
+            resource: 'lesson',
+            fields: ['title']
+          },
+          newLesson: {
+            type: 'action',
+            label: 'New Lesson',
+            resource: 'lesson'
+          }
+        }
+      },
+      lessonActivity: {
+        label: 'Lesson activity',
+        scope: 'resource',
+        resource: 'lesson',
+        cards: {
+          recentLessons: {
+            type: 'recent',
+            label: 'Recent lessons',
+            resource: 'lesson',
+            fields: ['title']
+          },
+          newLesson: {
+            type: 'action',
+            label: 'New Lesson',
+            resource: 'lesson'
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- pass the server-resolved canonical Bridge base path into the shared dashboard
- build recent-record, collection, and quick-action links from that single base
- preserve native Slipway routes, app-owned routes, non-root app prefixes, and resource dashboards

## Verification

- `npm run lint`
- `npm run check:consistency`
- 7 Bridge functional trials
- 2 Bridge dashboard browser trials

Fixes #399