### PR TITLE
fix(bridge): remove resource group commentary

### DIFF
--- a/api/helpers/bridge/normalize-resource-contract.js
+++ b/api/helpers/bridge/normalize-resource-contract.js
@@ -142,7 +142,6 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
   const RESOURCE_OPTION_KEYS = [
     'label',
     'singularLabel',
-    'group',
     'title',
     'search',
     'list',
@@ -292,7 +291,7 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
   }
 
   function normalizeResource(identity, model, raw, configured) {
-    for (const option of ['label', 'singularLabel', 'group']) {
+    for (const option of ['label', 'singularLabel']) {
       assertOptionalString(
         raw[option],
         `Bridge resource "${identity}".${option}`
@@ -393,7 +392,6 @@ function normalizeBridgeResourceContract({ models, config = {} }) {
       primaryKey,
       label,
       singularLabel,
-      group: readString(raw.group) || 'Resources',
       title: normalizeFieldName(
         identity,
         'title',

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -38,7 +38,8 @@ const searchQuery = ref('')
 // Sorted model list
 const modelList = computed(() => {
   return Object.values(props.models || {}).sort(
-    (a, b) => a.group.localeCompare(b.group) || a.label.localeCompare(b.label)
+    (a, b) =>
+      a.label.localeCompare(b.label) || a.identity.localeCompare(b.identity)
   )
 })
 
@@ -50,7 +51,6 @@ const filteredModels = computed(() => {
     (model) =>
       model.label.toLowerCase().includes(query) ||
       model.singularLabel.toLowerCase().includes(query) ||
-      model.group.toLowerCase().includes(query) ||
       model.identity.toLowerCase().includes(query) ||
       (model.globalId && model.globalId.toLowerCase().includes(query)) ||
       (model.tableName && model.tableName.toLowerCase().includes(query))
@@ -311,6 +311,7 @@ function switchDashboard(event) {
             <div
               v-for="model in filteredModels"
               :key="model.identity"
+              :data-test="`bridge-resource-row-${model.identity}`"
               class="group grid grid-cols-12 items-center gap-4 px-6 py-4 transition-colors hover:bg-gray-50 dark:hover:bg-gray-900/40"
             >
               <div class="col-span-5">
@@ -336,26 +337,24 @@ function switchDashboard(event) {
                       />
                     </svg>
                   </div>
-                  <div class="min-w-0">
-                    <div
-                      class="font-medium text-gray-900 transition-colors group-hover:text-gray-700 dark:text-white dark:group-hover:text-gray-300"
-                    >
-                      {{ model.label }}
-                    </div>
-                    <div class="text-xs text-gray-500 dark:text-gray-500">
-                      {{ model.group }}
-                    </div>
-                  </div>
+                  <span
+                    data-test="bridge-resource-label"
+                    class="min-w-0 truncate font-medium text-gray-900 transition-colors group-hover:text-gray-700 dark:text-white dark:group-hover:text-gray-300"
+                  >
+                    {{ model.label }}
+                  </span>
                 </Link>
               </div>
               <div class="col-span-2 text-right">
                 <span
+                  data-test="bridge-resource-record-count"
                   class="font-medium tabular-nums text-gray-900 dark:text-white"
                   >{{ (model.count || 0).toLocaleString() }}</span
                 >
               </div>
               <div class="col-span-2 text-right">
                 <span
+                  data-test="bridge-resource-attribute-count"
                   class="text-sm tabular-nums text-gray-500 dark:text-gray-400"
                   >{{ attrCount(model) }}</span
                 >
@@ -363,10 +362,16 @@ function switchDashboard(event) {
               <div class="col-span-2 text-right">
                 <span
                   v-if="assocCount(model) > 0"
+                  data-test="bridge-resource-association-count"
                   class="text-sm tabular-nums text-gray-500 dark:text-gray-400"
                   >{{ assocCount(model) }}</span
                 >
-                <span v-else class="text-gray-300 dark:text-gray-700">—</span>
+                <span
+                  v-else
+                  data-test="bridge-resource-association-count"
+                  class="text-gray-300 dark:text-gray-700"
+                  >—</span
+                >
               </div>
               <div class="col-span-1 flex items-center justify-end">
                 <Link

--- a/docs/bridge-resource-contract.md
+++ b/docs/bridge-resource-contract.md
@@ -12,7 +12,6 @@ module.exports.slipway = {
       course: {
         label: 'Courses',
         singularLabel: 'Course',
-        group: 'Content',
         title: 'title',
         search: ['title'],
         list: ['title', 'price', 'published', 'createdAt'],
@@ -130,9 +129,7 @@ module.exports.slipway = {
     schemaVersion: 1,
     discover: false,
     resources: {
-      course: {
-        group: 'Content'
-      }
+      course: {}
     }
   }
 }

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -466,9 +466,50 @@ test(
 
       await page.goto(bridgePath)
       await page.wait('text=Courses')
-      await expect(page).toSee('Content')
-      await expect(page).toSee('People')
       await expect(page).toSee('4 resources')
+      expect(
+        await page.raw
+          .locator('[data-test^="bridge-resource-row-"]')
+          .locator('[data-test="bridge-resource-label"]')
+          .allTextContents()
+      ).toEqual(['Chapters', 'Courses', 'Lessons', 'People'])
+      expect(
+        await page.raw
+          .locator('[data-test^="bridge-resource-row-"]')
+          .locator('[data-test="bridge-resource-record-count"]')
+          .allTextContents()
+      ).toEqual(['0', '3', '0', '1'])
+      for (const removedGroup of [
+        'Audience',
+        'Commerce',
+        'Content',
+        'Operations',
+        'Resources'
+      ]) {
+        expect(
+          await page.raw.getByText(removedGroup, { exact: true }).count()
+        ).toBe(0)
+      }
+      const resourceSearch = page.raw.getByPlaceholder('Search resources...')
+      await resourceSearch.fill('Person')
+      expect(
+        await page.raw
+          .locator('[data-test="bridge-resource-label"]')
+          .allTextContents()
+      ).toEqual(['People'])
+      await resourceSearch.fill('users')
+      expect(
+        await page.raw
+          .locator('[data-test="bridge-resource-label"]')
+          .allTextContents()
+      ).toEqual(['People'])
+      await resourceSearch.fill('Content')
+      expect(
+        await page.raw
+          .locator('[data-test="bridge-resource-label"]')
+          .allTextContents()
+      ).toEqual([])
+      await resourceSearch.fill('')
       expect(await page.raw.getByText('Model Settings').count()).toBe(0)
       await page.screenshot(path.join(screenshotRoot, 'resources-light.png'), {
         fullPage: true
@@ -1240,7 +1281,6 @@ function resourceConfig() {
       course: {
         label: 'Courses',
         singularLabel: 'Course',
-        group: 'Content',
         title: 'title',
         search: ['title'],
         list: ['title', 'price', 'published', 'createdAt'],
@@ -1448,7 +1488,6 @@ function resourceConfig() {
       user: {
         label: 'People',
         singularLabel: 'Person',
-        group: 'People',
         title: 'fullName',
         search: ['fullName', 'email'],
         list: ['fullName', 'email'],
@@ -1462,7 +1501,6 @@ function resourceConfig() {
       chapter: {
         label: 'Chapters',
         singularLabel: 'Chapter',
-        group: 'Content',
         title: 'title',
         search: ['title'],
         list: ['title']
@@ -1470,7 +1508,6 @@ function resourceConfig() {
       lesson: {
         label: 'Lessons',
         singularLabel: 'Lesson',
-        group: 'Content',
         title: 'title',
         search: ['title'],
         list: ['title'],

--- a/tests/unit/helpers/bridge/resource-contract.test.js
+++ b/tests/unit/helpers/bridge/resource-contract.test.js
@@ -106,7 +106,6 @@ test('Bridge merges a partial resource config over discovered metadata', async (
       resources: {
         course: {
           label: 'Learning paths',
-          group: 'Content',
           search: ['title'],
           list: ['title', 'published']
         },
@@ -117,7 +116,7 @@ test('Bridge merges a partial resource config over discovered metadata', async (
 
   expect(contract.resources.course.label).toBe('Learning paths')
   expect(contract.resources.course.singularLabel).toBe('Learning path')
-  expect(contract.resources.course.group).toBe('Content')
+  expect(Object.hasOwn(contract.resources.course, 'group')).toBe(false)
   expect(contract.resources.course.list).toEqual(['id', 'title', 'published'])
   expect(contract.resources.course.create).toEqual([
     'title',
@@ -142,7 +141,6 @@ test('Bridge represents a fully configured content resource', async ({
         course: {
           label: 'Courses',
           singularLabel: 'Course',
-          group: 'Content',
           title: 'title',
           search: ['title'],
           list: ['title', 'published'],
@@ -1233,6 +1231,32 @@ test('Bridge rejects unknown fields and unsupported config options', async ({
   )
   expect(unknownOptionError.message).toBe(
     'Bridge resource "course" contains unsupported option "magic".'
+  )
+})
+
+test('Bridge rejects the removed resource group option', async ({
+  sails,
+  expect
+}) => {
+  let receivedError
+
+  try {
+    await sails.helpers.bridge.normalizeResourceContract.with({
+      models: modelMetadata(),
+      config: {
+        resources: {
+          course: {
+            group: 'Content'
+          }
+        }
+      }
+    })
+  } catch (error) {
+    receivedError = error
+  }
+
+  expect(receivedError.message).toBe(
+    'Bridge resource "course" contains unsupported option "group".'
   )
 })
 


### PR DESCRIPTION
## What changed

- remove `group` from the strict Bridge resource contract and normalized payload
- sort resources alphabetically by display label with identity as a deterministic tie-breaker
- search only label, singular label, identity, global ID, and table name
- remove the secondary taxonomy line from resource rows
- remove group examples and fixtures from the Bridge documentation and trials
- prove labels, counts, removed terms, and identifier search in the browser trial

## Verification

- `npx sounding test tests/unit/helpers/bridge/resource-contract.test.js --test-concurrency=1`
- `npx sounding test tests/e2e/pages/projects/bridge-resource-contract.test.js --test-concurrency=1`
- `npm run lint`
- `npm run check:consistency`

## Rollout

Sailscasts still carries seven legacy `group` entries. sailscastshq/sailscasts.com#132 must land before Sailscasts installs the Slipway release containing this change.

Fixes #400