### PR TITLE
Fix Bearing route collisions with host apps

### DIFF
--- a/api/controllers/bearing/redirect-to-feedback.js
+++ b/api/controllers/bearing/redirect-to-feedback.js
@@ -1,0 +1,33 @@
+module.exports = {
+  friendlyName: 'Redirect to public Bearing feedback',
+
+  description:
+    'Make the app-owned Bearing namespace resolve to its default feedback surface.',
+
+  inputs: {
+    projectSlug: { type: 'string', required: true },
+    environmentSlug: { type: 'string', required: true },
+    appSlug: { type: 'string', required: true }
+  },
+
+  exits: {
+    success: { responseType: 'redirect' },
+    notFound: { statusCode: 404 }
+  },
+
+  fn: async function ({ projectSlug, environmentSlug, appSlug }) {
+    let resolved
+    try {
+      resolved = await sails.helpers.bearing.resolvePublicRequest.with({
+        req: this.req,
+        projectSlug,
+        environmentSlug,
+        appSlug
+      })
+    } catch {
+      throw 'notFound'
+    }
+
+    return `${resolved.publicBasePath}/feedback`
+  }
+}

--- a/api/controllers/bearing/session.js
+++ b/api/controllers/bearing/session.js
@@ -19,7 +19,7 @@ module.exports = {
     const tokenHash = crypto.createHash('sha256').update(code).digest('hex')
     const launchCode = await sails.helpers.bearing.consumeLaunchCode(tokenHash)
     if (!launchCode) {
-      throw { forbidden: '/feedback?error=bearing_link_expired' }
+      throw { forbidden: '/bearing/feedback?error=bearing_link_expired' }
     }
 
     const participant = await BearingParticipant.findOne({
@@ -36,7 +36,7 @@ module.exports = {
       : null
 
     if (!participant || participant.disabledAt || !app || !space) {
-      throw { forbidden: '/feedback?error=bearing_access_denied' }
+      throw { forbidden: '/bearing/feedback?error=bearing_access_denied' }
     }
 
     const existingUserId = this.req.session.userId
@@ -47,7 +47,7 @@ module.exports = {
     this.req.session.bearingAuthenticatedAt = Date.now()
     this.req.session.bearingCredentialHash = hashCredential(app.bearingSecret)
 
-    return `${safeRoutePrefix(app.routePath)}/feedback`
+    return `${safeRoutePrefix(app.routePath)}/bearing/feedback`
   }
 }
 

--- a/api/controllers/bearing/view-feedback.js
+++ b/api/controllers/bearing/view-feedback.js
@@ -136,7 +136,7 @@ module.exports = {
           feedbackPath,
           roadmapPath: `${resolved.publicBasePath}/roadmap`,
           updatesPath: `${resolved.publicBasePath}/updates`,
-          identityPath: `${resolved.publicBasePath}/_slipway/bearing/identity`,
+          identityPath: resolved.identityPath,
           publicUrl: absoluteUrl(this.req, publicPath),
           ogImageUrl: absoluteUrl(
             this.req,

--- a/api/controllers/project/view-bearing.js
+++ b/api/controllers/project/view-bearing.js
@@ -83,9 +83,9 @@ module.exports = {
         counts,
         publicUrls: appUrl
           ? {
-              feedback: `${appUrl}/feedback`,
-              roadmap: `${appUrl}/roadmap`,
-              updates: `${appUrl}/updates`
+              feedback: `${appUrl}/bearing/feedback`,
+              roadmap: `${appUrl}/bearing/roadmap`,
+              updates: `${appUrl}/bearing/updates`
             }
           : null,
         uploadsConfigured,

--- a/api/helpers/bearing/resolve-public-request.js
+++ b/api/helpers/bearing/resolve-public-request.js
@@ -64,7 +64,10 @@ module.exports = {
       app,
       space,
       participant,
-      publicBasePath: hostOrigin ? routePrefix : internalBasePath,
+      publicBasePath: hostOrigin ? `${routePrefix}/bearing` : internalBasePath,
+      identityPath: hostOrigin
+        ? `${routePrefix}/_slipway/bearing/identity`
+        : `${internalBasePath}/_slipway/bearing/identity`,
       hostAssetBasePath: hostOrigin
         ? `${routePrefix}/_slipway/bearing/_assets`
         : ''

--- a/api/helpers/bearing/resolve-public-request.js
+++ b/api/helpers/bearing/resolve-public-request.js
@@ -55,6 +55,9 @@ module.exports = {
     const routePrefix = normalizeRoutePrefix(app.routePath)
     const instanceUrl = await sails.helpers.getInstanceUrl()
     const hostOrigin = isHostOriginRequest(req, instanceUrl)
+    const integrationBasePath = hostOrigin
+      ? `${routePrefix}/_slipway/bearing`
+      : ''
     const internalBasePath = `/bearing/public/${encodeURIComponent(
       project.slug
     )}/${encodeURIComponent(environment.slug)}/${encodeURIComponent(app.slug)}`
@@ -65,12 +68,11 @@ module.exports = {
       space,
       participant,
       publicBasePath: hostOrigin ? `${routePrefix}/bearing` : internalBasePath,
+      integrationBasePath,
       identityPath: hostOrigin
-        ? `${routePrefix}/_slipway/bearing/identity`
+        ? `${integrationBasePath}/identity`
         : `${internalBasePath}/_slipway/bearing/identity`,
-      hostAssetBasePath: hostOrigin
-        ? `${routePrefix}/_slipway/bearing/_assets`
-        : ''
+      hostAssetBasePath: hostOrigin ? `${integrationBasePath}/_assets` : ''
     }
   }
 }

--- a/api/helpers/caddy/generate-route-config.js
+++ b/api/helpers/caddy/generate-route-config.js
@@ -183,6 +183,7 @@ function bearingHandlers({
 }) {
   const routePrefix = normalizeRoutePrefix(app.routePath)
   const bearingInternalPath = `${routePrefix}/_slipway/bearing`
+  const publicBasePath = `${routePrefix}/bearing`
   const internalBasePath = `/bearing/public/${projectSlug}/${environmentSlug}/${app.slug}`
   const appProxy = {
     handler: 'reverse_proxy',
@@ -223,9 +224,16 @@ function bearingHandlers({
       { handler: 'rewrite', uri: `${internalBasePath}/widget-config` },
       controlPlaneProxy
     ]),
+    subroute(publicBasePath, [
+      { handler: 'rewrite', uri: internalBasePath },
+      controlPlaneProxy
+    ]),
     ...['feedback', 'roadmap', 'updates'].map((surface) =>
-      subroute(`${routePrefix}/${surface}*`, [
-        { handler: 'rewrite', strip_path_prefix: `${routePrefix}/${surface}` },
+      subroute(`${publicBasePath}/${surface}*`, [
+        {
+          handler: 'rewrite',
+          strip_path_prefix: `${publicBasePath}/${surface}`
+        },
         {
           handler: 'rewrite',
           uri: `${internalBasePath}/${surface}{http.request.uri.path}`

--- a/api/helpers/caddy/update-route.js
+++ b/api/helpers/caddy/update-route.js
@@ -248,6 +248,7 @@ function buildRouteLabels({
 
     const routePrefix = normalizeRoutePrefix(app.routePath)
     const bearingInternalPath = `${routePrefix}/_slipway/bearing`
+    const publicBasePath = `${routePrefix}/bearing`
     const internalBasePath = `/bearing/public/${projectSlug}/${environmentSlug}/${app.slug}`
 
     addHandle({
@@ -292,8 +293,15 @@ function buildRouteLabels({
       uri: `replace ${bearingInternalPath}/widget-config ${internalBasePath}/widget-config`,
       upstream: controlPlaneUpstream
     })
+    addHandle({
+      labels,
+      index: handleIndex++,
+      matcher: publicBasePath,
+      uri: `replace ${publicBasePath} ${internalBasePath}`,
+      upstream: controlPlaneUpstream
+    })
     for (const surface of ['feedback', 'roadmap', 'updates']) {
-      const publicPath = `${routePrefix}/${surface}`
+      const publicPath = `${publicBasePath}/${surface}`
       addHandle({
         labels,
         index: handleIndex++,

--- a/api/lib/bearing-realtime.js
+++ b/api/lib/bearing-realtime.js
@@ -81,8 +81,8 @@ function buildRealtimeConfig({
       origin,
       secret
     }),
-    socketPath: resolved.hostAssetBasePath
-      ? `${resolved.publicBasePath}/_slipway/bearing/socket.io`
+    socketPath: resolved.integrationBasePath
+      ? `${resolved.integrationBasePath}/socket.io`
       : '/socket.io',
     subscribePath: `/bearing/public/${encodeURIComponent(
       projectSlug

--- a/config/routes.js
+++ b/config/routes.js
@@ -407,6 +407,8 @@ module.exports.routes = {
     'bearing/view-bootstrap',
   'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/widget-config':
     'bearing/view-widget-config',
+  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug':
+    'bearing/redirect-to-feedback',
   'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/:surface/og.png':
     'bearing/view-social-image',
   'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug/og.png':

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -196,10 +196,14 @@ app's own domain. Enable it from **App → Bearing**, choose who may participate
 then redeploy once so Slipway can inject the app-scoped exchange credential.
 
 ```text
-https://your-app.example.com/feedback
-https://your-app.example.com/roadmap
-https://your-app.example.com/updates
+https://your-app.example.com/bearing/feedback
+https://your-app.example.com/bearing/roadmap
+https://your-app.example.com/bearing/updates
 ```
+
+`/bearing` redirects to `/bearing/feedback`. Keeping every public surface below
+the Bearing namespace prevents Slipway from claiming app routes such as
+`/feedback`, `/roadmap`, or `/updates`.
 
 When the widget is enabled, the hook adds one same-origin, asynchronous
 bootstrap script to successful HTML responses. It does not edit the app's

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -184,7 +184,10 @@ test(
           page.raw
             .locator('[data-test="bearing-public-surface-feedback"]')
             .getByRole('link', { name: /Open Feedback/ })
-        ).toHaveAttribute('href', 'https://product.example.com/feedback')
+        ).toHaveAttribute(
+          'href',
+          'https://product.example.com/bearing/feedback'
+        )
 
         await page.raw.emulateMedia({ colorScheme: 'dark' })
         await page.raw.waitForTimeout(100)

--- a/tests/functional/pages/bearing.test.js
+++ b/tests/functional/pages/bearing.test.js
@@ -437,6 +437,7 @@ test(
       'app.identityPath': '/_slipway/bearing/identity',
       'app.publicUrl': 'https://ideas.example.com/bearing/feedback',
       'app.ogImageUrl': 'https://ideas.example.com/bearing/feedback/og.png',
+      'realtime.socketPath': '/_slipway/bearing/socket.io',
       hostAssetBasePath: '/_slipway/bearing/_assets'
     })
 

--- a/tests/functional/pages/bearing.test.js
+++ b/tests/functional/pages/bearing.test.js
@@ -48,9 +48,9 @@ test(
       'bearing.showPublicRoadmap': true,
       'bearing.showPublicUpdates': true,
       'bearing.widgetEnabled': false,
-      'publicUrls.feedback': 'https://product.example.com/feedback',
-      'publicUrls.roadmap': 'https://product.example.com/roadmap',
-      'publicUrls.updates': 'https://product.example.com/updates',
+      'publicUrls.feedback': 'https://product.example.com/bearing/feedback',
+      'publicUrls.roadmap': 'https://product.example.com/bearing/roadmap',
+      'publicUrls.updates': 'https://product.example.com/bearing/updates',
       hookDetected: true
     })
     expect(await sails.models.bearingspace.count({ app: app.id })).toBe(0)
@@ -352,13 +352,13 @@ test(
     const launchPath = `${launchUrl.pathname}${launchUrl.search}`
     const launch = await request.get(launchPath)
     expect(launch).toHaveStatus(302)
-    expect(launch).toRedirectTo('/feedback')
+    expect(launch).toRedirectTo('/bearing/feedback')
     expect(launch.session.bearingParticipantId).toBe(participant.id)
     expect(launch.session.bearingAppId).toBe(app.id)
 
     const replay = await request.get(launchPath)
     expect(replay).toHaveStatus(302)
-    expect(replay).toRedirectTo('/feedback?error=bearing_link_expired')
+    expect(replay).toRedirectTo('/bearing/feedback?error=bearing_link_expired')
   }
 )
 
@@ -400,6 +400,17 @@ test(
       })
       .fetch()
     const publicPath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/feedback`
+    const publicBasePath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}`
+
+    const namespace = await request.get(publicBasePath)
+    expect(namespace).toHaveStatus(302)
+    expect(namespace).toRedirectTo(`${publicBasePath}/feedback`)
+
+    const hostNamespace = await request
+      .withHeaders({ 'x-forwarded-host': 'ideas.example.com' })
+      .get(publicBasePath)
+    expect(hostNamespace).toHaveStatus(302)
+    expect(hostNamespace).toRedirectTo('/bearing/feedback')
 
     const guestPage = await visitPage(request, publicPath)
     expect(guestPage).toHaveStatus(200)
@@ -420,12 +431,12 @@ test(
       })
       .get(publicPath)
     expect(hostPage).toHaveInertiaProps({
-      'app.feedbackPath': '/feedback',
-      'app.roadmapPath': '/roadmap',
-      'app.updatesPath': '/updates',
+      'app.feedbackPath': '/bearing/feedback',
+      'app.roadmapPath': '/bearing/roadmap',
+      'app.updatesPath': '/bearing/updates',
       'app.identityPath': '/_slipway/bearing/identity',
-      'app.publicUrl': 'https://ideas.example.com/feedback',
-      'app.ogImageUrl': 'https://ideas.example.com/feedback/og.png',
+      'app.publicUrl': 'https://ideas.example.com/bearing/feedback',
+      'app.ogImageUrl': 'https://ideas.example.com/bearing/feedback/og.png',
       hostAssetBasePath: '/_slipway/bearing/_assets'
     })
 

--- a/tests/unit/config/routes.test.js
+++ b/tests/unit/config/routes.test.js
@@ -33,6 +33,9 @@ test('browser actions and JSON transports have explicit route contracts', ({
     ]
   ).toBe('project/upload-bearing-update-image')
   expect(
+    routes['GET /bearing/public/:projectSlug/:environmentSlug/:appSlug']
+  ).toBe('bearing/redirect-to-feedback')
+  expect(
     routes[
       'GET /api/v1/projects/:slug/environments/:envSlug/bridge/:modelIdentity/relationships/:relationshipAlias/options'
     ]

--- a/tests/unit/helpers/caddy/generate-route-config.test.js
+++ b/tests/unit/helpers/caddy/generate-route-config.test.js
@@ -26,3 +26,37 @@ test('generated Caddy config rewrites host Bridge paths to the control plane', (
     { dial: 'slipway:1337' }
   ])
 })
+
+test('generated Caddy config keeps public Bearing surfaces in their namespace', ({
+  expect
+}) => {
+  const handlers = generateRouteConfig._private.bearingHandlers({
+    app: {
+      slug: 'web',
+      routePath: '/academy',
+      hostPort: 1410
+    },
+    projectSlug: 'durable-ui',
+    environmentSlug: 'production',
+    controlPlaneUpstream: 'slipway:1337'
+  })
+
+  expect(handlers[6].routes[0].match[0].path).toEqual(['/academy/bearing'])
+  expect(handlers[6].routes[0].handle[0].uri).toBe(
+    '/bearing/public/durable-ui/production/web'
+  )
+  expect(handlers[7].routes[0].match[0].path).toEqual([
+    '/academy/bearing/feedback*'
+  ])
+  expect(handlers[7].routes[0].handle[0].strip_path_prefix).toBe(
+    '/academy/bearing/feedback'
+  )
+  expect(handlers[7].routes[0].handle[1].uri).toBe(
+    '/bearing/public/durable-ui/production/web/feedback{http.request.uri.path}'
+  )
+  expect(
+    handlers.some((handler) =>
+      handler.routes[0].match[0].path.includes('/academy/feedback*')
+    )
+  ).toBe(false)
+})

--- a/tests/unit/helpers/caddy/update-route.test.js
+++ b/tests/unit/helpers/caddy/update-route.test.js
@@ -169,17 +169,21 @@ test('Bearing sends identity to the app before proxying its public surfaces', ({
   expect(labels).toContain(
     'caddy.handle_5.0_uri=replace /admin/_slipway/bearing/widget-config /bearing/public/durable-ui/production/admin/widget-config'
   )
-  expect(labels).toContain('caddy.handle_6=/admin/feedback*')
+  expect(labels).toContain('caddy.handle_6=/admin/bearing')
   expect(labels).toContain(
-    'caddy.handle_6.0_uri=replace /admin/feedback /bearing/public/durable-ui/production/admin/feedback'
+    'caddy.handle_6.0_uri=replace /admin/bearing /bearing/public/durable-ui/production/admin'
   )
-  expect(labels).toContain('caddy.handle_9=/admin*')
+  expect(labels).toContain('caddy.handle_7=/admin/bearing/feedback*')
+  expect(labels).toContain(
+    'caddy.handle_7.0_uri=replace /admin/bearing/feedback /bearing/public/durable-ui/production/admin/feedback'
+  )
+  expect(labels).toContain('caddy.handle_10=/admin*')
   expect(
     labels.indexOf('caddy.handle_1=/admin/_slipway/bearing/identity')
   ).toBe(3)
   expect(
-    labels.indexOf('caddy.handle_9=/admin*') >
-      labels.indexOf('caddy.handle_8=/admin/updates*')
+    labels.indexOf('caddy.handle_10=/admin*') >
+      labels.indexOf('caddy.handle_9=/admin/bearing/updates*')
   ).toBe(true)
   expect(
     helper._private.routeUpstreams(

--- a/tests/unit/lib/bearing-realtime.test.js
+++ b/tests/unit/lib/bearing-realtime.test.js
@@ -1,10 +1,35 @@
 const { test } = require('sounding')
 const {
   authorizeSocketHandshake,
+  buildRealtimeConfig,
   issueRealtimeToken,
   serializeFeedback,
   verifyRealtimeToken
 } = require('../../../api/lib/bearing-realtime')
+
+test('Bearing realtime stays on its private integration path for mounted apps', ({
+  expect
+}) => {
+  const req = {
+    protocol: 'https',
+    get(name) {
+      return name === 'host' ? 'product.example.com' : undefined
+    }
+  }
+  const config = buildRealtimeConfig({
+    req,
+    resolved: {
+      space: { id: '42' },
+      integrationBasePath: '/academy/_slipway/bearing'
+    },
+    projectSlug: 'durable-ui',
+    environmentSlug: 'production',
+    appSlug: 'academy',
+    secret: 'test-bearing-realtime-secret'
+  })
+
+  expect(config.socketPath).toBe('/academy/_slipway/bearing/socket.io')
+})
 
 test('Bearing realtime tokens are short-lived, origin-bound, and tamper-safe', ({
   expect


### PR DESCRIPTION
Closes #404\n\nNamespaced every public Bearing surface beneath /bearing so enabling Bearing no longer captures an app's own /feedback, /roadmap, or /updates routes. /bearing now redirects to /bearing/feedback, mounted app prefixes are preserved, and identity plumbing remains private beneath /_slipway/bearing.\n\nAlso updates generated public URLs, widget destinations, session redirects, social metadata inputs, hook documentation, and routing coverage.\n\nVerified with Prettier, 317 unit trials, 6 focused functional trials, and 2 Bearing browser trials.