### PR TITLE
Fix 0.0.58 self-update health validation

### DIFF
--- a/api/helpers/docker/health-check-container.js
+++ b/api/helpers/docker/health-check-container.js
@@ -1,0 +1,141 @@
+const { execFile } = require('node:child_process')
+const { promisify } = require('node:util')
+
+const execFileAsync = promisify(execFile)
+
+module.exports = {
+  friendlyName: 'Health check container',
+
+  description:
+    'Poll an HTTP endpoint from inside a container without relying on Docker DNS or host port reachability.',
+
+  inputs: {
+    containerName: {
+      type: 'string',
+      required: true
+    },
+    port: {
+      type: 'number',
+      defaultsTo: 1337
+    },
+    path: {
+      type: 'string',
+      defaultsTo: '/health'
+    },
+    timeout: {
+      type: 'number',
+      defaultsTo: 60000
+    },
+    interval: {
+      type: 'number',
+      defaultsTo: 2000
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ containerName, port, path, timeout, interval }) {
+    const dockerPath = sails.config.docker?.binaryPath || 'docker'
+
+    return await waitForContainerHttp({
+      execute: execFileAsync,
+      dockerPath,
+      containerName,
+      port,
+      path,
+      timeout,
+      interval,
+      clock: {
+        now: () => Date.now(),
+        wait: delay
+      }
+    })
+  }
+}
+
+async function waitForContainerHttp({
+  execute,
+  dockerPath,
+  containerName,
+  port,
+  path,
+  timeout,
+  interval,
+  clock
+}) {
+  const healthPath = normalizePath(path)
+  const endpoint = `http://localhost:${port}${healthPath}`
+  const startedAt = clock.now()
+  let attempts = 0
+  let lastError = 'The candidate did not answer.'
+
+  do {
+    attempts += 1
+    const remaining = Math.max(1, timeout - (clock.now() - startedAt))
+    const probeTimeout = Math.min(5000, remaining)
+
+    try {
+      await execute(
+        dockerPath,
+        buildProbeArgs({
+          containerName,
+          endpoint,
+          probeTimeout
+        }),
+        {
+          timeout: probeTimeout + 2000,
+          maxBuffer: 64 * 1024
+        }
+      )
+
+      sails.log.info(
+        `Container health check passed inside ${containerName} (attempt ${attempts})`
+      )
+      return { attempts, endpoint }
+    } catch (error) {
+      lastError = String(error.stderr || error.message || error).trim()
+    }
+
+    const elapsed = clock.now() - startedAt
+    if (elapsed >= timeout) break
+    await clock.wait(Math.min(interval, timeout - elapsed))
+  } while (clock.now() - startedAt < timeout)
+
+  const error = new Error(
+    `Container health check failed inside ${containerName} after ${attempts} attempts. Last error: ${lastError}`
+  )
+  error.code = 'CONTAINER_HEALTH_CHECK_FAILED'
+  throw error
+}
+
+function buildProbeArgs({ containerName, endpoint, probeTimeout }) {
+  return [
+    'exec',
+    containerName,
+    'curl',
+    '-fsS',
+    '--max-time',
+    String(Math.max(1, Math.ceil(probeTimeout / 1000))),
+    endpoint
+  ]
+}
+
+function normalizePath(path) {
+  const normalized = String(path || '/health').trim()
+  if (!normalized) return '/health'
+  return normalized.startsWith('/') ? normalized : `/${normalized}`
+}
+
+function delay(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds))
+}
+
+module.exports._private = {
+  buildProbeArgs,
+  normalizePath,
+  waitForContainerHttp
+}

--- a/api/helpers/system/apply-update.js
+++ b/api/helpers/system/apply-update.js
@@ -171,10 +171,9 @@ module.exports = {
       // 7. Health-check the validation container
       await setProgress('validating', 'Health-checking new version')
       try {
-        await sails.helpers.docker.healthCheck.with({
+        await sails.helpers.docker.healthCheckContainer.with({
           containerName: 'slipway-next',
           port: 1337,
-          hostPort: tempPort,
           path: '/health',
           timeout: 60000,
           interval: 2000

--- a/tests/unit/helpers/docker/health-check-container.test.js
+++ b/tests/unit/helpers/docker/health-check-container.test.js
@@ -1,0 +1,101 @@
+const { test } = require('sounding')
+
+const { buildProbeArgs, normalizePath, waitForContainerHttp } =
+  require('../../../../api/helpers/docker/health-check-container')._private
+
+test('candidate health checks execute inside the target container', async ({
+  expect
+}) => {
+  const attempts = []
+  let now = 0
+
+  const result = await waitForContainerHttp({
+    execute: async (binary, args) => {
+      attempts.push([binary, ...args])
+      if (attempts.length < 3) {
+        throw new Error('curl: connection refused')
+      }
+    },
+    dockerPath: '/usr/bin/docker',
+    containerName: 'slipway-next',
+    port: 1337,
+    path: '/health',
+    timeout: 10000,
+    interval: 2000,
+    clock: {
+      now: () => now,
+      wait: async (milliseconds) => {
+        now += milliseconds
+      }
+    }
+  })
+
+  expect(result.attempts).toBe(3)
+  expect(attempts[0]).toEqual([
+    '/usr/bin/docker',
+    'exec',
+    'slipway-next',
+    'curl',
+    '-fsS',
+    '--max-time',
+    '5',
+    'http://localhost:1337/health'
+  ])
+})
+
+test('candidate health checks retain the final in-container error', async ({
+  expect
+}) => {
+  let now = 0
+  let thrown
+
+  try {
+    await waitForContainerHttp({
+      execute: async () => {
+        const error = new Error('docker exec failed')
+        error.stderr = 'candidate is not running'
+        throw error
+      },
+      dockerPath: 'docker',
+      containerName: 'slipway-next',
+      port: 1337,
+      path: 'health',
+      timeout: 4000,
+      interval: 2000,
+      clock: {
+        now: () => now,
+        wait: async (milliseconds) => {
+          now += milliseconds
+        }
+      }
+    })
+  } catch (error) {
+    thrown = error
+  }
+
+  expect(thrown.code).toBe('CONTAINER_HEALTH_CHECK_FAILED')
+  expect(thrown.message.includes('candidate is not running')).toBe(true)
+  expect(thrown.message.includes('after 2 attempts')).toBe(true)
+})
+
+test('candidate health paths and probe timeouts are normalized', async ({
+  expect
+}) => {
+  expect(normalizePath('health')).toBe('/health')
+  expect(normalizePath('')).toBe('/health')
+  expect(
+    buildProbeArgs({
+      containerName: 'candidate',
+      endpoint: 'http://localhost:1337/health',
+      probeTimeout: 1200
+    })
+  ).toEqual([
+    'exec',
+    'candidate',
+    'curl',
+    '-fsS',
+    '--max-time',
+    '2',
+    'http://localhost:1337/health'
+  ])
+})


### PR DESCRIPTION
## What changed

- Probe the new Slipway image from inside the candidate container.
- Remove the validator dependency on Docker DNS and incorrect container-localhost fallback behavior.
- Preserve the existing retry window and surface the final in-container error.
- Add deterministic tests for retries, command construction, path normalization, and failure reporting.

## Why

The published 0.0.58 candidate was healthy, but older Docker network topologies could not resolve its temporary container name. The fallback then checked localhost from the old Slipway container, so it could never reach the candidate and aborted a safe update.

## Verification

- Published 0.0.58 image reproduced on the legacy bridge topology.
- Old DNS and localhost paths fail while the candidate itself returns HTTP 200.
- Fixed in-container probe succeeds in one attempt on that same topology.
- 321 unit tests pass.
- 106 functional tests pass.
- 46 browser tests pass.
- Formatting and documentation consistency checks pass.

Fixes #406