### PR TITLE
Fix production schema upgrades before republishing 0.0.58

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ When you want a local run that mirrors the production installer more closely tha
 npm run local
 ```
 
+Before cutting a release, boot the current checkout locally and verify it
+against the previous release's production database shape:
+
+```bash
+npm run local
+npm run local:upgrade-check -- 0.0.57
+```
+
+Replace `0.0.57` with the release users will be upgrading from. The ordinary
+local boot catches current-code startup failures; the upgrade check catches
+`migrate: safe` ordering mistakes that only exist on an older database.
+
 This runs [local.sh](local.sh), the local counterpart to
 [install.sh](install.sh). It:
 

--- a/config/bootstrap.js
+++ b/config/bootstrap.js
@@ -13,12 +13,15 @@ module.exports.bootstrap = async function () {
   // Production uses `migrate: safe`; create coordinator tables before any
   // deployment job queries run on an existing installation.
   await sails.helpers.cleanup.ensureSchema()
+  // Add every App column before a helper hydrates the full App model.  This
+  // ordering is part of the production-upgrade contract: Waterline selects
+  // every modeled column even when a helper only needs one of them.
+  await sails.helpers.bridge.ensureSchema()
+  await sails.helpers.bearing.ensureSchema()
   await sails.helpers.configuration.ensureSchema()
   await sails.helpers.flag.ensureSchema()
   await sails.helpers.deploy.ensureQueueSchema()
   await sails.helpers.service.ensureVersionSchema()
-  await sails.helpers.bridge.ensureSchema()
-  await sails.helpers.bearing.ensureSchema()
   await sails.helpers.helm.ensureWorkspaceSchema()
 
   // Initialize CLI tokens map for Bearer token authentication

--- a/local.sh
+++ b/local.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Slipway local installer
-# Usage: bash ./local.sh [install|rebuild|stop|down|destroy|logs|status|shell|bridge-benchmark]
+# Usage: bash ./local.sh [install|rebuild|upgrade-check|stop|down|destroy|logs|status|shell|bridge-benchmark]
 
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COMMAND="${1:-install}"
+PREVIOUS_VERSION="${2:-}"
 
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -26,11 +27,14 @@ SLIPWAY_URL="${SLIPWAY_LOCAL_URL:-http://${HOST}:${PORT}}"
 
 usage() {
   cat <<EOF
-Usage: bash ./local.sh [install|rebuild|stop|down|destroy|logs|status|shell|bridge-benchmark]
+Usage: bash ./local.sh [install|rebuild|upgrade-check|stop|down|destroy|logs|status|shell|bridge-benchmark]
 
 Commands:
   install   Build the current checkout and run Slipway locally in Docker
   rebuild   Same as install, but forces a no-cache Docker build
+  upgrade-check <version>
+            Boot the current checkout in production against the previous
+            release's database shape (for example: upgrade-check 0.0.57)
   stop      Stop the local Slipway container, but keep it for restart/debugging
   down      Stop and remove the local Slipway container
   destroy   Remove the local container, cached volumes, and .tmp/local state
@@ -220,6 +224,118 @@ wait_for_health() {
   exit 1
 }
 
+wait_for_container_health() {
+  local container_name="$1"
+  local attempts="${2:-45}"
+
+  for _ in $(seq 1 "$attempts"); do
+    if docker exec "$container_name" \
+      curl -fsS http://localhost:1337/health >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "Health check failed for ${container_name}. Recent logs:" >&2
+  docker logs --tail 200 "$container_name" >&2 || true
+  return 1
+}
+
+check_upgrade_from_previous_release() {
+  if [ -z "$PREVIOUS_VERSION" ]; then
+    echo "Pass the previous release version, for example:" >&2
+    echo "  npm run local:upgrade-check -- 0.0.57" >&2
+    exit 1
+  fi
+
+  local suffix previous_image seed_container current_container
+  local candidate_container db_volume apps_volume session_secret
+  local data_encryption_key
+  suffix="$$"
+  previous_image="ghcr.io/sailscastshq/slipway:${PREVIOUS_VERSION#v}"
+  seed_container="slipway-upgrade-seed-${suffix}"
+  current_container="slipway-upgrade-current-${suffix}"
+  candidate_container="slipway-upgrade-candidate-${suffix}"
+  db_volume="slipway-upgrade-db-${suffix}"
+  apps_volume="slipway-upgrade-apps-${suffix}"
+  session_secret="$(generate_hex_secret)"
+  data_encryption_key="$(generate_base64_secret)"
+
+  cleanup_upgrade_check() {
+    docker rm -f \
+      "$seed_container" \
+      "$current_container" \
+      "$candidate_container" >/dev/null 2>&1 || true
+    docker volume rm -f "$db_volume" "$apps_volume" >/dev/null 2>&1 || true
+  }
+  trap cleanup_upgrade_check EXIT INT TERM
+
+  ensure_network
+  build_local_image
+  docker pull "$previous_image"
+  docker volume create "$db_volume" >/dev/null
+  docker volume create "$apps_volume" >/dev/null
+
+  echo "Creating the ${PREVIOUS_VERSION#v} database shape..."
+  docker run -d \
+    --name "$seed_container" \
+    --network "$NETWORK_NAME" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$db_volume:/app/db" \
+    -v "$apps_volume:/var/slipway/apps" \
+    -e NODE_ENV=development \
+    -e PORT=1337 \
+    -e SLIPWAY_URL="http://${seed_container}:1337" \
+    -e SLIPWAY_APP_PORT_HOST=127.0.0.1 \
+    -e SLIPWAY_APP_PORT_START=15500 \
+    -e SLIPWAY_APP_PORT_END=15600 \
+    -e SESSION_SECRET="$session_secret" \
+    -e DATA_ENCRYPTION_KEY="$data_encryption_key" \
+    "$previous_image" node app.js >/dev/null
+  wait_for_container_health "$seed_container"
+  docker rm -f "$seed_container" >/dev/null
+
+  echo "Starting the current ${PREVIOUS_VERSION#v} release..."
+  docker run -d \
+    --name "$current_container" \
+    --network "$NETWORK_NAME" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$db_volume:/app/db" \
+    -v "$apps_volume:/var/slipway/apps" \
+    -e NODE_ENV=production \
+    -e PORT=1337 \
+    -e SLIPWAY_URL="http://${current_container}:1337" \
+    -e SLIPWAY_APP_PORT_HOST=127.0.0.1 \
+    -e SLIPWAY_APP_PORT_START=15500 \
+    -e SLIPWAY_APP_PORT_END=15600 \
+    -e SESSION_SECRET="$session_secret" \
+    -e DATA_ENCRYPTION_KEY="$data_encryption_key" \
+    "$previous_image" >/dev/null
+  wait_for_container_health "$current_container"
+
+  echo "Validating the current checkout against that live database..."
+  docker run -d \
+    --name "$candidate_container" \
+    --network "$NETWORK_NAME" \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$db_volume:/app/db" \
+    -v "$apps_volume:/var/slipway/apps" \
+    -e NODE_ENV=production \
+    -e PORT=1337 \
+    -e SLIPWAY_URL="http://${candidate_container}:1337" \
+    -e SLIPWAY_APP_PORT_HOST=127.0.0.1 \
+    -e SLIPWAY_APP_PORT_START=15500 \
+    -e SLIPWAY_APP_PORT_END=15600 \
+    -e SESSION_SECRET="$session_secret" \
+    -e DATA_ENCRYPTION_KEY="$data_encryption_key" \
+    "$IMAGE_NAME" >/dev/null
+  wait_for_container_health "$candidate_container"
+
+  echo -e "${GREEN}Upgrade check passed: ${PREVIOUS_VERSION#v} -> current checkout${NC}"
+  cleanup_upgrade_check
+  trap - EXIT INT TERM
+}
+
 show_status() {
   docker ps -a --filter "name=^/${CONTAINER_NAME}$"
   echo
@@ -308,6 +424,9 @@ main() {
       echo "  Down: npm run local:down"
       echo "  Destroy: npm run local:destroy"
       echo
+      ;;
+    upgrade-check)
+      check_upgrade_from_previous_release
       ;;
     stop)
       stop_container

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "dev": "node --watch-path=api --watch-path=config app.js",
     "local": "bash ./local.sh",
     "local:rebuild": "bash ./local.sh rebuild",
+    "local:upgrade-check": "bash ./local.sh upgrade-check",
     "local:stop": "bash ./local.sh stop",
     "local:down": "bash ./local.sh down",
     "local:destroy": "bash ./local.sh destroy",

--- a/tests/unit/helpers/system/local-script.test.js
+++ b/tests/unit/helpers/system/local-script.test.js
@@ -15,6 +15,9 @@ test('local dev scripts preserve production-like Docker assumptions', async ({
 
   expect(packageJson.scripts.local).toBe('bash ./local.sh')
   expect(packageJson.scripts['local:rebuild']).toBe('bash ./local.sh rebuild')
+  expect(packageJson.scripts['local:upgrade-check']).toBe(
+    'bash ./local.sh upgrade-check'
+  )
   expect(packageJson.scripts['local:stop']).toBe('bash ./local.sh stop')
   expect(packageJson.scripts['local:down']).toBe('bash ./local.sh down')
   expect(packageJson.scripts['local:destroy']).toBe('bash ./local.sh destroy')
@@ -32,4 +35,30 @@ test('local dev scripts preserve production-like Docker assumptions', async ({
   expect(script.includes('/app/db')).toBe(true)
   expect(script.includes('/health')).toBe(true)
   expect(script.includes('.tmp/local')).toBe(true)
+  expect(script.includes('check_upgrade_from_previous_release()')).toBe(true)
+  expect(script.includes('NODE_ENV=production')).toBe(true)
+  expect(script.includes('previous_image')).toBe(true)
+  expect(script.includes('candidate_container')).toBe(true)
+})
+
+test('production bootstrap adds App columns before hydrating App records', async ({
+  expect
+}) => {
+  const bootstrap = fs.readFileSync(
+    path.join(appRoot, 'config/bootstrap.js'),
+    'utf8'
+  )
+  const bridgeSchema = bootstrap.indexOf('sails.helpers.bridge.ensureSchema()')
+  const bearingSchema = bootstrap.indexOf(
+    'sails.helpers.bearing.ensureSchema()'
+  )
+  const configurationMigration = bootstrap.indexOf(
+    'sails.helpers.configuration.ensureSchema()'
+  )
+
+  expect(bridgeSchema > -1).toBe(true)
+  expect(bearingSchema > -1).toBe(true)
+  expect(configurationMigration > -1).toBe(true)
+  expect(bridgeSchema < configurationMigration).toBe(true)
+  expect(bearingSchema < configurationMigration).toBe(true)
 })


### PR DESCRIPTION
Fixes #408\n\nThe 0.0.58 validation container was hydrating the full App model before the new Bearing columns existed on a 0.0.57 production database. Production migrate: safe therefore failed with no such column: bearing_enabled.\n\nThis moves Bridge and Bearing schema setup ahead of the configuration migration that calls App.find(), adds a regression assertion for that ordering, and adds a local previous-release upgrade gate.\n\nVerified:\n- npm run local\n- npm run local:upgrade-check -- 0.0.57\n- published 0.0.57 updater to published 0.0.58 after the documented emergency columns\n- replacement /health returned 0.0.58\n- focused unit tests\n- npm run lint\n- npm run check:consistency\n- bash -n local.sh