### PR TITLE
Fix interrupted deployment container reconciliation

### DIFF
--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -135,6 +135,36 @@ module.exports = {
         candidateContainerName: deployContainerName,
         imageName
       })
+      const candidatePreparation =
+        await sails.helpers.deploy.prepareCandidateContainer.with({
+          deploymentId,
+          leaseToken,
+          ...(targetApp?.id ? { appId: String(targetApp.id) } : {}),
+          containerName: deployContainerName
+        })
+      if (candidatePreparation.action === 'current') {
+        deployContainerName = null
+        await sails.helpers.deploy.finalizeCurrentCandidate.with({
+          deploymentId,
+          leaseToken,
+          environmentId: String(environment.id),
+          appId: String(targetApp.id)
+        })
+        return
+      }
+      if (
+        candidatePreparation.action !== 'ready' &&
+        candidatePreparation.action !== 'removed'
+      ) {
+        // The app record is the traffic authority. Keep its container out of
+        // generic failure cleanup even when the deployment metadata disagrees.
+        deployContainerName = null
+        const conflict = new Error(
+          `Container ${candidatePreparation.app.containerName} currently owns app traffic and cannot be replaced as a stale candidate.`
+        )
+        conflict.code = 'DEPLOYMENT_TRAFFIC_OWNER_CONFLICT'
+        throw conflict
+      }
       const { contextPath } =
         await sails.helpers.deploy.ensureBuildContext.with({
           project,

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -124,6 +124,37 @@ module.exports = {
         previousContainerName: oldContainerName || undefined
       })
 
+      const candidatePreparation =
+        await sails.helpers.deploy.prepareCandidateContainer.with({
+          deploymentId: rollbackId,
+          leaseToken,
+          ...(existingApp?.id ? { appId: String(existingApp.id) } : {}),
+          containerName: candidateContainerName
+        })
+      if (candidatePreparation.action === 'current') {
+        candidateContainerName = null
+        await sails.helpers.deploy.finalizeCurrentCandidate.with({
+          deploymentId: rollbackId,
+          leaseToken,
+          environmentId: String(environment.id),
+          appId: String(existingApp.id)
+        })
+        return
+      }
+      if (
+        candidatePreparation.action !== 'ready' &&
+        candidatePreparation.action !== 'removed'
+      ) {
+        // The app record is the traffic authority. Keep its container out of
+        // generic failure cleanup even when the deployment metadata disagrees.
+        candidateContainerName = null
+        const conflict = new Error(
+          `Container ${candidatePreparation.app.containerName} currently owns app traffic and cannot be replaced as a stale candidate.`
+        )
+        conflict.code = 'DEPLOYMENT_TRAFFIC_OWNER_CONFLICT'
+        throw conflict
+      }
+
       hostPort = await sails.helpers.docker.allocatePort.with({
         ownerType: 'deployment',
         ownerId: String(rollbackId)

--- a/api/helpers/deploy/finalize-current-candidate.js
+++ b/api/helpers/deploy/finalize-current-candidate.js
@@ -1,0 +1,135 @@
+module.exports = {
+  friendlyName: 'Finalize current candidate',
+
+  description:
+    'Finalize durable deployment state when the candidate already owns app traffic after an interrupted attempt.',
+
+  inputs: {
+    deploymentId: {
+      type: 'string',
+      required: true
+    },
+    leaseToken: {
+      type: 'string'
+    },
+    environmentId: {
+      type: 'string',
+      required: true
+    },
+    appId: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ deploymentId, leaseToken, environmentId, appId }) {
+    const [app, job] = await Promise.all([
+      App.findOne({ id: appId }),
+      DeploymentJob.findOne({ deployment: deploymentId })
+    ])
+    if (
+      !app ||
+      !app.containerName ||
+      String(app.currentDeployment) !== String(deploymentId)
+    ) {
+      const error = new Error(
+        `Deployment ${deploymentId} no longer owns app traffic.`
+      )
+      error.code = 'DEPLOYMENT_TRAFFIC_OWNER_CHANGED'
+      throw error
+    }
+
+    requireValidLease(
+      await sails.helpers.deploy.assertDeploymentLease.with({
+        deploymentId,
+        leaseToken
+      })
+    )
+
+    await sails.helpers.caddy.updateRoute.with({
+      environmentId
+    })
+
+    // Route repair can take long enough for ownership to change. Fence again
+    // before retiring the previous release or releasing port state.
+    requireValidLease(
+      await sails.helpers.deploy.assertDeploymentLease.with({
+        deploymentId,
+        leaseToken
+      })
+    )
+
+    if (
+      job?.previousContainerName &&
+      job.previousContainerName !== app.containerName
+    ) {
+      try {
+        await sails.helpers.docker.stopContainer.with({
+          containerName: job.previousContainerName
+        })
+      } catch (error) {
+        if (error !== 'notFound' && error?.code !== 'notFound') throw error
+      }
+    }
+
+    if (job?.hostPort) {
+      await sails.helpers.docker.releasePort.with({
+        hostPort: job.hostPort,
+        ownerType: 'deployment',
+        ownerId: String(deploymentId)
+      })
+    } else {
+      await PortReservation.destroy({
+        ownerType: 'deployment',
+        ownerId: String(deploymentId)
+      })
+    }
+
+    const stopCriteria = {
+      environment: environmentId,
+      app: appId,
+      status: 'running',
+      id: { '<': deploymentId }
+    }
+    await Deployment.update(stopCriteria).set({ status: 'stopped' })
+
+    requireValidLease(
+      await sails.helpers.deploy.updateDeploymentForLease.with({
+        deploymentId,
+        leaseToken,
+        values: {
+          status: 'running',
+          errorMessage: null,
+          finishedAt: Date.now()
+        }
+      })
+    )
+    requireValidLease(
+      await sails.helpers.deploy.recordDeploymentStage.with({
+        deploymentId,
+        leaseToken,
+        stage: 'complete'
+      })
+    )
+
+    await Deployment.appendDeployLog(
+      deploymentId,
+      'Recovered the already-committed candidate, retired the previous release, and finalized this deployment.\n'
+    )
+
+    return { action: 'finalized', app }
+  }
+}
+
+function requireValidLease(result) {
+  if (!result || result.valid !== false) return
+  const error = new Error(result.message)
+  error.code = result.code
+  throw error
+}

--- a/api/helpers/deploy/prepare-candidate-container.js
+++ b/api/helpers/deploy/prepare-candidate-container.js
@@ -1,0 +1,92 @@
+module.exports = {
+  friendlyName: 'Prepare candidate container',
+
+  description:
+    'Make a deployment-scoped Docker container name safe to reuse without ever removing the app container that owns traffic.',
+
+  inputs: {
+    deploymentId: {
+      type: 'string',
+      required: true
+    },
+    leaseToken: {
+      type: 'string'
+    },
+    appId: {
+      type: 'string'
+    },
+    containerName: {
+      type: 'string',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ deploymentId, leaseToken, appId, containerName }) {
+    requireValidLease(
+      await sails.helpers.deploy.assertDeploymentLease.with({
+        deploymentId,
+        leaseToken
+      })
+    )
+
+    let status
+    try {
+      status = await sails.helpers.docker.getContainerStatus.with({
+        containerName,
+        fresh: true
+      })
+    } catch (error) {
+      if (error !== 'notFound' && error?.code !== 'notFound') throw error
+      status = null
+    }
+
+    if (!status) return { action: 'ready' }
+
+    const app = appId ? await App.findOne({ id: appId }) : null
+    const ownsTraffic = app?.containerName === containerName
+    const isCommitted = Boolean(
+      ownsTraffic &&
+        app.currentDeployment &&
+        String(app.currentDeployment) === String(deploymentId)
+    )
+
+    if (ownsTraffic) {
+      return {
+        action:
+          isCommitted && status.running ? 'current' : 'traffic-owner-conflict',
+        app,
+        status
+      }
+    }
+
+    // Recheck the fencing token immediately before the destructive mutation.
+    // An expired worker must not remove a candidate owned by its successor.
+    requireValidLease(
+      await sails.helpers.deploy.assertDeploymentLease.with({
+        deploymentId,
+        leaseToken
+      })
+    )
+
+    await sails.helpers.docker.stopContainer.with({ containerName })
+    await Deployment.appendDeployLog(
+      deploymentId,
+      `Removed stale candidate container before retry: ${containerName}\n`
+    )
+
+    return { action: 'removed', status }
+  }
+}
+
+function requireValidLease(result) {
+  if (!result || result.valid !== false) return
+  const error = new Error(result.message)
+  error.code = result.code
+  throw error
+}

--- a/api/helpers/docker/get-container-status.js
+++ b/api/helpers/docker/get-container-status.js
@@ -11,6 +11,12 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'Name or ID of the container'
+    },
+    fresh: {
+      type: 'boolean',
+      defaultsTo: false,
+      description:
+        'Bypass the short-lived status cache for lifecycle decisions.'
     }
   },
   exits: {
@@ -22,16 +28,21 @@ module.exports = {
       description: 'Container not found'
     }
   },
-  fn: async function ({ containerName }) {
+  fn: async function ({ containerName, fresh }) {
     // Check cache first
     const cacheKey = `container:status:${containerName}`
-    try {
-      const cached = await sails.cache.get(cacheKey)
-      if (cached) {
-        return cached
+    if (!fresh) {
+      try {
+        const cached = await sails.cache.get(cacheKey)
+        if (cached) {
+          return cached
+        }
+      } catch (err) {
+        sails.log.verbose(
+          'Cache read failed for container status:',
+          err.message
+        )
       }
-    } catch (err) {
-      sails.log.verbose('Cache read failed for container status:', err.message)
     }
 
     try {

--- a/tests/unit/helpers/deploy/cutover-traffic.test.js
+++ b/tests/unit/helpers/deploy/cutover-traffic.test.js
@@ -454,6 +454,7 @@ test(
     const setup = await prepareCutover({ sails, world })
     const originals = {
       ensureNetwork: sails.helpers.docker.ensureNetwork,
+      prepareCandidateContainer: sails.helpers.deploy.prepareCandidateContainer,
       ensureBuildContext: sails.helpers.deploy.ensureBuildContext,
       buildImage: sails.helpers.docker.buildImage,
       detectFeatures: sails.helpers.sails.detectFeatures,
@@ -473,6 +474,9 @@ test(
     let candidateImage
 
     sails.helpers.docker.ensureNetwork = machineStub(async () => {})
+    sails.helpers.deploy.prepareCandidateContainer = machineStub(async () => ({
+      action: 'ready'
+    }))
     sails.helpers.deploy.ensureBuildContext = machineStub(async () => ({
       contextPath: '/tmp/slipway-cancel-before-cutover'
     }))
@@ -550,6 +554,8 @@ test(
       )
     } finally {
       sails.helpers.docker.ensureNetwork = originals.ensureNetwork
+      sails.helpers.deploy.prepareCandidateContainer =
+        originals.prepareCandidateContainer
       sails.helpers.deploy.ensureBuildContext = originals.ensureBuildContext
       sails.helpers.docker.buildImage = originals.buildImage
       sails.helpers.sails.detectFeatures = originals.detectFeatures
@@ -574,6 +580,7 @@ test(
     })
     const originals = {
       ensureNetwork: sails.helpers.docker.ensureNetwork,
+      prepareCandidateContainer: sails.helpers.deploy.prepareCandidateContainer,
       allocatePort: sails.helpers.docker.allocatePort,
       runContainer: sails.helpers.docker.runContainer,
       healthCheck: sails.helpers.docker.healthCheck,
@@ -588,6 +595,9 @@ test(
     let candidateName
 
     sails.helpers.docker.ensureNetwork = machineStub(async () => {})
+    sails.helpers.deploy.prepareCandidateContainer = machineStub(async () => ({
+      action: 'ready'
+    }))
     sails.helpers.docker.allocatePort = machineStub(async () => 1403)
     sails.helpers.docker.runContainer = machineStub(async (inputs) => {
       sequence.push('candidate-started')
@@ -658,6 +668,8 @@ test(
       ])
     } finally {
       sails.helpers.docker.ensureNetwork = originals.ensureNetwork
+      sails.helpers.deploy.prepareCandidateContainer =
+        originals.prepareCandidateContainer
       sails.helpers.docker.allocatePort = originals.allocatePort
       sails.helpers.docker.runContainer = originals.runContainer
       sails.helpers.docker.healthCheck = originals.healthCheck
@@ -681,6 +693,7 @@ test(
     })
     const originals = {
       ensureNetwork: sails.helpers.docker.ensureNetwork,
+      prepareCandidateContainer: sails.helpers.deploy.prepareCandidateContainer,
       allocatePort: sails.helpers.docker.allocatePort,
       runContainer: sails.helpers.docker.runContainer,
       healthCheck: sails.helpers.docker.healthCheck,
@@ -694,6 +707,9 @@ test(
     sails.log.error = () => {}
 
     sails.helpers.docker.ensureNetwork = machineStub(async () => {})
+    sails.helpers.deploy.prepareCandidateContainer = machineStub(async () => ({
+      action: 'ready'
+    }))
     sails.helpers.docker.allocatePort = machineStub(async () => 1404)
     sails.helpers.docker.runContainer = machineStub(async (inputs) => {
       candidateName = inputs.containerName
@@ -751,6 +767,8 @@ test(
       expect(sequence.includes('stopped:slipway-web-previous')).toBe(false)
     } finally {
       sails.helpers.docker.ensureNetwork = originals.ensureNetwork
+      sails.helpers.deploy.prepareCandidateContainer =
+        originals.prepareCandidateContainer
       sails.helpers.docker.allocatePort = originals.allocatePort
       sails.helpers.docker.runContainer = originals.runContainer
       sails.helpers.docker.healthCheck = originals.healthCheck

--- a/tests/unit/helpers/deploy/prepare-candidate-container.test.js
+++ b/tests/unit/helpers/deploy/prepare-candidate-container.test.js
@@ -1,0 +1,320 @@
+const { test } = require('sounding')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const appRoot = path.resolve(__dirname, '../../../../')
+
+function deploymentWorld(slug) {
+  return {
+    name: 'configured-slipway',
+    context: {
+      deploymentTarget: { slug }
+    }
+  }
+}
+
+test(
+  'candidate preparation starts normally when its Docker name is free',
+  { world: deploymentWorld('candidate-name-ready') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+    const doubles = installContainerDoubles(sails, { status: null })
+
+    try {
+      const result = await sails.helpers.deploy.prepareCandidateContainer.with({
+        deploymentId: String(deployment.id),
+        appId: String(current.apps.web.id),
+        containerName: 'candidate-ready'
+      })
+
+      expect(result).toEqual({ action: 'ready' })
+      expect(doubles.statusChecks).toEqual([
+        { containerName: 'candidate-ready', fresh: true }
+      ])
+      expect(doubles.stopped).toEqual([])
+    } finally {
+      doubles.restore()
+    }
+  }
+)
+
+test(
+  'candidate preparation removes an uncommitted leftover before retry',
+  { world: deploymentWorld('candidate-name-stale') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      deployLogs: ''
+    })
+    const status = { running: true, status: 'running' }
+    const doubles = installContainerDoubles(sails, { status })
+
+    try {
+      const result = await sails.helpers.deploy.prepareCandidateContainer.with({
+        deploymentId: String(deployment.id),
+        appId: String(current.apps.web.id),
+        containerName: 'candidate-stale'
+      })
+      const persisted = await sails.models.deployment.findOne({
+        id: deployment.id
+      })
+
+      expect(result).toEqual({ action: 'removed', status })
+      expect(doubles.stopped).toEqual(['candidate-stale'])
+      expect(persisted.deployLogs).toContain(
+        'Removed stale candidate container before retry: candidate-stale'
+      )
+    } finally {
+      doubles.restore()
+    }
+  }
+)
+
+test(
+  'candidate preparation cannot remove a leftover after its lease expires',
+  { world: deploymentWorld('candidate-name-fenced') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+    const token = `expired-${deployment.id}`
+    await world.create('deploymentlease').with({
+      deployment: deployment.id,
+      targetKey: `environment:${current.environments.production.id}`,
+      token,
+      expiresAt: Date.now() - 1
+    })
+    const doubles = installContainerDoubles(sails, {
+      status: { running: true, status: 'running' }
+    })
+
+    try {
+      const error = await captureError(
+        sails.helpers.deploy.prepareCandidateContainer.with({
+          deploymentId: String(deployment.id),
+          leaseToken: token,
+          appId: String(current.apps.web.id),
+          containerName: 'candidate-fenced'
+        })
+      )
+
+      expect(error.code).toBe('DEPLOYMENT_LEASE_LOST')
+      expect(doubles.statusChecks).toEqual([])
+      expect(doubles.stopped).toEqual([])
+    } finally {
+      doubles.restore()
+    }
+  }
+)
+
+test(
+  'candidate preparation protects the committed container that owns traffic',
+  { world: deploymentWorld('candidate-name-current') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'candidate-current',
+      currentDeployment: deployment.id
+    })
+    const status = { running: true, status: 'running' }
+    const doubles = installContainerDoubles(sails, { status })
+
+    try {
+      const result = await sails.helpers.deploy.prepareCandidateContainer.with({
+        deploymentId: String(deployment.id),
+        appId: String(current.apps.web.id),
+        containerName: 'candidate-current'
+      })
+
+      expect(result.action).toBe('current')
+      expect(result.status).toEqual(status)
+      expect(doubles.stopped).toEqual([])
+    } finally {
+      doubles.restore()
+    }
+  }
+)
+
+test('deploy and rollback reconcile candidate names before docker run', async ({
+  expect
+}) => {
+  for (const relativePath of [
+    'api/helpers/deploy/execute-pipeline.js',
+    'api/helpers/deploy/execute-rollback.js'
+  ]) {
+    const source = fs.readFileSync(path.join(appRoot, relativePath), 'utf8')
+    const preparation = source.indexOf(
+      'await sails.helpers.deploy.prepareCandidateContainer.with({'
+    )
+    const run = source.indexOf('await sails.helpers.docker.runContainer.with({')
+
+    expect(preparation > -1).toBe(true)
+    expect(run > -1).toBe(true)
+    expect(preparation < run).toBe(true)
+  }
+})
+
+test(
+  'candidate preparation refuses to remove an inconsistent traffic owner',
+  { world: deploymentWorld('candidate-name-traffic-owner') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'candidate-owner',
+      currentDeployment: null
+    })
+    const doubles = installContainerDoubles(sails, {
+      status: { running: true, status: 'running' }
+    })
+
+    try {
+      const result = await sails.helpers.deploy.prepareCandidateContainer.with({
+        deploymentId: String(deployment.id),
+        appId: String(current.apps.web.id),
+        containerName: 'candidate-owner'
+      })
+
+      expect(result.action).toBe('traffic-owner-conflict')
+      expect(doubles.stopped).toEqual([])
+    } finally {
+      doubles.restore()
+    }
+  }
+)
+
+test(
+  'an already committed candidate is finalized without starting another container',
+  { world: deploymentWorld('candidate-name-finalize') },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const previous = await world.create('deployment').with({
+      status: 'running',
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+    const deployment = await world.create('deployment').with({
+      status: 'deploying',
+      environment: current.environments.production.id,
+      app: current.apps.web.id
+    })
+    const job = await world.create('deploymentjob').with({
+      deployment: deployment.id,
+      targetKey: `environment:${current.environments.production.id}`,
+      stage: 'container_startup',
+      previousContainerName: 'candidate-previous',
+      hostPort: 1499
+    })
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      status: 'running',
+      containerName: 'candidate-finalized',
+      currentDeployment: deployment.id
+    })
+
+    const originalUpdateRoute = sails.helpers.caddy.updateRoute
+    const originalStopContainer = sails.helpers.docker.stopContainer
+    const originalReleasePort = sails.helpers.docker.releasePort
+    const routes = []
+    const stopped = []
+    const released = []
+    sails.helpers.caddy.updateRoute = {
+      with: async ({ environmentId }) => routes.push(environmentId)
+    }
+    sails.helpers.docker.stopContainer = {
+      with: async ({ containerName }) => stopped.push(containerName)
+    }
+    sails.helpers.docker.releasePort = {
+      with: async (inputs) => released.push(inputs)
+    }
+
+    try {
+      await sails.helpers.deploy.finalizeCurrentCandidate.with({
+        deploymentId: String(deployment.id),
+        environmentId: String(current.environments.production.id),
+        appId: String(current.apps.web.id)
+      })
+
+      const [persisted, persistedPrevious, persistedJob] = await Promise.all([
+        sails.models.deployment.findOne({ id: deployment.id }),
+        sails.models.deployment.findOne({ id: previous.id }),
+        sails.models.deploymentjob.findOne({ id: job.id })
+      ])
+      expect(persisted.status).toBe('running')
+      expect(persistedPrevious.status).toBe('stopped')
+      expect(persistedJob.stage).toBe('complete')
+      expect(routes).toEqual([String(current.environments.production.id)])
+      expect(stopped).toEqual(['candidate-previous'])
+      expect(released).toEqual([
+        {
+          hostPort: 1499,
+          ownerType: 'deployment',
+          ownerId: String(deployment.id)
+        }
+      ])
+    } finally {
+      sails.helpers.caddy.updateRoute = originalUpdateRoute
+      sails.helpers.docker.stopContainer = originalStopContainer
+      sails.helpers.docker.releasePort = originalReleasePort
+    }
+  }
+)
+
+function installContainerDoubles(sails, { status }) {
+  const originals = {
+    getContainerStatus: sails.helpers.docker.getContainerStatus,
+    stopContainer: sails.helpers.docker.stopContainer
+  }
+  const statusChecks = []
+  const stopped = []
+
+  sails.helpers.docker.getContainerStatus = {
+    with: async (inputs) => {
+      statusChecks.push(inputs)
+      if (!status) throw 'notFound'
+      return status
+    }
+  }
+  sails.helpers.docker.stopContainer = {
+    with: async ({ containerName }) => {
+      stopped.push(containerName)
+      return { stopped: true, removed: true }
+    }
+  }
+
+  return {
+    statusChecks,
+    stopped,
+    restore() {
+      sails.helpers.docker.getContainerStatus = originals.getContainerStatus
+      sails.helpers.docker.stopContainer = originals.stopContainer
+    }
+  }
+}
+
+async function captureError(promise) {
+  try {
+    await promise
+    return null
+  } catch (error) {
+    return error
+  }
+}


### PR DESCRIPTION
## What changed

- reconcile deterministic deployment candidate names before Docker startup
- remove only stale, uncommitted candidates while the worker still owns its fenced lease
- protect the app container that currently owns traffic from generic failure cleanup
- finalize an already committed candidate after interruption, including route repair, previous-container retirement, and port-reservation cleanup
- apply the same behavior to deployments and rollbacks
- bypass cached Docker status for lifecycle mutations

## Why

An interrupted deployment could leave its `...-app-<deployment-id>` candidate behind. A resumed attempt then failed immediately because `docker run --name` found that deterministic name already in use. The earlier deployment-history fix made the UI show only the committed traffic owner as Current, but it did not reconcile this physical Docker state.

## Verification

- `npx sounding test tests/unit/helpers/deploy --test-concurrency=1` — 33 passed
- `npx sounding test tests/functional/api/deploy.test.js --test-concurrency=1` — 5 passed
- `npm run test:unit` — 329 passed
- `npm run lint`
- `npm run check:consistency`
- `SLIPWAY_LOCAL_PORT=31337 npm run local` — healthy
- `npm run local:upgrade-check -- 0.0.58` — passed

Fixes #410
