### PR TITLE
fix(bearing): keep public URLs app-owned

### DIFF
--- a/api/controllers/bearing/view-feedback.js
+++ b/api/controllers/bearing/view-feedback.js
@@ -165,9 +165,6 @@ module.exports = {
         realtime: buildRealtimeConfig({
           req: this.req,
           resolved,
-          projectSlug,
-          environmentSlug,
-          appSlug,
           secret: sails.config.session.secret
         }),
         focusedFeedbackId: focusedFeedback?.publicId || null,

--- a/api/controllers/bearing/view-surface.js
+++ b/api/controllers/bearing/view-surface.js
@@ -98,9 +98,6 @@ module.exports = {
         realtime: buildRealtimeConfig({
           req: this.req,
           resolved,
-          projectSlug,
-          environmentSlug,
-          appSlug,
           secret: sails.config.session.secret
         }),
         surface,

--- a/api/helpers/bearing/resolve-public-request.js
+++ b/api/helpers/bearing/resolve-public-request.js
@@ -1,5 +1,4 @@
 const crypto = require('node:crypto')
-const { isHostOriginRequest } = require('../../lib/bridge-paths')
 
 module.exports = {
   friendlyName: 'Resolve public Bearing request',
@@ -20,6 +19,9 @@ module.exports = {
   },
 
   fn: async function ({ req, projectSlug, environmentSlug, appSlug }) {
+    const delivery = String(req.param('delivery') || '')
+    if (!['host', 'public'].includes(delivery)) throw 'notFound'
+
     const project = await Project.findOne({ slug: projectSlug })
     const environment = project
       ? await Environment.findOne({
@@ -53,12 +55,11 @@ module.exports = {
     if (!participant && req.session) clearBearingSession(req.session)
 
     const routePrefix = normalizeRoutePrefix(app.routePath)
-    const instanceUrl = await sails.helpers.getInstanceUrl()
-    const hostOrigin = isHostOriginRequest(req, instanceUrl)
+    const hostOrigin = delivery === 'host'
     const integrationBasePath = hostOrigin
       ? `${routePrefix}/_slipway/bearing`
       : ''
-    const internalBasePath = `/bearing/public/${encodeURIComponent(
+    const internalBasePath = `/bearing/${delivery}/${encodeURIComponent(
       project.slug
     )}/${encodeURIComponent(environment.slug)}/${encodeURIComponent(app.slug)}`
     return {
@@ -67,6 +68,8 @@ module.exports = {
       app,
       space,
       participant,
+      hostOrigin,
+      requestBasePath: internalBasePath,
       publicBasePath: hostOrigin ? `${routePrefix}/bearing` : internalBasePath,
       integrationBasePath,
       identityPath: hostOrigin

--- a/api/helpers/caddy/generate-route-config.js
+++ b/api/helpers/caddy/generate-route-config.js
@@ -184,7 +184,7 @@ function bearingHandlers({
   const routePrefix = normalizeRoutePrefix(app.routePath)
   const bearingInternalPath = `${routePrefix}/_slipway/bearing`
   const publicBasePath = `${routePrefix}/bearing`
-  const internalBasePath = `/bearing/public/${projectSlug}/${environmentSlug}/${app.slug}`
+  const internalBasePath = `/bearing/host/${projectSlug}/${environmentSlug}/${app.slug}`
   const appProxy = {
     handler: 'reverse_proxy',
     upstreams: [{ dial: `host.docker.internal:${app.hostPort}` }]

--- a/api/helpers/caddy/update-route.js
+++ b/api/helpers/caddy/update-route.js
@@ -249,7 +249,7 @@ function buildRouteLabels({
     const routePrefix = normalizeRoutePrefix(app.routePath)
     const bearingInternalPath = `${routePrefix}/_slipway/bearing`
     const publicBasePath = `${routePrefix}/bearing`
-    const internalBasePath = `/bearing/public/${projectSlug}/${environmentSlug}/${app.slug}`
+    const internalBasePath = `/bearing/host/${projectSlug}/${environmentSlug}/${app.slug}`
 
     addHandle({
       labels,

--- a/api/lib/bearing-realtime.js
+++ b/api/lib/bearing-realtime.js
@@ -66,14 +66,7 @@ function roomName(spaceId) {
   return `bearing:space:${String(spaceId)}`
 }
 
-function buildRealtimeConfig({
-  req,
-  resolved,
-  projectSlug,
-  environmentSlug,
-  appSlug,
-  secret
-}) {
+function buildRealtimeConfig({ req, resolved, secret }) {
   const origin = requestOrigin(req)
   return {
     token: issueRealtimeToken({
@@ -84,11 +77,7 @@ function buildRealtimeConfig({
     socketPath: resolved.integrationBasePath
       ? `${resolved.integrationBasePath}/socket.io`
       : '/socket.io',
-    subscribePath: `/bearing/public/${encodeURIComponent(
-      projectSlug
-    )}/${encodeURIComponent(environmentSlug)}/${encodeURIComponent(
-      appSlug
-    )}/realtime`
+    subscribePath: `${resolved.requestBasePath}/realtime`
   }
 }
 

--- a/config/routes.js
+++ b/config/routes.js
@@ -395,29 +395,29 @@ module.exports.routes = {
   },
   'GET /bearing/session': 'bearing/session',
   'GET /_slipway/bearing/session': 'bearing/session',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/feedback':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback':
     'bearing/view-feedback',
-  'POST /bearing/public/:projectSlug/:environmentSlug/:appSlug/feedback':
+  'POST /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback':
     'bearing/create-feedback',
-  'POST /bearing/public/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId/vote':
+  'POST /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId/vote':
     'bearing/toggle-vote',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/realtime':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/realtime':
     'bearing/subscribe-realtime',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/bootstrap.js':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/bootstrap.js':
     'bearing/view-bootstrap',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/widget-config':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/widget-config':
     'bearing/view-widget-config',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug':
     'bearing/redirect-to-feedback',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/:surface/og.png':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/:surface/og.png':
     'bearing/view-social-image',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug/og.png':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug/og.png':
     'bearing/view-update-social-image',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug':
     'bearing/view-update',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId':
     'bearing/view-feedback',
-  'GET /bearing/public/:projectSlug/:environmentSlug/:appSlug/:surface':
+  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/:surface':
     'bearing/view-surface',
   'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/access':
     'project/view-bridge-access',

--- a/tests/functional/pages/bearing.test.js
+++ b/tests/functional/pages/bearing.test.js
@@ -401,14 +401,14 @@ test(
       .fetch()
     const publicPath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/feedback`
     const publicBasePath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}`
+    const hostPath = `/bearing/host/${project.slug}/${environment.slug}/${app.slug}/feedback`
+    const hostBasePath = `/bearing/host/${project.slug}/${environment.slug}/${app.slug}`
 
     const namespace = await request.get(publicBasePath)
     expect(namespace).toHaveStatus(302)
     expect(namespace).toRedirectTo(`${publicBasePath}/feedback`)
 
-    const hostNamespace = await request
-      .withHeaders({ 'x-forwarded-host': 'ideas.example.com' })
-      .get(publicBasePath)
+    const hostNamespace = await request.get(hostBasePath)
     expect(hostNamespace).toHaveStatus(302)
     expect(hostNamespace).toRedirectTo('/bearing/feedback')
 
@@ -427,9 +427,10 @@ test(
     const hostPage = await request
       .withHeaders({
         ...INERTIA_HEADERS,
+        host: 'ideas.example.com',
         'x-forwarded-host': 'ideas.example.com'
       })
-      .get(publicPath)
+      .get(hostPath)
     expect(hostPage).toHaveInertiaProps({
       'app.feedbackPath': '/bearing/feedback',
       'app.roadmapPath': '/bearing/roadmap',
@@ -438,6 +439,7 @@ test(
       'app.publicUrl': 'https://ideas.example.com/bearing/feedback',
       'app.ogImageUrl': 'https://ideas.example.com/bearing/feedback/og.png',
       'realtime.socketPath': '/_slipway/bearing/socket.io',
+      'realtime.subscribePath': `${hostBasePath}/realtime`,
       hostAssetBasePath: '/_slipway/bearing/_assets'
     })
 

--- a/tests/unit/config/routes.test.js
+++ b/tests/unit/config/routes.test.js
@@ -33,7 +33,7 @@ test('browser actions and JSON transports have explicit route contracts', ({
     ]
   ).toBe('project/upload-bearing-update-image')
   expect(
-    routes['GET /bearing/public/:projectSlug/:environmentSlug/:appSlug']
+    routes['GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug']
   ).toBe('bearing/redirect-to-feedback')
   expect(
     routes[

--- a/tests/unit/helpers/caddy/generate-route-config.test.js
+++ b/tests/unit/helpers/caddy/generate-route-config.test.js
@@ -43,7 +43,7 @@ test('generated Caddy config keeps public Bearing surfaces in their namespace', 
 
   expect(handlers[6].routes[0].match[0].path).toEqual(['/academy/bearing'])
   expect(handlers[6].routes[0].handle[0].uri).toBe(
-    '/bearing/public/durable-ui/production/web'
+    '/bearing/host/durable-ui/production/web'
   )
   expect(handlers[7].routes[0].match[0].path).toEqual([
     '/academy/bearing/feedback*'
@@ -52,7 +52,7 @@ test('generated Caddy config keeps public Bearing surfaces in their namespace', 
     '/academy/bearing/feedback'
   )
   expect(handlers[7].routes[0].handle[1].uri).toBe(
-    '/bearing/public/durable-ui/production/web/feedback{http.request.uri.path}'
+    '/bearing/host/durable-ui/production/web/feedback{http.request.uri.path}'
   )
   expect(
     handlers.some((handler) =>

--- a/tests/unit/helpers/caddy/update-route.test.js
+++ b/tests/unit/helpers/caddy/update-route.test.js
@@ -167,15 +167,15 @@ test('Bearing sends identity to the app before proxying its public surfaces', ({
     'caddy.handle_5=/admin/_slipway/bearing/widget-config'
   )
   expect(labels).toContain(
-    'caddy.handle_5.0_uri=replace /admin/_slipway/bearing/widget-config /bearing/public/durable-ui/production/admin/widget-config'
+    'caddy.handle_5.0_uri=replace /admin/_slipway/bearing/widget-config /bearing/host/durable-ui/production/admin/widget-config'
   )
   expect(labels).toContain('caddy.handle_6=/admin/bearing')
   expect(labels).toContain(
-    'caddy.handle_6.0_uri=replace /admin/bearing /bearing/public/durable-ui/production/admin'
+    'caddy.handle_6.0_uri=replace /admin/bearing /bearing/host/durable-ui/production/admin'
   )
   expect(labels).toContain('caddy.handle_7=/admin/bearing/feedback*')
   expect(labels).toContain(
-    'caddy.handle_7.0_uri=replace /admin/bearing/feedback /bearing/public/durable-ui/production/admin/feedback'
+    'caddy.handle_7.0_uri=replace /admin/bearing/feedback /bearing/host/durable-ui/production/admin/feedback'
   )
   expect(labels).toContain('caddy.handle_10=/admin*')
   expect(

--- a/tests/unit/lib/bearing-realtime.test.js
+++ b/tests/unit/lib/bearing-realtime.test.js
@@ -20,15 +20,16 @@ test('Bearing realtime stays on its private integration path for mounted apps', 
     req,
     resolved: {
       space: { id: '42' },
-      integrationBasePath: '/academy/_slipway/bearing'
+      integrationBasePath: '/academy/_slipway/bearing',
+      requestBasePath: '/bearing/host/durable-ui/production/academy'
     },
-    projectSlug: 'durable-ui',
-    environmentSlug: 'production',
-    appSlug: 'academy',
     secret: 'test-bearing-realtime-secret'
   })
 
   expect(config.socketPath).toBe('/academy/_slipway/bearing/socket.io')
+  expect(config.subscribePath).toBe(
+    '/bearing/host/durable-ui/production/academy/realtime'
+  )
 })
 
 test('Bearing realtime tokens are short-lived, origin-bound, and tamper-safe', ({


### PR DESCRIPTION
Fixes #412\n\n## What changed\n- separate host-delivered Bearing requests from dashboard previews explicitly\n- keep app-facing links, redirects, forms, OG URLs, widget URLs, and realtime under /bearing\n- retain /bearing/public/... only for scoped Slipway-instance previews\n- update both Caddy routing implementations and regression coverage\n\n## Verification\n- 18 focused unit and functional tests pass\n- npm run lint\n- isolated npm run local lift healthy on port 31340