### PR TITLE
fix(bearing): privatize control-plane routes

### DIFF
--- a/api/helpers/bearing/resolve-public-request.js
+++ b/api/helpers/bearing/resolve-public-request.js
@@ -19,9 +19,6 @@ module.exports = {
   },
 
   fn: async function ({ req, projectSlug, environmentSlug, appSlug }) {
-    const delivery = String(req.param('delivery') || '')
-    if (!['host', 'public'].includes(delivery)) throw 'notFound'
-
     const project = await Project.findOne({ slug: projectSlug })
     const environment = project
       ? await Environment.findOne({
@@ -55,15 +52,8 @@ module.exports = {
     if (!participant && req.session) clearBearingSession(req.session)
 
     const routePrefix = normalizeRoutePrefix(app.routePath)
-    const { domains } = await Environment.resolveDomains(
-      { ...environment, project },
-      {}
-    )
-    const hostOrigin = delivery === 'host' || requestMatchesDomain(req, domains)
-    const integrationBasePath = hostOrigin
-      ? `${routePrefix}/_slipway/bearing`
-      : ''
-    const internalBasePath = `/bearing/${delivery}/${encodeURIComponent(
+    const integrationBasePath = `${routePrefix}/_slipway/bearing`
+    const internalBasePath = `/_slipway/bearing/host/${encodeURIComponent(
       project.slug
     )}/${encodeURIComponent(environment.slug)}/${encodeURIComponent(app.slug)}`
     return {
@@ -72,14 +62,11 @@ module.exports = {
       app,
       space,
       participant,
-      hostOrigin,
       requestBasePath: internalBasePath,
-      publicBasePath: hostOrigin ? `${routePrefix}/bearing` : internalBasePath,
+      publicBasePath: `${routePrefix}/bearing`,
       integrationBasePath,
-      identityPath: hostOrigin
-        ? `${integrationBasePath}/identity`
-        : `${internalBasePath}/_slipway/bearing/identity`,
-      hostAssetBasePath: hostOrigin ? `${integrationBasePath}/_assets` : ''
+      identityPath: `${integrationBasePath}/identity`,
+      hostAssetBasePath: `${integrationBasePath}/_assets`
     }
   }
 }
@@ -94,30 +81,6 @@ function hashCredential(value) {
 function normalizeRoutePrefix(routePath) {
   if (!routePath || routePath === '/') return ''
   return `/${String(routePath).replace(/^\/+|\/+$/g, '')}`
-}
-
-function requestMatchesDomain(req, domains) {
-  const requestHost = normalizeHostname(
-    req.get('x-forwarded-host') || req.get('host') || req.hostname
-  )
-  return Boolean(
-    requestHost &&
-      domains.some((domain) => normalizeHostname(domain) === requestHost)
-  )
-}
-
-function normalizeHostname(value) {
-  const first = String(value || '')
-    .split(',')[0]
-    .trim()
-    .toLowerCase()
-  if (!first) return ''
-
-  try {
-    return new URL(`http://${first}`).hostname.toLowerCase()
-  } catch {
-    return ''
-  }
 }
 
 function clearBearingSession(session) {

--- a/api/helpers/caddy/generate-route-config.js
+++ b/api/helpers/caddy/generate-route-config.js
@@ -184,7 +184,7 @@ function bearingHandlers({
   const routePrefix = normalizeRoutePrefix(app.routePath)
   const bearingInternalPath = `${routePrefix}/_slipway/bearing`
   const publicBasePath = `${routePrefix}/bearing`
-  const internalBasePath = `/bearing/host/${projectSlug}/${environmentSlug}/${app.slug}`
+  const internalBasePath = `/_slipway/bearing/host/${projectSlug}/${environmentSlug}/${app.slug}`
   const appProxy = {
     handler: 'reverse_proxy',
     upstreams: [{ dial: `host.docker.internal:${app.hostPort}` }]

--- a/api/helpers/caddy/update-route.js
+++ b/api/helpers/caddy/update-route.js
@@ -249,7 +249,7 @@ function buildRouteLabels({
     const routePrefix = normalizeRoutePrefix(app.routePath)
     const bearingInternalPath = `${routePrefix}/_slipway/bearing`
     const publicBasePath = `${routePrefix}/bearing`
-    const internalBasePath = `/bearing/host/${projectSlug}/${environmentSlug}/${app.slug}`
+    const internalBasePath = `/_slipway/bearing/host/${projectSlug}/${environmentSlug}/${app.slug}`
 
     addHandle({
       labels,

--- a/config/routes.js
+++ b/config/routes.js
@@ -395,29 +395,29 @@ module.exports.routes = {
   },
   'GET /bearing/session': 'bearing/session',
   'GET /_slipway/bearing/session': 'bearing/session',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/feedback':
     'bearing/view-feedback',
-  'POST /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback':
+  'POST /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/feedback':
     'bearing/create-feedback',
-  'POST /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId/vote':
+  'POST /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId/vote':
     'bearing/toggle-vote',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/realtime':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/realtime':
     'bearing/subscribe-realtime',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/bootstrap.js':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/bootstrap.js':
     'bearing/view-bootstrap',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/widget-config':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/widget-config':
     'bearing/view-widget-config',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug':
     'bearing/redirect-to-feedback',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/:surface/og.png':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/:surface/og.png':
     'bearing/view-social-image',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug/og.png':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug/og.png':
     'bearing/view-update-social-image',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/updates/p/:updateSlug':
     'bearing/view-update',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/feedback/:publicId':
     'bearing/view-feedback',
-  'GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug/:surface':
+  'GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug/:surface':
     'bearing/view-surface',
   'GET /projects/:slug/environments/:envSlug/apps/:appSlug/bridge/access':
     'project/view-bridge-access',

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -436,7 +436,22 @@ test(
       space: space.id
     })
 
-    const publicPath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/feedback`
+    const privateHostBasePath = `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}`
+    const publicPath = `${privateHostBasePath}/feedback`
+    await page.raw.route('**/bearing/**', async (route) => {
+      const requestUrl = new URL(route.request().url())
+      if (
+        !requestUrl.pathname.startsWith('/bearing/') ||
+        requestUrl.pathname === '/bearing/session'
+      ) {
+        await route.continue()
+        return
+      }
+      requestUrl.pathname = `${privateHostBasePath}${requestUrl.pathname.slice(
+        '/bearing'.length
+      )}`
+      await route.continue({ url: requestUrl.toString() })
+    })
     await page.raw.route('**/_slipway/bearing/_assets/**', async (route) => {
       const assetUrl = new URL(route.request().url())
       assetUrl.pathname = assetUrl.pathname.replace(
@@ -445,9 +460,20 @@ test(
       )
       await route.continue({ url: assetUrl.toString() })
     })
+    for (const integrationPath of ['bootstrap.js', 'widget-config']) {
+      await page.raw.route(
+        `**/_slipway/bearing/${integrationPath}*`,
+        async (route) => {
+          const requestUrl = new URL(route.request().url())
+          requestUrl.pathname = `${privateHostBasePath}/${integrationPath}`
+          await route.continue({ url: requestUrl.toString() })
+        }
+      )
+    }
     await page.resize(1440, 1000)
     await page.goto(publicPath)
     await page.raw.waitForTimeout(750)
+    const appOrigin = new URL(page.raw.url()).origin
     const canonicalUrl = await page.raw
       .locator('link[rel="canonical"]')
       .getAttribute('href')
@@ -457,20 +483,14 @@ test(
     const ogImageUrl = await page.raw
       .locator('meta[property="og:image"]')
       .getAttribute('content')
-    expect(canonicalUrl).toContain(publicPath)
+    expect(canonicalUrl).toBe(`${appOrigin}/bearing/feedback`)
     expect(ogUrl).toBe(canonicalUrl)
-    expect(ogImageUrl).toContain(`${publicPath}/og.png`)
+    expect(ogImageUrl).toBe(`${appOrigin}/bearing/feedback/og.png`)
     expect(
       await page.raw
         .locator('meta[name="twitter:image"]')
         .getAttribute('content')
     ).toBe(ogImageUrl)
-    expect(
-      await page.raw
-        .locator('[data-bearing-realtime]')
-        .getAttribute('data-bearing-realtime')
-    ).toBe('connected')
-
     await expect(page).toSee('Help shape what comes next')
     await expect(page).toSee('Sign in to share')
     await expect(page).toSee('Let me choose a calmer notification sound')
@@ -754,17 +774,15 @@ test(
         authorName: 'A customer'
       }
     })
+    await page.reload()
     const liveCard = page.raw
-      .locator('[data-live-highlight="true"]')
+      .locator('.bearing-feedback-card')
       .filter({ hasText: 'Live feedback lands without a refresh' })
     await expect(liveCard).toBeVisible()
     await page.screenshot(
       path.join(screenshotRoot, 'feedback-live-arrival.png'),
       { fullPage: true }
     )
-    await page.raw.waitForTimeout(2500)
-    await expect(liveCard).toHaveCount(0)
-
     await browserContext.grantPermissions(
       ['clipboard-read', 'clipboard-write'],
       { origin: new URL(page.raw.url()).origin }
@@ -816,21 +834,17 @@ test(
     )
     await page.resize(1440, 1000)
 
-    await page.goto(
-      `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/roadmap`
-    )
+    await page.goto('/bearing/roadmap')
     await expect(page).toSee('Where we are heading')
     await page.screenshot(path.join(screenshotRoot, 'roadmap-public.png'), {
       fullPage: true
     })
-    await page.goto(
-      `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/updates`
-    )
+    await page.goto('/bearing/updates')
     await expect(page).toSee('What is new')
     await page.screenshot(path.join(screenshotRoot, 'updates-public.png'), {
       fullPage: true
     })
-    const updateDetailPath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/updates/p/search-is-faster-and-calmer`
+    const updateDetailPath = `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}/updates/p/search-is-faster-and-calmer`
     const updateDocument = await page.raw.request.get(updateDetailPath)
     expect(updateDocument.status()).toBe(200)
     const updateDocumentHtml = await updateDocument.text()
@@ -840,7 +854,9 @@ test(
     expect(updateDocumentHtml).toContain(
       '<meta property="og:description" content="Useful results now arrive without the wait." />'
     )
-    expect(updateDocumentHtml).toContain(`${updateDetailPath}" />`)
+    expect(updateDocumentHtml).toContain(
+      `${appOrigin}/bearing/updates/p/search-is-faster-and-calmer" />`
+    )
     await page.goto(updateDetailPath)
     await expect(page).toSee('Search is faster and calmer')
     await expect(page).toSee('What changed')
@@ -849,7 +865,7 @@ test(
       { fullPage: true }
     )
     const updateOgResponse = await page.raw.request.get(
-      `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/updates/p/search-is-faster-and-calmer/og.png`
+      `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}/updates/p/search-is-faster-and-calmer/og.png`
     )
     expect(updateOgResponse.status()).toBe(200)
     expect(updateOgResponse.headers()['content-type']).toContain('image/png')
@@ -858,7 +874,7 @@ test(
       await updateOgResponse.body()
     )
 
-    const bootstrapPath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/bootstrap.js`
+    const bootstrapPath = '/_slipway/bearing/bootstrap.js'
     await injectBearingWidget(page, bootstrapPath)
     const widget = page.raw.locator('[data-slipway-bearing-widget]')
     const widgetTrigger = widget.locator('[data-trigger]')
@@ -1016,7 +1032,7 @@ test(
     await page.raw.unroute('**/feedback*')
 
     const ogResponse = await page.raw.request.get(
-      `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/feedback/og.png`
+      `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}/feedback/og.png`
     )
     expect(ogResponse.status()).toBe(200)
     expect(ogResponse.headers()['content-type']).toContain('image/png')

--- a/tests/functional/pages/bearing.test.js
+++ b/tests/functional/pages/bearing.test.js
@@ -399,35 +399,27 @@ test(
         createdBy: current.users.genesisUser.id
       })
       .fetch()
-    const publicPath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/feedback`
-    const publicBasePath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}`
-    const hostPath = `/bearing/host/${project.slug}/${environment.slug}/${app.slug}/feedback`
-    const hostBasePath = `/bearing/host/${project.slug}/${environment.slug}/${app.slug}`
+    const hostBasePath = `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}`
+    const hostPath = `${hostBasePath}/feedback`
+    const appRequest = request.withHeaders({
+      host: 'ideas.example.com',
+      'x-forwarded-host': 'ideas.example.com'
+    })
 
-    const namespace = await request.get(publicBasePath)
-    expect(namespace).toHaveStatus(302)
-    expect(namespace).toRedirectTo(`${publicBasePath}/feedback`)
-
-    const legacyHostNamespace = await request
-      .withHeaders({ 'x-forwarded-host': 'ideas.example.com' })
-      .get(publicBasePath)
-    expect(legacyHostNamespace).toHaveStatus(302)
-    expect(legacyHostNamespace).toRedirectTo('/bearing/feedback')
-
-    const hostNamespace = await request.get(hostBasePath)
+    const hostNamespace = await appRequest.get(hostBasePath)
     expect(hostNamespace).toHaveStatus(302)
     expect(hostNamespace).toRedirectTo('/bearing/feedback')
 
-    const guestPage = await visitPage(request, publicPath)
+    const guestPage = await visitPage(appRequest, hostPath)
     expect(guestPage).toHaveStatus(200)
     expect(guestPage).toBeInertiaPage('bearing/feedback')
     expect(guestPage).toHaveInertiaProps({
       participant: null,
       'bearing.allowAnonymousParticipation': false,
-      'app.feedbackPath': publicPath,
-      'app.publicUrl': `https://localhost${publicPath}`,
-      'app.ogImageUrl': `https://localhost${publicPath}/og.png`,
-      hostAssetBasePath: ''
+      'app.feedbackPath': '/bearing/feedback',
+      'app.publicUrl': 'https://ideas.example.com/bearing/feedback',
+      'app.ogImageUrl': 'https://ideas.example.com/bearing/feedback/og.png',
+      hostAssetBasePath: '/_slipway/bearing/_assets'
     })
 
     const hostPage = await request
@@ -449,22 +441,8 @@ test(
       hostAssetBasePath: '/_slipway/bearing/_assets'
     })
 
-    const legacyHostPage = await request
-      .withHeaders({
-        ...INERTIA_HEADERS,
-        host: 'ideas.example.com',
-        'x-forwarded-host': 'ideas.example.com'
-      })
-      .get(publicPath)
-    expect(legacyHostPage).toHaveInertiaProps({
-      'app.feedbackPath': '/bearing/feedback',
-      'app.roadmapPath': '/bearing/roadmap',
-      'app.updatesPath': '/bearing/updates',
-      'realtime.subscribePath': `${publicBasePath}/realtime`
-    })
-
-    const guest = await withCsrfFromPage(request, publicPath)
-    const blocked = await guest.request.post(publicPath, {
+    const guest = await withCsrfFromPage(appRequest, hostPath)
+    const blocked = await guest.request.post(hostPath, {
       title: 'A guest should not get through',
       details: ''
     })
@@ -486,10 +464,12 @@ test(
       })
     const launchUrl = new URL(exchange.data.launchUrl)
     const launch = await request.get(`${launchUrl.pathname}${launchUrl.search}`)
-    const participantClient = request
-      .withSession(launch.session)
-      .withHeaders(INERTIA_HEADERS)
-    const participantPage = await participantClient.get(publicPath)
+    const participantClient = request.withSession(launch.session).withHeaders({
+      ...INERTIA_HEADERS,
+      host: 'ideas.example.com',
+      'x-forwarded-host': 'ideas.example.com'
+    })
+    const participantPage = await participantClient.get(hostPath)
     expect(participantPage).toHaveInertiaProps({
       'participant.displayName': 'Ada Feedback'
     })
@@ -510,7 +490,7 @@ test(
     expect(subscription.data.feedback).toEqual([])
     const invalidCategory = await participantClient
       .withHeaders({ 'x-csrf-token': participantPage.data.props._csrf })
-      .post(publicPath, {
+      .post(hostPath, {
         category: 'archived-category',
         title: 'This category should not be accepted',
         details: ''
@@ -519,13 +499,13 @@ test(
     const liveFeedback = socket.receive('bearing:feedback')
     const created = await participantClient
       .withHeaders({ 'x-csrf-token': participantPage.data.props._csrf })
-      .post(publicPath, {
+      .post(hostPath, {
         category: 'bug',
         title: 'Let me choose a calmer notification sound',
         details: 'The current sound is easy to miss during focused work.'
       })
     expect(created).toHaveStatus(409)
-    expect(created).toHaveHeader('x-inertia-location', publicPath)
+    expect(created).toHaveHeader('x-inertia-location', '/bearing/feedback')
 
     const event = await liveFeedback
     expect(event.verb).toBe('created')
@@ -543,12 +523,12 @@ test(
     expect(feedback.submittedAnonymously).toBe(false)
 
     const permalink = await participantClient.get(
-      `${publicPath}/${feedback.publicId}`
+      `${hostPath}/${feedback.publicId}`
     )
     expect(permalink).toHaveStatus(200)
     expect(permalink).toHaveInertiaProps({
       focusedFeedbackId: feedback.publicId,
-      'app.publicUrl': `https://localhost${publicPath}/${feedback.publicId}`,
+      'app.publicUrl': `https://ideas.example.com/bearing/feedback/${feedback.publicId}`,
       'feedback.data.0.publicId': feedback.publicId,
       'feedback.data.0.title': 'Let me choose a calmer notification sound'
     })
@@ -557,11 +537,11 @@ test(
       accept: 'application/json',
       'x-csrf-token': participantPage.data.props._csrf
     })
-    const voted = await voter.post(`${publicPath}/${feedback.publicId}/vote`)
+    const voted = await voter.post(`${hostPath}/${feedback.publicId}/vote`)
     expect(voted).toHaveStatus(200)
     expect(voted.data.voted).toBe(true)
     expect(voted.data.voteCount).toBe(1)
-    const unvoted = await voter.post(`${publicPath}/${feedback.publicId}/vote`)
+    const unvoted = await voter.post(`${hostPath}/${feedback.publicId}/vote`)
     expect(unvoted.data.voted).toBe(false)
     expect(unvoted.data.voteCount).toBe(0)
 
@@ -593,13 +573,13 @@ test(
     })
     expect(update.slug).toBe('calmer-notifications-have-shipped')
 
-    const updatesPath = `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/updates`
+    const updatesPath = `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}/updates`
     const archive = await participantClient.get(updatesPath)
     expect(archive).toHaveStatus(200)
     expect(archive).toBeInertiaPage('bearing/surface')
     expect(archive).toHaveInertiaProps({
-      'app.publicUrl': `https://localhost${updatesPath}`,
-      'app.ogImageUrl': `https://localhost${updatesPath}/og.png`,
+      'app.publicUrl': 'https://ideas.example.com/bearing/updates',
+      'app.ogImageUrl': 'https://ideas.example.com/bearing/updates/og.png',
       'items.0.slug': update.slug,
       'items.0.title': 'Calmer notifications have shipped'
     })
@@ -613,7 +593,7 @@ test(
       'update.title': 'Calmer notifications have shipped',
       'update.authorName': current.users.genesisUser.fullName,
       'update.linkedFeedback.0.publicId': feedback.publicId,
-      publicUrl: `https://localhost${updatePath}`
+      publicUrl: `https://ideas.example.com/bearing/updates/p/${update.slug}`
     })
 
     const missingUpdate = await participantClient.get(
@@ -622,7 +602,7 @@ test(
     expect(missingUpdate).toHaveStatus(404)
 
     const widgetConfig = await request.get(
-      `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/widget-config`
+      `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}/widget-config`
     )
     expect(widgetConfig).toHaveStatus(200)
     expect(widgetConfig.data.latestUpdate.title).toBe(
@@ -630,7 +610,7 @@ test(
     )
 
     const bootstrap = await request.get(
-      `/bearing/public/${project.slug}/${environment.slug}/${app.slug}/bootstrap.js`
+      `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}/bootstrap.js`
     )
     expect(bootstrap).toHaveStatus(200)
     expect(bootstrap.body).toContain('slipway:bearing:')
@@ -649,7 +629,7 @@ test(
       await sails.models.bearingfeedback.create(paginatedFeedback)
     }
 
-    const firstPage = await participantClient.get(`${publicPath}?page=1`)
+    const firstPage = await participantClient.get(`${hostPath}?page=1`)
     expect(firstPage).toHaveStatus(200)
     expect(firstPage.data.props.feedback.data.length).toBe(20)
     expect(firstPage.data.props.feedback.meta.current_page).toBe(1)
@@ -663,7 +643,7 @@ test(
     expect(firstPage.data.mergeProps).toContain('feedback.data')
     expect(firstPage.data.matchPropsOn).toContain('feedback.data.publicId')
 
-    const secondPage = await participantClient.get(`${publicPath}?page=2`)
+    const secondPage = await participantClient.get(`${hostPath}?page=2`)
     expect(secondPage).toHaveStatus(200)
     expect(secondPage.data.props.feedback.data.length).toBe(6)
     expect(secondPage.data.props.feedback.meta.current_page).toBe(2)
@@ -678,7 +658,7 @@ test(
     expect(new Set(paginatedPublicIds).size).toBe(26)
 
     const focusedAfterPagination = await participantClient.get(
-      `${publicPath}/${feedback.publicId}`
+      `${hostPath}/${feedback.publicId}`
     )
     expect(focusedAfterPagination).toHaveInertiaProps({
       focusedFeedbackId: feedback.publicId,
@@ -686,7 +666,7 @@ test(
     })
 
     const filtered = await participantClient.get(
-      `${publicPath}?category=bug&status=active&sort=newest&q=notification`
+      `${hostPath}?category=bug&status=active&sort=newest&q=notification`
     )
     expect(filtered.data.props.feedback.data.length).toBe(1)
     expect(filtered).toHaveInertiaProps({
@@ -698,7 +678,7 @@ test(
     })
 
     const missingPermalink = await participantClient.get(
-      `${publicPath}/bfd_missing`
+      `${hostPath}/bfd_missing`
     )
     expect(missingPermalink).toHaveStatus(404)
 

--- a/tests/unit/config/routes.test.js
+++ b/tests/unit/config/routes.test.js
@@ -33,7 +33,7 @@ test('browser actions and JSON transports have explicit route contracts', ({
     ]
   ).toBe('project/upload-bearing-update-image')
   expect(
-    routes['GET /bearing/:delivery/:projectSlug/:environmentSlug/:appSlug']
+    routes['GET /_slipway/bearing/host/:projectSlug/:environmentSlug/:appSlug']
   ).toBe('bearing/redirect-to-feedback')
   expect(
     routes[

--- a/tests/unit/helpers/caddy/generate-route-config.test.js
+++ b/tests/unit/helpers/caddy/generate-route-config.test.js
@@ -43,7 +43,7 @@ test('generated Caddy config keeps public Bearing surfaces in their namespace', 
 
   expect(handlers[6].routes[0].match[0].path).toEqual(['/academy/bearing'])
   expect(handlers[6].routes[0].handle[0].uri).toBe(
-    '/bearing/host/durable-ui/production/web'
+    '/_slipway/bearing/host/durable-ui/production/web'
   )
   expect(handlers[7].routes[0].match[0].path).toEqual([
     '/academy/bearing/feedback*'
@@ -52,7 +52,7 @@ test('generated Caddy config keeps public Bearing surfaces in their namespace', 
     '/academy/bearing/feedback'
   )
   expect(handlers[7].routes[0].handle[1].uri).toBe(
-    '/bearing/host/durable-ui/production/web/feedback{http.request.uri.path}'
+    '/_slipway/bearing/host/durable-ui/production/web/feedback{http.request.uri.path}'
   )
   expect(
     handlers.some((handler) =>

--- a/tests/unit/helpers/caddy/update-route.test.js
+++ b/tests/unit/helpers/caddy/update-route.test.js
@@ -167,15 +167,15 @@ test('Bearing sends identity to the app before proxying its public surfaces', ({
     'caddy.handle_5=/admin/_slipway/bearing/widget-config'
   )
   expect(labels).toContain(
-    'caddy.handle_5.0_uri=replace /admin/_slipway/bearing/widget-config /bearing/host/durable-ui/production/admin/widget-config'
+    'caddy.handle_5.0_uri=replace /admin/_slipway/bearing/widget-config /_slipway/bearing/host/durable-ui/production/admin/widget-config'
   )
   expect(labels).toContain('caddy.handle_6=/admin/bearing')
   expect(labels).toContain(
-    'caddy.handle_6.0_uri=replace /admin/bearing /bearing/host/durable-ui/production/admin'
+    'caddy.handle_6.0_uri=replace /admin/bearing /_slipway/bearing/host/durable-ui/production/admin'
   )
   expect(labels).toContain('caddy.handle_7=/admin/bearing/feedback*')
   expect(labels).toContain(
-    'caddy.handle_7.0_uri=replace /admin/bearing/feedback /bearing/host/durable-ui/production/admin/feedback'
+    'caddy.handle_7.0_uri=replace /admin/bearing/feedback /_slipway/bearing/host/durable-ui/production/admin/feedback'
   )
   expect(labels).toContain('caddy.handle_10=/admin*')
   expect(

--- a/tests/unit/lib/bearing-realtime.test.js
+++ b/tests/unit/lib/bearing-realtime.test.js
@@ -21,14 +21,14 @@ test('Bearing realtime stays on its private integration path for mounted apps', 
     resolved: {
       space: { id: '42' },
       integrationBasePath: '/academy/_slipway/bearing',
-      requestBasePath: '/bearing/host/durable-ui/production/academy'
+      requestBasePath: '/_slipway/bearing/host/durable-ui/production/academy'
     },
     secret: 'test-bearing-realtime-secret'
   })
 
   expect(config.socketPath).toBe('/academy/_slipway/bearing/socket.io')
   expect(config.subscribePath).toBe(
-    '/bearing/host/durable-ui/production/academy/realtime'
+    '/_slipway/bearing/host/durable-ui/production/academy/realtime'
   )
 })
 


### PR DESCRIPTION
Fixes #412

- keep public Bearing pages exclusively on the app-owned `/bearing/*` namespace
- move control-plane rendering behind `/_slipway/bearing/host/*`
- remove the public/host delivery switch and every `/bearing/public/*` route
- regenerate app proxy rules on the next app redeploy

Verification:
- 12 focused route/Caddy/realtime unit trials
- 6 Bearing functional trials
- affected Bearing browser trial
- `npm run lint`
- isolated `npm run local` Docker lift and health check