### PR TITLE
Fix Bearing app-owned navigation

### DIFF
--- a/api/controllers/bearing/view-feedback.js
+++ b/api/controllers/bearing/view-feedback.js
@@ -133,6 +133,7 @@ module.exports = {
         hostAssetBasePath: resolved.hostAssetBasePath,
         app: {
           name: resolved.project.name,
+          homeUrl: resolved.homeUrl,
           feedbackPath,
           roadmapPath: `${resolved.publicBasePath}/roadmap`,
           updatesPath: `${resolved.publicBasePath}/updates`,

--- a/api/controllers/bearing/view-surface.js
+++ b/api/controllers/bearing/view-surface.js
@@ -79,6 +79,7 @@ module.exports = {
         hostAssetBasePath: resolved.hostAssetBasePath,
         app: {
           name: resolved.project.name,
+          homeUrl: resolved.homeUrl,
           feedbackPath: `${resolved.publicBasePath}/feedback`,
           roadmapPath: `${resolved.publicBasePath}/roadmap`,
           updatesPath: `${resolved.publicBasePath}/updates`,

--- a/api/controllers/bearing/view-update.js
+++ b/api/controllers/bearing/view-update.js
@@ -54,6 +54,7 @@ module.exports = {
         hostAssetBasePath: resolved.hostAssetBasePath,
         app: {
           name: resolved.project.name,
+          homeUrl: resolved.homeUrl,
           feedbackPath: `${resolved.publicBasePath}/feedback`,
           roadmapPath: `${resolved.publicBasePath}/roadmap`,
           updatesPath: `${resolved.publicBasePath}/updates`

--- a/api/helpers/bearing/resolve-public-request.js
+++ b/api/helpers/bearing/resolve-public-request.js
@@ -56,6 +56,15 @@ module.exports = {
     const internalBasePath = `/_slipway/bearing/host/${encodeURIComponent(
       project.slug
     )}/${encodeURIComponent(environment.slug)}/${encodeURIComponent(app.slug)}`
+    const publicBasePath = `${routePrefix}/bearing`
+
+    // Caddy sends the private renderer path to Slipway, but Inertia uses
+    // req.url as the browser-history URL. Restore the app-owned namespace
+    // before the page object is built, just as Bridge does for host requests.
+    if (typeof req.url === 'string') {
+      req.url = replacePathPrefix(req.url, internalBasePath, publicBasePath)
+    }
+
     return {
       project,
       environment,
@@ -63,12 +72,31 @@ module.exports = {
       space,
       participant,
       requestBasePath: internalBasePath,
-      publicBasePath: `${routePrefix}/bearing`,
+      publicBasePath,
       integrationBasePath,
+      homeUrl: absoluteUrl(req, routePrefix || '/'),
       identityPath: `${integrationBasePath}/identity`,
       hostAssetBasePath: `${integrationBasePath}/_assets`
     }
   }
+}
+
+function absoluteUrl(req, path) {
+  const protocol = req.get('x-forwarded-proto') || req.protocol || 'https'
+  const host =
+    req.get('x-forwarded-host') ||
+    req.get('host') ||
+    req.hostname ||
+    'localhost'
+  return `${protocol}://${host}${path}`
+}
+
+function replacePathPrefix(url, currentPrefix, publicPrefix) {
+  return url === currentPrefix ||
+    url.startsWith(`${currentPrefix}/`) ||
+    url.startsWith(`${currentPrefix}?`)
+    ? `${publicPrefix}${url.slice(currentPrefix.length)}`
+    : url
 }
 
 function hashCredential(value) {

--- a/assets/js/pages/bearing/feedback.vue
+++ b/assets/js/pages/bearing/feedback.vue
@@ -656,10 +656,7 @@ function shortDate(value) {
         class="mx-auto flex h-16 max-w-5xl items-center justify-between"
         aria-label="Bearing"
       >
-        <a
-          :href="app.feedbackPath"
-          class="text-sm font-semibold tracking-tight"
-        >
+        <a :href="app.homeUrl" class="text-sm font-semibold tracking-tight">
           {{ app.name }}
         </a>
         <div class="flex items-center gap-5 text-sm">

--- a/assets/js/pages/bearing/surface.vue
+++ b/assets/js/pages/bearing/surface.vue
@@ -174,11 +174,9 @@ function isoDate(value) {
         class="mx-auto flex h-16 max-w-5xl items-center justify-between"
         aria-label="Bearing"
       >
-        <a
-          :href="app.feedbackPath"
-          class="text-sm font-semibold tracking-tight"
-          >{{ app.name }}</a
-        >
+        <a :href="app.homeUrl" class="text-sm font-semibold tracking-tight">{{
+          app.name
+        }}</a>
         <div class="flex items-center gap-5 text-sm">
           <a
             :href="app.feedbackPath"

--- a/assets/js/pages/bearing/update.vue
+++ b/assets/js/pages/bearing/update.vue
@@ -65,10 +65,7 @@ function longDate(value) {
         class="mx-auto flex h-16 max-w-5xl items-center justify-between"
         aria-label="Bearing"
       >
-        <a
-          :href="app.feedbackPath"
-          class="text-sm font-semibold tracking-tight"
-        >
+        <a :href="app.homeUrl" class="text-sm font-semibold tracking-tight">
           {{ app.name }}
         </a>
         <div class="flex items-center gap-5 text-sm">

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -491,6 +491,9 @@ test(
         .locator('meta[name="twitter:image"]')
         .getAttribute('content')
     ).toBe(ogImageUrl)
+    await expect(
+      page.raw.getByRole('link', { name: 'Northstar', exact: true })
+    ).toHaveAttribute('href', `${appOrigin}/`)
     await expect(page).toSee('Help shape what comes next')
     await expect(page).toSee('Sign in to share')
     await expect(page).toSee('Let me choose a calmer notification sound')
@@ -967,7 +970,7 @@ test(
       ) {
         await nextPageGate
       }
-      await route.continue()
+      await route.fallback()
     })
     await page.goto(publicPath)
     const feedbackCards = page.raw.locator('.bearing-feedback-card')

--- a/tests/functional/pages/bearing.test.js
+++ b/tests/functional/pages/bearing.test.js
@@ -413,9 +413,11 @@ test(
     const guestPage = await visitPage(appRequest, hostPath)
     expect(guestPage).toHaveStatus(200)
     expect(guestPage).toBeInertiaPage('bearing/feedback')
+    expect(guestPage.data.url).toBe('/bearing/feedback')
     expect(guestPage).toHaveInertiaProps({
       participant: null,
       'bearing.allowAnonymousParticipation': false,
+      'app.homeUrl': 'https://ideas.example.com/',
       'app.feedbackPath': '/bearing/feedback',
       'app.publicUrl': 'https://ideas.example.com/bearing/feedback',
       'app.ogImageUrl': 'https://ideas.example.com/bearing/feedback/og.png',
@@ -440,6 +442,7 @@ test(
       'realtime.subscribePath': `${hostBasePath}/realtime`,
       hostAssetBasePath: '/_slipway/bearing/_assets'
     })
+    expect(hostPage.data.url).toBe('/bearing/feedback')
 
     const guest = await withCsrfFromPage(appRequest, hostPath)
     const blocked = await guest.request.post(hostPath, {
@@ -473,6 +476,11 @@ test(
     expect(participantPage).toHaveInertiaProps({
       'participant.displayName': 'Ada Feedback'
     })
+    expect(participantPage.data.url).toBe('/bearing/feedback')
+    const roadmapPage = await participantClient.get(`${hostBasePath}/roadmap`)
+    expect(roadmapPage).toHaveStatus(200)
+    expect(roadmapPage).toBeInertiaPage('bearing/surface')
+    expect(roadmapPage.data.url).toBe('/bearing/roadmap')
     const realtime = participantPage.data.props.realtime
     const tokenPayload = JSON.parse(
       Buffer.from(realtime.token.split('.')[0], 'base64url').toString('utf8')
@@ -532,6 +540,7 @@ test(
       'feedback.data.0.publicId': feedback.publicId,
       'feedback.data.0.title': 'Let me choose a calmer notification sound'
     })
+    expect(permalink.data.url).toBe(`/bearing/feedback/${feedback.publicId}`)
 
     const voter = participantClient.withHeaders({
       accept: 'application/json',
@@ -578,23 +587,27 @@ test(
     expect(archive).toHaveStatus(200)
     expect(archive).toBeInertiaPage('bearing/surface')
     expect(archive).toHaveInertiaProps({
+      'app.homeUrl': 'https://ideas.example.com/',
       'app.publicUrl': 'https://ideas.example.com/bearing/updates',
       'app.ogImageUrl': 'https://ideas.example.com/bearing/updates/og.png',
       'items.0.slug': update.slug,
       'items.0.title': 'Calmer notifications have shipped'
     })
+    expect(archive.data.url).toBe('/bearing/updates')
 
     const updatePath = `${updatesPath}/p/${update.slug}`
     const updatePage = await participantClient.get(updatePath)
     expect(updatePage).toHaveStatus(200)
     expect(updatePage).toBeInertiaPage('bearing/update')
     expect(updatePage).toHaveInertiaProps({
+      'app.homeUrl': 'https://ideas.example.com/',
       'update.slug': update.slug,
       'update.title': 'Calmer notifications have shipped',
       'update.authorName': current.users.genesisUser.fullName,
       'update.linkedFeedback.0.publicId': feedback.publicId,
       publicUrl: `https://ideas.example.com/bearing/updates/p/${update.slug}`
     })
+    expect(updatePage.data.url).toBe(`/bearing/updates/p/${update.slug}`)
 
     const missingUpdate = await participantClient.get(
       `${updatesPath}/p/not-a-real-update`
@@ -676,6 +689,9 @@ test(
       'filters.q': 'notification',
       'feedback.data.0.publicId': feedback.publicId
     })
+    expect(filtered.data.url).toBe(
+      '/bearing/feedback?category=bug&status=active&sort=newest&q=notification'
+    )
 
     const missingPermalink = await participantClient.get(
       `${hostPath}/bfd_missing`


### PR DESCRIPTION
## What changed

- normalize Bearing's private renderer URL back to the app-owned `/bearing` namespace before Inertia builds browser history
- keep query strings, permalinks, roadmap, updates, and update-detail navigation on clean public URLs
- link the product name in every public Bearing header to the app's actual root URL
- cover guest and signed-in flows with functional and browser regressions

## Verification

- `npm run lint`
- `npx sounding test tests/functional/pages/bearing.test.js --test-concurrency=1`
- `npx sounding test tests/unit/config/routes.test.js tests/unit/helpers/caddy/generate-route-config.test.js tests/unit/helpers/caddy/update-route.test.js --test-concurrency=1`
- `npx sounding test tests/e2e/pages/projects/bearing.test.js --grep "Bearing public feedback feels app-owned" --test-concurrency=1`
- isolated `npm run local`, then `GET /health` returned `200` for Slipway `0.0.59`

Fixes #415
