### PR TITLE
fix: separate live deployment ownership from outcomes

### DIFF
--- a/api/helpers/deployment/describe-outcome.js
+++ b/api/helpers/deployment/describe-outcome.js
@@ -40,22 +40,12 @@ module.exports = {
     const isCurrent = currentIds.has(Number(deployment.id))
     const status = deployment.status
 
-    if (isCurrent) {
-      return {
-        status,
-        outcome: 'current',
-        outcomeLabel: 'Current',
-        isCurrent: true,
-        isActive: false
-      }
-    }
-
     if (ACTIVE_LABELS[status]) {
       return {
         status,
         outcome: 'in-progress',
         outcomeLabel: ACTIVE_LABELS[status],
-        isCurrent: false,
+        isCurrent,
         isActive: true
       }
     }
@@ -65,7 +55,7 @@ module.exports = {
         status,
         outcome: 'succeeded',
         outcomeLabel: 'Succeeded',
-        isCurrent: false,
+        isCurrent,
         isActive: false
       }
     }
@@ -75,7 +65,7 @@ module.exports = {
         status,
         outcome: 'failed',
         outcomeLabel: 'Failed',
-        isCurrent: false,
+        isCurrent,
         isActive: false
       }
     }
@@ -85,7 +75,7 @@ module.exports = {
         status,
         outcome: 'cancelled',
         outcomeLabel: 'Cancelled',
-        isCurrent: false,
+        isCurrent,
         isActive: false
       }
     }
@@ -94,7 +84,7 @@ module.exports = {
       status,
       outcome: 'neutral',
       outcomeLabel: humanize(status),
-      isCurrent: false,
+      isCurrent,
       isActive: false
     }
   }

--- a/api/helpers/notification/send-deployment-notification.js
+++ b/api/helpers/notification/send-deployment-notification.js
@@ -25,7 +25,7 @@ module.exports = {
     const outcome = await sails.helpers.deployment.resolveOutcome.with({
       deployment
     })
-    const isSuccess = ['current', 'succeeded'].includes(outcome.outcome)
+    const isSuccess = outcome.outcome === 'succeeded'
     const isFailure = outcome.outcome === 'failed'
 
     // Check notification preferences

--- a/assets/js/components/DeploymentHistory.vue
+++ b/assets/js/components/DeploymentHistory.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Link, router } from '@inertiajs/vue3'
 import { onBeforeUnmount, ref, watch } from 'vue'
+import DeploymentOutcome from '@/components/DeploymentOutcome.vue'
 
 const props = defineProps({
   history: {
@@ -174,38 +175,6 @@ onBeforeUnmount(() => {
   activeSources.clear()
 })
 
-function outcomeBadge(deployment) {
-  const map = {
-    current: {
-      classes:
-        'bg-emerald-100 text-emerald-800 ring-1 ring-inset ring-emerald-600/20 dark:bg-emerald-900/30 dark:text-emerald-300 dark:ring-emerald-400/20'
-    },
-    succeeded: {
-      classes:
-        'bg-gray-100 text-gray-700 ring-1 ring-inset ring-gray-500/15 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-400/20'
-    },
-    'in-progress': {
-      classes:
-        'bg-blue-100 text-blue-700 ring-1 ring-inset ring-blue-600/20 dark:bg-blue-900/30 dark:text-blue-300 dark:ring-blue-400/20'
-    },
-    failed: {
-      classes:
-        'bg-red-100 text-red-700 ring-1 ring-inset ring-red-600/20 dark:bg-red-900/30 dark:text-red-300 dark:ring-red-400/20'
-    },
-    cancelled: {
-      classes:
-        'bg-gray-100 text-gray-600 ring-1 ring-inset ring-gray-500/15 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-400/20'
-    }
-  }
-
-  return {
-    label: deployment.outcomeLabel || deployment.status,
-    classes:
-      map[deployment.outcome]?.classes ||
-      'bg-gray-100 text-gray-600 ring-1 ring-inset ring-gray-500/15 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-400/20'
-  }
-}
-
 function timeAgo(date) {
   if (!date) return 'Never'
   const seconds = Math.floor((new Date() - new Date(date)) / 1000)
@@ -261,22 +230,14 @@ function deploymentTestId(deployment) {
           data-testid="deployment-row"
           :data-test="deploymentTestId(deployment)"
         >
-          <div class="flex items-center space-x-3">
+          <div class="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
             <span
               v-if="showEnvironment"
               class="text-sm text-gray-900 dark:text-white"
             >
               {{ deployment.environment?.name || 'Unknown' }}
             </span>
-            <span
-              v-if="showStatus"
-              :class="[
-                'inline-flex items-center whitespace-nowrap rounded-md px-2 py-0.5 text-xs font-medium',
-                outcomeBadge(deployment).classes
-              ]"
-            >
-              {{ outcomeBadge(deployment).label }}
-            </span>
+            <DeploymentOutcome v-if="showStatus" :deployment="deployment" />
             <span
               v-if="deployment.app?.name"
               class="inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
@@ -285,22 +246,26 @@ function deploymentTestId(deployment) {
             </span>
             <span
               v-if="deployment.gitBranch"
-              class="text-xs text-gray-500 dark:text-gray-400"
+              class="hidden text-xs text-gray-500 dark:text-gray-400 sm:inline"
             >
               {{ deployment.gitBranch }}
             </span>
             <span
               v-if="showStatus && deployment.gitCommit"
-              class="font-mono text-xs text-gray-400 dark:text-gray-500"
+              class="hidden font-mono text-xs text-gray-400 dark:text-gray-500 sm:inline"
             >
               {{ deployment.gitCommit.slice(0, 7) }}
             </span>
           </div>
-          <div class="flex items-center space-x-4">
-            <span class="text-xs text-gray-500 dark:text-gray-400">
+          <div class="ml-3 flex shrink-0 items-center sm:space-x-4">
+            <span
+              class="hidden text-xs text-gray-500 dark:text-gray-400 sm:inline"
+            >
               {{ deployment.actor }}
             </span>
-            <span class="text-xs text-gray-400 dark:text-gray-500">
+            <span
+              class="whitespace-nowrap text-right text-xs text-gray-400 dark:text-gray-500"
+            >
               {{ timeAgo(deployment.createdAt) }}
             </span>
           </div>

--- a/assets/js/components/DeploymentOutcome.vue
+++ b/assets/js/components/DeploymentOutcome.vue
@@ -1,0 +1,62 @@
+<script setup>
+import { computed } from 'vue'
+
+const props = defineProps({
+  deployment: {
+    type: Object,
+    required: true
+  }
+})
+
+const presentation = computed(() => {
+  const styles = {
+    succeeded:
+      'bg-gray-100 text-gray-700 ring-gray-500/15 dark:bg-gray-800 dark:text-gray-300 dark:ring-gray-400/20',
+    'in-progress':
+      'bg-blue-50 text-blue-700 ring-blue-600/15 dark:bg-blue-950/60 dark:text-blue-300 dark:ring-blue-400/20',
+    failed:
+      'bg-red-50 text-red-700 ring-red-600/15 dark:bg-red-950/60 dark:text-red-300 dark:ring-red-400/20',
+    cancelled:
+      'bg-gray-100 text-gray-600 ring-gray-500/15 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-400/20',
+    neutral:
+      'bg-gray-100 text-gray-600 ring-gray-500/15 dark:bg-gray-800 dark:text-gray-400 dark:ring-gray-400/20'
+  }
+
+  return {
+    label: props.deployment.outcomeLabel || props.deployment.status,
+    classes: styles[props.deployment.outcome] || styles.neutral
+  }
+})
+
+const isCurrent = computed(
+  () =>
+    props.deployment.isCurrent === true ||
+    props.deployment.isCurrentDeployment === true
+)
+</script>
+
+<template>
+  <span class="inline-flex shrink-0 items-center gap-1.5">
+    <span
+      data-test="deployment-outcome"
+      :class="[
+        'inline-flex h-5 items-center whitespace-nowrap rounded-[5px] px-1.5 text-[11px] font-medium leading-none ring-1 ring-inset',
+        presentation.classes
+      ]"
+    >
+      {{ presentation.label }}
+    </span>
+    <span
+      v-if="isCurrent"
+      data-test="current-deployment-marker"
+      class="inline-flex items-center gap-1 text-[11px] font-medium leading-none text-emerald-700 dark:text-emerald-400"
+    >
+      <span
+        aria-hidden="true"
+        class="h-1.5 w-1.5 rounded-full bg-emerald-500"
+      ></span>
+      <span>Live</span>
+      <span class="sr-only"> — currently serving traffic</span>
+    </span>
+  </span>
+</template>

--- a/assets/js/components/DeploymentToast.vue
+++ b/assets/js/components/DeploymentToast.vue
@@ -133,9 +133,7 @@ const statusConfig = computed(() => {
 const isActive = computed(() => {
   return ['pending', 'building', 'pushing', 'deploying'].includes(status.value)
 })
-const isSuccessful = computed(() =>
-  ['current', 'succeeded'].includes(outcome.value)
-)
+const isSuccessful = computed(() => outcome.value === 'succeeded')
 
 const elapsedFormatted = computed(() => {
   const mins = Math.floor(elapsed.value / 60)

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -3,6 +3,7 @@ import { Link, Head, router } from '@inertiajs/vue3'
 import { inject, ref, computed, onMounted, onBeforeUnmount } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
+import DeploymentOutcome from '@/components/DeploymentOutcome.vue'
 import LogViewer from '@/components/LogViewer.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import { useEventSource } from '@/composables/sse'
@@ -73,35 +74,6 @@ const {
     }
   }
 })
-
-function outcomeBadge(deployment) {
-  const map = {
-    current: {
-      classes:
-        'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-300'
-    },
-    succeeded: {
-      classes: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300'
-    },
-    'in-progress': {
-      classes:
-        'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'
-    },
-    failed: {
-      classes: 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400'
-    },
-    cancelled: {
-      classes: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-    }
-  }
-
-  return {
-    label: deployment.outcomeLabel || deployment.status,
-    classes:
-      map[deployment.outcome]?.classes ||
-      'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
-  }
-}
 
 function formatDuration(seconds) {
   if (!seconds) return '—'
@@ -396,18 +368,11 @@ function executeRollback() {
         <!-- Deployment Info -->
         <div class="mb-6 flex items-start justify-between">
           <div>
-            <div class="flex items-center space-x-3">
+            <div class="flex items-center gap-2">
               <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
                 Deployment
               </h1>
-              <span
-                :class="[
-                  'inline-flex items-center rounded-md px-2.5 py-1 text-xs font-medium',
-                  outcomeBadge(deployment).classes
-                ]"
-              >
-                {{ outcomeBadge(deployment).label }}
-              </span>
+              <DeploymentOutcome :deployment="deployment" />
               <span
                 v-if="isInProgress"
                 class="inline-flex items-center space-x-1 text-xs text-blue-600 dark:text-blue-400"

--- a/tests/e2e/pages/projects/deployment-history.test.js
+++ b/tests/e2e/pages/projects/deployment-history.test.js
@@ -99,7 +99,7 @@ test(
     await page.wait('@active-deployment-row')
     await page.wait('@failed-deployment-row')
     await expect(page).toSee('Deployments')
-    await expect(page).toSee('Current')
+    await expect(page).toSee('Live')
     await expect(page).toSee('Building')
     await expect(page).toSee('Queued')
     await expect(page).toSee('Failed')
@@ -114,11 +114,12 @@ test(
     )
     expect(rows.length).toBe(5)
     expect(rows[0].includes('Building')).toBe(true)
-    expect(rows[1].includes('Current')).toBe(true)
+    expect(rows[1].includes('Succeeded')).toBe(true)
+    expect(rows[1].includes('Live')).toBe(true)
     expect(rows[2].includes('Queued')).toBe(true)
     expect(rows[3].includes('Failed')).toBe(true)
     expect(rows[4].includes('Succeeded')).toBe(true)
-    expect(rows.filter((row) => row.includes('Current')).length).toBe(1)
+    expect(rows.filter((row) => row.includes('Live')).length).toBe(1)
     expect(rows.some((row) => row.includes('Running'))).toBe(false)
 
     const deploymentToasts = await page.raw
@@ -134,11 +135,19 @@ test(
     await page.raw
       .locator('[data-testid="deployment-history-section"]')
       .screenshot({
-        path: path.resolve('.tmp/issue-377-deployment-outcomes.png')
+        path: path.resolve('.tmp/issue-421-deployment-outcomes-light.png')
       })
 
-    // A completed SSE transition must transfer the Current outcome without
-    // briefly leaving the previous traffic owner presented as Current.
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await page.raw
+      .locator('[data-testid="deployment-history-section"]')
+      .screenshot({
+        path: path.resolve('.tmp/issue-421-deployment-outcomes-dark.png')
+      })
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+
+    // A completed SSE transition must transfer the Live marker without
+    // changing the lifecycle outcome or presenting two traffic owners.
     await sails.models.app.updateOne({ id: target.appId }).set({
       currentDeployment: target.buildingReleaseId,
       lastDeployedAt: Date.now()
@@ -152,8 +161,10 @@ test(
         ...document.querySelectorAll('[data-testid="deployment-row"]')
       ].map((row) => row.textContent)
       return (
-        rows.filter((row) => row.includes('Current')).length === 1 &&
-        rows.filter((row) => row.includes('Succeeded')).length >= 2 &&
+        rows[0].includes('Succeeded') &&
+        rows[0].includes('Live') &&
+        !rows[1].includes('Live') &&
+        rows.filter((row) => row.includes('Live')).length === 1 &&
         rows.every((row) => !row.includes('Running'))
       )
     })
@@ -176,11 +187,19 @@ test(
     await page.wait('@deployment-history')
     await page.wait('@active-deployment-row')
     await expect(page).toSee('Deployments')
-    await expect(page).toSee('Current')
+    await expect(page).toSee('Live')
     await expect(page).toSee('Building')
     await expect(page).toSee('Queued')
     await expect(page).toSee('Failed')
     await expect(page).toSee('Succeeded')
+    await page.raw
+      .locator('.pointer-events-none.fixed.bottom-4.right-4')
+      .evaluate((element) => element.setAttribute('hidden', ''))
+    await page.raw
+      .locator('[data-testid="deployment-history-section"]')
+      .screenshot({
+        path: path.resolve('.tmp/issue-421-deployment-outcomes-mobile.png')
+      })
     expect(page).toHaveNoJavascriptErrors()
   }
 )

--- a/tests/functional/pages/projects.test.js
+++ b/tests/functional/pages/projects.test.js
@@ -290,7 +290,7 @@ test(
     )
     expect(firstPage).toHaveInertiaProp(
       'deploymentHistory.items.0.outcomeLabel',
-      'Current'
+      'Succeeded'
     )
     expect(firstPage).toHaveInertiaProp(
       'deploymentHistory.items.1.outcomeLabel',

--- a/tests/unit/helpers/deployment/describe-outcome.test.js
+++ b/tests/unit/helpers/deployment/describe-outcome.test.js
@@ -12,8 +12,8 @@ test('deployment outcomes separate traffic ownership from lifecycle status', ({
 
   expect(describe({ id: 42, status: 'running' }, [42])).toEqual({
     status: 'running',
-    outcome: 'current',
-    outcomeLabel: 'Current',
+    outcome: 'succeeded',
+    outcomeLabel: 'Succeeded',
     isCurrent: true,
     isActive: false
   })


### PR DESCRIPTION
## What changed

- keep lifecycle outcomes such as Succeeded, Failed, Building, and Queued independent from traffic ownership
- replace the competing Current outcome with a small green-dot Live marker
- share one compact outcome treatment across deployment history and deployment detail
- simplify mobile rows to the outcome, app, ownership, and time
- preserve the atomic realtime handoff between old and new live deployments

## Verification

- npm run lint
- targeted unit and functional Sounding trials
- targeted desktop and mobile browser trials, including light and dark screenshots

Closes #421