### PR TITLE
feat(ui): consolidate boolean toggles into Klean Switch

### DIFF
--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -3,6 +3,7 @@ import { router } from '@inertiajs/vue3'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
 import BridgeRelationshipSelect from '@/components/bridge/BridgeRelationshipSelect.vue'
+import Switch from '@/components/ui/switch/Switch.vue'
 import {
   bridgeFieldType,
   bridgeSelectOptions,
@@ -690,32 +691,17 @@ function defaultPlaceholder(fieldType) {
         {{ label }}
       </label>
       <div class="flex items-center gap-3">
-        <button
+        <Switch
           :id="fieldId"
-          type="button"
-          role="switch"
-          :aria-checked="Boolean(modelValue)"
+          :model-value="Boolean(modelValue)"
           :aria-describedby="describedBy"
+          :aria-invalid="Boolean(visibleError)"
           :disabled="field.readOnly"
           :data-test="`${fieldId}-input`"
-          :class="[
-            'relative inline-flex h-5 w-9 shrink-0 rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 focus-visible:ring-offset-2 motion-reduce:transition-none dark:focus-visible:ring-gray-600 dark:focus-visible:ring-offset-gray-900',
-            modelValue
-              ? 'bg-gray-900 dark:bg-white'
-              : 'bg-gray-300 dark:bg-gray-600',
-            field.readOnly ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'
-          ]"
-          @click="update(!modelValue)"
+          class="after:size-4 h-5 w-9 bg-gray-300 checked:bg-gray-950 checked:after:[transform:translate(1rem,-50%)] dark:bg-gray-600 dark:checked:bg-white dark:checked:after:bg-gray-950"
+          @update:model-value="update"
           @blur="handleBlur"
-        >
-          <span
-            :class="[
-              'pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform motion-reduce:transition-none dark:bg-gray-900',
-              modelValue ? 'translate-x-4' : 'translate-x-0'
-            ]"
-            aria-hidden="true"
-          ></span>
-        </button>
+        />
         <span class="w-6 text-sm text-gray-500 dark:text-gray-400">
           {{ modelValue ? 'Yes' : 'No' }}
         </span>

--- a/assets/js/components/ui/switch/Switch.vue
+++ b/assets/js/components/ui/switch/Switch.vue
@@ -1,0 +1,91 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const model = defineModel({ type: Boolean, default: false })
+const attrs = useAttrs()
+const element = ref()
+let form
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    type: _type,
+    role: _role,
+    checked: _checked,
+    'true-value': _trueValue,
+    'false-value': _falseValue,
+    'aria-checked': _ariaChecked,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-disabled': _dataDisabled,
+    'data-invalid': _dataInvalid,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const disabled = computed(
+  () => attrs.disabled !== undefined && attrs.disabled !== false
+)
+const invalid = computed(
+  () => attrs['aria-invalid'] === true || attrs['aria-invalid'] === 'true'
+)
+
+function handleChange(event) {
+  model.value = Boolean(event.currentTarget.checked)
+}
+
+function handleReset() {
+  queueMicrotask(() => {
+    if (element.value) model.value = Boolean(element.value.checked)
+  })
+}
+
+onMounted(() => {
+  element.value.defaultChecked = Boolean(model.value)
+  form = element.value.form
+  form?.addEventListener('reset', handleReset)
+})
+
+onBeforeUnmount(() => {
+  form?.removeEventListener('reset', handleReset)
+})
+
+defineExpose({
+  element,
+  focus: (options) => element.value?.focus(options)
+})
+</script>
+
+<template>
+  <input
+    ref="element"
+    v-bind="forwardedAttrs"
+    v-model="model"
+    type="checkbox"
+    role="switch"
+    data-slot="switch"
+    :data-state="model ? 'checked' : 'unchecked'"
+    :data-disabled="disabled ? '' : undefined"
+    :data-invalid="invalid ? '' : undefined"
+    :class="
+      twMerge(
+        [
+          `after:size-5 relative inline-flex h-6 w-11 shrink-0 cursor-pointer appearance-none rounded-full border-0 bg-gray-300 p-0 outline-none transition-colors duration-200 ease-[cubic-bezier(0.32,0.72,0,1)] after:pointer-events-none after:absolute after:left-0.5 after:top-1/2 after:block after:rounded-full after:bg-white after:duration-200 after:ease-[cubic-bezier(0.32,0.72,0,1)] after:content-[''] after:[transform:translate(0,-50%)] after:[transition-property:transform]`,
+          'checked:bg-gray-950 checked:after:[transform:translate(1.25rem,-50%)]',
+          'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          'aria-invalid:outline-2 aria-invalid:outline-offset-2 aria-invalid:outline-red-600 aria-invalid:focus-visible:outline-red-600',
+          'motion-reduce:duration-100 motion-reduce:ease-out motion-reduce:after:duration-100 motion-reduce:after:ease-out',
+          'dark:aria-invalid:outline-red-500 dark:bg-gray-700 dark:checked:bg-white dark:checked:after:bg-gray-950 dark:focus-visible:outline-white',
+          'forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:checked:bg-[Highlight] forced-colors:after:bg-[CanvasText] forced-colors:checked:after:bg-[HighlightText]'
+        ],
+        attrs.class
+      )
+    "
+    @change="handleChange"
+  />
+</template>

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -17,6 +17,7 @@ import Tooltip from '@/components/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
 import ReleaseFlagMenu from '@/components/ReleaseFlagMenu.vue'
+import Switch from '@/components/ui/switch/Switch.vue'
 import { useToast } from '@/composables/toast'
 import SlippyLoader from '@/components/SlippyLoader.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
@@ -727,7 +728,7 @@ async function createReleaseFlag() {
 }
 
 async function updateReleaseFlag(flag, updates) {
-  if (savingFlag.value) return
+  if (savingFlag.value) return false
   savingFlag.value = true
   try {
     const data = await flagRequest(flagUrl(flag), {
@@ -744,10 +745,20 @@ async function updateReleaseFlag(flag, updates) {
       (candidate) => candidate.id === flag.id
     )
     if (index >= 0) localReleaseFlags.value[index] = data.flag
+    return true
   } catch (error) {
     toast({ message: error.message, type: 'error' })
+    return false
   } finally {
     savingFlag.value = false
+  }
+}
+
+async function toggleReleaseFlag(flag, enabled) {
+  const previous = flag.enabled
+  flag.enabled = enabled
+  if (!(await updateReleaseFlag(flag, { enabled }))) {
+    flag.enabled = previous
   }
 }
 
@@ -1840,29 +1851,16 @@ onBeforeUnmount(() => {
                       {{ flag.description }}
                     </p>
                   </div>
-                  <button
-                    type="button"
-                    role="switch"
-                    :aria-checked="flag.enabled"
+                  <Switch
+                    :model-value="flag.enabled"
                     :aria-label="`${flag.enabled ? 'Disable' : 'Enable'} ${
                       flag.key
                     }`"
                     :disabled="savingFlag"
-                    @click="updateReleaseFlag(flag, { enabled: !flag.enabled })"
-                    :class="[
-                      'relative inline-flex h-5 w-9 shrink-0 rounded-full transition-colors disabled:opacity-50',
-                      flag.enabled
-                        ? 'bg-gray-900 dark:bg-white'
-                        : 'bg-gray-200 dark:bg-gray-700'
-                    ]"
-                  >
-                    <span
-                      :class="[
-                        'mt-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform dark:bg-gray-900',
-                        flag.enabled ? 'translate-x-[18px]' : 'translate-x-0.5'
-                      ]"
-                    ></span>
-                  </button>
+                    :data-test="`release-flag-${flag.key}-switch`"
+                    class="after:size-4 h-5 w-9 bg-gray-200 checked:bg-gray-950 checked:after:[transform:translate(1rem,-50%)] dark:bg-gray-700 dark:checked:bg-white dark:checked:after:bg-gray-950"
+                    @update:model-value="toggleReleaseFlag(flag, $event)"
+                  />
                   <ReleaseFlagMenu
                     :flag="flag"
                     @update="updateReleaseFlag(flag, $event)"

--- a/assets/js/pages/settings/notifications.vue
+++ b/assets/js/pages/settings/notifications.vue
@@ -3,6 +3,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
+import Switch from '@/components/ui/switch/Switch.vue'
 
 defineOptions({
   layout: AppLayout
@@ -104,6 +105,8 @@ function testChannel(channel) {
 }
 
 const revealToken = ref(false)
+const providerSwitchClass =
+  'h-5 w-9 bg-gray-200 after:size-4 checked:bg-brand checked:after:[transform:translate(1rem,-50%)] dark:bg-gray-700 dark:checked:bg-brand dark:checked:after:bg-white'
 
 // Define all notification events for filtering
 const allEvents = [
@@ -469,14 +472,11 @@ const categoryIcons = {
                   <label
                     class="relative inline-flex cursor-pointer items-center"
                   >
-                    <input
-                      type="checkbox"
+                    <Switch
                       v-model="form.discordEnabled"
-                      class="peer sr-only"
+                      aria-label="Discord notifications"
+                      :class="providerSwitchClass"
                     />
-                    <div
-                      class="peer-checked:bg-brand peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none dark:border-gray-600 dark:bg-gray-700"
-                    ></div>
                   </label>
                 </div>
                 <div
@@ -574,14 +574,11 @@ const categoryIcons = {
                   <label
                     class="relative inline-flex cursor-pointer items-center"
                   >
-                    <input
-                      type="checkbox"
+                    <Switch
                       v-model="form.slackEnabled"
-                      class="peer sr-only"
+                      aria-label="Slack notifications"
+                      :class="providerSwitchClass"
                     />
-                    <div
-                      class="peer-checked:bg-brand peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none dark:border-gray-600 dark:bg-gray-700"
-                    ></div>
                   </label>
                 </div>
                 <div
@@ -677,14 +674,11 @@ const categoryIcons = {
                   <label
                     class="relative inline-flex cursor-pointer items-center"
                   >
-                    <input
-                      type="checkbox"
+                    <Switch
                       v-model="form.telegramEnabled"
-                      class="peer sr-only"
+                      aria-label="Telegram notifications"
+                      :class="providerSwitchClass"
                     />
-                    <div
-                      class="peer-checked:bg-brand peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none dark:border-gray-600 dark:bg-gray-700"
-                    ></div>
                   </label>
                 </div>
                 <div
@@ -899,14 +893,11 @@ const categoryIcons = {
                   <label
                     class="relative inline-flex cursor-pointer items-center"
                   >
-                    <input
-                      type="checkbox"
+                    <Switch
                       v-model="form.smtpEnabled"
-                      class="peer sr-only"
+                      aria-label="Email notifications"
+                      :class="providerSwitchClass"
                     />
-                    <div
-                      class="peer-checked:bg-brand peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none dark:border-gray-600 dark:bg-gray-700"
-                    ></div>
                   </label>
                 </div>
                 <div
@@ -1134,15 +1125,12 @@ const categoryIcons = {
                   <label
                     class="relative inline-flex cursor-pointer items-center"
                   >
-                    <input
+                    <Switch
                       data-test="webhook-enabled"
-                      type="checkbox"
                       v-model="form.webhookEnabled"
-                      class="peer sr-only"
+                      aria-label="Webhook notifications"
+                      :class="providerSwitchClass"
                     />
-                    <div
-                      class="peer-checked:bg-brand peer h-5 w-9 rounded-full bg-gray-200 after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:border after:border-gray-300 after:bg-white after:transition-all after:content-[''] peer-checked:after:translate-x-full peer-checked:after:border-white peer-focus:outline-none dark:border-gray-600 dark:bg-gray-700"
-                    ></div>
                   </label>
                 </div>
                 <div

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "sails-sqlite": "^0.2.6",
         "sails-stash": "^0.2.0",
         "skipper-s3": "^0.6.0",
+        "tailwind-merge": "^3.6.0",
         "vue": "^3.5.8"
       },
       "devDependencies": {
@@ -9365,6 +9366,16 @@
       "license": "MIT",
       "dependencies": {
         "@sailshq/lodash": "^3.10.3"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "sails-sqlite": "^0.2.6",
     "sails-stash": "^0.2.0",
     "skipper-s3": "^0.6.0",
+    "tailwind-merge": "^3.6.0",
     "vue": "^3.5.8"
   },
   "devDependencies": {

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -719,6 +719,17 @@ test(
       await expect(page).toSee('Metadata')
       await expect(page).toSee('Creator')
       expect(await page.raw.getByLabel('Id').count()).toBe(0)
+      const publishedSwitch = page.raw.locator(
+        '[data-test="bridge-course-published-input"]'
+      )
+      expect(await publishedSwitch.getAttribute('type')).toBe('checkbox')
+      expect(await publishedSwitch.getAttribute('role')).toBe('switch')
+      expect(await publishedSwitch.getAttribute('data-state')).toBe('unchecked')
+      await page.raw.locator('label[for="bridge-course-published"]').click()
+      expect(await publishedSwitch.isChecked()).toBe(true)
+      await publishedSwitch.focus()
+      await page.raw.keyboard.press('Space')
+      expect(await publishedSwitch.isChecked()).toBe(false)
       const createRecordButton = page.raw.getByRole('button', {
         name: 'Create record'
       })

--- a/tests/e2e/pages/release-flags.test.js
+++ b/tests/e2e/pages/release-flags.test.js
@@ -77,12 +77,77 @@ test(
     await page.wait('@release-flags')
     await expect(page).toSee('new-checkout')
     await expect(page).toSee('25% · 2 targets')
+
+    const flagsEndpoint = `/api/v1/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/flags`
+    let successfulToggleRequests = 0
+    page.raw.on('request', (request) => {
+      if (
+        request.method() === 'PATCH' &&
+        request.url().includes(`${flagsEndpoint}/`)
+      ) {
+        successfulToggleRequests += 1
+      }
+    })
+    const fasterSearchSwitch = page.raw.locator(
+      '[data-test="release-flag-faster-search-switch"]'
+    )
+    expect(await fasterSearchSwitch.getAttribute('type')).toBe('checkbox')
+    expect(await fasterSearchSwitch.getAttribute('role')).toBe('switch')
+    expect(await fasterSearchSwitch.isChecked()).toBe(false)
+    const fasterSearchSaved = page.raw.waitForResponse(
+      (response) =>
+        response.url().includes(`${flagsEndpoint}/`) &&
+        response.request().method() === 'PATCH'
+    )
+    await fasterSearchSwitch.focus()
+    await page.raw.keyboard.press('Space')
+    expect((await fasterSearchSaved).status()).toBe(200)
+    expect(await fasterSearchSwitch.isChecked()).toBe(true)
+    expect(successfulToggleRequests).toBe(1)
+    expect(
+      (
+        await sails.models.featureflag.findOne({
+          key: 'faster-search',
+          app: app.id
+        })
+      ).enabled
+    ).toBe(true)
+
+    let failedToggleRequests = 0
+    await page.raw.route(`**${flagsEndpoint}/*`, async (route) => {
+      if (route.request().method() !== 'PATCH') return route.continue()
+      failedToggleRequests += 1
+      await route.fulfill({
+        status: 422,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          message: 'Release flag rejected for testing.'
+        })
+      })
+    })
+    const newCheckoutSwitch = page.raw.locator(
+      '[data-test="release-flag-new-checkout-switch"]'
+    )
+    expect(await newCheckoutSwitch.isChecked()).toBe(true)
+    await newCheckoutSwitch.focus()
+    await page.raw.keyboard.press('Space')
+    await page.wait('text=Release flag rejected for testing.')
+    expect(await newCheckoutSwitch.isChecked()).toBe(true)
+    expect(failedToggleRequests).toBe(1)
+    await page.raw.unroute(`**${flagsEndpoint}/*`)
+
     await page.screenshot('.tmp/issue-227-release-flags-light.png', {
       fullPage: true
     })
 
     await page.inDarkMode()
+    await page.raw.emulateMedia({ reducedMotion: 'reduce' })
     await page.wait(250)
+    expect(
+      await newCheckoutSwitch.evaluate(
+        (element) => getComputedStyle(element).transitionDuration
+      )
+    ).toBe('0.1s')
     await page.screenshot('.tmp/issue-227-release-flags-dark.png', {
       fullPage: true
     })

--- a/tests/e2e/pages/settings/precognition-validation.test.js
+++ b/tests/e2e/pages/settings/precognition-validation.test.js
@@ -28,12 +28,27 @@ test(
       .locator('#instance-domain-error')
       .waitFor({ state: 'hidden' })
 
-    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await page.raw.emulateMedia({
+      colorScheme: 'dark',
+      reducedMotion: 'reduce'
+    })
     await page.goto('/settings/notifications')
     const webhookEnabled = page.raw.locator('[data-test="webhook-enabled"]')
+    expect(await webhookEnabled.getAttribute('type')).toBe('checkbox')
+    expect(await webhookEnabled.getAttribute('role')).toBe('switch')
+    expect(await webhookEnabled.getAttribute('aria-label')).toBe(
+      'Webhook notifications'
+    )
+    expect(
+      await webhookEnabled.evaluate(
+        (element) => getComputedStyle(element).transitionDuration
+      )
+    ).toBe('0.1s')
     if (!(await webhookEnabled.isChecked())) {
-      await webhookEnabled.check({ force: true })
+      await webhookEnabled.focus()
+      await page.raw.keyboard.press('Space')
     }
+    expect(await webhookEnabled.isChecked()).toBe(true)
     await page.fill(
       '#webhookUrl',
       'https://operator:private-token@example.com/hook'

--- a/tests/unit/assets/switch.test.js
+++ b/tests/unit/assets/switch.test.js
@@ -1,0 +1,34 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('sounding')
+
+const switchSource = fs.readFileSync(
+  path.resolve('assets/js/components/ui/switch/Switch.vue'),
+  'utf8'
+)
+
+test('Klean Switch keeps one native boolean control and caller-owned styling', ({
+  expect
+}) => {
+  expect(switchSource.includes('defineModel({ type: Boolean')).toBe(true)
+  expect(switchSource.includes('type="checkbox"')).toBe(true)
+  expect(switchSource.includes('role="switch"')).toBe(true)
+  expect(switchSource.includes('data-slot="switch"')).toBe(true)
+  expect(switchSource.includes('import { twMerge }')).toBe(true)
+  expect(switchSource.includes('attrs.class')).toBe(true)
+  expect(switchSource.includes('variant')).toBe(false)
+  expect(switchSource.includes('true-value')).toBe(true)
+  expect(switchSource.includes('false-value')).toBe(true)
+})
+
+test('Klean Switch preserves native reset, disabled, invalid, and motion behavior', ({
+  expect
+}) => {
+  expect(switchSource.includes("form?.addEventListener('reset'")).toBe(true)
+  expect(switchSource.includes(':data-disabled')).toBe(true)
+  expect(switchSource.includes(':data-invalid')).toBe(true)
+  expect(switchSource.includes('disabled:cursor-not-allowed')).toBe(true)
+  expect(switchSource.includes('aria-invalid:outline-2')).toBe(true)
+  expect(switchSource.includes('motion-reduce:duration-100')).toBe(true)
+  expect(switchSource.includes('forced-colors:border')).toBe(true)
+})


### PR DESCRIPTION
Closes #338

## What changed

- install the source-owned Vue Switch from Klean UI
- migrate release flags, Bridge boolean fields, and five notification-provider toggles
- keep ordinary notification-event checkboxes as checkboxes
- preserve release-flag optimistic state, processing locks, failure rollback, and error announcements
- retain Slipway’s compact light/dark presentation while adding native checkbox, label, keyboard, form, invalid, forced-colour, and reduced-motion behavior

## Verification

- `npm run lint`
- `npm run test:unit`
- `npx sounding test tests/unit/assets/switch.test.js --test-concurrency=1`
- `npx sounding test tests/e2e/pages/release-flags.test.js tests/e2e/pages/settings/precognition-validation.test.js --test-concurrency=1`
- `npx sounding test tests/e2e/pages/projects/bridge-resource-contract.test.js --test-concurrency=1`

The browser coverage verifies native Space/label activation, one release-flag PATCH per toggle, rollback after a rejected PATCH, provider accessible names, dark mode, and reduced motion.