### PR TITLE
feat(bearing): open widget from host app actions

### DIFF
--- a/api/controllers/bearing/view-bootstrap.js
+++ b/api/controllers/bearing/view-bootstrap.js
@@ -35,12 +35,27 @@ function bearingBootstrap() {
       if (!config?.enabled) return
 
       const side = config.side === 'left' ? 'left' : 'right'
+      const surfaceOrder = ['feedback', 'roadmap', 'updates']
+      const surfaces = Object.fromEntries(
+        surfaceOrder
+          .filter((key) => config.surfaces?.[key]?.path)
+          .map((key) => [key, config.surfaces[key]])
+      )
+      const openingView = surfaces[config.openingView]
+        ? config.openingView
+        : surfaceOrder.find((key) => surfaces[key])
+      if (!openingView) return
+
       const seenKey = `slipway:bearing:${config.space}:seen-update`
       const latestUpdateId = config.latestUpdate?.publicId || ''
       let open = false
+      let currentSurface = openingView
+      let opener = null
+      let openedFromInjectedTrigger = false
       let fresh = Boolean(
         config.showUnread &&
           latestUpdateId &&
+          surfaces.updates &&
           readStorage(seenKey) !== latestUpdateId
       )
 
@@ -117,12 +132,13 @@ function bearingBootstrap() {
           }
           .bearing-panel[data-side='right'] { left: auto; right: 20px; }
           .bearing-panel[data-side='left'] { left: 20px; right: auto; }
+          .bearing-panel[data-opened-from='host'] { bottom: 20px; }
           .bearing-panel[open] {
             animation: bearing-panel-in 180ms cubic-bezier(.2, .8, .2, 1);
             display: grid;
-            grid-template-rows: 52px minmax(0, 1fr);
+            grid-template-rows: 52px minmax(0, 1fr) auto 30px;
           }
-          .bearing-panel::backdrop { display: none; }
+          .bearing-panel::backdrop { background: transparent; }
 
           .bearing-panel-header {
             align-items: center;
@@ -160,6 +176,54 @@ function bearingBootstrap() {
             height: 100%;
             width: 100%;
           }
+          .bearing-panel-nav {
+            background: #fafafa;
+            display: grid;
+            gap: 4px;
+            grid-auto-columns: minmax(0, 1fr);
+            grid-auto-flow: column;
+            padding: 8px;
+          }
+          .bearing-panel-nav button {
+            align-items: center;
+            background: transparent;
+            border: 0;
+            border-radius: 10px;
+            color: #777;
+            cursor: pointer;
+            display: inline-flex;
+            font: 500 13px/1 system-ui, sans-serif;
+            justify-content: center;
+            min-height: 44px;
+            padding: 0 10px;
+          }
+          .bearing-panel-nav button:hover { background: #f0f0f0; color: #111; }
+          .bearing-panel-nav button:focus-visible {
+            outline: 2px solid #3b82f6;
+            outline-offset: -2px;
+          }
+          .bearing-panel-nav button[aria-current='page'] {
+            background: #fff;
+            box-shadow: 0 1px 4px rgb(0 0 0 / 10%);
+            color: #111;
+            font-weight: 650;
+          }
+          .bearing-panel-nav button[hidden] { display: none; }
+          .bearing-powered-by {
+            align-items: center;
+            background: #fafafa;
+            color: #999;
+            display: flex;
+            font: 500 11px/1 system-ui, sans-serif;
+            justify-content: center;
+            text-decoration: none;
+          }
+          .bearing-powered-by:hover { color: #555; }
+          .bearing-powered-by:focus-visible {
+            border-radius: 4px;
+            outline: 2px solid #3b82f6;
+            outline-offset: -1px;
+          }
 
           @keyframes bearing-panel-in {
             from { opacity: 0; transform: translateY(10px) scale(.985); }
@@ -182,6 +246,19 @@ function bearingBootstrap() {
             .bearing-panel-close { color: #aaa; }
             .bearing-panel-close:hover { background: #171b22; color: #fff; }
             .bearing-panel iframe { background: #030712; }
+            .bearing-panel-nav,
+            .bearing-powered-by { background: #090d14; }
+            .bearing-panel-nav button { color: #999; }
+            .bearing-panel-nav button:hover {
+              background: #171b22;
+              color: #fff;
+            }
+            .bearing-panel-nav button[aria-current='page'] {
+              background: #1d222b;
+              box-shadow: none;
+              color: #fff;
+            }
+            .bearing-powered-by:hover { color: #ddd; }
           }
 
           @media (max-width: 640px) {
@@ -195,6 +272,7 @@ function bearingBootstrap() {
             }
             .bearing-panel[data-side='right'] { left: auto; right: 8px; }
             .bearing-panel[data-side='left'] { left: 8px; right: auto; }
+            .bearing-panel[data-opened-from='host'] { bottom: 8px; }
           }
 
           @media (prefers-reduced-motion: reduce) {
@@ -216,7 +294,9 @@ function bearingBootstrap() {
           class="bearing-panel"
           data-panel
           data-side="${side}"
+          data-opened-from="host"
           aria-labelledby="slipway-bearing-title"
+          aria-modal="true"
         >
           <header class="bearing-panel-header">
             <span id="slipway-bearing-title">${escapeHtml(
@@ -229,19 +309,35 @@ function bearingBootstrap() {
               aria-label="Close"
             >×</button>
           </header>
-          <iframe title="${escapeHtml(config.appName)} feedback"></iframe>
+          <iframe data-frame title="${escapeHtml(
+            config.appName
+          )} Feedback"></iframe>
+          <nav class="bearing-panel-nav" aria-label="Bearing">
+            <button type="button" data-surface="feedback">Feedback</button>
+            <button type="button" data-surface="roadmap">Roadmap</button>
+            <button type="button" data-surface="updates">Updates</button>
+          </nav>
+          <a
+            class="bearing-powered-by"
+            href="https://docs.sailscasts.com/slipway"
+            target="_blank"
+            rel="noreferrer"
+          >Powered by Slipway</a>
         </dialog>
       `
 
       const trigger = root.querySelector('[data-trigger]')
       const panel = root.querySelector('[data-panel]')
       const closeButton = root.querySelector('[data-close]')
-      const frame = root.querySelector('iframe')
+      const frame = root.querySelector('[data-frame]')
+      const surfaceButtons = root.querySelectorAll('[data-surface]')
 
       function paintTrigger() {
-        trigger.setAttribute('aria-expanded', String(open))
-        trigger.hidden = !open && !fresh
-        if (open) {
+        const controlsOpenPanel = open && openedFromInjectedTrigger
+        trigger.setAttribute('aria-expanded', String(controlsOpenPanel))
+        trigger.tabIndex = controlsOpenPanel ? -1 : 0
+        trigger.hidden = !controlsOpenPanel && !(fresh && !open)
+        if (controlsOpenPanel) {
           trigger.innerHTML =
             '<span class="bearing-trigger-mark" aria-hidden="true">×</span><span>Close</span>'
           trigger.setAttribute('aria-label', `Close ${config.appName} feedback`)
@@ -258,36 +354,159 @@ function bearingBootstrap() {
         }
       }
 
+      function paintSurfaceNavigation() {
+        surfaceButtons.forEach((button) => {
+          const surface = button.dataset.surface
+          button.hidden = !surfaces[surface]
+          if (surface === currentSurface) {
+            button.setAttribute('aria-current', 'page')
+          } else {
+            button.removeAttribute('aria-current')
+          }
+        })
+      }
+
       function markLatestSeen() {
         if (!latestUpdateId) return
         writeStorage(seenKey, latestUpdateId)
         fresh = false
       }
 
-      function openPanel() {
-        if (!frame.src) {
-          frame.src = config.updatesPath
+      function setSurface(surface) {
+        if (!surfaces[surface]) return false
+        currentSurface = surface
+        if (frame.getAttribute('src') !== surfaces[surface].path) {
+          frame.src = surfaces[surface].path
         }
-        markLatestSeen()
-        panel.show()
+        frame.title = `${config.appName} ${surfaces[surface].label}`
+        if (surface === 'updates') markLatestSeen()
+        paintSurfaceNavigation()
+        paintTrigger()
+        return true
+      }
+
+      function openPanel(surface = openingView, nextOpener = null) {
+        if (!setSurface(surface)) return false
+        opener = nextOpener || document.activeElement
+        openedFromInjectedTrigger = opener === trigger
+        panel.dataset.openedFrom = openedFromInjectedTrigger ? 'widget' : 'host'
+        if (!panel.open) panel.show()
         open = true
         paintTrigger()
         requestAnimationFrame(() => closeButton.focus())
+        return true
       }
 
       function closePanel() {
+        const previousOpener = opener
         if (panel.open) panel.close()
         open = false
+        opener = null
+        openedFromInjectedTrigger = false
         paintTrigger()
-        trigger.focus()
+        if (previousOpener?.isConnected && previousOpener !== trigger) {
+          previousOpener.focus()
+        }
+      }
+
+      function requestedSurface(element) {
+        const requested = element.getAttribute('data-slipway-bearing-open')
+        if (requested !== null) return requested || openingView
+        if (element.tagName !== 'A') return null
+        try {
+          const destination = new URL(element.href, window.location.href)
+          if (destination.origin !== window.location.origin) return null
+          return (
+            surfaceOrder.find((surface) => {
+              if (!surfaces[surface]) return false
+              const configured = new URL(
+                surfaces[surface].path,
+                window.location.href
+              )
+              return destination.pathname === configured.pathname
+            }) || null
+          )
+        } catch {
+          return null
+        }
+      }
+
+      function shouldKeepLinkNavigation(event, link) {
+        return Boolean(
+          event.defaultPrevented ||
+            event.button !== 0 ||
+            event.metaKey ||
+            event.ctrlKey ||
+            event.shiftKey ||
+            event.altKey ||
+            link.hasAttribute('download') ||
+            (link.target && link.target !== '_self')
+        )
+      }
+
+      function handleHostTrigger(event) {
+        const target = event.target
+        if (!target?.closest) return
+        const element = target.closest('a[href], [data-slipway-bearing-open]')
+        if (!element) return
+        const surface = requestedSurface(element)
+        if (!surfaces[surface]) return
+        if (
+          element.tagName === 'A' &&
+          shouldKeepLinkNavigation(event, element)
+        ) {
+          return
+        }
+        event.preventDefault()
+        openPanel(surface, element)
+      }
+
+      function trapPanelFocus(event) {
+        if (event.key !== 'Tab') return
+        const focusable = panel.querySelectorAll(
+          'a[href], button:not([disabled]):not([hidden]), iframe'
+        )
+        if (!focusable.length) return
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+        const active = root.activeElement
+        if (event.shiftKey && active === first) {
+          event.preventDefault()
+          last.focus()
+        } else if (!event.shiftKey && active === last) {
+          event.preventDefault()
+          first.focus()
+        }
       }
 
       paintTrigger()
+      paintSurfaceNavigation()
       trigger.addEventListener('click', () => {
         if (open) closePanel()
-        else openPanel()
+        else openPanel('updates', trigger)
       })
       closeButton.addEventListener('click', closePanel)
+      surfaceButtons.forEach((button) => {
+        button.addEventListener('click', () =>
+          setSurface(button.dataset.surface)
+        )
+      })
+      panel.addEventListener('cancel', (event) => {
+        event.preventDefault()
+        closePanel()
+      })
+      panel.addEventListener('keydown', trapPanelFocus)
+      panel.addEventListener('click', (event) => {
+        if (event.target !== panel) return
+        const bounds = panel.getBoundingClientRect()
+        const inside =
+          event.clientX >= bounds.left &&
+          event.clientX <= bounds.right &&
+          event.clientY >= bounds.top &&
+          event.clientY <= bounds.bottom
+        if (!inside) closePanel()
+      })
+      document.addEventListener('click', handleHostTrigger, true)
       window.addEventListener('keydown', (event) => {
         if (open && event.key === 'Escape') closePanel()
       })
@@ -301,9 +520,18 @@ function bearingBootstrap() {
         },
         true
       )
+      window.addEventListener('slipway:bearing:open', (event) => {
+        const surface = event.detail?.surface || openingView
+        if (!surfaces[surface]) return
+        openPanel(surface, document.activeElement)
+      })
       window.addEventListener('storage', (event) => {
         if (event.key !== seenKey || !latestUpdateId) return
-        fresh = Boolean(config.showUnread && event.newValue !== latestUpdateId)
+        fresh = Boolean(
+          config.showUnread &&
+            surfaces.updates &&
+            event.newValue !== latestUpdateId
+        )
         paintTrigger()
       })
     })

--- a/api/controllers/bearing/view-bootstrap.js
+++ b/api/controllers/bearing/view-bootstrap.js
@@ -263,21 +263,41 @@ function bearingBootstrap() {
 
           @media (max-width: 640px) {
             .bearing-trigger { bottom: 12px; }
+            .bearing-trigger[aria-expanded='true'] { display: none; }
             .bearing-trigger[data-side='right'] { right: 12px; }
             .bearing-trigger[data-side='left'] { left: 12px; }
             .bearing-panel {
-              bottom: 68px;
-              height: min(680px, calc(100dvh - 84px));
-              width: calc(100vw - 16px);
+              border-bottom: 0;
+              border-radius: 20px 20px 0 0;
+              bottom: 0;
+              height: min(760px, calc(100dvh - 16px));
+              width: 100vw;
             }
-            .bearing-panel[data-side='right'] { left: auto; right: 8px; }
-            .bearing-panel[data-side='left'] { left: 8px; right: auto; }
-            .bearing-panel[data-opened-from='host'] { bottom: 8px; }
+            .bearing-panel[data-side='right'],
+            .bearing-panel[data-side='left'] {
+              left: 0;
+              right: 0;
+            }
+            .bearing-panel[data-opened-from='host'] { bottom: 0; }
+            .bearing-panel[open] {
+              animation-name: bearing-sheet-in;
+              grid-template-rows:
+                52px minmax(0, 1fr) auto
+                calc(30px + env(safe-area-inset-bottom));
+            }
+            .bearing-powered-by {
+              padding-bottom: env(safe-area-inset-bottom);
+            }
           }
 
           @media (prefers-reduced-motion: reduce) {
             .bearing-panel[open] { animation: none; }
             .bearing-trigger { transition: none; }
+          }
+
+          @keyframes bearing-sheet-in {
+            from { opacity: .96; transform: translateY(100%); }
+            to { opacity: 1; transform: translateY(0); }
           }
         </style>
         <button
@@ -411,24 +431,7 @@ function bearingBootstrap() {
 
       function requestedSurface(element) {
         const requested = element.getAttribute('data-slipway-bearing-open')
-        if (requested !== null) return requested || openingView
-        if (element.tagName !== 'A') return null
-        try {
-          const destination = new URL(element.href, window.location.href)
-          if (destination.origin !== window.location.origin) return null
-          return (
-            surfaceOrder.find((surface) => {
-              if (!surfaces[surface]) return false
-              const configured = new URL(
-                surfaces[surface].path,
-                window.location.href
-              )
-              return destination.pathname === configured.pathname
-            }) || null
-          )
-        } catch {
-          return null
-        }
+        return requested === null ? null : requested || openingView
       }
 
       function shouldKeepLinkNavigation(event, link) {
@@ -447,7 +450,7 @@ function bearingBootstrap() {
       function handleHostTrigger(event) {
         const target = event.target
         if (!target?.closest) return
-        const element = target.closest('a[href], [data-slipway-bearing-open]')
+        const element = target.closest('[data-slipway-bearing-open]')
         if (!element) return
         const surface = requestedSurface(element)
         if (!surfaces[surface]) return

--- a/api/controllers/bearing/view-widget-config.js
+++ b/api/controllers/bearing/view-widget-config.js
@@ -37,16 +37,37 @@ module.exports = {
         })
       : []
 
+    const surfaces = {
+      feedback: {
+        label: 'Feedback',
+        path: `${resolved.publicBasePath}/feedback?embedded=1`
+      },
+      roadmap: resolved.space.showPublicRoadmap
+        ? {
+            label: 'Roadmap',
+            path: `${resolved.publicBasePath}/roadmap?embedded=1`
+          }
+        : null,
+      updates: resolved.space.showPublicUpdates
+        ? {
+            label: 'Updates',
+            path: `${resolved.publicBasePath}/updates?embedded=1`
+          }
+        : null
+    }
+    const openingView = surfaces[resolved.space.widgetOpeningView]
+      ? resolved.space.widgetOpeningView
+      : 'feedback'
+
     this.res.set('Cache-Control', 'private, no-store')
     return {
       enabled: resolved.space.widgetEnabled,
       appName: resolved.project.name,
       space: resolved.space.publicSlug,
       side: resolved.space.widgetSide,
-      openingView: resolved.space.widgetOpeningView,
+      openingView,
       showUnread: resolved.space.showUnread,
-      feedbackPath: `${resolved.publicBasePath}/feedback?embedded=1`,
-      updatesPath: `${resolved.publicBasePath}/updates?embedded=1`,
+      surfaces,
       latestUpdate: updates[0] ? serializeUpdate(updates[0]) : null
     }
   }

--- a/assets/js/pages/bearing/feedback.vue
+++ b/assets/js/pages/bearing/feedback.vue
@@ -684,9 +684,15 @@ function shortDate(value) {
       </nav>
     </header>
 
-    <main class="px-5 pb-20 pt-14 sm:px-8 sm:pt-20">
+    <main
+      :class="
+        embedded
+          ? 'px-5 pb-10 pt-8 sm:px-6 sm:pt-10'
+          : 'px-5 pb-20 pt-14 sm:px-8 sm:pt-20'
+      "
+    >
       <div class="mx-auto max-w-3xl">
-        <div class="max-w-2xl">
+        <div v-if="!embedded" class="max-w-2xl">
           <p
             class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400"
           >
@@ -701,7 +707,10 @@ function shortDate(value) {
           </p>
         </div>
 
-        <section class="mt-10" aria-labelledby="share-feedback-heading">
+        <section
+          :class="embedded ? 'mt-0' : 'mt-10'"
+          aria-labelledby="share-feedback-heading"
+        >
           <form
             v-if="canSubmit"
             :class="[

--- a/assets/js/pages/bearing/surface.vue
+++ b/assets/js/pages/bearing/surface.vue
@@ -207,7 +207,13 @@ function isoDate(value) {
       </nav>
     </header>
 
-    <main class="px-5 pb-20 pt-14 sm:px-8 sm:pt-20">
+    <main
+      :class="
+        embedded
+          ? 'px-5 pb-10 pt-8 sm:px-6 sm:pt-10'
+          : 'px-5 pb-20 pt-14 sm:px-8 sm:pt-20'
+      "
+    >
       <div class="mx-auto max-w-3xl">
         <p
           class="text-xs font-semibold uppercase tracking-[0.18em] text-gray-400"

--- a/assets/js/pages/projects/bearing.vue
+++ b/assets/js/pages/projects/bearing.vue
@@ -1255,7 +1255,7 @@ function handleViewKeydown(event, index) {
                 <p
                   class="mt-1 text-sm leading-6 text-gray-500 dark:text-gray-400"
                 >
-                  Host-app links can open it directly. Unseen updates add a
+                  Host-app buttons can open it directly. Unseen updates add a
                   quiet lower-corner trigger until they are opened.
                 </p>
               </div>

--- a/assets/js/pages/projects/bearing.vue
+++ b/assets/js/pages/projects/bearing.vue
@@ -1240,8 +1240,8 @@ function handleViewKeydown(event, index) {
               <p
                 class="mt-1 text-sm leading-6 text-gray-500 dark:text-gray-400"
               >
-                A small, lazy trigger that appears when customers have an unseen
-                product update. No app template changes.
+                A lazy in-app panel for feedback, roadmap, and updates. It stays
+                out of the way until your app opens it or something new ships.
               </p>
             </div>
 
@@ -1255,7 +1255,8 @@ function handleViewKeydown(event, index) {
                 <p
                   class="mt-1 text-sm leading-6 text-gray-500 dark:text-gray-400"
                 >
-                  It disappears after the latest update has been opened.
+                  Host-app links can open it directly. Unseen updates add a
+                  quiet lower-corner trigger until they are opened.
                 </p>
               </div>
               <button

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -219,6 +219,41 @@ click, or the panel's close control also dismisses it and returns focus. The
 trigger then disappears until another update is published. No published or
 unseen update means no injected UI is visible.
 
+The host app can also open the same panel from its own navigation. Prefer a
+real link so Bearing is progressive enhancement rather than a JavaScript-only
+dead end:
+
+```html
+<a href="https://your-app.example.com/bearing/feedback">Share feedback</a>
+```
+
+Bearing recognizes ordinary same-origin links to its enabled Feedback, Roadmap,
+and Updates paths. It listens with event delegation, so menu items rendered
+after the bootstrap loads work too. Modified clicks, downloads, and links
+targeting another browsing context keep their normal browser behavior. When the
+widget is unavailable or disabled, the link simply navigates to its `href`.
+
+Buttons have no navigation fallback, so give them an explicit surface:
+
+```html
+<button type="button" data-slipway-bearing-open="feedback">
+  Share feedback
+</button>
+```
+
+For a programmatic action, dispatch the equivalent event:
+
+```js
+window.dispatchEvent(
+  new CustomEvent('slipway:bearing:open', {
+    detail: { surface: 'feedback' }
+  })
+)
+```
+
+Opening Feedback from the host app does not mark a product update as seen. The
+unread watermark changes only when the Updates surface is actually opened.
+
 ### One host identity contract
 
 Bearing resolves the same verified host-app identity as Bridge, but creates a

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -219,26 +219,24 @@ click, or the panel's close control also dismisses it and returns focus. The
 trigger then disappears until another update is published. No published or
 unseen update means no injected UI is visible.
 
-The host app can also open the same panel from its own navigation. Prefer a
-real link so Bearing is progressive enhancement rather than a JavaScript-only
-dead end:
-
-```html
-<a href="https://your-app.example.com/bearing/feedback">Share feedback</a>
-```
-
-Bearing recognizes ordinary same-origin links to its enabled Feedback, Roadmap,
-and Updates paths. It listens with event delegation, so menu items rendered
-after the bootstrap loads work too. Modified clicks, downloads, and links
-targeting another browsing context keep their normal browser behavior. When the
-widget is unavailable or disabled, the link simply navigates to its `href`.
-
-Buttons have no navigation fallback, so give them an explicit surface:
+The host app can open the same panel from an explicit action in a menu or
+toolbar:
 
 ```html
 <button type="button" data-slipway-bearing-open="feedback">
   Share feedback
 </button>
+```
+
+Bearing listens with event delegation, so buttons rendered after the bootstrap
+loads work too. Use `feedback`, `roadmap`, or `updates` as the requested surface.
+Unknown or disabled surfaces do nothing safely.
+
+Ordinary links remain ordinary navigation and are never intercepted. This makes
+it safe to offer the full Bearing page elsewhere, such as in the app footer:
+
+```html
+<a href="https://your-app.example.com/bearing/feedback">Feedback</a>
 ```
 
 For a programmatic action, dispatch the equivalent event:

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -943,9 +943,7 @@ test(
       right: Math.round(mobileWidgetBounds.x + mobileWidgetBounds.width),
       bottom: Math.round(mobileWidgetBounds.y + mobileWidgetBounds.height)
     }).toEqual({ left: 0, right: 390, bottom: 844 })
-    await page.screenshot(path.join(screenshotRoot, 'widget-open-mobile.png'), {
-      fullPage: true
-    })
+    await page.screenshot(path.join(screenshotRoot, 'widget-open-mobile.png'))
     await page.resize(1440, 1000)
     await widgetTrigger.click()
     await expect(widgetPanel).not.toBeVisible()
@@ -1050,8 +1048,7 @@ test(
       )
     }).toEqual({ left: 0, right: 390, bottom: 844 })
     await page.screenshot(
-      path.join(screenshotRoot, 'widget-feedback-from-host-mobile.png'),
-      { fullPage: true }
+      path.join(screenshotRoot, 'widget-feedback-from-host-mobile.png')
     )
     await page.resize(1440, 1000)
     await expect(widget.locator('[data-close]')).toBeFocused()

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -936,11 +936,13 @@ test(
       fullPage: true
     })
     await page.resize(390, 844)
+    await page.raw.waitForTimeout(220)
     const mobileWidgetBounds = await widgetPanel.boundingBox()
-    expect(Math.round(mobileWidgetBounds.x) >= 8).toBe(true)
-    expect(
-      Math.round(mobileWidgetBounds.x + mobileWidgetBounds.width) <= 382
-    ).toBe(true)
+    expect({
+      left: Math.round(mobileWidgetBounds.x),
+      right: Math.round(mobileWidgetBounds.x + mobileWidgetBounds.width),
+      bottom: Math.round(mobileWidgetBounds.y + mobileWidgetBounds.height)
+    }).toEqual({ left: 0, right: 390, bottom: 844 })
     await page.screenshot(path.join(screenshotRoot, 'widget-open-mobile.png'), {
       fullPage: true
     })
@@ -975,12 +977,35 @@ test(
     await expect(reloadedWidgetTrigger).toBeHidden()
 
     await revealLatestUpdateTrigger(page, space.publicSlug)
-    await page.raw.evaluate(() => {
+    const ordinaryLinkWasIntercepted = await page.raw.evaluate(async () => {
       const link = document.querySelector('a[href="/bearing/feedback"]')
       link.id = 'host-feedback-link'
+      return new Promise((resolve) => {
+        link.addEventListener(
+          'click',
+          (event) => {
+            resolve(event.defaultPrevented)
+            event.preventDefault()
+          },
+          { once: true }
+        )
+        link.click()
+      })
     })
-    const hostFeedbackLink = page.raw.locator('#host-feedback-link')
-    await hostFeedbackLink.click()
+    expect(ordinaryLinkWasIntercepted).toBe(false)
+    await page.raw.evaluate(() => {
+      const link = document.querySelector('#host-feedback-link')
+      const button = document.createElement('button')
+      button.id = 'host-feedback-button'
+      button.type = 'button'
+      button.className = link.className
+      button.dataset.slipwayBearingOpen = 'feedback'
+      button.textContent = 'Feedback'
+      button.setAttribute('aria-label', 'Share feedback')
+      link.replaceWith(button)
+    })
+    const hostFeedbackButton = page.raw.locator('#host-feedback-button')
+    await hostFeedbackButton.click()
     await expect(widgetPanel).toBeVisible()
     await expect(widgetPanel).toHaveAttribute('data-opened-from', 'host')
     await expect(widgetTrigger).toBeHidden()
@@ -1013,6 +1038,7 @@ test(
     })
     await page.raw.waitForTimeout(220)
     await page.resize(390, 844)
+    await page.raw.waitForTimeout(220)
     const hostWidgetMobileBounds = await widgetPanel.boundingBox()
     expect({
       left: Math.round(hostWidgetMobileBounds.x),
@@ -1022,7 +1048,7 @@ test(
       bottom: Math.round(
         hostWidgetMobileBounds.y + hostWidgetMobileBounds.height
       )
-    }).toEqual({ left: 8, right: 382, bottom: 836 })
+    }).toEqual({ left: 0, right: 390, bottom: 844 })
     await page.screenshot(
       path.join(screenshotRoot, 'widget-feedback-from-host-mobile.png'),
       { fullPage: true }
@@ -1035,10 +1061,10 @@ test(
     await expect(widget.locator('[data-close]')).toBeFocused()
     await widget.locator('[data-close]').click()
     await expect(widgetPanel).not.toBeVisible()
-    await expect(hostFeedbackLink).toBeFocused()
+    await expect(hostFeedbackButton).toBeFocused()
     await expect(widgetTrigger).toContainText('What’s new')
 
-    await hostFeedbackLink.click()
+    await hostFeedbackButton.click()
     await widget.locator('[data-surface="roadmap"]').click()
     await expect(widgetFrame).toHaveAttribute(
       'src',

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -937,8 +937,10 @@ test(
     })
     await page.resize(390, 844)
     const mobileWidgetBounds = await widgetPanel.boundingBox()
-    expect(mobileWidgetBounds.x >= 8).toBe(true)
-    expect(mobileWidgetBounds.x + mobileWidgetBounds.width <= 382).toBe(true)
+    expect(Math.round(mobileWidgetBounds.x) >= 8).toBe(true)
+    expect(
+      Math.round(mobileWidgetBounds.x + mobileWidgetBounds.width) <= 382
+    ).toBe(true)
     await page.screenshot(path.join(screenshotRoot, 'widget-open-mobile.png'), {
       fullPage: true
     })
@@ -956,7 +958,7 @@ test(
     await revealLatestUpdateTrigger(page, space.publicSlug)
     await widgetTrigger.click()
     await expect(widgetPanel).toBeVisible()
-    await page.raw.locator('body').click({ position: { x: 80, y: 80 } })
+    await page.raw.mouse.click(80, 80)
     await expect(widgetPanel).not.toBeVisible()
     await expect(widgetTrigger).toBeHidden()
     await revealLatestUpdateTrigger(page, space.publicSlug)
@@ -971,6 +973,118 @@ test(
       .locator('[data-slipway-bearing-widget]')
       .locator('[data-trigger]')
     await expect(reloadedWidgetTrigger).toBeHidden()
+
+    await revealLatestUpdateTrigger(page, space.publicSlug)
+    await page.raw.evaluate(() => {
+      const link = document.querySelector('a[href="/bearing/feedback"]')
+      link.id = 'host-feedback-link'
+    })
+    const hostFeedbackLink = page.raw.locator('#host-feedback-link')
+    await hostFeedbackLink.click()
+    await expect(widgetPanel).toBeVisible()
+    await expect(widgetPanel).toHaveAttribute('data-opened-from', 'host')
+    await expect(widgetTrigger).toBeHidden()
+    const widgetFrame = widget.locator('iframe')
+    await expect(widgetFrame).toHaveAttribute(
+      'src',
+      '/bearing/feedback?embedded=1'
+    )
+    await expect(
+      page.raw
+        .frameLocator('[data-slipway-bearing-widget] iframe')
+        .getByLabel('Summary')
+    ).toBeVisible()
+    await page.screenshot(
+      path.join(screenshotRoot, 'widget-feedback-from-host.png'),
+      { fullPage: true }
+    )
+    await page.raw.emulateMedia({
+      colorScheme: 'dark',
+      reducedMotion: 'reduce'
+    })
+    await expect(widgetPanel).toHaveCSS('animation-name', 'none')
+    await page.screenshot(
+      path.join(screenshotRoot, 'widget-feedback-from-host-dark.png'),
+      { fullPage: true, animations: 'disabled' }
+    )
+    await page.raw.emulateMedia({
+      colorScheme: 'light',
+      reducedMotion: 'no-preference'
+    })
+    await page.raw.waitForTimeout(220)
+    await page.resize(390, 844)
+    const hostWidgetMobileBounds = await widgetPanel.boundingBox()
+    expect({
+      left: Math.round(hostWidgetMobileBounds.x),
+      right: Math.round(
+        hostWidgetMobileBounds.x + hostWidgetMobileBounds.width
+      ),
+      bottom: Math.round(
+        hostWidgetMobileBounds.y + hostWidgetMobileBounds.height
+      )
+    }).toEqual({ left: 8, right: 382, bottom: 836 })
+    await page.screenshot(
+      path.join(screenshotRoot, 'widget-feedback-from-host-mobile.png'),
+      { fullPage: true }
+    )
+    await page.resize(1440, 1000)
+    await expect(widget.locator('[data-close]')).toBeFocused()
+    await page.raw.keyboard.press('Shift+Tab')
+    await expect(widget.locator('.bearing-powered-by')).toBeFocused()
+    await page.raw.keyboard.press('Tab')
+    await expect(widget.locator('[data-close]')).toBeFocused()
+    await widget.locator('[data-close]').click()
+    await expect(widgetPanel).not.toBeVisible()
+    await expect(hostFeedbackLink).toBeFocused()
+    await expect(widgetTrigger).toContainText('What’s new')
+
+    await hostFeedbackLink.click()
+    await widget.locator('[data-surface="roadmap"]').click()
+    await expect(widgetFrame).toHaveAttribute(
+      'src',
+      '/bearing/roadmap?embedded=1'
+    )
+    await expect(widget.locator('[data-surface="roadmap"]')).toHaveAttribute(
+      'aria-current',
+      'page'
+    )
+    await widget.locator('[data-surface="updates"]').click()
+    await expect(widgetFrame).toHaveAttribute(
+      'src',
+      '/bearing/updates?embedded=1'
+    )
+    await widget.locator('[data-close]').click()
+    await expect(widgetTrigger).toBeHidden()
+
+    await page.raw.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent('slipway:bearing:open', {
+          detail: { surface: 'feedback' }
+        })
+      )
+    })
+    await expect(widgetPanel).toBeVisible()
+    await expect(widgetFrame).toHaveAttribute(
+      'src',
+      '/bearing/feedback?embedded=1'
+    )
+    await widget.locator('[data-close]').click()
+
+    await page.raw.evaluate(() => {
+      const button = document.createElement('button')
+      button.id = 'host-roadmap-button'
+      button.type = 'button'
+      button.dataset.slipwayBearingOpen = 'roadmap'
+      button.textContent = 'Open roadmap'
+      document.body.append(button)
+    })
+    await page.raw.locator('#host-roadmap-button').click()
+    await expect(widgetPanel).toBeVisible()
+    await expect(widgetFrame).toHaveAttribute(
+      'src',
+      '/bearing/roadmap?embedded=1'
+    )
+    await widget.locator('[data-close]').click()
 
     const infiniteFeedbackStartedAt = Date.now() - 100_000
     for (const infiniteFeedback of Array.from({ length: 25 }, (_, index) => ({

--- a/tests/functional/pages/bearing.test.js
+++ b/tests/functional/pages/bearing.test.js
@@ -396,7 +396,9 @@ test(
       .create({
         publicSlug: 'public-feedback-space',
         app: app.id,
-        createdBy: current.users.genesisUser.id
+        createdBy: current.users.genesisUser.id,
+        widgetEnabled: true,
+        widgetOpeningView: 'updates'
       })
       .fetch()
     const hostBasePath = `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}`
@@ -618,6 +620,22 @@ test(
       `/_slipway/bearing/host/${project.slug}/${environment.slug}/${app.slug}/widget-config`
     )
     expect(widgetConfig).toHaveStatus(200)
+    expect(widgetConfig.data.enabled).toBe(true)
+    expect(widgetConfig.data.openingView).toBe('updates')
+    expect(widgetConfig.data.surfaces).toEqual({
+      feedback: {
+        label: 'Feedback',
+        path: '/bearing/feedback?embedded=1'
+      },
+      roadmap: {
+        label: 'Roadmap',
+        path: '/bearing/roadmap?embedded=1'
+      },
+      updates: {
+        label: 'Updates',
+        path: '/bearing/updates?embedded=1'
+      }
+    })
     expect(widgetConfig.data.latestUpdate.title).toBe(
       'Calmer notifications have shipped'
     )
@@ -628,6 +646,8 @@ test(
     expect(bootstrap).toHaveStatus(200)
     expect(bootstrap.body).toContain('slipway:bearing:')
     expect(bootstrap.body).toContain('What’s new')
+    expect(bootstrap.body).toContain('data-slipway-bearing-open')
+    expect(bootstrap.body).toContain('slipway:bearing:open')
 
     for (const paginatedFeedback of Array.from({ length: 25 }, (_, index) => ({
       publicId: `bfd-pagination-${index + 1}`,


### PR DESCRIPTION
## Summary

- let explicit host buttons and programmatic actions open Feedback, Roadmap, or Updates while ordinary `/bearing/*` links always navigate to the full pages
- reuse the existing embedded pages and configured public surfaces instead of building a second feedback experience
- make mobile a flush, safe-area-aware bottom sheet while retaining the compact desktop panel
- keep the floating launcher exclusive to unseen updates, return focus to the host opener, and support close, Escape, outside click, dark mode, and reduced motion
- document the integration and cover config, identity-safe public behavior, navigation, seen state, focus, and responsive layout

## Verification

- `npm run lint`
- `npm run check:consistency`
- `npm run test:unit` — 341 passed
- `npm run test:functional` — 106 passed
- `npx sounding test tests/e2e/pages/projects/bearing.test.js --test-concurrency=1` — 2 passed

Closes #424
