### PR TITLE
fix(lookout): preserve failed Quest traces

### DIFF
--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -342,6 +342,12 @@ module.exports.slipway = {
 
 Telemetry failures never break the host application.
 
+With `sails-hook-quest` 0.0.5 or newer, failed job output continues streaming
+to the application log while its final bounded diagnostic is attached to the
+Lookout exception. The Slipway hook removes terminal formatting and redacts
+known secret values before telemetry leaves the application. Older Quest
+payloads remain supported and use their runner stack when one is available.
+
 ## Release flags
 
 Slipway injects the private flag endpoint and app identity during deployments

--- a/packages/hook/index.js
+++ b/packages/hook/index.js
@@ -29,6 +29,7 @@ const https = require('https')
 const crypto = require('crypto')
 const { createReleaseFlags } = require('./lib/release-flags')
 const { injectBearingWidget } = require('./lib/bearing-widget')
+const { normalizeQuestDiagnostic } = require('./lib/quest-diagnostics')
 const buildFlagsEnabledHelper = require('./lib/helpers/flags/enabled')
 const {
   ACCESS_DENIED_MESSAGE,
@@ -730,7 +731,7 @@ module.exports = function defineSlipwayHook(sails) {
             ? data.error.message || String(data.error)
             : 'Unknown error'
         }`,
-        stackTrace: data.error ? data.error.stack : null,
+        stackTrace: normalizeQuestDiagnostic(data.error),
         handled: true,
         method: null,
         url: null,

--- a/packages/hook/lib/quest-diagnostics.js
+++ b/packages/hook/lib/quest-diagnostics.js
@@ -1,0 +1,69 @@
+const MAX_QUEST_TRACE_BYTES = 64 * 1024
+const ANSI_ESCAPE_PATTERN = /\u001B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g
+const SENSITIVE_ASSIGNMENT_PATTERN =
+  /\b([A-Z0-9_]*(?:PASSWORD|PASSWD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|CREDENTIAL)[A-Z0-9_]*)\s*=\s*([^\s,;]+)/gi
+const BEARER_PATTERN = /\bBearer\s+[^\s,;]+/gi
+const SENSITIVE_ENV_KEY_PATTERN =
+  /(?:PASSWORD|PASSWD|SECRET|TOKEN|API_KEY|PRIVATE_KEY|CREDENTIAL)/i
+
+function normalizeQuestDiagnostic(error, options = {}) {
+  if (!error || typeof error !== 'object') {
+    return null
+  }
+
+  const diagnostic = sanitizeQuestDiagnostic(error.diagnostic, options)
+  const stack = sanitizeQuestDiagnostic(error.stack, options)
+  const trace = [diagnostic, stack]
+    .filter(Boolean)
+    .filter((value, index, values) => values.indexOf(value) === index)
+    .join('\n\nQuest runner:\n')
+
+  return boundTail(trace, options.maxBytes || MAX_QUEST_TRACE_BYTES) || null
+}
+
+function sanitizeQuestDiagnostic(value, options = {}) {
+  if (typeof value !== 'string' || value.trim() === '') {
+    return ''
+  }
+
+  let sanitized = value
+    .replace(ANSI_ESCAPE_PATTERN, '')
+    .replace(BEARER_PATTERN, 'Bearer <redacted>')
+    .replace(SENSITIVE_ASSIGNMENT_PATTERN, '$1=<redacted>')
+
+  const environment = options.environment || process.env
+  const secretValues = Object.entries(environment)
+    .filter(
+      ([key, secret]) =>
+        SENSITIVE_ENV_KEY_PATTERN.test(key) &&
+        typeof secret === 'string' &&
+        secret.length >= 6
+    )
+    .map(([, secret]) => secret)
+    .sort((left, right) => right.length - left.length)
+
+  for (const secret of secretValues) {
+    sanitized = sanitized.split(secret).join('<redacted>')
+  }
+
+  return sanitized.trim()
+}
+
+function boundTail(value, maxBytes) {
+  if (!value) {
+    return ''
+  }
+
+  const buffer = Buffer.from(value)
+  if (buffer.length <= maxBytes) {
+    return value
+  }
+
+  return buffer.subarray(buffer.length - maxBytes).toString('utf8')
+}
+
+module.exports = {
+  MAX_QUEST_TRACE_BYTES,
+  normalizeQuestDiagnostic,
+  sanitizeQuestDiagnostic
+}

--- a/tests/functional/pages/lookout.test.js
+++ b/tests/functional/pages/lookout.test.js
@@ -1,3 +1,4 @@
+const crypto = require('node:crypto')
 const { test } = require('sounding')
 
 test(
@@ -36,6 +37,69 @@ test(
     expect(page).toHaveInertiaProp(
       'observabilityHealth.retention.rowCount',
       120
+    )
+  }
+)
+
+test(
+  'failed Quest traces survive ingestion and appear in Lookout',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'lookout-quest-traces',
+          name: 'Lookout Quest traces'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, visit, expect }) => {
+    const { projects, environments } = world.current
+    const project = projects.deploymentTarget
+    const environment = environments.production
+    const token = 'stk_' + crypto.randomBytes(24).toString('hex')
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      telemetryToken: token,
+      telemetryTokenHash: crypto
+        .createHash('sha256')
+        .update(token)
+        .digest('hex')
+    })
+
+    const trace =
+      'Error: database exploded\n    at sendIssueNotifications (/app/scripts/send-issue-notifications.js:12:3)'
+    const response = await request
+      .withHeaders({
+        authorization: `Bearer ${token}`,
+        accept: 'application/json'
+      })
+      .post('/api/v1/telemetry/ingest', {
+        exceptions: [
+          {
+            exceptionType: 'QuestJobError',
+            message: 'Job "send-issue-notifications" failed',
+            stackTrace: trace,
+            handled: true,
+            occurredAt: Date.now()
+          }
+        ]
+      })
+
+    expect(response).toHaveStatus(200)
+    const stored = await sails.models.telemetryexception.findOne({
+      environment: environment.id,
+      exceptionType: 'QuestJobError'
+    })
+    expect(stored.stackTrace).toBe(trace)
+
+    const page = await visit.as('genesisUser')(
+      `/projects/${project.slug}/environments/${environment.slug}/lookout`
+    )
+    expect(page).toHaveStatus(200)
+    expect(page).toHaveInertiaProp(
+      'telemetry.exceptions.groups.0.lastStackTrace',
+      trace
     )
   }
 )

--- a/tests/unit/packages/hook-quest-diagnostics.test.js
+++ b/tests/unit/packages/hook-quest-diagnostics.test.js
@@ -1,0 +1,32 @@
+const { test } = require('sounding')
+const {
+  normalizeQuestDiagnostic
+} = require('../../../packages/hook/lib/quest-diagnostics')
+
+test('Quest diagnostics are useful, bounded, redacted, and backward compatible', ({
+  expect
+}) => {
+  const trace = normalizeQuestDiagnostic(
+    {
+      diagnostic:
+        '\u001b[31mError: database exploded\u001b[0m\n    at sendIssueNotifications (/app/scripts/send-issue-notifications.js:12:3)\nAPI_TOKEN=visible-token Bearer visible-token',
+      stack: 'Error: Job exited with code 1\n    at executor.js:143:23'
+    },
+    {
+      environment: { API_TOKEN: 'visible-token' },
+      maxBytes: 1024
+    }
+  )
+
+  expect(trace).toContain('sendIssueNotifications')
+  expect(trace).toContain('Quest runner:')
+  expect(trace).toContain('executor.js')
+  expect(trace.includes('visible-token')).toBe(false)
+  expect(trace.includes('\u001b')).toBe(false)
+  expect(Buffer.byteLength(trace) <= 1024).toBe(true)
+
+  expect(
+    normalizeQuestDiagnostic({ stack: 'Error: older Quest payload' })
+  ).toBe('Error: older Quest payload')
+  expect(normalizeQuestDiagnostic({ message: 'no trace available' })).toBe(null)
+})


### PR DESCRIPTION
Failed Quest jobs currently reach Lookout with an exit message but no useful trace.

This normalizes the additive Quest diagnostic payload into the existing exception stack, strips terminal formatting, redacts bearer tokens, sensitive assignments, and known secret environment values, and bounds the result before telemetry leaves the app. Older Quest payloads continue to use their existing stack or the current fallback.

Sounding verification:
- focused unit normalization/redaction trial
- authenticated ingestion → persistence → Lookout Inertia trial
- 302 retained unit trials
- 102 retained functional trials
- npm run lint

The upstream diagnostic event is implemented and merged in sailscastshq/sails-hook-quest#12.

Fixes #428