### PR TITLE
fix: restore live logs and page responsiveness in 0.0.60

### DIFF
--- a/api/controllers/api/v1/bosun/stream-instance-logs.js
+++ b/api/controllers/api/v1/bosun/stream-instance-logs.js
@@ -51,34 +51,23 @@ module.exports = {
 
     const docker = spawn(dockerPath, args)
 
-    // Track whether we ever received real log output from the container.
-    // If docker closes before any stdout, the container doesn't exist (local dev).
-    let stdoutReceived = false
-    const pendingStderr = []
-
+    // Docker preserves the container's stdout/stderr split. A healthy Node
+    // process can legitimately write only to stderr for long stretches, so
+    // both streams must be delivered immediately. Waiting for stdout makes a
+    // live EventSource look connected while its useful output is held forever.
     const stdoutLines = createLineFramer({
       onLine(line) {
-        if (!stdoutReceived) {
-          stdoutReceived = true
-          for (const pendingLine of pendingStderr.splice(0)) {
-            stream.send({ log: pendingLine })
-          }
-        }
         stream.send({ log: line })
       }
     })
     const stderrLines = createLineFramer({
       onLine(line) {
-        if (stdoutReceived) stream.send({ log: line })
-        else pendingStderr.push(line)
+        stream.send({ log: line })
       }
     })
 
     docker.stdout.on('data', (data) => stdoutLines.write(data))
 
-    // Buffer stderr until we know the container exists.
-    // docker logs sends container stderr here during normal operation,
-    // but also sends its own errors (e.g. "No such container") here.
     docker.stderr.on('data', (data) => {
       stderrLines.write(data)
     })
@@ -99,13 +88,13 @@ module.exports = {
       sails.log.debug(
         `[stream-instance-logs] Docker process closed with code: ${code}, signal: ${signal}`
       )
-      if (code !== 0 && !stdoutReceived) {
-        // Docker couldn't find the container — likely running outside Docker (local dev)
+      if (code !== 0) {
+        // Preserve Docker's output above, then add a useful product-level
+        // explanation instead of treating a failed command as a clean close.
         stream.send({
           error: 'Instance logs are available when running in Docker'
         })
       } else {
-        for (const line of pendingStderr.splice(0)) stream.send({ log: line })
         stream.send({ closed: true })
       }
       stream.close()

--- a/api/hooks/sse/index.js
+++ b/api/hooks/sse/index.js
@@ -240,6 +240,11 @@ module.exports = function defineSseHook(sails) {
               }
 
               activeStreams.add(stream)
+              const heartbeatInterval = setInterval(() => {
+                stream.heartbeat()
+              }, 15 * 1000)
+              heartbeatInterval.unref?.()
+              stream.onClose(() => clearInterval(heartbeatInterval))
               _sseStream = stream
               return stream
             }

--- a/assets/js/components/LogViewer.vue
+++ b/assets/js/components/LogViewer.vue
@@ -163,37 +163,40 @@ function levelLabel(value) {
 
 function badgeClass(event) {
   return {
-    error: 'text-rose-300',
-    warning: 'text-amber-300',
-    info: 'text-sky-300',
-    debug: 'text-zinc-500'
+    error: 'text-rose-700 dark:text-rose-300',
+    warning: 'text-amber-700 dark:text-amber-300',
+    info: 'text-sky-700 dark:text-sky-300',
+    debug: 'text-gray-500 dark:text-zinc-500'
   }[event.level]
 }
 
 function eventClass(event) {
   return {
-    error: 'border-l-rose-500/70 bg-rose-950/20 hover:bg-rose-950/30',
-    warning: 'border-l-amber-400/60 bg-amber-950/10 hover:bg-amber-950/20',
-    info: 'border-l-transparent hover:bg-white/[0.035]',
-    debug: 'border-l-transparent hover:bg-white/[0.025]'
+    error:
+      'border-l-rose-500/70 bg-rose-50/80 hover:bg-rose-100/70 dark:bg-rose-950/20 dark:hover:bg-rose-950/30',
+    warning:
+      'border-l-amber-400/60 bg-amber-50/70 hover:bg-amber-100/60 dark:bg-amber-950/10 dark:hover:bg-amber-950/20',
+    info: 'border-l-transparent hover:bg-gray-100/80 dark:hover:bg-white/[0.035]',
+    debug: 'border-l-transparent hover:bg-gray-50 dark:hover:bg-white/[0.025]'
   }[event.level]
 }
 
 function segmentClass(type) {
   return {
-    error: 'font-semibold text-rose-300',
-    warning: 'font-medium text-amber-300',
-    info: 'text-sky-300',
-    debug: 'text-zinc-500',
-    method: 'font-semibold text-cyan-300',
-    url: 'text-violet-300 underline decoration-violet-400/40 underline-offset-2',
-    path: 'text-cyan-300',
-    tag: 'text-zinc-500',
-    'status-error': 'rounded bg-rose-500/15 px-1 font-semibold text-rose-300',
+    error: 'font-semibold text-rose-700 dark:text-rose-300',
+    warning: 'font-medium text-amber-700 dark:text-amber-300',
+    info: 'text-sky-700 dark:text-sky-300',
+    debug: 'text-gray-500 dark:text-zinc-500',
+    method: 'font-semibold text-cyan-700 dark:text-cyan-300',
+    url: 'text-violet-700 underline decoration-violet-400/40 underline-offset-2 dark:text-violet-300',
+    path: 'text-cyan-700 dark:text-cyan-300',
+    tag: 'text-gray-500 dark:text-zinc-500',
+    'status-error':
+      'rounded bg-rose-100 px-1 font-semibold text-rose-700 dark:bg-rose-500/15 dark:text-rose-300',
     'status-warning':
-      'rounded bg-amber-500/15 px-1 font-semibold text-amber-300',
-    'status-redirect': 'text-sky-300',
-    'status-success': 'text-emerald-300'
+      'rounded bg-amber-100 px-1 font-semibold text-amber-700 dark:bg-amber-500/15 dark:text-amber-300',
+    'status-redirect': 'text-sky-700 dark:text-sky-300',
+    'status-success': 'text-emerald-700 dark:text-emerald-300'
   }[type]
 }
 </script>
@@ -201,14 +204,14 @@ function segmentClass(type) {
 <template>
   <section
     data-test="log-viewer"
-    class="overflow-hidden bg-zinc-950 text-zinc-200"
+    class="overflow-hidden bg-white text-gray-800 dark:bg-zinc-950 dark:text-zinc-200"
     aria-label="Live logs"
   >
     <div
-      class="flex flex-wrap items-center gap-x-3 gap-y-2 border-y border-white/[0.07] bg-zinc-900/80 px-3 py-2 sm:flex-nowrap"
+      class="flex flex-wrap items-center gap-x-3 gap-y-2 border-y border-gray-200 bg-gray-50/90 px-3 py-2 dark:border-white/[0.07] dark:bg-zinc-900/80 sm:flex-nowrap"
     >
       <div
-        class="min-w-24 order-1 flex items-center gap-2 font-sans text-xs text-zinc-400"
+        class="min-w-24 order-1 flex items-center gap-2 font-sans text-xs text-gray-600 dark:text-zinc-400"
         role="status"
         aria-live="polite"
       >
@@ -216,12 +219,12 @@ function segmentClass(type) {
           :class="[
             'h-1.5 w-1.5 rounded-full',
             connectionState === 'live' && 'bg-emerald-400',
-            connectionState === 'complete' && 'bg-zinc-500',
+            connectionState === 'complete' && 'bg-gray-400 dark:bg-zinc-500',
             connectionState === 'connecting' &&
               'animate-pulse bg-amber-300 motion-reduce:animate-none',
             connectionState === 'reconnecting' &&
               'animate-pulse bg-rose-400 motion-reduce:animate-none',
-            connectionState === 'inactive' && 'bg-zinc-600'
+            connectionState === 'inactive' && 'bg-gray-400 dark:bg-zinc-600'
           ]"
         ></span>
         <span>{{ connectionLabel }}</span>
@@ -233,7 +236,7 @@ function segmentClass(type) {
         <span class="sr-only">Search logs</span>
         <svg
           aria-hidden="true"
-          class="pointer-events-none absolute left-0 top-1/2 h-4 w-4 -translate-y-1/2 text-zinc-600"
+          class="pointer-events-none absolute left-0 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400 dark:text-zinc-600"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -251,7 +254,7 @@ function segmentClass(type) {
           type="search"
           autocomplete="off"
           placeholder="Find in logs…"
-          class="h-9 w-full border-0 border-b border-dashed border-zinc-700 bg-transparent pl-6 pr-2 font-sans text-xs text-zinc-200 outline-none placeholder:text-zinc-600 focus:border-sky-400 focus:ring-0"
+          class="h-9 w-full border-0 border-b border-dashed border-gray-300 bg-transparent pl-6 pr-2 font-sans text-xs text-gray-800 outline-none placeholder:text-gray-400 focus:border-sky-500 focus:ring-0 dark:border-zinc-700 dark:text-zinc-200 dark:placeholder:text-zinc-600 dark:focus:border-sky-400"
         />
       </label>
 
@@ -261,7 +264,7 @@ function segmentClass(type) {
           <select
             v-model="level"
             data-test="log-level-filter"
-            class="h-10 appearance-none border-0 border-b border-dashed border-zinc-700 bg-transparent py-0 pl-2 pr-7 font-sans text-xs text-zinc-300 outline-none focus:border-sky-400 focus:ring-0"
+            class="h-10 appearance-none border-0 border-b border-dashed border-gray-300 bg-transparent py-0 pl-2 pr-7 font-sans text-xs text-gray-700 outline-none focus:border-sky-500 focus:ring-0 dark:border-zinc-700 dark:text-zinc-300 dark:focus:border-sky-400"
           >
             <option value="all">All · {{ events.length }}</option>
             <option v-for="value in LOG_LEVELS" :key="value" :value="value">
@@ -270,7 +273,7 @@ function segmentClass(type) {
           </select>
           <svg
             aria-hidden="true"
-            class="pointer-events-none absolute right-1.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-zinc-500"
+            class="pointer-events-none absolute right-1.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-500 dark:text-zinc-500"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -295,10 +298,10 @@ function segmentClass(type) {
             "
             :aria-pressed="following"
             :class="[
-              'min-w-10 inline-flex h-10 items-center justify-center gap-1.5 rounded-md px-2 font-sans text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70',
+              'min-w-10 inline-flex h-10 items-center justify-center gap-1.5 rounded-md px-2 font-sans text-xs transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 dark:focus-visible:ring-sky-400/70',
               following
-                ? 'bg-white/[0.07] text-zinc-200'
-                : 'text-zinc-500 hover:bg-white/5 hover:text-zinc-300'
+                ? 'bg-gray-200/80 text-gray-800 dark:bg-white/[0.07] dark:text-zinc-200'
+                : 'text-gray-500 hover:bg-gray-200/70 hover:text-gray-800 dark:text-zinc-500 dark:hover:bg-white/5 dark:hover:text-zinc-300'
             ]"
             @click="toggleFollowing"
           >
@@ -333,8 +336,9 @@ function segmentClass(type) {
             "
             :aria-pressed="wrap"
             :class="[
-              'min-w-10 inline-flex h-10 items-center justify-center rounded-md text-zinc-500 transition-colors hover:bg-white/5 hover:text-zinc-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70',
-              wrap && 'bg-white/[0.07] text-zinc-200'
+              'min-w-10 inline-flex h-10 items-center justify-center rounded-md text-gray-500 transition-colors hover:bg-gray-200/70 hover:text-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 dark:text-zinc-500 dark:hover:bg-white/5 dark:hover:text-zinc-300 dark:focus-visible:ring-sky-400/70',
+              wrap &&
+                'bg-gray-200/80 text-gray-800 dark:bg-white/[0.07] dark:text-zinc-200'
             ]"
             @click="wrap = !wrap"
           >
@@ -368,10 +372,10 @@ function segmentClass(type) {
               copyState === 'copied' ? 'Logs copied' : 'Copy visible logs'
             "
             :class="[
-              'min-w-10 inline-flex h-10 items-center justify-center rounded-md text-zinc-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400/70',
+              'min-w-10 inline-flex h-10 items-center justify-center rounded-md text-gray-500 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/70 dark:text-zinc-500 dark:focus-visible:ring-sky-400/70',
               visibleEvents.length === 0
                 ? 'cursor-not-allowed opacity-30'
-                : 'hover:bg-white/5 hover:text-zinc-300'
+                : 'hover:bg-gray-200/70 hover:text-gray-800 dark:hover:bg-white/5 dark:hover:text-zinc-300'
             ]"
             @click="copyVisibleLogs"
           >
@@ -412,7 +416,7 @@ function segmentClass(type) {
 
     <div
       v-if="error && events.length > 0"
-      class="flex items-center gap-2 border-b border-amber-400/10 bg-amber-400/[0.06] px-3 py-2 font-sans text-xs text-amber-200/80"
+      class="flex items-center gap-2 border-b border-amber-200 bg-amber-50 px-3 py-2 font-sans text-xs text-amber-800 dark:border-amber-400/10 dark:bg-amber-400/[0.06] dark:text-amber-200/80"
       role="status"
     >
       <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-300"></span>
@@ -428,33 +432,33 @@ function segmentClass(type) {
     >
       <div
         v-if="inactiveMessage && events.length === 0"
-        class="flex h-full items-center justify-center px-6 text-center font-sans text-sm text-zinc-500"
+        class="flex h-full items-center justify-center px-6 text-center font-sans text-sm text-gray-500 dark:text-zinc-500"
       >
         {{ inactiveMessage }}
       </div>
       <div
         v-else-if="error && events.length === 0"
         role="status"
-        class="flex h-full items-center justify-center px-6 text-center font-sans text-sm text-rose-300"
+        class="flex h-full items-center justify-center px-6 text-center font-sans text-sm text-rose-700 dark:text-rose-300"
       >
         {{ error }}
       </div>
       <div
         v-else-if="!connected && events.length === 0"
-        class="flex h-full items-center justify-center font-sans text-sm text-zinc-500"
+        class="flex h-full items-center justify-center font-sans text-sm text-gray-500 dark:text-zinc-500"
       >
         <Spinner class="mr-2 h-4 w-4" />
         Connecting to logs…
       </div>
       <div
         v-else-if="events.length === 0"
-        class="flex h-full items-center justify-center font-sans text-sm text-zinc-500"
+        class="flex h-full items-center justify-center font-sans text-sm text-gray-500 dark:text-zinc-500"
       >
         Waiting for output…
       </div>
       <div
         v-else-if="visibleEvents.length === 0"
-        class="flex h-full items-center justify-center px-6 text-center font-sans text-sm text-zinc-500"
+        class="flex h-full items-center justify-center px-6 text-center font-sans text-sm text-gray-500 dark:text-zinc-500"
       >
         No logs match this search and severity.
       </div>
@@ -473,7 +477,7 @@ function segmentClass(type) {
             <time
               :datetime="event.timestamp || undefined"
               :title="event.timestamp || 'Timestamp unavailable'"
-              class="select-none tabular-nums text-zinc-600 sm:text-right"
+              class="select-none tabular-nums text-gray-400 dark:text-zinc-600 sm:text-right"
             >
               {{ event.time || '—' }}
             </time>
@@ -491,8 +495,8 @@ function segmentClass(type) {
               v-for="(entry, entryIndex) in event.entries"
               :key="entryIndex"
               :class="[
-                'min-h-5 block bg-transparent p-0 font-mono text-[12px] text-zinc-300',
-                entryIndex > 0 && 'text-zinc-500',
+                'min-h-5 block bg-transparent p-0 font-mono text-[12px] text-gray-700 dark:text-zinc-300',
+                entryIndex > 0 && 'text-gray-500 dark:text-zinc-500',
                 wrap ? 'whitespace-pre-wrap break-words' : 'whitespace-pre'
               ]"
               ><span

--- a/assets/js/composables/sse.js
+++ b/assets/js/composables/sse.js
@@ -1,4 +1,4 @@
-import { ref, onUnmounted, isRef, unref } from 'vue'
+import { ref, onScopeDispose, isRef, unref } from 'vue'
 
 /**
  * Vue composable for Server-Sent Events.
@@ -31,22 +31,29 @@ export function useEventSource(url, options = {}) {
   let reconnectTimer = null
   let unmounted = false
   let disposed = false
+  let connectionSequence = 0
+  let reconnectEnabled = false
 
   function connect() {
     close()
+    if (disposed) return
     error.value = null
 
     const resolvedUrl = isRef(url) ? unref(url) : url
     if (!resolvedUrl) return
 
+    reconnectEnabled = true
+    const sequence = ++connectionSequence
     es = new EventSource(resolvedUrl)
 
     es.onopen = () => {
+      if (sequence !== connectionSequence) return
       connected.value = true
       error.value = null
     }
 
     es.onmessage = (event) => {
+      if (sequence !== connectionSequence) return
       try {
         const parsed = JSON.parse(event.data)
         data.value = parsed
@@ -56,7 +63,7 @@ export function useEventSource(url, options = {}) {
         }
 
         if (parsed.closed) {
-          connected.value = false
+          close()
         }
 
         if (onMessage) {
@@ -68,24 +75,29 @@ export function useEventSource(url, options = {}) {
     }
 
     es.onerror = () => {
+      if (sequence !== connectionSequence) return
       connected.value = false
       if (es) {
         es.close()
         es = null
       }
 
-      if (!unmounted && autoReconnect) {
+      if (!unmounted && reconnectEnabled && autoReconnect) {
         if (!error.value) {
           error.value = 'Connection lost. Reconnecting...'
         }
+        if (reconnectTimer) clearTimeout(reconnectTimer)
         reconnectTimer = setTimeout(() => {
-          if (!unmounted) connect()
+          reconnectTimer = null
+          if (!unmounted && reconnectEnabled) connect()
         }, reconnectDelay)
       }
     }
   }
 
   function close() {
+    reconnectEnabled = false
+    connectionSequence += 1
     if (reconnectTimer) {
       clearTimeout(reconnectTimer)
       reconnectTimer = null
@@ -117,7 +129,7 @@ export function useEventSource(url, options = {}) {
     window.addEventListener('beforeunload', dispose)
   }
 
-  onUnmounted(dispose)
+  onScopeDispose(dispose)
 
   return { data, connected, error, close, connect }
 }

--- a/tests/e2e/pages/projects/log-viewer.test.js
+++ b/tests/e2e/pages/projects/log-viewer.test.js
@@ -30,11 +30,16 @@ test(
   },
   async ({ world, login, page, expect }) => {
     await page.raw.addInitScript((logs) => {
+      window.__slipwayTestEventSources = []
+
       class SlipwayTestEventSource {
         constructor(url) {
           this.url = String(url)
           this.readyState = 0
+          this.closed = false
+          window.__slipwayTestEventSources.push(this)
           this.timer = window.setTimeout(() => {
+            if (this.closed) return
             this.readyState = 1
             this.onopen?.({ type: 'open' })
             if (!this.url.includes('/logs/stream')) return
@@ -47,6 +52,7 @@ test(
 
         close() {
           window.clearTimeout(this.timer)
+          this.closed = true
           this.readyState = 2
         }
       }
@@ -59,7 +65,7 @@ test(
       password: current.auth.genesisUserPassword
     })
     await page.resize(1440, 900)
-    await page.inDarkMode()
+    await page.inLightMode()
     await page.goto(
       `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/apps/${current.apps.web.slug}?logs=1`
     )
@@ -77,15 +83,28 @@ test(
         .locator('[data-test="log-event"][data-level="error"]')
         .count()
     ).toBe(1)
+    const lightSurface = await viewer.evaluate(
+      (element) => getComputedStyle(element).backgroundColor
+    )
     await viewer.screenshot({
-      path: path.resolve('.tmp/issue-383-log-viewer-desktop-dark.png')
+      path: path.resolve('.tmp/issue-434-log-viewer-desktop-light.png')
+    })
+
+    await page.inDarkMode()
+    await page.wait(100)
+    const darkSurface = await viewer.evaluate(
+      (element) => getComputedStyle(element).backgroundColor
+    )
+    expect(lightSurface === darkSurface).toBe(false)
+    await viewer.screenshot({
+      path: path.resolve('.tmp/issue-434-log-viewer-desktop-dark.png')
     })
 
     await viewer.locator('[data-test="log-level-filter"]').selectOption('error')
     expect(await viewer.locator('[data-test="log-event"]').count()).toBe(1)
     await expect(page).toSee('Timeout.<anonymous>')
     await viewer.screenshot({
-      path: path.resolve('.tmp/issue-383-log-viewer-error-filter.png')
+      path: path.resolve('.tmp/issue-434-log-viewer-error-filter.png')
     })
 
     await viewer.locator('[data-test="log-level-filter"]').selectOption('all')
@@ -97,8 +116,15 @@ test(
     }))
     expect(viewportWidth.scroll <= viewportWidth.client + 1).toBe(true)
     await viewer.screenshot({
-      path: path.resolve('.tmp/issue-383-log-viewer-mobile-dark.png')
+      path: path.resolve('.tmp/issue-434-log-viewer-mobile-dark.png')
     })
+
+    const logStreams = await page.raw.evaluate(() =>
+      window.__slipwayTestEventSources
+        .filter((stream) => stream.url.includes('/logs/stream'))
+        .map((stream) => ({ closed: stream.closed }))
+    )
+    expect(logStreams).toEqual([{ closed: false }])
     expect(page).toHaveNoJavascriptErrors()
   }
 )

--- a/tests/unit/assets/sse.test.js
+++ b/tests/unit/assets/sse.test.js
@@ -1,0 +1,42 @@
+const { test } = require('sounding')
+
+test('closing an SSE stream cancels its pending reconnect', async ({
+  expect
+}) => {
+  const originalEventSource = global.EventSource
+  const instances = []
+
+  class TestEventSource {
+    constructor(url) {
+      this.url = url
+      instances.push(this)
+    }
+
+    close() {
+      this.closed = true
+    }
+  }
+
+  global.EventSource = TestEventSource
+
+  try {
+    const [{ effectScope }, { useEventSource }] = await Promise.all([
+      import('vue'),
+      import('../../../assets/js/composables/sse.js')
+    ])
+    const scope = effectScope()
+    let stream
+    scope.run(() => {
+      stream = useEventSource('/events', { reconnectDelay: 5 })
+    })
+
+    instances[0].onerror()
+    scope.stop()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(instances.length).toBe(1)
+    expect(instances[0].closed).toBe(true)
+  } finally {
+    global.EventSource = originalEventSource
+  }
+})

--- a/tests/unit/controllers/bosun-stream-instance-logs.test.js
+++ b/tests/unit/controllers/bosun-stream-instance-logs.test.js
@@ -1,0 +1,69 @@
+const { EventEmitter } = require('node:events')
+const { PassThrough } = require('node:stream')
+const childProcess = require('node:child_process')
+const { test } = require('sounding')
+
+test('Bosun delivers stderr logs without waiting for stdout', async ({
+  sails,
+  expect
+}) => {
+  const docker = new EventEmitter()
+  docker.stdout = new PassThrough()
+  docker.stderr = new PassThrough()
+  docker.kill = () => {}
+
+  const originalSpawn = childProcess.spawn
+  const controllerPath = require.resolve(
+    '../../../api/controllers/api/v1/bosun/stream-instance-logs'
+  )
+  childProcess.spawn = () => docker
+  delete require.cache[controllerPath]
+
+  const sent = []
+  const cleanup = []
+  let finish
+  const stream = {
+    send(message) {
+      sent.push(message)
+    },
+    close() {
+      for (const callback of cleanup) callback()
+      finish()
+    },
+    onClose(callback) {
+      cleanup.push(callback)
+    },
+    wait() {
+      return new Promise((resolve) => {
+        finish = resolve
+      })
+    }
+  }
+
+  try {
+    const controller = require(controllerPath)
+    const result = controller.fn.call(
+      {
+        req: {},
+        res: { sse: () => stream }
+      },
+      { tail: 200 }
+    )
+
+    docker.stderr.write('2026-08-12T12:00:00Z info: server ready\n')
+    await new Promise((resolve) => setImmediate(resolve))
+
+    expect(
+      sent.some(
+        (message) => message.log === '2026-08-12T12:00:00Z info: server ready'
+      )
+    ).toBe(true)
+
+    docker.emit('close', 0, null)
+    await result
+  } finally {
+    childProcess.spawn = originalSpawn
+    delete require.cache[controllerPath]
+    sails.config.docker ||= {}
+  }
+})


### PR DESCRIPTION
## What changed

- stream Bosun stdout and stderr immediately instead of buffering stderr indefinitely
- make SSE cleanup cancel stale reconnects and prevent duplicate live streams
- add a server heartbeat to every SSE response so proxies keep active streams healthy
- give the shared log viewer first-class light and dark themes
- cover stderr-only delivery, reconnect cleanup, browser rendering, severity filtering, and responsive layout

## Verification

- `npm run lint`
- `npm run check:consistency`
- `npm test` — 304 unit, 102 functional, and 25 browser trials passed
- `npm run local` on isolated port 14337 — healthy; `/health` 9 ms TTFB and `/login` 8 ms TTFB

Fixes #434
