### PR TITLE
fix(bearing): server-render social metadata

### DIFF
--- a/api/controllers/bearing/view-feedback.js
+++ b/api/controllers/bearing/view-feedback.js
@@ -1,5 +1,8 @@
 const { normalizeBearingCategories } = require('../../lib/bearing-categories')
 const {
+  buildBearingSocialMetadata
+} = require('../../lib/bearing-social-metadata')
+const {
   buildRealtimeConfig,
   serializeFeedback
 } = require('../../lib/bearing-realtime')
@@ -126,6 +129,21 @@ module.exports = {
     const publicPath = focusedFeedback
       ? `${feedbackPath}/${encodeURIComponent(focusedFeedback.publicId)}`
       : feedbackPath
+    const title = focusedFeedback
+      ? `${focusedFeedback.title} · ${resolved.project.name}`
+      : `Feedback · ${resolved.project.name}`
+    const description =
+      focusedFeedback?.details?.trim() ||
+      `Share feedback and help shape what comes next for ${resolved.project.name}.`
+    const social = buildBearingSocialMetadata({
+      req: this.req,
+      appName: resolved.project.name,
+      path: publicPath,
+      imagePath: `${resolved.publicBasePath}/feedback/og.png`,
+      title,
+      description,
+      type: focusedFeedback ? 'article' : 'website'
+    })
 
     return {
       page: 'bearing/feedback',
@@ -138,11 +156,8 @@ module.exports = {
           roadmapPath: `${resolved.publicBasePath}/roadmap`,
           updatesPath: `${resolved.publicBasePath}/updates`,
           identityPath: resolved.identityPath,
-          publicUrl: absoluteUrl(this.req, publicPath),
-          ogImageUrl: absoluteUrl(
-            this.req,
-            `${resolved.publicBasePath}/feedback/og.png`
-          )
+          publicUrl: social.publicUrl,
+          ogImageUrl: social.ogImageUrl
         },
         bearing: {
           acceptFeedback: resolved.space.acceptFeedback,
@@ -178,7 +193,8 @@ module.exports = {
           total,
           matchOn: 'publicId'
         })
-      }
+      },
+      locals: social.locals
     }
   }
 }
@@ -239,14 +255,4 @@ function buildCriteria({ spaceId, filters }) {
   }
 
   return criteria
-}
-
-function absoluteUrl(req, path) {
-  const protocol = req.get('x-forwarded-proto') || req.protocol || 'https'
-  const host =
-    req.get('x-forwarded-host') ||
-    req.get('host') ||
-    req.hostname ||
-    'localhost'
-  return `${protocol}://${host}${path}`
 }

--- a/api/controllers/bearing/view-surface.js
+++ b/api/controllers/bearing/view-surface.js
@@ -3,6 +3,9 @@ const {
   serializeFeedback,
   serializeUpdate
 } = require('../../lib/bearing-realtime')
+const {
+  buildBearingSocialMetadata
+} = require('../../lib/bearing-social-metadata')
 
 module.exports = {
   friendlyName: 'View public Bearing surface',
@@ -72,6 +75,19 @@ module.exports = {
               .sort('updatedAt DESC')
               .limit(100)
           ).map(serializeFeedback)
+    const title = surface === 'roadmap' ? 'Roadmap' : 'Updates'
+    const description =
+      surface === 'roadmap'
+        ? `A clear look at what ${resolved.project.name} is considering and building next.`
+        : `The useful things that recently changed in ${resolved.project.name}.`
+    const social = buildBearingSocialMetadata({
+      req: this.req,
+      appName: resolved.project.name,
+      path: `${resolved.publicBasePath}/${surface}`,
+      imagePath: `${resolved.publicBasePath}/${surface}/og.png`,
+      title: `${title} · ${resolved.project.name}`,
+      description
+    })
 
     return {
       page: 'bearing/surface',
@@ -83,14 +99,8 @@ module.exports = {
           feedbackPath: `${resolved.publicBasePath}/feedback`,
           roadmapPath: `${resolved.publicBasePath}/roadmap`,
           updatesPath: `${resolved.publicBasePath}/updates`,
-          publicUrl: absoluteUrl(
-            this.req,
-            `${resolved.publicBasePath}/${surface}`
-          ),
-          ogImageUrl: absoluteUrl(
-            this.req,
-            `${resolved.publicBasePath}/${surface}/og.png`
-          )
+          publicUrl: social.publicUrl,
+          ogImageUrl: social.ogImageUrl
         },
         bearing: {
           showPublicRoadmap: resolved.space.showPublicRoadmap,
@@ -104,17 +114,8 @@ module.exports = {
         surface,
         embedded,
         items
-      }
+      },
+      locals: social.locals
     }
   }
-}
-
-function absoluteUrl(req, path) {
-  const protocol = req.get('x-forwarded-proto') || req.protocol || 'https'
-  const host =
-    req.get('x-forwarded-host') ||
-    req.get('host') ||
-    req.hostname ||
-    'localhost'
-  return `${protocol}://${host}${path}`
 }

--- a/api/controllers/bearing/view-update.js
+++ b/api/controllers/bearing/view-update.js
@@ -1,4 +1,7 @@
 const { serializeUpdate } = require('../../lib/bearing-realtime')
+const {
+  buildBearingSocialMetadata
+} = require('../../lib/bearing-social-metadata')
 
 module.exports = {
   friendlyName: 'View public Bearing update',
@@ -45,8 +48,15 @@ module.exports = {
     const publicPath = `${
       resolved.publicBasePath
     }/updates/p/${encodeURIComponent(update.slug)}`
-    const ogImageUrl = absoluteUrl(this.req, `${publicPath}/og.png`)
-    const canonicalUrl = absoluteUrl(this.req, publicPath)
+    const social = buildBearingSocialMetadata({
+      req: this.req,
+      appName: resolved.project.name,
+      path: publicPath,
+      imagePath: `${publicPath}/og.png`,
+      title: `${update.title} · ${resolved.project.name}`,
+      description: update.excerpt,
+      type: 'article'
+    })
 
     return {
       page: 'bearing/update',
@@ -64,15 +74,10 @@ module.exports = {
           showPublicUpdates: resolved.space.showPublicUpdates
         },
         update: serializeUpdate({ ...update, linkedFeedback }),
-        publicUrl: canonicalUrl,
-        ogImageUrl
+        publicUrl: social.publicUrl,
+        ogImageUrl: social.ogImageUrl
       },
-      locals: {
-        title: `${update.title} · ${resolved.project.name}`,
-        description: update.excerpt,
-        ogImage: ogImageUrl,
-        canonicalUrl
-      }
+      locals: social.locals
     }
   }
 }
@@ -86,14 +91,4 @@ async function resolveRequest(req, inputs) {
   } catch {
     throw 'notFound'
   }
-}
-
-function absoluteUrl(req, path) {
-  const protocol = req.get('x-forwarded-proto') || req.protocol || 'https'
-  const host =
-    req.get('x-forwarded-host') ||
-    req.get('host') ||
-    req.hostname ||
-    'localhost'
-  return `${protocol}://${host}${path}`
 }

--- a/api/lib/bearing-social-metadata.js
+++ b/api/lib/bearing-social-metadata.js
@@ -1,0 +1,40 @@
+function buildBearingSocialMetadata({
+  req,
+  appName,
+  path,
+  imagePath,
+  title,
+  description,
+  type = 'website'
+}) {
+  const publicUrl = absoluteUrl(req, path)
+  const ogImageUrl = absoluteUrl(req, imagePath)
+
+  return {
+    publicUrl,
+    ogImageUrl,
+    locals: {
+      title,
+      description,
+      canonicalUrl: publicUrl,
+      ogUrl: publicUrl,
+      ogType: type,
+      ogSiteName: appName,
+      ogImage: ogImageUrl,
+      ogImageWidth: 1200,
+      ogImageHeight: 630
+    }
+  }
+}
+
+function absoluteUrl(req, path) {
+  const protocol = req.get('x-forwarded-proto') || req.protocol || 'https'
+  const host =
+    req.get('x-forwarded-host') ||
+    req.get('host') ||
+    req.hostname ||
+    'localhost'
+  return `${protocol}://${host}${path}`
+}
+
+module.exports = { buildBearingSocialMetadata }

--- a/assets/js/pages/bearing/feedback.vue
+++ b/assets/js/pages/bearing/feedback.vue
@@ -633,20 +633,45 @@ function shortDate(value) {
 
 <template>
   <Head :title="pageTitle">
-    <meta name="description" :content="pageDescription" />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" :content="app.name" />
-    <meta property="og:title" :content="pageTitle" />
-    <meta property="og:description" :content="pageDescription" />
-    <meta property="og:url" :content="app.publicUrl" />
-    <meta property="og:image" :content="app.ogImageUrl" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" :content="pageTitle" />
-    <meta name="twitter:description" :content="pageDescription" />
-    <meta name="twitter:image" :content="app.ogImageUrl" />
-    <link rel="canonical" :href="app.publicUrl" />
+    <meta
+      head-key="description"
+      name="description"
+      :content="pageDescription"
+    />
+    <meta
+      head-key="og:type"
+      property="og:type"
+      :content="focusedFeedback ? 'article' : 'website'"
+    />
+    <meta head-key="og:site_name" property="og:site_name" :content="app.name" />
+    <meta head-key="og:title" property="og:title" :content="pageTitle" />
+    <meta
+      head-key="og:description"
+      property="og:description"
+      :content="pageDescription"
+    />
+    <meta head-key="og:url" property="og:url" :content="app.publicUrl" />
+    <meta head-key="og:image" property="og:image" :content="app.ogImageUrl" />
+    <meta head-key="og:image:width" property="og:image:width" content="1200" />
+    <meta head-key="og:image:height" property="og:image:height" content="630" />
+    <meta
+      head-key="twitter:card"
+      name="twitter:card"
+      content="summary_large_image"
+    />
+    <meta head-key="twitter:title" name="twitter:title" :content="pageTitle" />
+    <meta
+      head-key="twitter:description"
+      name="twitter:description"
+      :content="pageDescription"
+    />
+    <meta head-key="twitter:url" name="twitter:url" :content="app.publicUrl" />
+    <meta
+      head-key="twitter:image"
+      name="twitter:image"
+      :content="app.ogImageUrl"
+    />
+    <link head-key="canonical" rel="canonical" :href="app.publicUrl" />
   </Head>
   <div
     class="min-h-screen bg-white text-gray-950 dark:bg-gray-950 dark:text-white"

--- a/assets/js/pages/bearing/surface.vue
+++ b/assets/js/pages/bearing/surface.vue
@@ -150,20 +150,45 @@ function isoDate(value) {
 
 <template>
   <Head :title="`${title} · ${app.name}`">
-    <meta name="description" :content="description" />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" :content="app.name" />
-    <meta property="og:title" :content="`${title} · ${app.name}`" />
-    <meta property="og:description" :content="description" />
-    <meta property="og:url" :content="app.publicUrl" />
-    <meta property="og:image" :content="app.ogImageUrl" />
-    <meta property="og:image:width" content="1200" />
-    <meta property="og:image:height" content="630" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" :content="`${title} · ${app.name}`" />
-    <meta name="twitter:description" :content="description" />
-    <meta name="twitter:image" :content="app.ogImageUrl" />
-    <link rel="canonical" :href="app.publicUrl" />
+    <meta head-key="description" name="description" :content="description" />
+    <meta head-key="og:type" property="og:type" content="website" />
+    <meta head-key="og:site_name" property="og:site_name" :content="app.name" />
+    <meta
+      head-key="og:title"
+      property="og:title"
+      :content="`${title} · ${app.name}`"
+    />
+    <meta
+      head-key="og:description"
+      property="og:description"
+      :content="description"
+    />
+    <meta head-key="og:url" property="og:url" :content="app.publicUrl" />
+    <meta head-key="og:image" property="og:image" :content="app.ogImageUrl" />
+    <meta head-key="og:image:width" property="og:image:width" content="1200" />
+    <meta head-key="og:image:height" property="og:image:height" content="630" />
+    <meta
+      head-key="twitter:card"
+      name="twitter:card"
+      content="summary_large_image"
+    />
+    <meta
+      head-key="twitter:title"
+      name="twitter:title"
+      :content="`${title} · ${app.name}`"
+    />
+    <meta
+      head-key="twitter:description"
+      name="twitter:description"
+      :content="description"
+    />
+    <meta head-key="twitter:url" name="twitter:url" :content="app.publicUrl" />
+    <meta
+      head-key="twitter:image"
+      name="twitter:image"
+      :content="app.ogImageUrl"
+    />
+    <link head-key="canonical" rel="canonical" :href="app.publicUrl" />
   </Head>
   <div
     class="min-h-screen bg-white text-gray-950 dark:bg-gray-950 dark:text-white"

--- a/assets/js/pages/bearing/update.vue
+++ b/assets/js/pages/bearing/update.vue
@@ -50,11 +50,20 @@ function longDate(value) {
     <meta head-key="og:image" property="og:image" :content="ogImageUrl" />
     <meta head-key="og:image:width" property="og:image:width" content="1200" />
     <meta head-key="og:image:height" property="og:image:height" content="630" />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" :content="pageTitle" />
-    <meta name="twitter:description" :content="update.excerpt" />
-    <meta name="twitter:image" :content="ogImageUrl" />
-    <link rel="canonical" :href="publicUrl" />
+    <meta
+      head-key="twitter:card"
+      name="twitter:card"
+      content="summary_large_image"
+    />
+    <meta head-key="twitter:title" name="twitter:title" :content="pageTitle" />
+    <meta
+      head-key="twitter:description"
+      name="twitter:description"
+      :content="update.excerpt"
+    />
+    <meta head-key="twitter:url" name="twitter:url" :content="publicUrl" />
+    <meta head-key="twitter:image" name="twitter:image" :content="ogImageUrl" />
+    <link head-key="canonical" rel="canonical" :href="publicUrl" />
   </Head>
 
   <div

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -889,10 +889,10 @@ test(
     expect(updateDocument.status()).toBe(200)
     const updateDocumentHtml = await updateDocument.text()
     expect(updateDocumentHtml).toContain(
-      '<title>Search is faster and calmer · Northstar</title>'
+      '<title data-inertia="">Search is faster and calmer · Northstar</title>'
     )
     expect(updateDocumentHtml).toContain(
-      '<meta property="og:description" content="Useful results now arrive without the wait." />'
+      'property="og:description" content="Useful results now arrive without the wait."'
     )
     expect(updateDocumentHtml).toContain(
       `${appOrigin}/bearing/updates/p/search-is-faster-and-calmer" />`

--- a/tests/functional/pages/bearing.test.js
+++ b/tests/functional/pages/bearing.test.js
@@ -407,6 +407,13 @@ test(
       host: 'ideas.example.com',
       'x-forwarded-host': 'ideas.example.com'
     })
+    const appDocumentRequest = request.using('http').withHeaders({
+      accept: 'text/html',
+      host: 'ideas.example.com',
+      'x-forwarded-host': 'ideas.example.com',
+      'x-forwarded-proto': 'https',
+      'user-agent': 'Twitterbot/1.0'
+    })
 
     const hostNamespace = await appRequest.get(hostBasePath)
     expect(hostNamespace).toHaveStatus(302)
@@ -425,6 +432,18 @@ test(
       'app.ogImageUrl': 'https://ideas.example.com/bearing/feedback/og.png',
       hostAssetBasePath: '/_slipway/bearing/_assets'
     })
+    expectBearingDocumentMetadata(
+      expect,
+      await appDocumentRequest.get(hostPath),
+      {
+        title: `Feedback · ${project.name}`,
+        description: `Share feedback and help shape what comes next for ${project.name}.`,
+        url: 'https://ideas.example.com/bearing/feedback',
+        image: 'https://ideas.example.com/bearing/feedback/og.png',
+        type: 'website',
+        siteName: project.name
+      }
+    )
 
     const hostPage = await request
       .withHeaders({
@@ -543,6 +562,18 @@ test(
       'feedback.data.0.title': 'Let me choose a calmer notification sound'
     })
     expect(permalink.data.url).toBe(`/bearing/feedback/${feedback.publicId}`)
+    expectBearingDocumentMetadata(
+      expect,
+      await appDocumentRequest.get(`${hostPath}/${feedback.publicId}`),
+      {
+        title: `Let me choose a calmer notification sound · ${project.name}`,
+        description: 'The current sound is easy to miss during focused work.',
+        url: `https://ideas.example.com/bearing/feedback/${feedback.publicId}`,
+        image: 'https://ideas.example.com/bearing/feedback/og.png',
+        type: 'article',
+        siteName: project.name
+      }
+    )
 
     const voter = participantClient.withHeaders({
       accept: 'application/json',
@@ -596,6 +627,30 @@ test(
       'items.0.title': 'Calmer notifications have shipped'
     })
     expect(archive.data.url).toBe('/bearing/updates')
+    expectBearingDocumentMetadata(
+      expect,
+      await appDocumentRequest.get(`${hostBasePath}/roadmap`),
+      {
+        title: `Roadmap · ${project.name}`,
+        description: `A clear look at what ${project.name} is considering and building next.`,
+        url: 'https://ideas.example.com/bearing/roadmap',
+        image: 'https://ideas.example.com/bearing/roadmap/og.png',
+        type: 'website',
+        siteName: project.name
+      }
+    )
+    expectBearingDocumentMetadata(
+      expect,
+      await appDocumentRequest.get(updatesPath),
+      {
+        title: `Updates · ${project.name}`,
+        description: `The useful things that recently changed in ${project.name}.`,
+        url: 'https://ideas.example.com/bearing/updates',
+        image: 'https://ideas.example.com/bearing/updates/og.png',
+        type: 'website',
+        siteName: project.name
+      }
+    )
 
     const updatePath = `${updatesPath}/p/${update.slug}`
     const updatePage = await participantClient.get(updatePath)
@@ -610,6 +665,25 @@ test(
       publicUrl: `https://ideas.example.com/bearing/updates/p/${update.slug}`
     })
     expect(updatePage.data.url).toBe(`/bearing/updates/p/${update.slug}`)
+    expectBearingDocumentMetadata(
+      expect,
+      await appDocumentRequest.get(updatePath),
+      {
+        title: `Calmer notifications have shipped · ${project.name}`,
+        description: 'Notification sounds now fit focused work.',
+        url: `https://ideas.example.com/bearing/updates/p/${update.slug}`,
+        image: `https://ideas.example.com/bearing/updates/p/${update.slug}/og.png`,
+        type: 'article',
+        siteName: project.name
+      }
+    )
+
+    const socialImage = await appDocumentRequest.get(
+      `${hostBasePath}/feedback/og.png`
+    )
+    expect(socialImage).toHaveStatus(200)
+    expect(socialImage).toHaveHeader('content-type', 'image/png')
+    expect(socialImage.body.length > 1000).toBe(true)
 
     const missingUpdate = await participantClient.get(
       `${updatesPath}/p/not-a-real-update`
@@ -728,4 +802,64 @@ function bearingPath(project, environment, app) {
 
 function visitPage(request, path) {
   return request.withHeaders(INERTIA_HEADERS).get(path)
+}
+
+function expectBearingDocumentMetadata(
+  expect,
+  response,
+  { title, description, url, image, type, siteName }
+) {
+  expect(response).toHaveStatus(200)
+  expect(response.header('content-type')).toContain('text/html')
+  const head = response.body.split('</head>')[0]
+
+  expectHeadValue(expect, head, 'title', title)
+  expectHeadValue(expect, head, 'meta[name="description"]', description)
+  expectHeadValue(expect, head, 'meta[property="og:site_name"]', siteName)
+  expectHeadValue(expect, head, 'meta[property="og:title"]', title)
+  expectHeadValue(expect, head, 'meta[property="og:description"]', description)
+  expectHeadValue(expect, head, 'meta[property="og:type"]', type)
+  expectHeadValue(expect, head, 'meta[property="og:url"]', url)
+  expectHeadValue(expect, head, 'meta[property="og:image"]', image)
+  expectHeadValue(expect, head, 'meta[property="og:image:width"]', '1200')
+  expectHeadValue(expect, head, 'meta[property="og:image:height"]', '630')
+  expectHeadValue(
+    expect,
+    head,
+    'meta[name="twitter:card"]',
+    'summary_large_image'
+  )
+  expectHeadValue(expect, head, 'meta[name="twitter:title"]', title)
+  expectHeadValue(expect, head, 'meta[name="twitter:description"]', description)
+  expectHeadValue(expect, head, 'meta[name="twitter:url"]', url)
+  expectHeadValue(expect, head, 'meta[name="twitter:image"]', image)
+  expectHeadValue(expect, head, 'link[rel="canonical"]', url)
+  expect(head.includes('slipway.sailscasts.com')).toBe(false)
+  expect(head.includes('/_slipway/bearing/host/')).toBe(false)
+}
+
+function expectHeadValue(expect, head, selector, expected) {
+  let pattern
+  if (selector === 'title') {
+    pattern = /<title[^>]*>([^<]*)<\/title>/
+  } else {
+    const [, tag, attribute, value] = selector.match(
+      /^(meta|link)\[(name|property|rel)="([^"]+)"\]$/
+    )
+    pattern = new RegExp(
+      `<${tag}(?=[^>]*${attribute}="${escapeRegExp(value)}")` +
+        `[^>]*(?:content|href)="([^"]+)"[^>]*>`
+    )
+  }
+
+  const match = head.match(pattern)
+  expect(
+    match,
+    `Missing ${selector} in the initial document head.`
+  ).toBeTruthy()
+  expect(match[1]).toBe(expected)
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
 }

--- a/views/app.ejs
+++ b/views/app.ejs
@@ -7,6 +7,11 @@
       hostAssetBasePath
         ? tags.replace(/(src|href)="\//g, `$1="${hostAssetBasePath}/`)
         : tags
+    const pageTitle = locals.title
+    const pageDescription = locals.description
+    const pageUrl = locals.ogUrl || locals.canonicalUrl
+    const pageImage = locals.ogImage
+    const pageType = locals.ogType || 'website'
   %>
   <head>
     <meta charset="UTF-8" />
@@ -15,20 +20,39 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, maximum-scale=1.0"
     />
-    <% if (locals.title) { %>
-      <title><%= locals.title %></title>
-      <meta property="og:title" content="<%= locals.title %>" />
+    <% if (pageTitle) { %>
+      <title data-inertia=""><%= pageTitle %></title>
+      <meta data-inertia="og:title" property="og:title" content="<%= pageTitle %>" />
+      <meta data-inertia="twitter:title" name="twitter:title" content="<%= pageTitle %>" />
     <% } %>
-    <% if (locals.description) { %>
-      <meta name="description" content="<%= locals.description %>" />
-      <meta property="og:description" content="<%= locals.description %>" />
+    <% if (pageDescription) { %>
+      <meta data-inertia="description" name="description" content="<%= pageDescription %>" />
+      <meta data-inertia="og:description" property="og:description" content="<%= pageDescription %>" />
+      <meta data-inertia="twitter:description" name="twitter:description" content="<%= pageDescription %>" />
     <% } %>
-    <% if (locals.ogImage) { %>
-      <meta property="og:image" content="<%= locals.ogImage %>" />
-      <meta name="twitter:card" content="summary_large_image" />
+    <% if (locals.ogSiteName) { %>
+      <meta data-inertia="og:site_name" property="og:site_name" content="<%= locals.ogSiteName %>" />
+    <% } %>
+    <% if (pageUrl) { %>
+      <meta data-inertia="og:url" property="og:url" content="<%= pageUrl %>" />
+      <meta data-inertia="twitter:url" name="twitter:url" content="<%= pageUrl %>" />
+    <% } %>
+    <% if (locals.ogType) { %>
+      <meta data-inertia="og:type" property="og:type" content="<%= pageType %>" />
+    <% } %>
+    <% if (pageImage) { %>
+      <meta data-inertia="og:image" property="og:image" content="<%= pageImage %>" />
+      <% if (locals.ogImageWidth) { %>
+        <meta data-inertia="og:image:width" property="og:image:width" content="<%= locals.ogImageWidth %>" />
+      <% } %>
+      <% if (locals.ogImageHeight) { %>
+        <meta data-inertia="og:image:height" property="og:image:height" content="<%= locals.ogImageHeight %>" />
+      <% } %>
+      <meta data-inertia="twitter:card" name="twitter:card" content="summary_large_image" />
+      <meta data-inertia="twitter:image" name="twitter:image" content="<%= pageImage %>" />
     <% } %>
     <% if (locals.canonicalUrl) { %>
-      <link rel="canonical" href="<%= locals.canonicalUrl %>" />
+      <link data-inertia="canonical" rel="canonical" href="<%= locals.canonicalUrl %>" />
     <% } %>
     <link
       rel="icon"


### PR DESCRIPTION
## What changed

- added one Bearing social-metadata builder so each public controller resolves its app-domain canonical URL and image URL once
- passed complete page-specific metadata to the root EJS view for feedback, focused feedback, roadmap, updates, and update detail
- completed the Open Graph, Twitter, image-dimension, site-name, type, URL, and canonical tags in the initial HTML document
- keyed the Vue Inertia head tags to the same server tags so hydration and later client navigation stay in sync without duplicate metadata
- added production-shaped Sounding coverage using a real HTTP request, social-crawler user agent, and no Inertia header

## Verification

- `npx sounding test --file tests/functional/pages/bearing.test.js --test-concurrency=1 --compact` — 6 passed
- `npx sounding test --file tests/e2e/pages/projects/bearing.test.js --test-name-pattern "Bearing public feedback feels" --test-concurrency=1 --compact` — 1 passed
- crawler-shaped raw HTML assertions cover feedback, focused feedback, roadmap, updates, and update detail
- the advertised unauthenticated OG image endpoint returns a non-empty PNG
- canonical and social URLs are asserted to remain on the host app domain and never expose the private Slipway renderer namespace

## Follow-up found while verifying

The production Hagfish OG endpoint is reachable, but its text layer is missing because the slim production image has no deterministic font available to Resvg. That separate renderer defect is tracked in #439 and is intentionally not mixed into this metadata-delivery fix.

Fixes #438
