### PR TITLE
fix(logs): preserve deployment occurrence times

### DIFF
--- a/api/controllers/api/v1/deploy/stream-deployment.js
+++ b/api/controllers/api/v1/deploy/stream-deployment.js
@@ -15,6 +15,18 @@ module.exports = {
       type: 'string',
       required: true,
       description: 'The deployment ID.'
+    },
+    buildOffset: {
+      type: 'number',
+      min: 0,
+      defaultsTo: 0,
+      description: 'Number of persisted build-log characters already rendered.'
+    },
+    deployOffset: {
+      type: 'number',
+      min: 0,
+      defaultsTo: 0,
+      description: 'Number of persisted deploy-log characters already rendered.'
     }
   },
 
@@ -28,7 +40,7 @@ module.exports = {
     }
   },
 
-  fn: async function ({ id }) {
+  fn: async function ({ id, buildOffset, deployOffset }) {
     const req = this.req
     const res = this.res
 
@@ -53,7 +65,14 @@ module.exports = {
     }
 
     let lastStatus = deployment.status
-    let lastLogLength = 0
+    let lastBuildLogLength = Math.min(
+      buildOffset,
+      (deployment.buildLogs || '').length
+    )
+    let lastDeployLogLength = Math.min(
+      deployOffset,
+      (deployment.deployLogs || '').length
+    )
 
     const checkInterval = setInterval(async () => {
       try {
@@ -80,15 +99,24 @@ module.exports = {
           stream.send(await deploymentState(current))
         }
 
-        // Stream new build log output if available
-        if (current.buildLogs && current.buildLogs.length > lastLogLength) {
-          const newOutput = current.buildLogs.slice(lastLogLength)
-          lastLogLength = current.buildLogs.length
+        // Stream the exact persisted suffix so live output and a later reload
+        // share line boundaries and timestamps.
+        if (
+          current.buildLogs &&
+          current.buildLogs.length > lastBuildLogLength
+        ) {
+          const newOutput = current.buildLogs.slice(lastBuildLogLength)
+          lastBuildLogLength = current.buildLogs.length
+          stream.send({ output: newOutput, source: 'build' })
+        }
 
-          const lines = newOutput.split('\n').filter((l) => l.trim())
-          for (const line of lines) {
-            stream.send({ output: line })
-          }
+        if (
+          current.deployLogs &&
+          current.deployLogs.length > lastDeployLogLength
+        ) {
+          const newOutput = current.deployLogs.slice(lastDeployLogLength)
+          lastDeployLogLength = current.deployLogs.length
+          stream.send({ output: newOutput, source: 'deploy' })
         }
 
         // End stream when deployment is complete

--- a/api/lib/deployment-log.js
+++ b/api/lib/deployment-log.js
@@ -1,0 +1,53 @@
+const ISO_TIMESTAMP_PATTERN =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z(?:\s|$)/
+
+/**
+ * Append one captured stdout/stderr chunk while giving every new logical line
+ * one canonical occurrence time. A line split across chunks keeps the
+ * timestamp written with its first fragment.
+ *
+ * Existing untimestamped history is intentionally left alone. If it ends in a
+ * partial line, the first fragment of the new chunk remains part of that
+ * historical line rather than receiving a fabricated time.
+ */
+function appendTimestampedChunk(currentValue, chunkValue, occurredAt) {
+  const current = String(currentValue || '')
+  const chunk = String(chunkValue || '')
+  if (!chunk) return current
+
+  const timestamp = String(occurredAt || new Date().toISOString())
+  let output = current
+  let cursor = 0
+  let atLineStart = current.length === 0 || current.endsWith('\n')
+
+  while (cursor < chunk.length) {
+    const newlineIndex = chunk.indexOf('\n', cursor)
+
+    // Preserve deliberate spacing without turning an empty line into a
+    // timestamp-only log event.
+    if (atLineStart && newlineIndex === cursor) {
+      output += '\n'
+      cursor += 1
+      continue
+    }
+
+    if (atLineStart) {
+      const remainder = chunk.slice(cursor)
+      if (!ISO_TIMESTAMP_PATTERN.test(remainder)) output += `${timestamp} `
+      atLineStart = false
+    }
+
+    if (newlineIndex === -1) {
+      output += chunk.slice(cursor)
+      break
+    }
+
+    output += chunk.slice(cursor, newlineIndex + 1)
+    cursor = newlineIndex + 1
+    atLineStart = true
+  }
+
+  return output
+}
+
+module.exports = { appendTimestampedChunk }

--- a/api/models/Deployment.js
+++ b/api/models/Deployment.js
@@ -1,3 +1,7 @@
+const { appendTimestampedChunk } = require('../lib/deployment-log')
+
+const logAppendQueues = new Map()
+
 /**
  * Deployment.js
  *
@@ -157,25 +161,38 @@ module.exports = {
    * Append to build logs
    */
   appendBuildLog: async function (deploymentId, log) {
-    const deployment = await Deployment.findOne({ id: deploymentId })
-    if (!deployment) return
-
-    const currentLogs = deployment.buildLogs || ''
-    await Deployment.updateOne({ id: deploymentId }).set({
-      buildLogs: currentLogs + log
-    })
+    return appendLog(deploymentId, 'buildLogs', log)
   },
 
   /**
    * Append to deploy logs
    */
   appendDeployLog: async function (deploymentId, log) {
-    const deployment = await Deployment.findOne({ id: deploymentId })
-    if (!deployment) return
+    return appendLog(deploymentId, 'deployLogs', log)
+  }
+}
 
-    const currentLogs = deployment.deployLogs || ''
-    await Deployment.updateOne({ id: deploymentId }).set({
-      deployLogs: currentLogs + log
+async function appendLog(deploymentId, field, log) {
+  if (!log) return
+
+  const key = `${deploymentId}:${field}`
+  const occurredAt = new Date().toISOString()
+  const previous = logAppendQueues.get(key) || Promise.resolve()
+  const pending = previous
+    .catch(() => {})
+    .then(async () => {
+      const deployment = await Deployment.findOne({ id: deploymentId })
+      if (!deployment) return
+
+      await Deployment.updateOne({ id: deploymentId }).set({
+        [field]: appendTimestampedChunk(deployment[field], log, occurredAt)
+      })
     })
+
+  logAppendQueues.set(key, pending)
+  try {
+    await pending
+  } finally {
+    if (logAppendQueues.get(key) === pending) logAppendQueues.delete(key)
   }
 }

--- a/assets/js/components/LogViewer.vue
+++ b/assets/js/components/LogViewer.vue
@@ -54,7 +54,11 @@ const levelCounts = computed(() => {
   for (const event of events.value) counts[event.level] += 1
   return counts
 })
-const heightClass = computed(() => (props.height === 'lg' ? 'h-96' : 'h-80'))
+const fillsAvailableHeight = computed(() => props.height === 'fill')
+const heightClass = computed(() => {
+  if (fillsAvailableHeight.value) return 'min-h-0 flex-1'
+  return props.height === 'lg' ? 'h-96' : 'h-80'
+})
 const connectionState = computed(() => {
   if (props.inactiveMessage) return 'inactive'
   if (props.error) return 'reconnecting'
@@ -204,11 +208,14 @@ function segmentClass(type) {
 <template>
   <section
     data-test="log-viewer"
-    class="overflow-hidden bg-white text-gray-800 dark:bg-zinc-950 dark:text-zinc-200"
+    :class="[
+      'overflow-hidden bg-white text-gray-800 dark:bg-zinc-950 dark:text-zinc-200',
+      fillsAvailableHeight && 'flex min-h-0 flex-1 flex-col'
+    ]"
     aria-label="Live logs"
   >
     <div
-      class="flex flex-wrap items-center gap-x-3 gap-y-2 border-y border-gray-200 bg-gray-50/90 px-3 py-2 dark:border-white/[0.07] dark:bg-zinc-900/80 sm:flex-nowrap"
+      class="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-2 border-y border-gray-200 bg-gray-50/90 px-3 py-2 dark:border-white/[0.07] dark:bg-zinc-900/80 sm:flex-nowrap"
     >
       <div
         class="min-w-24 order-1 flex items-center gap-2 font-sans text-xs text-gray-600 dark:text-zinc-400"
@@ -416,7 +423,7 @@ function segmentClass(type) {
 
     <div
       v-if="error && events.length > 0"
-      class="flex items-center gap-2 border-b border-amber-200 bg-amber-50 px-3 py-2 font-sans text-xs text-amber-800 dark:border-amber-400/10 dark:bg-amber-400/[0.06] dark:text-amber-200/80"
+      class="flex shrink-0 items-center gap-2 border-b border-amber-200 bg-amber-50 px-3 py-2 font-sans text-xs text-amber-800 dark:border-amber-400/10 dark:bg-amber-400/[0.06] dark:text-amber-200/80"
       role="status"
     >
       <span class="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-300"></span>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -1541,15 +1541,6 @@ onUnmounted(() => {
                 <h2 class="text-sm font-medium text-gray-900 dark:text-white">
                   Logs
                 </h2>
-                <span
-                  v-if="logsConnected"
-                  class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
-                >
-                  <span
-                    class="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500"
-                  ></span>
-                  Live
-                </span>
               </button>
               <div class="flex items-center gap-2">
                 <button

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -1499,15 +1499,6 @@ onBeforeUnmount(() => {
                 <h2 class="text-sm font-medium text-gray-900 dark:text-white">
                   Logs
                 </h2>
-                <span
-                  v-if="logsConnected"
-                  class="inline-flex items-center space-x-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700 dark:bg-green-900/30 dark:text-green-400"
-                >
-                  <span
-                    class="h-1.5 w-1.5 animate-pulse rounded-full bg-green-500"
-                  ></span>
-                  <span>Live</span>
-                </span>
               </button>
               <button
                 @click="logsOpen = !logsOpen"

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -24,7 +24,8 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 
 // SSE-powered real-time updates
 const sseState = ref(null)
-const sseLogs = ref('')
+const sseBuildLogs = ref('')
+const sseDeployLogs = ref('')
 
 const deployment = computed(() => ({
   ...props.deployment,
@@ -39,19 +40,26 @@ const isInProgress = computed(
     )
 )
 
+const initialBuildLogLength = (props.deployment.buildLogs || '').length
+const initialDeployLogLength = (props.deployment.deployLogs || '').length
+const deploymentStreamUrl = `/api/v1/deployments/${props.deployment.id}/stream?buildOffset=${initialBuildLogLength}&deployOffset=${initialDeployLogLength}`
+
 const allLogs = computed(() => {
-  const build = props.deployment.buildLogs || ''
-  const deploy = props.deployment.deployLogs || ''
-  return [build, deploy, sseLogs.value].filter(Boolean).join('\n').trim()
+  const build = (props.deployment.buildLogs || '') + sseBuildLogs.value
+  const deploy = (props.deployment.deployLogs || '') + sseDeployLogs.value
+  return joinLogSections(build, deploy)
 })
-const allLogLines = computed(() =>
-  allLogs.value ? allLogs.value.split('\n') : []
-)
+const allLogLines = computed(() => {
+  if (!allLogs.value) return []
+  const lines = allLogs.value.split('\n')
+  if (lines.at(-1) === '') lines.pop()
+  return lines
+})
 
 const {
   connected: deploymentStreamConnected,
   close: disconnectDeploymentStream
-} = useEventSource(`/api/v1/deployments/${props.deployment.id}/stream`, {
+} = useEventSource(deploymentStreamUrl, {
   immediate: isInProgress.value,
   onMessage(data) {
     if (data.status) {
@@ -70,10 +78,21 @@ const {
       }
     }
     if (data.output) {
-      sseLogs.value += data.output + '\n'
+      if (data.source === 'deploy') sseDeployLogs.value += data.output
+      else sseBuildLogs.value += data.output
     }
   }
 })
+
+function joinLogSections(...sections) {
+  return sections.filter(Boolean).reduce((combined, section) => {
+    if (!combined) return section
+    if (combined.endsWith('\n') || section.startsWith('\n')) {
+      return combined + section
+    }
+    return `${combined}\n${section}`
+  }, '')
+}
 
 function formatDuration(seconds) {
   if (!seconds) return '—'
@@ -553,7 +572,7 @@ function executeRollback() {
         <!-- Log Viewer -->
         <div
           data-test="deployment-log-viewer"
-          class="flex flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
+          class="flex min-h-0 flex-1 flex-col overflow-hidden rounded-lg border border-gray-200 dark:border-gray-800"
         >
           <div
             class="flex items-center justify-between border-b border-gray-200 bg-gray-50 px-4 py-2 dark:border-gray-800 dark:bg-gray-900"
@@ -571,7 +590,7 @@ function executeRollback() {
                 ? 'No additional logs were captured.'
                 : ''
             "
-            height="lg"
+            height="fill"
           />
         </div>
       </div>

--- a/assets/js/pages/projects/service.vue
+++ b/assets/js/pages/projects/service.vue
@@ -726,16 +726,7 @@ onUnmounted(() => {
                   Logs
                 </h2>
                 <span
-                  v-if="logsConnected"
-                  class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400"
-                >
-                  <span
-                    class="h-1.5 w-1.5 animate-pulse rounded-full bg-emerald-500"
-                  ></span>
-                  Live
-                </span>
-                <span
-                  v-else-if="serviceStatus !== 'running'"
+                  v-if="serviceStatus !== 'running'"
                   class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
                 >
                   Not running

--- a/tests/e2e/pages/projects/log-viewer.test.js
+++ b/tests/e2e/pages/projects/log-viewer.test.js
@@ -108,6 +108,31 @@ test(
     })
 
     await viewer.locator('[data-test="log-level-filter"]').selectOption('all')
+
+    await page.raw.evaluate(() => {
+      const stream = window.__slipwayTestEventSources.find((candidate) =>
+        candidate.url.includes('/logs/stream')
+      )
+      for (let index = 0; index < 40; index += 1) {
+        stream.onmessage?.({
+          data: JSON.stringify({
+            log: `2026-08-10T08:43:${String(index).padStart(
+              2,
+              '0'
+            )}.000Z info: follow proof ${index}`
+          })
+        })
+      }
+    })
+    await page.raw.waitForFunction(() => {
+      const viewport = document.querySelector('[data-test="log-viewport"]')
+      return (
+        viewport &&
+        viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight < 40
+      )
+    })
+    expect(await page.raw.getByText('Live', { exact: true }).count()).toBe(1)
+
     await page.resize(390, 844)
     await page.wait(100)
     const viewportWidth = await viewer.evaluate((element) => ({
@@ -125,6 +150,143 @@ test(
         .map((stream) => ({ closed: stream.closed }))
     )
     expect(logStreams).toEqual([{ closed: false }])
+
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto('/bosun?logs=1')
+    const bosunViewer = page.raw.locator('[data-test="log-viewer"]')
+    await bosunViewer.waitFor()
+    await page.raw.waitForFunction(
+      () => document.querySelectorAll('[data-test="log-event"]').length === 5
+    )
+    expect(await page.raw.getByText('Live', { exact: true }).count()).toBe(1)
+    await bosunViewer.screenshot({
+      path: path.resolve('.tmp/issue-437-bosun-light.png')
+    })
+
+    await page.inDarkMode()
+    await page.wait(100)
+    await bosunViewer.screenshot({
+      path: path.resolve('.tmp/issue-437-bosun-dark.png')
+    })
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)
+
+test(
+  'deployment history keeps occurrence times and fills its log card',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'timestamped-deployment-logs',
+          name: 'Timestamped Deployment Logs'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const lines = Array.from(
+      { length: 48 },
+      (_, index) =>
+        `2026-08-13T09:10:${String(index).padStart(
+          2,
+          '0'
+        )}.120Z info: Deployment step ${index + 1}`
+    )
+    const deployment = await world.create('deployment').with({
+      status: 'running',
+      triggerType: 'manual',
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      triggeredBy: current.users.genesisUser.id,
+      buildLogs: `${lines.join('\n')}\n`,
+      deployLogs: '2026-08-13T09:11:00.340Z info: Deployment complete.\n',
+      startedAt: Date.now() - 5000,
+      finishedAt: Date.now()
+    })
+    await sails.models.app.updateOne({ id: current.apps.web.id }).set({
+      currentDeployment: deployment.id
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/deployments/${deployment.id}`
+    )
+
+    const card = page.raw.locator('[data-test="deployment-log-viewer"]')
+    const viewer = card.locator('[data-test="log-viewer"]')
+    const viewport = viewer.locator('[data-test="log-viewport"]')
+    await viewer.waitFor()
+    await expect(page).toSee('09:10:00.120')
+    await expect(page).toSee('09:11:00.340')
+
+    const desktopGeometry = await page.raw.evaluate(() => {
+      const cardElement = document.querySelector(
+        '[data-test="deployment-log-viewer"]'
+      )
+      const viewerElement = cardElement.querySelector(
+        '[data-test="log-viewer"]'
+      )
+      const viewportElement = cardElement.querySelector(
+        '[data-test="log-viewport"]'
+      )
+      const cardRect = cardElement.getBoundingClientRect()
+      const viewerRect = viewerElement.getBoundingClientRect()
+      const viewportRect = viewportElement.getBoundingClientRect()
+      return {
+        cardBottom: cardRect.bottom,
+        viewerBottom: viewerRect.bottom,
+        viewportBottom: viewportRect.bottom,
+        viewportHeight: viewportRect.height
+      }
+    })
+    expect(
+      Math.abs(desktopGeometry.cardBottom - desktopGeometry.viewerBottom) < 2
+    ).toBe(true)
+    expect(
+      Math.abs(desktopGeometry.viewerBottom - desktopGeometry.viewportBottom) <
+        2
+    ).toBe(true)
+    expect(desktopGeometry.viewportHeight > 384).toBe(true)
+    await card.screenshot({
+      path: path.resolve('.tmp/issue-437-deployment-light.png')
+    })
+
+    await page.inDarkMode()
+    await page.wait(100)
+    await card.screenshot({
+      path: path.resolve('.tmp/issue-437-deployment-dark.png')
+    })
+
+    await page.resize(390, 844)
+    await page.wait(100)
+    const mobileGeometry = await viewport.evaluate((element) => {
+      const viewerElement = element.closest('[data-test="log-viewer"]')
+      const toolbarElement = viewerElement.firstElementChild
+      const viewerRect = viewerElement.getBoundingClientRect()
+      const viewportRect = element.getBoundingClientRect()
+      const toolbarRect = toolbarElement.getBoundingClientRect()
+      return {
+        toolbarBottom: toolbarRect.bottom,
+        viewportTop: viewportRect.top,
+        viewerBottom: viewerRect.bottom,
+        viewportBottom: viewportRect.bottom
+      }
+    })
+    expect(mobileGeometry.toolbarBottom <= mobileGeometry.viewportTop + 1).toBe(
+      true
+    )
+    expect(
+      Math.abs(mobileGeometry.viewerBottom - mobileGeometry.viewportBottom) < 2
+    ).toBe(true)
     expect(page).toHaveNoJavascriptErrors()
   }
 )

--- a/tests/unit/controllers/deploy-stream-deployment.test.js
+++ b/tests/unit/controllers/deploy-stream-deployment.test.js
@@ -1,0 +1,70 @@
+const { test } = require('sounding')
+
+test(
+  'deployment stream emits only persisted build and deploy suffixes',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: { deploymentTarget: { slug: 'stream-deployment-logs' } }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const buildLogs = '2026-08-13T09:10:00.000Z old build\n'
+    const deployLogs = '2026-08-13T09:10:01.000Z old deploy\n'
+    const deployment = await world.create('deployment').with({
+      status: 'building',
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      buildLogs,
+      deployLogs
+    })
+    const sent = []
+    const closeCallbacks = []
+    let resolveWait
+    const stream = {
+      send(message) {
+        sent.push(message)
+      },
+      close() {
+        for (const callback of closeCallbacks) callback()
+        resolveWait()
+      },
+      onClose(callback) {
+        closeCallbacks.push(callback)
+      },
+      wait() {
+        return new Promise((resolve) => {
+          resolveWait = resolve
+        })
+      }
+    }
+    const controller = require('../../../api/controllers/api/v1/deploy/stream-deployment')
+
+    const result = controller.fn.call(
+      { req: {}, res: { sse: () => stream } },
+      {
+        id: String(deployment.id),
+        buildOffset: buildLogs.length,
+        deployOffset: deployLogs.length
+      }
+    )
+
+    await sails.models.deployment.updateOne({ id: deployment.id }).set({
+      status: 'running',
+      finishedAt: Date.now(),
+      buildLogs: `${buildLogs}2026-08-13T09:10:02.000Z fresh build\n`,
+      deployLogs: `${deployLogs}2026-08-13T09:10:03.000Z fresh deploy\n`
+    })
+
+    await result
+    expect(sent.some((message) => message.source === 'build')).toBe(true)
+    expect(sent.some((message) => message.source === 'deploy')).toBe(true)
+    expect(sent.find((message) => message.source === 'build').output).toBe(
+      '2026-08-13T09:10:02.000Z fresh build\n'
+    )
+    expect(sent.find((message) => message.source === 'deploy').output).toBe(
+      '2026-08-13T09:10:03.000Z fresh deploy\n'
+    )
+  }
+)

--- a/tests/unit/lib/deployment-log.test.js
+++ b/tests/unit/lib/deployment-log.test.js
@@ -1,0 +1,40 @@
+const { test } = require('sounding')
+
+const { appendTimestampedChunk } = require('../../../api/lib/deployment-log')
+
+test('deployment log timestamps logical lines across arbitrary chunks', ({
+  expect
+}) => {
+  const firstTime = '2026-08-13T09:10:11.120Z'
+  const secondTime = '2026-08-13T09:10:12.340Z'
+  let logs = appendTimestampedChunk('', 'Building lay', firstTime)
+  logs = appendTimestampedChunk(logs, 'er\nNext line\n', secondTime)
+
+  expect(logs).toBe(`${firstTime} Building layer\n${secondTime} Next line\n`)
+})
+
+test('deployment log preserves historical lines and existing timestamps', ({
+  expect
+}) => {
+  const time = '2026-08-13T09:10:11.120Z'
+  const existingTime = '2026-08-13T09:09:00.000Z'
+  let logs = appendTimestampedChunk('Historical partial', ' line\n', time)
+  logs = appendTimestampedChunk(
+    logs,
+    `${existingTime} Already canonical\nFresh\n`,
+    time
+  )
+
+  expect(logs).toBe(
+    `Historical partial line\n${existingTime} Already canonical\n${time} Fresh\n`
+  )
+})
+
+test('deployment log preserves deliberate blank lines without fake events', ({
+  expect
+}) => {
+  const time = '2026-08-13T09:10:11.120Z'
+  const logs = appendTimestampedChunk('', '\nBuild failed\n\n', time)
+
+  expect(logs).toBe(`\n${time} Build failed\n\n`)
+})

--- a/tests/unit/models/deployment-logs.test.js
+++ b/tests/unit/models/deployment-logs.test.js
@@ -1,0 +1,39 @@
+const { test } = require('sounding')
+
+test(
+  'deployment log appends persist every concurrent chunk with occurrence times',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: { slug: 'persist-deployment-logs' }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const current = world.current
+    const deployment = await world.create('deployment').with({
+      environment: current.environments.production.id,
+      app: current.apps.web.id,
+      buildLogs: 'Historical line\n'
+    })
+
+    await Promise.all([
+      sails.models.deployment.appendBuildLog(deployment.id, 'First line\n'),
+      sails.models.deployment.appendBuildLog(deployment.id, 'Second '),
+      sails.models.deployment.appendBuildLog(deployment.id, 'line\n')
+    ])
+
+    const persisted = await sails.models.deployment.findOne({
+      id: deployment.id
+    })
+    const lines = persisted.buildLogs.split('\n')
+    expect(lines[0]).toBe('Historical line')
+    expect(lines[1]).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z First line$/
+    )
+    expect(lines[2]).toMatch(
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z Second line$/
+    )
+  }
+)


### PR DESCRIPTION
## What changed

- timestamp deployment output at server ingestion while preserving chunk and multiline boundaries
- stream only persisted build/deploy suffixes so live output and reloaded history agree
- let full-page deployment logs fill their card while embedded viewers stay bounded
- make LogViewer the sole owner of connection state across Bosun, apps, and services
- verify timestamps, persistence, follow behavior, responsive geometry, and light/dark presentation with Sounding

## Verification

- `npm run lint`
- `npm run check:consistency`
- `npm run test:unit` (308 passed)
- `npm run test:functional` (102 passed)
- `npm run test:e2e` (26 passed)

Fixes #437