### PR TITLE
fix(bosun): make SQLite schema migrations safe

### DIFF
--- a/api/controllers/api/v1/bosun/apply-migration.js
+++ b/api/controllers/api/v1/bosun/apply-migration.js
@@ -1,5 +1,3 @@
-const Database = require('better-sqlite3')
-
 module.exports = {
   friendlyName: 'Apply Bosun migration',
 
@@ -44,10 +42,67 @@ module.exports = {
       throw { badRequest: 'No statements provided.' }
     }
 
-    const service = await sails.helpers.bosun.getDatabaseService(database)
-    const sqlStatements = statements.map((statement) =>
-      typeof statement === 'string' ? statement : statement.sql
+    const requestedTables = new Set(
+      statements
+        .filter((statement) => statement && typeof statement === 'object')
+        .map((statement) => statement.table)
+        .filter(Boolean)
     )
+
+    if (requestedTables.size === 0) {
+      throw { badRequest: 'Select at least one current schema change.' }
+    }
+
+    const service = await sails.helpers.bosun.getDatabaseService(database)
+    const modelsResult = await sails.helpers.bosun.getModels(database)
+    const schemaResult = await sails.helpers.dock.getSchema(service)
+
+    if (schemaResult.error) {
+      throw { badRequest: `Failed to get schema: ${schemaResult.error}` }
+    }
+
+    const diff = await sails.helpers.dock.generateDiff(
+      modelsResult.models,
+      schemaResult.tables,
+      service.type
+    )
+    const generated = await sails.helpers.dock.generateMigrationSql(
+      diff,
+      service.type,
+      modelsResult.models,
+      schemaResult.tables
+    )
+    const migrationStatements = generated.statements.filter(
+      (statement) => !statement.table || requestedTables.has(statement.table)
+    )
+
+    if (migrationStatements.length === 0) {
+      throw {
+        badRequest:
+          'The selected schema changes are no longer pending. Refresh the migration tab.'
+      }
+    }
+    const blockedStatement = migrationStatements.find(
+      (statement) => statement.blocked || statement.type === 'blocked_rebuild'
+    )
+
+    if (blockedStatement) {
+      throw {
+        badRequest:
+          blockedStatement.reason ||
+          `Bosun blocked the ${blockedStatement.table || 'SQLite'} migration.`
+      }
+    }
+
+    if (
+      migrationStatements.some(
+        (statement) => !statement || typeof statement.sql !== 'string'
+      )
+    ) {
+      throw { badRequest: 'Every migration statement must contain SQL.' }
+    }
+
+    const sqlStatements = migrationStatements.map((statement) => statement.sql)
 
     if (dryRun) {
       return {
@@ -57,50 +112,13 @@ module.exports = {
       }
     }
 
-    let db
-    const results = []
-    let successCount = 0
-    let errorCount = 0
-
-    try {
-      db = new Database(service.path, { fileMustExist: true })
-
-      for (const sql of sqlStatements) {
-        try {
-          db.exec(sql)
-          successCount++
-          results.push({
-            sql,
-            success: true,
-            message: 'OK'
-          })
-        } catch (error) {
-          errorCount++
-          try {
-            db.exec('ROLLBACK;')
-          } catch {
-            // Ignore rollback failures when no transaction is open.
-          }
-
-          results.push({
-            sql,
-            success: false,
-            error: error.message
-          })
-          break
-        }
-      }
-    } finally {
-      if (db) {
-        db.close()
-      }
-    }
+    const result = await sails.helpers.dock.applySqliteMigration(
+      service.path,
+      migrationStatements
+    )
 
     return {
-      success: errorCount === 0,
-      executed: successCount,
-      failed: errorCount,
-      results,
+      ...result,
       appliedBy: user.fullName,
       appliedAt: new Date().toISOString()
     }

--- a/api/controllers/api/v1/bosun/get-diff.js
+++ b/api/controllers/api/v1/bosun/get-diff.js
@@ -78,7 +78,8 @@ module.exports = {
       modelCount: modelsResult.modelCount,
       diff,
       statements,
-      hasPendingChanges: statements.length > 0
+      hasPendingChanges: statements.length > 0,
+      hasBlockedChanges: statements.some((statement) => statement.blocked)
     }
   }
 }

--- a/api/controllers/api/v1/dock/apply-migration.js
+++ b/api/controllers/api/v1/dock/apply-migration.js
@@ -80,6 +80,23 @@ module.exports = {
       throw { badRequest: 'No statements provided.' }
     }
 
+    const blockedStatement = statements.find(
+      (statement) =>
+        statement &&
+        typeof statement === 'object' &&
+        (statement.blocked || statement.type === 'blocked_rebuild')
+    )
+
+    if (blockedStatement) {
+      throw {
+        badRequest:
+          blockedStatement.reason ||
+          `Slipway blocked the ${
+            blockedStatement.table || 'database'
+          } migration.`
+      }
+    }
+
     // Extract SQL from statement objects
     const sqlStatements = statements.map((s) =>
       typeof s === 'string' ? s : s.sql

--- a/api/controllers/api/v1/dock/get-diff.js
+++ b/api/controllers/api/v1/dock/get-diff.js
@@ -157,6 +157,7 @@ module.exports = {
       diff,
       statements,
       hasPendingChanges: statements.length > 0,
+      hasBlockedChanges: statements.some((statement) => statement.blocked),
       modelsSource // 'runtime' or 'static'
     }
   }

--- a/api/helpers/dock/apply-sqlite-migration.js
+++ b/api/helpers/dock/apply-sqlite-migration.js
@@ -1,0 +1,165 @@
+const Database = require('better-sqlite3')
+
+module.exports = {
+  friendlyName: 'Apply SQLite migration',
+
+  description:
+    'Apply SQLite schema statements atomically and verify rebuild integrity before commit.',
+
+  inputs: {
+    databasePath: {
+      type: 'string',
+      required: true
+    },
+    statements: {
+      type: 'ref',
+      required: true
+    }
+  },
+
+  exits: {
+    success: {
+      outputType: 'ref'
+    }
+  },
+
+  fn: async function ({ databasePath, statements }) {
+    let db
+    const results = []
+    let foreignKeysWereEnabled = false
+
+    try {
+      db = new Database(databasePath, { fileMustExist: true })
+      const rebuildStatements = statements.filter(
+        (statement) => statement.type === 'rebuild_table'
+      )
+      const rowCountsBefore = new Map()
+
+      for (const statement of rebuildStatements) {
+        const row = db
+          .prepare(
+            `SELECT COUNT(*) AS count FROM ${quoteSqliteIdentifier(
+              statement.table
+            )}`
+          )
+          .get()
+        rowCountsBefore.set(statement.table, row.count)
+      }
+
+      foreignKeysWereEnabled = Boolean(
+        db.pragma('foreign_keys', { simple: true })
+      )
+      if (rebuildStatements.length > 0) {
+        db.pragma('foreign_keys = OFF')
+      }
+
+      db.exec('BEGIN IMMEDIATE;')
+
+      for (const statement of statements) {
+        db.exec(statement.sql)
+        results.push({
+          sql: statement.sql,
+          success: true,
+          message: 'OK'
+        })
+      }
+
+      for (const statement of rebuildStatements) {
+        verifySqliteRebuild(db, statement, rowCountsBefore.get(statement.table))
+      }
+
+      db.exec('COMMIT;')
+
+      return {
+        success: true,
+        executed: statements.length,
+        failed: 0,
+        results
+      }
+    } catch (error) {
+      try {
+        db?.exec('ROLLBACK;')
+      } catch {
+        // Ignore rollback failures when no transaction is open.
+      }
+
+      return {
+        success: false,
+        executed: 0,
+        failed: 1,
+        results: [
+          ...results.map((result) => ({
+            ...result,
+            success: false,
+            rolledBack: true,
+            message: 'Rolled back'
+          })),
+          {
+            sql: null,
+            success: false,
+            error: error.message
+          }
+        ]
+      }
+    } finally {
+      if (db) {
+        if (foreignKeysWereEnabled) {
+          db.pragma('foreign_keys = ON')
+        }
+        db.close()
+      }
+    }
+  }
+}
+
+function verifySqliteRebuild(db, statement, rowCountBefore) {
+  const rowCountAfter = db
+    .prepare(
+      `SELECT COUNT(*) AS count FROM ${quoteSqliteIdentifier(statement.table)}`
+    )
+    .get().count
+
+  if (rowCountAfter !== rowCountBefore) {
+    throw new Error(
+      `Row-count verification failed for ${statement.table}: expected ${rowCountBefore}, found ${rowCountAfter}.`
+    )
+  }
+
+  const integrity = db.pragma('integrity_check')
+  if (
+    integrity.length !== 1 ||
+    String(integrity[0].integrity_check).toLowerCase() !== 'ok'
+  ) {
+    throw new Error(
+      `SQLite integrity verification failed: ${integrity
+        .map((row) => row.integrity_check)
+        .join('; ')}`
+    )
+  }
+
+  const foreignKeyFailures = db.pragma('foreign_key_check')
+  if (foreignKeyFailures.length > 0) {
+    throw new Error(
+      `SQLite foreign-key verification found ${foreignKeyFailures.length} violation(s).`
+    )
+  }
+
+  for (const object of statement.preservedObjects || []) {
+    if (object.type === 'unique constraint') continue
+
+    const schemaType = object.type === 'view' ? 'view' : object.type
+    const exists = db
+      .prepare('SELECT 1 FROM sqlite_schema WHERE type = ? AND name = ?')
+      .get(schemaType, object.name)
+
+    if (!exists) {
+      throw new Error(
+        `SQLite ${object.type} verification failed: ${object.name} was not preserved.`
+      )
+    }
+  }
+}
+
+function quoteSqliteIdentifier(value) {
+  return `\`${String(value).replace(/`/g, '``')}\``
+}

--- a/api/helpers/dock/generate-diff.js
+++ b/api/helpers/dock/generate-diff.js
@@ -238,9 +238,9 @@ function findRenameSourceColumn(existingColumns, attrName, columnName) {
  *   _json        -> LONGTEXT
  *   _ref         -> LONGTEXT
  *
- * SQLite mappings mirror sails-sqlite's current physical model handling:
- *   _boolean     -> TEXT
- *   boolean      -> INTEGER when explicitly provided as a physical columnType
+ * SQLite booleans use INTEGER as Bosun's canonical representation. Existing
+ * INTEGER, BOOLEAN, and sails-sqlite legacy TEXT columns compare as the same
+ * logical boolean contract, so healthy schemas do not churn.
  */
 function mapWaterlineToSql(attr, attrName, dbType, modelPrimaryKey) {
   // If explicit columnType is set, use it directly (adapters do this too)
@@ -250,6 +250,7 @@ function mapWaterlineToSql(attr, attrName, dbType, modelPrimaryKey) {
         dbType === 'sqlite'
           ? normalizeSqlitePhysicalType(attr.columnType)
           : attr.columnType,
+      logicalType: attr.type,
       nullable: !attr.required && attr.allowNull !== false,
       defaultValue: attr.defaultsTo,
       autoIncrement: attr.autoIncrement || false,
@@ -294,6 +295,7 @@ function mapWaterlineToSql(attr, attrName, dbType, modelPrimaryKey) {
 
   return {
     sqlType,
+    logicalType: attr.type,
     nullable: !attr.required && attr.allowNull !== false,
     defaultValue: attr.defaultsTo,
     autoIncrement: isAutoIncrement,
@@ -338,7 +340,7 @@ function getSqliteType(
       return 'INTEGER'
 
     case 'boolean':
-      return 'TEXT'
+      return 'INTEGER'
 
     case 'json':
     case 'ref':
@@ -453,7 +455,19 @@ function needsModification(existing, expected, dbType) {
   const normalizedExisting = normalizeType(existing.type)
   const normalizedExpected = normalizeType(expected.sqlType)
 
+  if (
+    dbType === 'sqlite' &&
+    expected.logicalType === 'boolean' &&
+    isSqliteBooleanStorageType(normalizedExisting)
+  ) {
+    return false
+  }
+
   return !typesMatch(normalizedExisting, normalizedExpected, dbType)
+}
+
+function isSqliteBooleanStorageType(type) {
+  return ['boolean', 'bool', 'integer', 'int', 'text'].includes(type)
 }
 
 /**
@@ -535,7 +549,7 @@ function normalizeSqlitePhysicalType(type) {
     case '_json':
       return 'TEXT'
     case '_boolean':
-      return 'TEXT'
+      return 'INTEGER'
     case 'float':
     case 'double':
     case 'real':

--- a/api/helpers/dock/generate-migration-sql.js
+++ b/api/helpers/dock/generate-migration-sql.js
@@ -131,7 +131,6 @@ module.exports = {
 function generateSqliteStatements(diff, models, schema) {
   const statements = []
   const rebuiltTables = new Set()
-  const renameMap = createRenameMap(diff.columnsToRename || [])
 
   for (const table of diff.tablesToCreate) {
     statements.push({
@@ -159,16 +158,24 @@ function generateSqliteStatements(diff, models, schema) {
     }
 
     rebuiltTables.add(tableName)
-    statements.push({
-      type: 'rebuild_table',
-      table: tableName,
-      sql: generateSqliteTableRebuild(
+    statements.push(
+      generateSqliteTableRebuildStatement({
         tableName,
-        model,
         existingTable,
-        renameMap.get(tableName) || new Map()
-      )
-    })
+        modifications: diff.columnsToModify.filter(
+          (column) => column.tableName === tableName
+        ),
+        renames: (diff.columnsToRename || []).filter(
+          (column) => column.tableName === tableName
+        ),
+        additions: (diff.columnsToAdd || []).filter(
+          (column) => column.tableName === tableName
+        ),
+        drops: (diff.columnsToDrop || []).filter(
+          (column) => column.tableName === tableName
+        )
+      })
+    )
   }
 
   for (const column of diff.columnsToRename || []) {
@@ -217,22 +224,6 @@ function generateSqliteStatements(diff, models, schema) {
   }
 
   return statements
-}
-
-function createRenameMap(columnsToRename) {
-  const renameMap = new Map()
-
-  for (const column of columnsToRename) {
-    if (!renameMap.has(column.tableName)) {
-      renameMap.set(column.tableName, new Map())
-    }
-
-    renameMap
-      .get(column.tableName)
-      .set(column.toColumnName.toLowerCase(), column.fromColumnName)
-  }
-
-  return renameMap
 }
 
 /**
@@ -419,73 +410,436 @@ function generateSqliteCreateTable(tableName, columns) {
   )}\n);`
 }
 
-function generateSqliteTableRebuild(
+function generateSqliteTableRebuildStatement({
   tableName,
-  model,
   existingTable,
-  renamedColumns = new Map()
-) {
-  const columns = []
+  modifications,
+  renames,
+  additions,
+  drops
+}) {
+  const unsupportedChanges = [
+    renames.length > 0 && 'column renames',
+    additions.length > 0 && 'column additions',
+    drops.length > 0 && 'column removals'
+  ].filter(Boolean)
 
-  for (const [attrName, attr] of Object.entries(model.attributes)) {
-    const mapped = mapSqliteModelColumn(attr, attrName, model.primaryKey)
-    columns.push({
-      name: attr.columnName || attrName,
-      ...mapped
-    })
+  if (unsupportedChanges.length > 0) {
+    return blockedSqliteRebuild(
+      tableName,
+      `A table rebuild combined with ${unsupportedChanges.join(
+        ', '
+      )} cannot be represented without guessing.`
+    )
   }
 
-  const oldTableName = `${tableName}__old`
-  const createSql = generateSqliteCreateTable(tableName, columns)
-  const existingColumnNames = new Set(
-    (existingTable?.columns || []).map((column) => column.name.toLowerCase())
-  )
-  const copyableColumns = columns
-    .map((column) => {
-      const targetColumn = column.name
-      const sourceColumn =
-        existingColumnNames.has(targetColumn.toLowerCase()) && targetColumn
+  if (!existingTable.sql) {
+    return blockedSqliteRebuild(
+      tableName,
+      'SQLite did not return the original CREATE TABLE definition.'
+    )
+  }
 
-      if (sourceColumn) {
-        return { targetColumn, sourceColumn }
-      }
-
-      const renamedSource = renamedColumns.get(targetColumn.toLowerCase())
-      if (
-        renamedSource &&
-        existingColumnNames.has(renamedSource.toLowerCase())
-      ) {
-        return { targetColumn, sourceColumn: renamedSource }
-      }
-
-      return null
+  try {
+    const temporaryTableName = `${tableName}__slipway_new`
+    const createSql = rewriteSqliteCreateTable({
+      sql: existingTable.sql,
+      tableName,
+      temporaryTableName,
+      modifications
     })
-    .filter(Boolean)
-  const quotedTargetColumns = copyableColumns
-    .map(({ targetColumn }) => `\`${targetColumn}\``)
-    .join(', ')
-  const quotedSourceColumns = copyableColumns
-    .map(({ sourceColumn }) => `\`${sourceColumn}\``)
-    .join(', ')
-  const copySql =
-    copyableColumns.length > 0
-      ? `INSERT INTO \`${tableName}\` (${quotedTargetColumns}) SELECT ${quotedSourceColumns} FROM \`${oldTableName}\`;`
-      : null
-  const indexStatements = generateSqliteIndexStatements(tableName, model).map(
-    (statement) => statement.sql
+    const columns = (existingTable.columns || []).map((column) => column.name)
+
+    if (columns.length === 0) {
+      throw new Error('The existing table has no copyable columns.')
+    }
+
+    const recreateSql = []
+    const dropDependentViewsSql = []
+    const preservedObjects = []
+
+    for (const index of existingTable.indexes || []) {
+      if (index.origin === 'u' && !index.sql) {
+        preservedObjects.push({ type: 'unique constraint', name: index.name })
+        continue
+      }
+
+      if (!index.sql) {
+        throw new Error(
+          `Index ${index.name} does not have a replayable SQLite definition.`
+        )
+      }
+
+      recreateSql.push(terminateSql(index.sql))
+      preservedObjects.push({ type: 'index', name: index.name })
+    }
+
+    for (const trigger of existingTable.triggers || []) {
+      if (!trigger.sql) {
+        throw new Error(
+          `Trigger ${trigger.name} does not have a replayable SQLite definition.`
+        )
+      }
+
+      recreateSql.push(terminateSql(trigger.sql))
+      preservedObjects.push({ type: 'trigger', name: trigger.name })
+    }
+
+    for (const view of existingTable.views || []) {
+      if (!view.sql) {
+        throw new Error(
+          `View ${view.name} does not have a replayable SQLite definition.`
+        )
+      }
+
+      dropDependentViewsSql.push(
+        `DROP VIEW ${quoteSqliteIdentifier(view.name)};`
+      )
+      recreateSql.push(terminateSql(view.sql))
+      preservedObjects.push({ type: 'view', name: view.name })
+    }
+
+    const quotedColumns = columns.map(quoteSqliteIdentifier).join(', ')
+    const sql = [
+      terminateSql(createSql),
+      `INSERT INTO ${quoteSqliteIdentifier(
+        temporaryTableName
+      )} (${quotedColumns}) SELECT ${quotedColumns} FROM ${quoteSqliteIdentifier(
+        tableName
+      )};`,
+      ...dropDependentViewsSql,
+      `DROP TABLE ${quoteSqliteIdentifier(tableName)};`,
+      `ALTER TABLE ${quoteSqliteIdentifier(
+        temporaryTableName
+      )} RENAME TO ${quoteSqliteIdentifier(tableName)};`,
+      ...recreateSql
+    ].join('\n')
+
+    return {
+      type: 'rebuild_table',
+      table: tableName,
+      risk: 'high',
+      sql,
+      currentSchemaSql: existingTable.sql,
+      changedColumns: modifications.map((modification) => ({
+        column: modification.columnName,
+        current: {
+          type: modification.current.type,
+          defaultValue: modification.current.defaultValue,
+          nullable: modification.current.nullable
+        },
+        expected: {
+          type: modification.expected.sqlType,
+          defaultValue: modification.expected.defaultValue,
+          nullable: modification.expected.nullable
+        }
+      })),
+      preservedObjects,
+      verification: {
+        rowCount: true,
+        integrityCheck: true,
+        foreignKeyCheck: true
+      }
+    }
+  } catch (error) {
+    return blockedSqliteRebuild(tableName, error.message)
+  }
+}
+
+function blockedSqliteRebuild(tableName, reason) {
+  return {
+    type: 'blocked_rebuild',
+    table: tableName,
+    blocked: true,
+    risk: 'blocked',
+    reason,
+    sql: `-- Bosun blocked this rebuild: ${reason}`
+  }
+}
+
+function rewriteSqliteCreateTable({
+  sql,
+  tableName,
+  temporaryTableName,
+  modifications
+}) {
+  const openParen = findFirstSqliteStructuralCharacter(sql, '(')
+  const closeParen = findMatchingSqliteParenthesis(sql, openParen)
+
+  if (openParen === -1 || closeParen === -1) {
+    throw new Error('The CREATE TABLE definition could not be parsed safely.')
+  }
+
+  const prefix = sql.slice(0, openParen)
+  const rewrittenPrefix = prefix.replace(
+    /^(\s*CREATE\s+TABLE\s+)(?:IF\s+NOT\s+EXISTS\s+)?(?:"(?:[^"]|"")*"|`(?:[^`]|``)*`|\[[^\]]*\]|[^\s(]+)(\s*)$/i,
+    `$1${quoteSqliteIdentifier(temporaryTableName)}$2`
   )
 
-  return [
-    'BEGIN;',
-    `ALTER TABLE \`${tableName}\` RENAME TO \`${oldTableName}\`;`,
-    createSql,
-    copySql,
-    ...indexStatements,
-    `DROP TABLE \`${oldTableName}\`;`,
-    'COMMIT;'
-  ]
-    .filter(Boolean)
-    .join('\n')
+  if (rewrittenPrefix === prefix) {
+    throw new Error(`The CREATE TABLE prefix for ${tableName} is unsupported.`)
+  }
+
+  const definitions = splitSqliteDefinitions(
+    sql.slice(openParen + 1, closeParen)
+  )
+  const modificationMap = new Map(
+    modifications.map((modification) => [
+      modification.columnName.toLowerCase(),
+      modification
+    ])
+  )
+  const rewrittenColumns = new Set()
+  const rewrittenDefinitions = definitions.map((definition) => {
+    const parsed = parseSqliteColumnDefinition(definition)
+    if (!parsed || !modificationMap.has(parsed.name.toLowerCase())) {
+      return definition
+    }
+
+    const modification = modificationMap.get(parsed.name.toLowerCase())
+    rewrittenColumns.add(parsed.name.toLowerCase())
+    return replaceSqliteDeclaredType(
+      definition,
+      parsed.identifierEnd,
+      modification.expected.sqlType
+    )
+  })
+
+  if (rewrittenColumns.size !== modificationMap.size) {
+    const missingColumns = Array.from(modificationMap.keys()).filter(
+      (column) => !rewrittenColumns.has(column)
+    )
+    throw new Error(
+      `Could not safely locate column definition(s): ${missingColumns.join(
+        ', '
+      )}.`
+    )
+  }
+
+  return `${rewrittenPrefix}(${rewrittenDefinitions.join(',')})${sql.slice(
+    closeParen + 1
+  )}`
+}
+
+function splitSqliteDefinitions(body) {
+  const definitions = []
+  let start = 0
+  let depth = 0
+  let quote = null
+
+  for (let index = 0; index < body.length; index++) {
+    const character = body[index]
+    const next = body[index + 1]
+
+    if (quote) {
+      if (character === quote) {
+        if (next === quote && quote !== ']') {
+          index++
+        } else {
+          quote = null
+        }
+      }
+      continue
+    }
+
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character
+    } else if (character === '[') {
+      quote = ']'
+    } else if (character === '(') {
+      depth++
+    } else if (character === ')') {
+      depth--
+    } else if (character === ',' && depth === 0) {
+      definitions.push(body.slice(start, index))
+      start = index + 1
+    }
+  }
+
+  if (quote || depth !== 0) {
+    throw new Error('The CREATE TABLE column list is not balanced.')
+  }
+
+  definitions.push(body.slice(start))
+  return definitions
+}
+
+function parseSqliteColumnDefinition(definition) {
+  const leadingWhitespace = definition.match(/^\s*/)[0].length
+  const firstWord = definition
+    .slice(leadingWhitespace)
+    .match(/^(CONSTRAINT|PRIMARY|UNIQUE|CHECK|FOREIGN)\b/i)
+
+  if (firstWord) return null
+
+  const identifier = readSqliteIdentifier(definition, leadingWhitespace)
+  if (!identifier) return null
+
+  return identifier
+}
+
+function readSqliteIdentifier(sql, start) {
+  const first = sql[start]
+
+  if (first === '"' || first === '`' || first === '[') {
+    const closing = first === '[' ? ']' : first
+    let value = ''
+
+    for (let index = start + 1; index < sql.length; index++) {
+      if (sql[index] === closing) {
+        if (sql[index + 1] === closing && closing !== ']') {
+          value += closing
+          index++
+          continue
+        }
+
+        return { name: value, identifierEnd: index + 1 }
+      }
+      value += sql[index]
+    }
+
+    return null
+  }
+
+  const match = sql.slice(start).match(/^[^\s,()]+/)
+  if (!match) return null
+  return { name: match[0], identifierEnd: start + match[0].length }
+}
+
+function replaceSqliteDeclaredType(definition, identifierEnd, expectedType) {
+  if (
+    !/^[A-Za-z][A-Za-z0-9_ ]*(?:\(\s*\d+(?:\s*,\s*\d+)?\s*\))?$/.test(
+      expectedType
+    )
+  ) {
+    throw new Error(`Unsafe SQLite type: ${expectedType}.`)
+  }
+
+  let typeStart = identifierEnd
+  while (/\s/.test(definition[typeStart] || '')) typeStart++
+
+  if (
+    /^(PRIMARY|NOT|UNIQUE|CHECK|DEFAULT|COLLATE|REFERENCES|GENERATED|AS)\b/i.test(
+      definition.slice(typeStart)
+    )
+  ) {
+    throw new Error(
+      'A column without a declared type cannot be rewritten safely.'
+    )
+  }
+
+  let typeEnd = definition.length
+  let depth = 0
+  let quote = null
+
+  for (let index = typeStart; index < definition.length; index++) {
+    const character = definition[index]
+    const next = definition[index + 1]
+
+    if (quote) {
+      if (character === quote) {
+        if (next === quote && quote !== ']') index++
+        else quote = null
+      }
+      continue
+    }
+
+    if (character === "'" || character === '"' || character === '`') {
+      quote = character
+    } else if (character === '[') {
+      quote = ']'
+    } else if (character === '(') {
+      depth++
+    } else if (character === ')') {
+      depth--
+    } else if (depth === 0 && /\s/.test(character)) {
+      const remainder = definition.slice(index).trimStart()
+      if (
+        /^(PRIMARY|NOT|UNIQUE|CHECK|DEFAULT|COLLATE|REFERENCES|GENERATED|AS)\b/i.test(
+          remainder
+        )
+      ) {
+        typeEnd = index
+        break
+      }
+    }
+  }
+
+  if (!definition.slice(typeStart, typeEnd).trim()) {
+    throw new Error(
+      'A column without a declared type cannot be rewritten safely.'
+    )
+  }
+
+  return `${definition.slice(0, typeStart)}${expectedType}${definition.slice(
+    typeEnd
+  )}`
+}
+
+function findFirstSqliteStructuralCharacter(sql, target) {
+  let quote = null
+
+  for (let index = 0; index < sql.length; index++) {
+    const character = sql[index]
+    const next = sql[index + 1]
+
+    if (quote) {
+      if (character === quote) {
+        if (next === quote && quote !== ']') index++
+        else quote = null
+      }
+      continue
+    }
+
+    if (character === '"' || character === '`' || character === "'") {
+      quote = character
+    } else if (character === '[') {
+      quote = ']'
+    } else if (character === target) {
+      return index
+    }
+  }
+
+  return -1
+}
+
+function findMatchingSqliteParenthesis(sql, openParen) {
+  let depth = 0
+  let quote = null
+
+  for (let index = openParen; index < sql.length; index++) {
+    const character = sql[index]
+    const next = sql[index + 1]
+
+    if (quote) {
+      if (character === quote) {
+        if (next === quote && quote !== ']') index++
+        else quote = null
+      }
+      continue
+    }
+
+    if (character === '"' || character === '`' || character === "'") {
+      quote = character
+    } else if (character === '[') {
+      quote = ']'
+    } else if (character === '(') {
+      depth++
+    } else if (character === ')') {
+      depth--
+      if (depth === 0) return index
+    }
+  }
+
+  return -1
+}
+
+function quoteSqliteIdentifier(value) {
+  return `\`${String(value).replace(/`/g, '``')}\``
+}
+
+function terminateSql(sql) {
+  return `${String(sql).trim().replace(/;+$/, '')};`
 }
 
 function generateSqliteIndexStatements(tableName, model) {
@@ -566,7 +920,7 @@ function mapSqliteType(
     case 'number':
       return isPrimaryKey || isForeignKey ? 'INTEGER' : 'INTEGER'
     case 'boolean':
-      return 'TEXT'
+      return 'INTEGER'
     case 'json':
     case 'ref':
       return 'TEXT'
@@ -594,8 +948,9 @@ function normalizeSqliteType(type) {
     case 'integer':
       return 'INTEGER'
     case '_json':
-    case '_boolean':
       return 'TEXT'
+    case '_boolean':
+      return 'INTEGER'
     case 'float':
     case 'double':
     case 'real':

--- a/api/helpers/dock/get-schema.js
+++ b/api/helpers/dock/get-schema.js
@@ -255,10 +255,20 @@ function getSqliteSchema(service) {
     const tableRows = db
       .prepare(
         `
-      SELECT name
-      FROM sqlite_master
+      SELECT name, sql
+      FROM sqlite_schema
       WHERE type = 'table'
         AND name NOT LIKE 'sqlite_%'
+      ORDER BY name
+    `
+      )
+      .all()
+    const viewRows = db
+      .prepare(
+        `
+      SELECT name, sql
+      FROM sqlite_schema
+      WHERE type = 'view'
       ORDER BY name
     `
       )
@@ -266,14 +276,29 @@ function getSqliteSchema(service) {
 
     const tables = {}
 
-    for (const { name } of tableRows) {
+    for (const { name, sql } of tableRows) {
       const tableName = escapeSqliteIdentifier(name)
       const columns = db.prepare(`PRAGMA table_info('${tableName}')`).all()
       const indexes = db.prepare(`PRAGMA index_list('${tableName}')`).all()
+      const foreignKeys = db
+        .prepare(`PRAGMA foreign_key_list('${tableName}')`)
+        .all()
+      const triggers = db
+        .prepare(
+          `
+          SELECT name, sql
+          FROM sqlite_schema
+          WHERE type = 'trigger' AND tbl_name = ?
+          ORDER BY name
+        `
+        )
+        .all(name)
 
       tables[name] = {
         name,
+        sql,
         columns: columns.map((column) => ({
+          position: column.cid,
           name: column.name,
           type: column.type,
           maxLength: null,
@@ -286,14 +311,47 @@ function getSqliteSchema(service) {
           .map((index) => {
             const indexName = escapeSqliteIdentifier(index.name)
             const indexColumns = db
-              .prepare(`PRAGMA index_info('${indexName}')`)
+              .prepare(`PRAGMA index_xinfo('${indexName}')`)
               .all()
+            const schemaEntry = db
+              .prepare(
+                `SELECT sql FROM sqlite_schema WHERE type = 'index' AND name = ?`
+              )
+              .get(index.name)
+
             return {
               name: index.name,
-              columns: indexColumns.map((column) => column.name),
-              unique: Boolean(index.unique)
+              columns: indexColumns
+                .filter((column) => column.key === 1)
+                .map((column) => column.name),
+              unique: Boolean(index.unique),
+              origin: index.origin,
+              partial: Boolean(index.partial),
+              sql: schemaEntry?.sql || null,
+              definition: indexColumns.map((column) => ({
+                position: column.seqno,
+                columnId: column.cid,
+                name: column.name,
+                descending: Boolean(column.desc),
+                collation: column.coll,
+                key: Boolean(column.key)
+              }))
             }
-          })
+          }),
+        foreignKeys: foreignKeys.map((foreignKey) => ({
+          id: foreignKey.id,
+          sequence: foreignKey.seq,
+          table: foreignKey.table,
+          from: foreignKey.from,
+          to: foreignKey.to,
+          onUpdate: foreignKey.on_update,
+          onDelete: foreignKey.on_delete,
+          match: foreignKey.match
+        })),
+        triggers,
+        // SQLite validates the full schema during table replacement. Keep the
+        // complete view inventory so rebuilds can replay transitive dependencies.
+        views: viewRows
       }
     }
 

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -480,6 +480,15 @@ const filteredStatements = computed(() => {
   )
 })
 
+const blockedStatements = computed(() =>
+  filteredStatements.value.filter((statement) => statement.blocked)
+)
+
+const canApplyMigration = computed(
+  () =>
+    filteredStatements.value.length > 0 && blockedStatements.value.length === 0
+)
+
 const diffSummary = computed(() => {
   if (!diff.value?.diff) {
     return {
@@ -519,7 +528,7 @@ function deselectAllModels() {
 }
 
 function confirmMigration() {
-  if (!filteredStatements.value.length) return
+  if (!canApplyMigration.value) return
   showMigrateConfirm.value = true
 }
 
@@ -1814,11 +1823,28 @@ onUnmounted(() => {
 
                 <button
                   @click="confirmMigration"
-                  :disabled="migrateLoading || filteredStatements.length === 0"
+                  :disabled="migrateLoading || !canApplyMigration"
                   class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
                 >
                   {{ migrateLoading ? 'Applying...' : 'Apply migration' }}
                 </button>
+              </div>
+
+              <div
+                v-if="blockedStatements.length > 0"
+                class="border-t border-red-200 bg-red-50 px-4 py-4 dark:border-red-900/60 dark:bg-red-950/30"
+                role="alert"
+              >
+                <p class="text-sm font-medium text-red-800 dark:text-red-300">
+                  {{ blockedStatements.length }} rebuild{{
+                    blockedStatements.length === 1 ? '' : 's'
+                  }}
+                  blocked
+                </p>
+                <p class="mt-1 text-sm text-red-700 dark:text-red-400">
+                  Bosun cannot prove that every schema object would survive.
+                  Apply is disabled instead of guessing.
+                </p>
               </div>
 
               <div class="grid gap-4 px-4 py-4 sm:grid-cols-4">
@@ -1967,11 +1993,62 @@ onUnmounted(() => {
                     </p>
                   </div>
                   <span
-                    v-if="statement.column"
+                    v-if="statement.blocked"
+                    class="rounded bg-red-100 px-2 py-1 text-xs font-medium text-red-700 dark:bg-red-950 dark:text-red-300"
+                  >
+                    Blocked
+                  </span>
+                  <span
+                    v-else-if="statement.risk === 'high'"
+                    class="rounded bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 dark:bg-amber-950 dark:text-amber-300"
+                  >
+                    High risk · verified rebuild
+                  </span>
+                  <span
+                    v-else-if="statement.column"
                     class="rounded bg-gray-100 px-2 py-1 font-mono text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-300"
                   >
                     {{ statement.column }}
                   </span>
+                </div>
+
+                <div
+                  v-if="statement.reason"
+                  class="border-b border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700 dark:border-red-900/60 dark:bg-red-950/30 dark:text-red-300"
+                >
+                  {{ statement.reason }}
+                </div>
+
+                <div
+                  v-if="statement.changedColumns?.length"
+                  class="border-b border-gray-200 px-4 py-3 dark:border-gray-800"
+                >
+                  <div
+                    v-for="change in statement.changedColumns"
+                    :key="change.column"
+                    class="grid gap-2 text-xs sm:grid-cols-[minmax(8rem,0.7fr)_1fr_1fr] sm:items-center"
+                  >
+                    <span class="font-mono text-gray-900 dark:text-white">
+                      {{ change.column }}
+                    </span>
+                    <span class="text-gray-500 dark:text-gray-400">
+                      Current: {{ change.current.type }} ·
+                      {{ change.current.nullable ? 'nullable' : 'not null' }} ·
+                      default {{ change.current.defaultValue ?? 'none' }}
+                    </span>
+                    <span class="text-gray-700 dark:text-gray-300">
+                      Expected: {{ change.expected.type }} ·
+                      {{ change.expected.nullable ? 'nullable' : 'not null' }} ·
+                      default {{ change.expected.defaultValue ?? 'none' }}
+                    </span>
+                  </div>
+                  <p
+                    v-if="statement.verification"
+                    class="mt-2 text-xs text-gray-500 dark:text-gray-400"
+                  >
+                    Before commit, Bosun verifies row count, SQLite integrity,
+                    foreign keys, and preserved schema objects.
+                  </p>
                 </div>
 
                 <div class="overflow-x-auto bg-white dark:bg-gray-950">

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -520,6 +520,10 @@ const filteredStatements = computed(() => {
   )
 })
 
+const hasBlockedStatements = computed(() =>
+  filteredStatements.value.some((statement) => statement.blocked)
+)
+
 function toggleModel(model) {
   if (selectedModels.value.has(model)) {
     selectedModels.value.delete(model)
@@ -540,7 +544,7 @@ function deselectAllModels() {
 
 // Show migration confirmation modal
 function confirmMigration() {
-  if (!filteredStatements.value.length) return
+  if (!filteredStatements.value.length || hasBlockedStatements.value) return
   showMigrateConfirm.value = true
 }
 
@@ -2635,7 +2639,7 @@ onUnmounted(() => {
         <button
           v-if="activeTab === 'migrate' && filteredStatements.length > 0"
           @click="confirmMigration"
-          :disabled="migrateLoading"
+          :disabled="migrateLoading || hasBlockedStatements"
           class="flex h-8 items-center rounded-md bg-gray-900 px-3 text-sm font-medium text-white transition-colors hover:bg-gray-800 disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
         >
           {{ migrateLoading ? 'Applying...' : 'Apply' }}

--- a/tests/unit/helpers/dock/generate-diff.test.js
+++ b/tests/unit/helpers/dock/generate-diff.test.js
@@ -89,7 +89,7 @@ test('schema diff treats old camelCase physical columns as rename candidates', a
   expect(diff.columnsToAdd).toEqual([])
 })
 
-test('schema diff follows sails-sqlite boolean physical columns', async ({
+test('schema diff treats SQLite boolean storage forms as one logical contract', async ({
   sails,
   expect
 }) => {
@@ -109,6 +109,41 @@ test('schema diff follows sails-sqlite boolean physical columns', async ({
             columnName: 'is_default',
             columnType: '_boolean',
             defaultsTo: true
+          },
+          bridgeEnabled: {
+            type: 'boolean',
+            columnName: 'bridge_enabled',
+            defaultsTo: false
+          }
+        }
+      },
+      featureFlag: {
+        identity: 'featureFlag',
+        tableName: 'feature_flags',
+        primaryKey: 'id',
+        attributes: {
+          id: {
+            type: 'number',
+            autoIncrement: true
+          },
+          enabled: {
+            type: 'boolean',
+            defaultsTo: false
+          }
+        }
+      },
+      helmHistoryEntry: {
+        identity: 'helmHistoryEntry',
+        tableName: 'helm_history_entries',
+        primaryKey: 'id',
+        attributes: {
+          id: {
+            type: 'number',
+            autoIncrement: true
+          },
+          pinned: {
+            type: 'boolean',
+            defaultsTo: false
           }
         }
       },
@@ -133,7 +168,22 @@ test('schema diff follows sails-sqlite boolean physical columns', async ({
       apps: {
         columns: [
           { name: 'id', type: 'integer' },
-          { name: 'is_default', type: 'text' }
+          { name: 'is_default', type: 'text' },
+          { name: 'bridge_enabled', type: 'BOOLEAN' }
+        ],
+        indexes: []
+      },
+      feature_flags: {
+        columns: [
+          { name: 'id', type: 'integer' },
+          { name: 'enabled', type: 'INTEGER' }
+        ],
+        indexes: []
+      },
+      helm_history_entries: {
+        columns: [
+          { name: 'id', type: 'integer' },
+          { name: 'pinned', type: 'BOOLEAN' }
         ],
         indexes: []
       },

--- a/tests/unit/helpers/dock/generate-migration-sql.test.js
+++ b/tests/unit/helpers/dock/generate-migration-sql.test.js
@@ -1,6 +1,6 @@
 const { test } = require('sounding')
 
-test('sqlite migration SQL rebuilds tables for modified columns', async ({
+test('sqlite migration SQL preserves the original table contract and schema objects', async ({
   sails,
   expect
 }) => {
@@ -66,6 +66,38 @@ test('sqlite migration SQL rebuilds tables for modified columns', async ({
           { name: 'updated_at' },
           { name: 'email' },
           { name: 'is_genesis_user' }
+        ],
+        sql: `CREATE TABLE "users" (
+          "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+          "created_at" INTEGER,
+          "updated_at" INTEGER,
+          "email" INTEGER NOT NULL COLLATE NOCASE CHECK (length("email") > 3),
+          "is_genesis_user" INTEGER NOT NULL DEFAULT 0,
+          CONSTRAINT "users_email_genesis_unique" UNIQUE ("email", "is_genesis_user")
+        ) STRICT`,
+        indexes: [
+          {
+            name: 'users_email_search',
+            origin: 'c',
+            sql: `CREATE INDEX "users_email_search" ON "users" (lower("email") DESC) WHERE "is_genesis_user" = 0`
+          },
+          {
+            name: 'sqlite_autoindex_users_1',
+            origin: 'u',
+            sql: null
+          }
+        ],
+        triggers: [
+          {
+            name: 'users_email_audit',
+            sql: `CREATE TRIGGER "users_email_audit" AFTER UPDATE OF "email" ON "users" BEGIN SELECT NEW."email"; END`
+          }
+        ],
+        views: [
+          {
+            name: 'active_users',
+            sql: `CREATE VIEW "active_users" AS SELECT * FROM "users"`
+          }
         ]
       }
     }
@@ -73,19 +105,38 @@ test('sqlite migration SQL rebuilds tables for modified columns', async ({
 
   expect(result.statements.length).toBe(1)
   expect(result.statements[0].type).toBe('rebuild_table')
+  expect(result.statements[0].risk).toBe('high')
   expect(result.statements[0].sql).toContain(
-    'ALTER TABLE `users` RENAME TO `users__old`;'
+    'CREATE TABLE `users__slipway_new`'
+  )
+  expect(result.statements[0].sql.includes('IF NOT EXISTS')).toBe(false)
+  expect(result.statements[0].sql).toContain(
+    '"email" TEXT NOT NULL COLLATE NOCASE CHECK (length("email") > 3)'
   )
   expect(result.statements[0].sql).toContain(
-    'CREATE TABLE IF NOT EXISTS `users`'
+    'CONSTRAINT "users_email_genesis_unique" UNIQUE ("email", "is_genesis_user")'
   )
-  expect(result.statements[0].sql).toContain('`is_genesis_user` TEXT DEFAULT 0')
+  expect(result.statements[0].sql).toContain(') STRICT;')
   expect(result.statements[0].sql).toContain(
-    'INSERT INTO `users` (`id`, `created_at`, `updated_at`, `email`, `is_genesis_user`)'
+    'INSERT INTO `users__slipway_new` (`id`, `created_at`, `updated_at`, `email`, `is_genesis_user`) SELECT `id`, `created_at`, `updated_at`, `email`, `is_genesis_user` FROM `users`;'
   )
   expect(result.statements[0].sql).toContain(
-    'CREATE UNIQUE INDEX IF NOT EXISTS `idx_users_email`'
+    'CREATE INDEX "users_email_search" ON "users" (lower("email") DESC) WHERE "is_genesis_user" = 0;'
   )
+  expect(result.statements[0].sql).toContain(
+    'CREATE TRIGGER "users_email_audit" AFTER UPDATE OF "email" ON "users"'
+  )
+  expect(result.statements[0].preservedObjects).toEqual([
+    { type: 'index', name: 'users_email_search' },
+    { type: 'unique constraint', name: 'sqlite_autoindex_users_1' },
+    { type: 'trigger', name: 'users_email_audit' },
+    { type: 'view', name: 'active_users' }
+  ])
+  expect(result.statements[0].verification).toEqual({
+    rowCount: true,
+    integrityCheck: true,
+    foreignKeyCheck: true
+  })
 })
 
 test('sqlite migration SQL renames camelCase columns without rebuilding tables', async ({
@@ -124,7 +175,7 @@ test('sqlite migration SQL renames camelCase columns without rebuilding tables',
   ])
 })
 
-test('sqlite table rebuild copies data from renamed source columns', async ({
+test('sqlite table rebuild fails closed when combined with a column rename', async ({
   sails,
   expect
 }) => {
@@ -178,14 +229,19 @@ test('sqlite table rebuild copies data from renamed source columns', async ({
     },
     {
       apps: {
-        columns: [{ name: 'id' }, { name: 'name' }, { name: 'dockerfilePath' }]
+        sql: 'CREATE TABLE `apps` (`id` INTEGER PRIMARY KEY, `name` INTEGER, `dockerfilePath` TEXT)',
+        columns: [{ name: 'id' }, { name: 'name' }, { name: 'dockerfilePath' }],
+        indexes: [],
+        triggers: [],
+        views: []
       }
     }
   )
 
   expect(result.statements.length).toBe(1)
-  expect(result.statements[0].type).toBe('rebuild_table')
-  expect(result.statements[0].sql).toContain(
-    'INSERT INTO `apps` (`id`, `name`, `dockerfile_path`) SELECT `id`, `name`, `dockerfilePath` FROM `apps__old`;'
-  )
+  expect(result.statements[0].type).toBe('blocked_rebuild')
+  expect(result.statements[0].table).toBe('apps')
+  expect(result.statements[0].blocked).toBe(true)
+  expect(result.statements[0].risk).toBe('blocked')
+  expect(result.statements[0].reason).toContain('column renames')
 })

--- a/tests/unit/helpers/dock/sqlite-schema-migrations.test.js
+++ b/tests/unit/helpers/dock/sqlite-schema-migrations.test.js
@@ -1,0 +1,275 @@
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const Database = require('better-sqlite3')
+const { test } = require('sounding')
+
+test('Bosun considers Slipway SQLite boolean schemas idempotent', async ({
+  sails,
+  expect
+}) => {
+  await withDatabase(async (databasePath) => {
+    const db = new Database(databasePath)
+    db.exec(`
+      CREATE TABLE apps (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        bridge_enabled BOOLEAN NOT NULL DEFAULT 0
+      );
+      CREATE TABLE feature_flags (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE INDEX feature_flags_app_key ON feature_flags (enabled, id);
+      CREATE INDEX feature_flags_environment_updated ON feature_flags (id DESC) WHERE enabled = 1;
+      CREATE TABLE helm_history_entries (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        pinned BOOLEAN NOT NULL DEFAULT 0
+      );
+      CREATE INDEX helm_history_scope ON helm_history_entries (pinned, id);
+      CREATE INDEX helm_history_retention ON helm_history_entries (id DESC) WHERE pinned = 0;
+    `)
+    db.close()
+
+    const schema = await sails.helpers.dock.getSchema({
+      type: 'sqlite',
+      path: databasePath
+    })
+    const models = booleanModels()
+    const diff = await sails.helpers.dock.generateDiff(
+      models,
+      schema.tables,
+      'sqlite'
+    )
+    const migration = await sails.helpers.dock.generateMigrationSql(
+      diff,
+      'sqlite',
+      models,
+      schema.tables
+    )
+
+    expect(diff.columnsToModify).toEqual([])
+    expect(migration.statements).toEqual([])
+    expect(
+      schema.tables.feature_flags.indexes.map((index) => index.name)
+    ).toEqual(['feature_flags_environment_updated', 'feature_flags_app_key'])
+    expect(
+      schema.tables.feature_flags.indexes.find(
+        (index) => index.name === 'feature_flags_environment_updated'
+      ).partial
+    ).toBe(true)
+  })
+})
+
+test('verified SQLite rebuild preserves rows, constraints, indexes, triggers, views, and foreign keys', async ({
+  sails,
+  expect
+}) => {
+  await withDatabase(async (databasePath) => {
+    const db = new Database(databasePath)
+    db.exec(`
+      PRAGMA foreign_keys = ON;
+      CREATE TABLE teams (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        name TEXT NOT NULL UNIQUE
+      );
+      CREATE TABLE widgets (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        team_id INTEGER NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+        state INTEGER NOT NULL DEFAULT 0 CHECK (state IN (0, 1)),
+        slug TEXT NOT NULL,
+        UNIQUE (team_id, slug)
+      );
+      CREATE INDEX widgets_active_slug ON widgets (lower(slug) DESC) WHERE state = 1;
+      CREATE TRIGGER widgets_slug_guard BEFORE UPDATE OF slug ON widgets
+      BEGIN
+        SELECT CASE WHEN NEW.slug = '' THEN RAISE(ABORT, 'slug required') END;
+      END;
+      CREATE VIEW active_widgets AS SELECT id, slug FROM widgets WHERE state = 1;
+      INSERT INTO teams (name) VALUES ('Slipway');
+      INSERT INTO widgets (team_id, state, slug) VALUES (1, 1, 'bearing'), (1, 0, 'bridge');
+    `)
+    db.close()
+
+    const schemaBefore = await sails.helpers.dock.getSchema({
+      type: 'sqlite',
+      path: databasePath
+    })
+    const diff = {
+      tablesToCreate: [],
+      tablesToDrop: [],
+      columnsToRename: [],
+      columnsToAdd: [],
+      columnsToModify: [
+        {
+          tableName: 'widgets',
+          columnName: 'state',
+          current: { type: 'INTEGER' },
+          expected: { sqlType: 'TEXT' }
+        }
+      ],
+      columnsToDrop: [],
+      indexesToCreate: []
+    }
+    const migration = await sails.helpers.dock.generateMigrationSql(
+      diff,
+      'sqlite',
+      {
+        widget: {
+          identity: 'widget',
+          tableName: 'widgets',
+          primaryKey: 'id',
+          attributes: {}
+        }
+      },
+      schemaBefore.tables
+    )
+    const result = await sails.helpers.dock.applySqliteMigration(
+      databasePath,
+      migration.statements
+    )
+
+    if (!result.success) {
+      throw new Error(JSON.stringify(result.results, null, 2))
+    }
+    expect(result.success).toBe(true)
+
+    const migrated = new Database(databasePath)
+    const tableSql = migrated
+      .prepare(
+        "SELECT sql FROM sqlite_schema WHERE type = 'table' AND name = 'widgets'"
+      )
+      .get().sql
+    expect(tableSql).toContain(
+      'state TEXT NOT NULL DEFAULT 0 CHECK (state IN (0, 1))'
+    )
+    expect(
+      migrated.prepare('SELECT COUNT(*) AS count FROM widgets').get().count
+    ).toBe(2)
+    expect(
+      migrated
+        .prepare(
+          "SELECT COUNT(*) AS count FROM sqlite_schema WHERE name IN ('widgets_active_slug', 'widgets_slug_guard', 'active_widgets')"
+        )
+        .get().count
+    ).toBe(3)
+    expect(migrated.pragma('foreign_key_check')).toEqual([])
+    expect(migrated.pragma('integrity_check')).toEqual([
+      { integrity_check: 'ok' }
+    ])
+    migrated.close()
+  })
+})
+
+test('SQLite rebuild verification rolls the whole migration back on row loss', async ({
+  sails,
+  expect
+}) => {
+  await withDatabase(async (databasePath) => {
+    const db = new Database(databasePath)
+    db.exec(`
+      CREATE TABLE widgets (id INTEGER PRIMARY KEY, state INTEGER NOT NULL DEFAULT 0);
+      INSERT INTO widgets (id, state) VALUES (1, 0), (2, 1);
+    `)
+    db.close()
+
+    const schema = await sails.helpers.dock.getSchema({
+      type: 'sqlite',
+      path: databasePath
+    })
+    const migration = await sails.helpers.dock.generateMigrationSql(
+      {
+        tablesToCreate: [],
+        tablesToDrop: [],
+        columnsToRename: [],
+        columnsToAdd: [],
+        columnsToModify: [
+          {
+            tableName: 'widgets',
+            columnName: 'state',
+            current: { type: 'INTEGER' },
+            expected: { sqlType: 'TEXT' }
+          }
+        ],
+        columnsToDrop: [],
+        indexesToCreate: []
+      },
+      'sqlite',
+      {
+        widget: {
+          identity: 'widget',
+          tableName: 'widgets',
+          primaryKey: 'id',
+          attributes: {}
+        }
+      },
+      schema.tables
+    )
+    migration.statements[0].sql = migration.statements[0].sql.replace(
+      'SELECT `id`, `state` FROM `widgets`;',
+      'SELECT `id`, `state` FROM `widgets` WHERE `id` = 1;'
+    )
+
+    const result = await sails.helpers.dock.applySqliteMigration(
+      databasePath,
+      migration.statements
+    )
+
+    expect(result.success).toBe(false)
+    expect(result.results.at(-1).error).toContain(
+      'Row-count verification failed'
+    )
+
+    const rolledBack = new Database(databasePath)
+    expect(
+      rolledBack.prepare('SELECT COUNT(*) AS count FROM widgets').get().count
+    ).toBe(2)
+    expect(
+      rolledBack
+        .prepare(
+          "SELECT type FROM pragma_table_info('widgets') WHERE name = 'state'"
+        )
+        .get().type
+    ).toBe('INTEGER')
+    rolledBack.close()
+  })
+})
+
+function booleanModels() {
+  return {
+    app: model('app', 'apps', 'bridge_enabled'),
+    featureFlag: model('featureFlag', 'feature_flags', 'enabled'),
+    helmHistoryEntry: model(
+      'helmHistoryEntry',
+      'helm_history_entries',
+      'pinned'
+    )
+  }
+}
+
+function model(identity, tableName, booleanColumn) {
+  return {
+    identity,
+    tableName,
+    primaryKey: 'id',
+    attributes: {
+      id: { type: 'number', autoIncrement: true },
+      [booleanColumn]: {
+        type: 'boolean',
+        columnName: booleanColumn,
+        defaultsTo: false
+      }
+    }
+  }
+}
+
+async function withDatabase(fn) {
+  const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'slipway-schema-'))
+  const databasePath = path.join(directory, 'test.sqlite')
+
+  try {
+    new Database(databasePath).close()
+    await fn(databasePath)
+  } finally {
+    fs.rmSync(directory, { recursive: true, force: true })
+  }
+}


### PR DESCRIPTION
## What changed

- Treat SQLite `BOOLEAN`, `INTEGER`, and sails-sqlite legacy boolean storage as one logical 0/1 contract, eliminating the false `apps`, `feature_flags`, and `helm_history_entries` rebuilds.
- Inventory original SQLite table SQL, foreign keys, indexes (including expression, descending, and partial definitions), triggers, and views.
- Rebuild genuine type changes from the original SQLite table definition using create-copy-drop-rename, then restore schema objects.
- Apply Bosun migrations atomically with row-count, `integrity_check`, `foreign_key_check`, and schema-object verification before commit.
- Regenerate selected Bosun migrations server-side at apply time instead of trusting SQL posted by the browser.
- Fail closed and disable Apply when Bosun cannot prove a rebuild is lossless; show current versus expected definitions and risk in the UI.

## Verification

- `npm run test:unit` — 312 passing
- `npm run lint`
- `npm run check:consistency`
- `npm run local` on an isolated port; verified the initialized Bosun app datastore reports no pending schema changes
- Focused fixtures prove idempotence for the three reported boolean tables, preservation of rows/constraints/indexes/triggers/views/FKs, and full rollback on forced row loss

Fixes #368