### PR TITLE
fix(bearing): separate Slipway social attribution

### DIFF
--- a/api/helpers/bearing/render-social-image.js
+++ b/api/helpers/bearing/render-social-image.js
@@ -50,8 +50,8 @@ module.exports = {
         <text x="88" y="137" fill="#777773" font-family="${
           FONT.family
         }" font-size="20">${surfaceName}</text>
-        <rect x="1016" y="72" width="96" height="96" rx="24" fill="#17171a"/>
-        <svg x="1034" y="89" width="60" height="60" viewBox="0 0 32 32" fill="none">
+        <rect x="964" y="68" width="148" height="148" rx="30" fill="#17171a"/>
+        <svg x="996" y="84" width="84" height="84" viewBox="0 0 32 32" fill="none">
           <path d="M7 17 C7 3 25 3 25 17 Z" stroke="#38bdf8" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
           <path d="M7 17 C4 21 4 25 8 28" stroke="#38bdf8" stroke-width="2.5" stroke-linecap="round"/>
           <path d="M12 17 C11 21 10 25 13 28" stroke="#38bdf8" stroke-width="2.5" stroke-linecap="round"/>
@@ -60,6 +60,9 @@ module.exports = {
           <circle cx="13" cy="11" r="1.8" fill="#38bdf8"/>
           <circle cx="19" cy="11" r="1.8" fill="#38bdf8"/>
         </svg>
+        <text x="1038" y="198" text-anchor="middle" fill="#d4d4d8" font-family="${
+          FONT.family
+        }" font-size="12" font-weight="700" letter-spacing="2.5">SLIPWAY</text>
         <text x="88" y="203" fill="#969691" font-family="${
           FONT.family
         }" font-size="16" font-weight="700" letter-spacing="3">BEARING</text>
@@ -86,9 +89,6 @@ module.exports = {
         }" font-size="17">${itemCount} ${
       itemCount === 1 ? 'post' : 'posts'
     } on ${surfaceName}</text>
-        <text x="1112" y="548" text-anchor="end" fill="#8b8b86" font-family="${
-          FONT.family
-        }" font-size="17">Powered by Slipway</text>
       </svg>`
 
     return new Resvg(svg, {

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -1250,6 +1250,7 @@ async function expectSocialImageText(page, image, expect) {
     context.drawImage(element, 0, 0)
 
     const headline = context.getImageData(88, 220, 900, 56).data
+    const platformBadge = context.getImageData(964, 68, 148, 148).data
     let darkPixels = 0
     for (let index = 0; index < headline.length; index += 4) {
       if (
@@ -1262,16 +1263,41 @@ async function expectSocialImageText(page, image, expect) {
       }
     }
 
+    let badgePixels = 0
+    let slippyPixels = 0
+    for (let index = 0; index < platformBadge.length; index += 4) {
+      if (
+        platformBadge[index] < 50 &&
+        platformBadge[index + 1] < 50 &&
+        platformBadge[index + 2] < 55 &&
+        platformBadge[index + 3] > 0
+      ) {
+        badgePixels += 1
+      }
+      if (
+        platformBadge[index] < 90 &&
+        platformBadge[index + 1] > 140 &&
+        platformBadge[index + 2] > 190 &&
+        platformBadge[index + 3] > 0
+      ) {
+        slippyPixels += 1
+      }
+    }
+
     return {
       width: element.naturalWidth,
       height: element.naturalHeight,
-      darkPixels
+      darkPixels,
+      badgePixels,
+      slippyPixels
     }
   }, `data:image/png;base64,${image.toString('base64')}`)
 
   expect(metrics.width).toBe(1200)
   expect(metrics.height).toBe(630)
   expect(metrics.darkPixels > 500).toBe(true)
+  expect(metrics.badgePixels > 10000).toBe(true)
+  expect(metrics.slippyPixels > 200).toBe(true)
 }
 
 function helper(fn) {


### PR DESCRIPTION
## What changed

- keep the host app name and Bearing surface as the content identity on the left
- move the actual Slippy mark into a larger, self-contained Slipway platform tile in the far top-right
- label the platform tile explicitly and remove the duplicate bottom attribution
- verify the rendered tile and Slippy pixels through the real Bearing social-image browser trial

## Verification

- `npx sounding test --file tests/e2e/pages/projects/bearing.test.js --grep "Bearing public feedback feels app-owned" --test-concurrency=1 --compact`
- `npx prettier --check api/helpers/bearing/render-social-image.js tests/e2e/pages/projects/bearing.test.js`
- `npm run check:consistency`
- `git diff --check`

Fixes #445