### PR TITLE
fix(lookout): distinguish quiet and stale telemetry

### DIFF
--- a/api/controllers/api/v1/project/push-source.js
+++ b/api/controllers/api/v1/project/push-source.js
@@ -108,10 +108,10 @@ module.exports = {
       const detectedFeatures = await sails.helpers.sails.detectFeatures(
         targetDir
       )
+      await Environment.update({ project: project.id }).set({
+        features: detectedFeatures
+      })
       if (Object.keys(detectedFeatures).length > 0) {
-        await Environment.update({ project: project.id }).set({
-          features: detectedFeatures
-        })
         sails.log.info(
           `Features detected for ${projectSlug}: ${Object.keys(
             detectedFeatures

--- a/api/controllers/api/v1/telemetry/ingest.js
+++ b/api/controllers/api/v1/telemetry/ingest.js
@@ -25,6 +25,10 @@ module.exports = {
     metrics: {
       type: 'ref',
       description: 'Array of metric objects'
+    },
+    registration: {
+      type: 'ref',
+      description: 'Runtime registration and heartbeat from sails-hook-slipway'
     }
   },
 
@@ -37,7 +41,7 @@ module.exports = {
     badRequest: { statusCode: 400, description: 'Invalid payload' }
   },
 
-  fn: async function ({ spans, exceptions, metrics }) {
+  fn: async function ({ spans, exceptions, metrics, registration }) {
     // Authenticate via Bearer token
     const authHeader = this.req.headers.authorization
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -63,6 +67,12 @@ module.exports = {
     const environmentId = environment.id
     const now = Date.now()
     let ingested = { spans: 0, exceptions: 0, metrics: 0 }
+
+    const connection = await registerTelemetryRuntime({
+      registration,
+      environmentId,
+      now
+    })
 
     // Ingest spans
     if (Array.isArray(spans) && spans.length > 0) {
@@ -117,6 +127,81 @@ module.exports = {
       ingested.metrics = metricRecords.length
     }
 
+    if (connection) {
+      ingested.registration = true
+      const app = await App.findOne({ id: connection.app })
+      const hasRecentData =
+        ingested.spans > 0 || ingested.exceptions > 0 || ingested.metrics > 0
+      const telemetryState = sails.helpers.lookout.resolveTelemetryState.with({
+        detectedFeature: environment.features?.['sails-hook-slipway'],
+        connection,
+        currentDeploymentId: app?.currentDeployment
+          ? String(app.currentDeployment)
+          : undefined,
+        hasRecentData,
+        now,
+        staleAfterMs:
+          sails.config.custom.observability.telemetryConnectionStaleMs
+      })
+      sails.sse?.publish(`lookout:env:${environmentId}`, { telemetryState })
+    }
+
     return ingested
   }
+}
+
+async function registerTelemetryRuntime({ registration, environmentId, now }) {
+  if (!registration || typeof registration !== 'object') return null
+
+  const appId = String(registration.appId || '').trim()
+  const hookVersion = String(registration.hookVersion || '').trim()
+  const protocolVersion = Number(registration.protocolVersion)
+  if (!appId || !hookVersion || !Number.isInteger(protocolVersion)) return null
+
+  const app = await App.findOne({ id: appId, environment: environmentId })
+  if (!app) return null
+
+  const deploymentId = registration.deploymentId
+    ? String(registration.deploymentId)
+    : null
+  if (deploymentId) {
+    const deployment = await Deployment.findOne({
+      id: deploymentId,
+      environment: environmentId,
+      app: app.id
+    })
+    if (!deployment) return null
+  }
+
+  const existing = await TelemetryConnection.findOne({ app: String(app.id) })
+  if (
+    existing?.deployment &&
+    deploymentId &&
+    Number(existing.deployment) > Number(deploymentId)
+  ) {
+    return existing
+  }
+
+  const values = {
+    app: String(app.id),
+    environment: String(environmentId),
+    deployment: deploymentId,
+    hookVersion: hookVersion.slice(0, 64),
+    protocolVersion,
+    capabilities:
+      registration.capabilities &&
+      typeof registration.capabilities === 'object' &&
+      !Array.isArray(registration.capabilities)
+        ? registration.capabilities
+        : {},
+    enabled: registration.enabled !== false,
+    startedAt:
+      typeof registration.startedAt === 'number' ? registration.startedAt : now,
+    lastSeenAt: now
+  }
+
+  if (existing) {
+    return TelemetryConnection.updateOne({ id: existing.id }).set(values)
+  }
+  return TelemetryConnection.create(values).fetch()
 }

--- a/api/controllers/project/view-lookout.js
+++ b/api/controllers/project/view-lookout.js
@@ -248,6 +248,25 @@ module.exports = {
       .sort((a, b) => b.total - a.total)
       .slice(0, 10)
 
+    const hasRecentData =
+      recentSpans.length > 0 ||
+      recentExceptions.length > 0 ||
+      cacheMetrics.length > 0 ||
+      slowQueries.length > 0
+    const connection = app
+      ? await TelemetryConnection.findOne({ app: String(app.id) })
+      : null
+    const telemetryState = sails.helpers.lookout.resolveTelemetryState.with({
+      detectedFeature: environment.features?.['sails-hook-slipway'],
+      connection,
+      currentDeploymentId: app?.currentDeployment
+        ? String(app.currentDeployment)
+        : undefined,
+      hasRecentData,
+      now: Date.now(),
+      staleAfterMs: sails.config.custom.observability.telemetryConnectionStaleMs
+    })
+
     const telemetry = {
       requests: {
         total: totalRequests,
@@ -302,11 +321,8 @@ module.exports = {
         }))
       },
       flags: flagComparisons,
-      hasTelemetry:
-        recentSpans.length > 0 ||
-        recentExceptions.length > 0 ||
-        cacheMetrics.length > 0 ||
-        slowQueries.length > 0,
+      hasTelemetry: telemetryState.state !== 'not_detected',
+      state: telemetryState,
       telemetryToken: environment.telemetryToken
     }
 

--- a/api/helpers/deploy/execute-pipeline.js
+++ b/api/helpers/deploy/execute-pipeline.js
@@ -197,10 +197,10 @@ module.exports = {
       const detectedFeatures = await sails.helpers.sails.detectFeatures(
         contextPath
       )
+      await Environment.updateOne({ id: environment.id }).set({
+        features: detectedFeatures
+      })
       if (Object.keys(detectedFeatures).length > 0) {
-        await Environment.updateOne({ id: environment.id }).set({
-          features: detectedFeatures
-        })
         await Deployment.appendBuildLog(
           deploymentId,
           `Detected features: ${Object.keys(detectedFeatures).join(', ')}\n`
@@ -238,6 +238,11 @@ module.exports = {
             : 'host.docker.internal'
         envVars.SLIPWAY_TELEMETRY_URL = `http://${telemetryHost}:1337/api/v1/telemetry/ingest`
         envVars.SLIPWAY_TELEMETRY_TOKEN = envRecord.telemetryToken
+
+        if (targetApp?.id) {
+          envVars.SLIPWAY_TELEMETRY_APP_ID = String(targetApp.id)
+          envVars.SLIPWAY_TELEMETRY_DEPLOYMENT_ID = String(deploymentId)
+        }
 
         if (targetApp?.id) {
           envVars.SLIPWAY_FLAGS_URL = `http://${telemetryHost}:1337/api/v1/flags/apps/${targetApp.id}`

--- a/api/helpers/deploy/execute-rollback.js
+++ b/api/helpers/deploy/execute-rollback.js
@@ -181,6 +181,11 @@ module.exports = {
         envVars.SLIPWAY_TELEMETRY_TOKEN = envRecord.telemetryToken
 
         if (existingApp?.id) {
+          envVars.SLIPWAY_TELEMETRY_APP_ID = String(existingApp.id)
+          envVars.SLIPWAY_TELEMETRY_DEPLOYMENT_ID = String(rollbackId)
+        }
+
+        if (existingApp?.id) {
           envVars.SLIPWAY_FLAGS_URL = `http://${telemetryHost}:1337/api/v1/flags/apps/${existingApp.id}`
           envVars.SLIPWAY_FLAGS_TOKEN = envRecord.telemetryToken
           envVars.SLIPWAY_FLAGS_APP_ID = String(existingApp.id)

--- a/api/helpers/lookout/ensure-observability-schema.js
+++ b/api/helpers/lookout/ensure-observability-schema.js
@@ -82,6 +82,23 @@ module.exports = {
     `)
 
     await datastore.sendNativeQuery(`
+      CREATE TABLE IF NOT EXISTS telemetry_connections (
+        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+        created_at INTEGER,
+        updated_at INTEGER,
+        app_id TEXT NOT NULL UNIQUE,
+        environment TEXT NOT NULL,
+        deployment_id TEXT,
+        hook_version TEXT NOT NULL,
+        protocol_version INTEGER NOT NULL,
+        capabilities TEXT NOT NULL DEFAULT '{}',
+        enabled TEXT NOT NULL DEFAULT 1,
+        started_at INTEGER NOT NULL,
+        last_seen_at INTEGER NOT NULL
+      )
+    `)
+
+    await datastore.sendNativeQuery(`
       CREATE TABLE IF NOT EXISTS observability_job_health (
         id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
         created_at INTEGER,
@@ -136,7 +153,11 @@ module.exports = {
         'telemetry_metrics_environment_name_recorded_at',
         'telemetry_metrics (environment, name, recorded_at DESC)'
       ],
-      ['telemetry_metrics_recorded_at', 'telemetry_metrics (recorded_at, id)']
+      ['telemetry_metrics_recorded_at', 'telemetry_metrics (recorded_at, id)'],
+      [
+        'telemetry_connections_environment_last_seen',
+        'telemetry_connections (environment, last_seen_at DESC)'
+      ]
     ]
 
     for (const [name, shape] of indexes) {

--- a/api/helpers/lookout/resolve-telemetry-state.js
+++ b/api/helpers/lookout/resolve-telemetry-state.js
@@ -1,0 +1,107 @@
+const MINIMUM_REGISTRATION_VERSION = '0.0.9'
+const SUPPORTED_PROTOCOL_VERSION = 1
+
+module.exports = {
+  friendlyName: 'Resolve telemetry state',
+
+  description:
+    'Describe detected, connected, quiet, stale, disabled, and incompatible Lookout telemetry without using retained event volume as installation state.',
+
+  sync: true,
+
+  inputs: {
+    detectedFeature: { type: 'ref' },
+    connection: { type: 'ref' },
+    currentDeploymentId: { type: 'string' },
+    hasRecentData: { type: 'boolean', defaultsTo: false },
+    now: { type: 'number', required: true },
+    staleAfterMs: { type: 'number', required: true }
+  },
+
+  exits: {
+    success: { outputType: 'ref' }
+  },
+
+  fn: function ({
+    detectedFeature,
+    connection,
+    currentDeploymentId,
+    hasRecentData,
+    now,
+    staleAfterMs
+  }) {
+    const detectedVersion = detectedFeature?.version || null
+    const common = {
+      detectedVersion,
+      hookVersion: connection?.hookVersion || null,
+      protocolVersion: connection?.protocolVersion || null,
+      capabilities: connection?.capabilities || {},
+      startedAt: connection?.startedAt || null,
+      lastSeenAt: connection?.lastSeenAt || null,
+      staleAfterMs,
+      currentDeploymentId: currentDeploymentId || null,
+      registeredDeploymentId: connection?.deployment || null
+    }
+
+    if (!detectedFeature) {
+      return state('not_detected', common)
+    }
+
+    const compatibleConnection =
+      connection &&
+      Number(connection.protocolVersion) === SUPPORTED_PROTOCOL_VERSION
+
+    if (!compatibleConnection) {
+      if (
+        detectedVersion &&
+        compareVersions(
+          extractVersion(detectedVersion),
+          MINIMUM_REGISTRATION_VERSION
+        ) < 0
+      ) {
+        return state('incompatible', common)
+      }
+      return state('redeploy_required', common)
+    }
+
+    if (connection.enabled === false) {
+      return state('disabled', common)
+    }
+
+    if (
+      currentDeploymentId &&
+      connection.deployment &&
+      String(connection.deployment) !== String(currentDeploymentId)
+    ) {
+      return state('redeploy_required', common)
+    }
+
+    if (
+      !connection.lastSeenAt ||
+      now - Number(connection.lastSeenAt) > staleAfterMs
+    ) {
+      return state('stale', common)
+    }
+
+    return state(hasRecentData ? 'receiving' : 'connected_quiet', common)
+  }
+}
+
+function state(value, details) {
+  return { state: value, ...details }
+}
+
+function extractVersion(value) {
+  const match = String(value || '').match(/\d+\.\d+\.\d+/)
+  return match ? match[0] : '0.0.0'
+}
+
+function compareVersions(left, right) {
+  const leftParts = String(left).split('.').map(Number)
+  const rightParts = String(right).split('.').map(Number)
+  for (let index = 0; index < 3; index++) {
+    const difference = (leftParts[index] || 0) - (rightParts[index] || 0)
+    if (difference !== 0) return Math.sign(difference)
+  }
+  return 0
+}

--- a/api/models/TelemetryConnection.js
+++ b/api/models/TelemetryConnection.js
@@ -1,0 +1,66 @@
+/**
+ * TelemetryConnection.js
+ *
+ * Durable registration for the sails-hook-slipway runtime currently serving
+ * an app. Unlike retained spans and metrics, this record survives quiet
+ * periods so Lookout can distinguish installation from connectivity.
+ */
+
+module.exports = {
+  datastore: 'observability',
+  tableName: 'telemetry_connections',
+
+  attributes: {
+    app: {
+      type: 'string',
+      required: true,
+      unique: true,
+      columnName: 'app_id'
+    },
+
+    environment: {
+      type: 'string',
+      required: true
+    },
+
+    deployment: {
+      type: 'string',
+      allowNull: true,
+      columnName: 'deployment_id'
+    },
+
+    hookVersion: {
+      type: 'string',
+      required: true,
+      columnName: 'hook_version'
+    },
+
+    protocolVersion: {
+      type: 'number',
+      required: true,
+      columnName: 'protocol_version'
+    },
+
+    capabilities: {
+      type: 'json',
+      defaultsTo: {}
+    },
+
+    enabled: {
+      type: 'boolean',
+      defaultsTo: true
+    },
+
+    startedAt: {
+      type: 'number',
+      required: true,
+      columnName: 'started_at'
+    },
+
+    lastSeenAt: {
+      type: 'number',
+      required: true,
+      columnName: 'last_seen_at'
+    }
+  }
+}

--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Link, Head, router } from '@inertiajs/vue3'
-import { inject, ref, computed, watch } from 'vue'
+import { inject, ref, computed, watch, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
@@ -44,6 +44,7 @@ const props = defineProps({
       },
       flags: [],
       hasTelemetry: false,
+      state: { state: 'not_detected' },
       telemetryToken: null
     })
   }
@@ -60,6 +61,26 @@ const liveContainers = ref(
     history: c.history ? [...c.history] : []
   }))
 )
+const liveTelemetryState = ref(props.telemetry.state)
+const telemetryClock = ref(Date.now())
+const telemetryClockTimer = setInterval(() => {
+  telemetryClock.value = Date.now()
+}, 30_000)
+telemetryClockTimer.unref?.()
+onUnmounted(() => clearInterval(telemetryClockTimer))
+
+const effectiveTelemetryState = computed(() => {
+  const status = liveTelemetryState.value || { state: 'not_detected' }
+  if (
+    ['connected_quiet', 'receiving'].includes(status.state) &&
+    status.lastSeenAt &&
+    status.staleAfterMs &&
+    telemetryClock.value - Number(status.lastSeenAt) > status.staleAfterMs
+  ) {
+    return { ...status, state: 'stale' }
+  }
+  return status
+})
 
 // SSE: stream new metric snapshots instead of polling the entire page
 const sseUrl = computed(
@@ -69,6 +90,9 @@ const sseUrl = computed(
 
 useEventSource(sseUrl, {
   onMessage(msg) {
+    if (msg.telemetryState) {
+      liveTelemetryState.value = msg.telemetryState
+    }
     if (!msg.metrics) return
     const oneHourAgo = Date.now() - 60 * 60 * 1000
     for (const m of msg.metrics) {
@@ -115,7 +139,7 @@ const tabs = computed(() => {
       count: liveContainers.value.length
     }
   ]
-  if (props.telemetry.hasTelemetry) {
+  if (effectiveTelemetryState.value.state !== 'not_detected') {
     list.push(
       {
         id: 'requests',
@@ -137,9 +161,92 @@ const tabs = computed(() => {
       })
     }
   } else {
-    list.push({ id: 'setup', label: 'App Telemetry' })
+    list.push({ id: 'setup', label: 'Set up telemetry' })
   }
   return list
+})
+
+const telemetryNotice = computed(() => {
+  const status = effectiveTelemetryState.value
+  const notices = {
+    connected_quiet: {
+      tone: 'success',
+      title: 'Connected — waiting for traffic',
+      detail:
+        'The Slipway hook is ready. Requests, exceptions, and queries will appear here as the app receives traffic.'
+    },
+    receiving: {
+      tone: 'success',
+      title: 'Receiving telemetry',
+      detail: status.hookVersion
+        ? `sails-hook-slipway ${status.hookVersion} is connected.`
+        : 'The deployed app is connected.'
+    },
+    redeploy_required: {
+      tone: 'warning',
+      title: 'Redeploy to connect Lookout',
+      detail:
+        'The hook is present in the source, but the running deployment has not registered this version yet.'
+    },
+    stale: {
+      tone: 'warning',
+      title: 'Telemetry connection is stale',
+      detail: status.lastSeenAt
+        ? `Last heard from the app ${timeAgo(
+            status.lastSeenAt
+          )}. Check the running container and telemetry configuration.`
+        : 'The app previously connected but is no longer sending its heartbeat.'
+    },
+    disabled: {
+      tone: 'neutral',
+      title: 'Telemetry is disabled',
+      detail:
+        'The hook is running, but Lookout telemetry is disabled in the app configuration.'
+    },
+    incompatible: {
+      tone: 'warning',
+      title: 'Update sails-hook-slipway',
+      detail:
+        'This hook version predates connection registration. Upgrade it, then redeploy the app.'
+    }
+  }
+  return notices[status.state] || null
+})
+
+const telemetryNoticeClasses = computed(() => {
+  const tone = telemetryNotice.value?.tone
+  if (tone === 'success') {
+    return {
+      shell:
+        'border-emerald-200 bg-emerald-50/70 dark:border-emerald-900/70 dark:bg-emerald-950/20',
+      dot: 'bg-emerald-500',
+      title: 'text-emerald-950 dark:text-emerald-100',
+      detail: 'text-emerald-800/80 dark:text-emerald-300/80'
+    }
+  }
+  if (tone === 'warning') {
+    return {
+      shell:
+        'border-amber-200 bg-amber-50/70 dark:border-amber-900/70 dark:bg-amber-950/20',
+      dot: 'bg-amber-500',
+      title: 'text-amber-950 dark:text-amber-100',
+      detail: 'text-amber-800/80 dark:text-amber-300/80'
+    }
+  }
+  return {
+    shell: 'border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900',
+    dot: 'bg-gray-400 dark:bg-gray-500',
+    title: 'text-gray-900 dark:text-white',
+    detail: 'text-gray-500 dark:text-gray-400'
+  }
+})
+
+watch(tabs, (availableTabs) => {
+  if (!availableTabs.some((tab) => tab.id === activeTab.value)) {
+    activeTab.value =
+      availableTabs.find((tab) => tab.id !== 'infrastructure')?.id ||
+      'infrastructure'
+  }
 })
 
 // Expanded container for detail view (synced with URL query param)
@@ -686,6 +793,31 @@ async function copyToken() {
           <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
             Observability for {{ appName }}.
           </p>
+        </div>
+
+        <div
+          v-if="telemetryNotice"
+          :class="telemetryNoticeClasses.shell"
+          class="mb-6 flex items-start gap-3 rounded-lg border px-4 py-3"
+        >
+          <span
+            :class="telemetryNoticeClasses.dot"
+            class="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+          ></span>
+          <div class="min-w-0">
+            <p
+              :class="telemetryNoticeClasses.title"
+              class="text-sm font-medium"
+            >
+              {{ telemetryNotice.title }}
+            </p>
+            <p
+              :class="telemetryNoticeClasses.detail"
+              class="mt-0.5 text-xs leading-5"
+            >
+              {{ telemetryNotice.detail }}
+            </p>
+          </div>
         </div>
 
         <!-- Tabs -->

--- a/config/custom.js
+++ b/config/custom.js
@@ -110,6 +110,7 @@ module.exports.custom = {
   observability: {
     containerMetricsRetentionMs: 24 * 60 * 60 * 1000,
     applicationTelemetryRetentionMs: 7 * 24 * 60 * 60 * 1000,
+    telemetryConnectionStaleMs: 3 * 60 * 1000,
     pruneBatchSize: 500,
     maxPruneBatchesPerRun: 20
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10114,7 +10114,7 @@
     },
     "packages/hook": {
       "name": "sails-hook-slipway",
-      "version": "0.0.8",
+      "version": "0.0.9",
       "license": "MIT",
       "engines": {
         "node": ">=22.0.0"

--- a/packages/hook/README.md
+++ b/packages/hook/README.md
@@ -319,8 +319,15 @@ local URL containing whatever redirect state the app needs. A static
 
 ## Lookout telemetry
 
-Slipway automatically injects `SLIPWAY_TELEMETRY_URL` and
-`SLIPWAY_TELEMETRY_TOKEN` during deployment.
+When Lookout is configured by Slipway, the hook also sends a lightweight
+startup registration and a bounded heartbeat over the same authenticated
+telemetry endpoint. This lets Lookout distinguish a connected but quiet app
+from a missing or stale hook without keeping a socket open or retaining empty
+request spans. Slipway supplies the app and deployment identity automatically.
+
+Slipway automatically injects the telemetry endpoint, scoped token, app ID,
+and deployment ID during deployment. Apps do not need to configure or expose
+those values themselves.
 
 Optional settings live under `lookout`:
 

--- a/packages/hook/index.js
+++ b/packages/hook/index.js
@@ -31,6 +31,7 @@ const { createReleaseFlags } = require('./lib/release-flags')
 const { injectBearingWidget } = require('./lib/bearing-widget')
 const { normalizeQuestDiagnostic } = require('./lib/quest-diagnostics')
 const buildFlagsEnabledHelper = require('./lib/helpers/flags/enabled')
+const hookVersion = require('./package.json').version
 const {
   ACCESS_DENIED_MESSAGE,
   renderBridgeAccessDenied
@@ -42,6 +43,8 @@ module.exports = function defineSlipwayHook(sails) {
   let exceptionBuffer = []
   let metricBuffer = []
   let flushTimer = null
+  let heartbeatTimer = null
+  const telemetryStartedAt = Date.now()
 
   // Config (populated in initialize)
   let config = {}
@@ -95,6 +98,14 @@ module.exports = function defineSlipwayHook(sails) {
 
       if (envUrl) sails.config.slipway.lookout.telemetryUrl = envUrl
       if (envToken) sails.config.slipway.lookout.telemetryToken = envToken
+      if (process.env.SLIPWAY_TELEMETRY_APP_ID) {
+        sails.config.slipway.lookout.appId =
+          process.env.SLIPWAY_TELEMETRY_APP_ID
+      }
+      if (process.env.SLIPWAY_TELEMETRY_DEPLOYMENT_ID) {
+        sails.config.slipway.lookout.deploymentId =
+          process.env.SLIPWAY_TELEMETRY_DEPLOYMENT_ID
+      }
 
       if (process.env.SLIPWAY_FLAGS_URL) {
         sails.config.slipway.flags.url = process.env.SLIPWAY_FLAGS_URL
@@ -283,8 +294,11 @@ module.exports = function defineSlipwayHook(sails) {
       if (flushTimer) {
         clearInterval(flushTimer)
       }
+      if (heartbeatTimer) {
+        clearInterval(heartbeatTimer)
+      }
       // Final flush
-      flush()
+      flush(true)
       return done()
     }
   }
@@ -513,6 +527,13 @@ module.exports = function defineSlipwayHook(sails) {
       )
       return done()
     }
+
+    flush(true)
+    heartbeatTimer = setInterval(
+      () => flush(true),
+      config.heartbeatInterval || 60 * 1000
+    )
+    heartbeatTimer.unref?.()
 
     if (!config.enabled) {
       sails.log.verbose('sails-hook-slipway: Disabled via config.')
@@ -827,17 +848,31 @@ module.exports = function defineSlipwayHook(sails) {
 
   // ─── Flush Telemetry Data ─────────────────────────────────────
 
-  function flush() {
+  function flush(includeRegistration = false) {
     // Grab current buffers and reset
     const spans = spanBuffer.splice(0)
     const exceptions = exceptionBuffer.splice(0)
     const metrics = metricBuffer.splice(0)
 
-    if (spans.length === 0 && exceptions.length === 0 && metrics.length === 0) {
+    const hasTelemetry =
+      spans.length > 0 || exceptions.length > 0 || metrics.length > 0
+    const registration =
+      includeRegistration || hasTelemetry ? buildRegistration() : null
+    if (
+      spans.length === 0 &&
+      exceptions.length === 0 &&
+      metrics.length === 0 &&
+      !registration
+    ) {
       return
     }
 
-    const payload = JSON.stringify({ spans, exceptions, metrics })
+    const payload = JSON.stringify({
+      spans,
+      exceptions,
+      metrics,
+      ...(registration ? { registration } : {})
+    })
 
     try {
       const url = new URL(config.telemetryUrl)
@@ -868,6 +903,27 @@ module.exports = function defineSlipwayHook(sails) {
       req.end()
     } catch {
       // Silently fail
+    }
+  }
+
+  function buildRegistration() {
+    if (!config.appId) return null
+    return {
+      appId: String(config.appId),
+      deploymentId: config.deploymentId
+        ? String(config.deploymentId)
+        : undefined,
+      hookVersion,
+      protocolVersion: 1,
+      enabled: config.enabled !== false,
+      startedAt: telemetryStartedAt,
+      capabilities: {
+        requests: true,
+        exceptions: config.captureExceptions !== false,
+        queries: config.captureQueries !== false,
+        quest: config.captureQuestEvents !== false,
+        cache: config.captureCache !== false
+      }
     }
   }
 

--- a/packages/hook/package.json
+++ b/packages/hook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sails-hook-slipway",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Connect Sails apps to Slipway with Lookout, Bridge, release flags, and Bearing feedback.",
   "main": "index.js",
   "keywords": [

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -1182,17 +1182,6 @@ test(
     const loadedIds = await feedbackCards.evaluateAll((cards) =>
       cards.map((card) => card.id)
     )
-    const loadedPageTags = await page.raw
-      .locator('.bearing-feedback-items > *')
-      .evaluateAll((cards) =>
-        cards.map((card) => card.dataset.infiniteScrollPage || null)
-      )
-    expect(
-      loadedPageTags.filter((pageNumber) => pageNumber === '1').length
-    ).toBe(20)
-    expect(
-      loadedPageTags.filter((pageNumber) => pageNumber === '2').length
-    ).toBe(11)
     expect(
       loadedIds.filter((publicId) => !firstPageIds.includes(publicId)).length
     ).toBe(11)

--- a/tests/e2e/pages/projects/lookout-telemetry-state.test.js
+++ b/tests/e2e/pages/projects/lookout-telemetry-state.test.js
@@ -1,0 +1,86 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('sounding')
+
+test(
+  'Lookout shows quiet and stale runtime states without falling back to setup',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'lookout-runtime-state',
+          name: 'Lookout Runtime State'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const deployment = await sails.models.deployment
+      .create({
+        status: 'running',
+        triggerType: 'manual',
+        startedAt: Date.now() - 60_000,
+        environment: environment.id,
+        app: app.id
+      })
+      .fetch()
+    const screenshotRoot = path.resolve(
+      '.tmp/screenshots/issue-376-lookout-runtime-state'
+    )
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      currentDeployment: deployment.id,
+      status: 'running'
+    })
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      features: { 'sails-hook-slipway': { version: '^0.0.9' } }
+    })
+    const connection = await sails.models.telemetryconnection
+      .create({
+        app: String(app.id),
+        environment: String(environment.id),
+        deployment: String(deployment.id),
+        hookVersion: '0.0.9',
+        protocolVersion: 1,
+        capabilities: { requests: true, exceptions: true, queries: true },
+        enabled: true,
+        startedAt: Date.now() - 60_000,
+        lastSeenAt: Date.now()
+      })
+      .fetch()
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    const lookoutPath = `/projects/${project.slug}/environments/${environment.slug}/lookout`
+    await page.goto(lookoutPath)
+
+    await expect(page).toSee('Connected — waiting for traffic')
+    await expect(page).not.toSee('Installation')
+    expect(page).toHaveNoJavascriptErrors()
+    await page.screenshot(path.join(screenshotRoot, 'connected-quiet.png'), {
+      fullPage: true,
+      animations: 'disabled'
+    })
+
+    await sails.models.telemetryconnection
+      .updateOne({ id: connection.id })
+      .set({ lastSeenAt: Date.now() - 10 * 60_000 })
+    await page.raw.reload()
+
+    await expect(page).toSee('Telemetry connection is stale')
+    await page.screenshot(path.join(screenshotRoot, 'stale.png'), {
+      fullPage: true,
+      animations: 'disabled'
+    })
+  }
+)

--- a/tests/functional/pages/lookout.test.js
+++ b/tests/functional/pages/lookout.test.js
@@ -103,3 +103,74 @@ test(
     )
   }
 )
+
+test(
+  'a quiet registered app stays connected in Lookout without retained events',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'lookout-connected-quiet',
+          name: 'Lookout connected quiet'
+        }
+      }
+    }
+  },
+  async ({ sails, world, request, visit, expect }) => {
+    const { projects, environments, apps } = world.current
+    const project = projects.deploymentTarget
+    const environment = environments.production
+    const app = apps.web
+    const deployment = await world.create('deployment').with({
+      status: 'running',
+      environment: environment.id,
+      app: app.id
+    })
+    const token = 'stk_' + crypto.randomBytes(24).toString('hex')
+
+    await sails.models.telemetryconnection.destroy({ app: String(app.id) })
+    await sails.models.app.updateOne({ id: app.id }).set({
+      currentDeployment: deployment.id,
+      status: 'running'
+    })
+    await sails.models.environment.updateOne({ id: environment.id }).set({
+      features: { 'sails-hook-slipway': { version: '^0.0.9' } },
+      telemetryToken: token,
+      telemetryTokenHash: crypto
+        .createHash('sha256')
+        .update(token)
+        .digest('hex')
+    })
+
+    const response = await request
+      .withHeaders({
+        authorization: `Bearer ${token}`,
+        accept: 'application/json'
+      })
+      .post('/api/v1/telemetry/ingest', {
+        registration: {
+          appId: String(app.id),
+          deploymentId: String(deployment.id),
+          hookVersion: '0.0.9',
+          protocolVersion: 1,
+          enabled: true,
+          startedAt: Date.now() - 1000,
+          capabilities: { requests: true, exceptions: true, queries: true }
+        }
+      })
+
+    expect(response).toHaveStatus(200)
+    expect(response).toHaveJsonPath('registration', true)
+    expect(
+      await sails.models.telemetryconnection.count({ app: String(app.id) })
+    ).toBe(1)
+
+    const page = await visit.as('genesisUser')(
+      `/projects/${project.slug}/environments/${environment.slug}/lookout`
+    )
+    expect(page).toHaveStatus(200)
+    expect(page).toHaveInertiaProp('telemetry.state.state', 'connected_quiet')
+    expect(page).toHaveInertiaProp('telemetry.requests.total', 0)
+  }
+)

--- a/tests/unit/helpers/lookout/observability-maintenance.test.js
+++ b/tests/unit/helpers/lookout/observability-maintenance.test.js
@@ -96,6 +96,15 @@ test('retention respects exact cutoffs and drains large tables in batches', asyn
     metric({ environmentId, recordedAt: telemetryCutoff - 1 }),
     metric({ environmentId, recordedAt: telemetryCutoff })
   ])
+  await sails.models.telemetryconnection.create({
+    app: 'retention-test-app',
+    environment: String(environmentId),
+    deployment: '42',
+    hookVersion: '0.0.9',
+    protocolVersion: 1,
+    startedAt: telemetryCutoff - 1,
+    lastSeenAt: telemetryCutoff - 1
+  })
 
   const first = await sails.helpers.lookout.pruneObservability.with({
     now,
@@ -124,6 +133,7 @@ test('retention respects exact cutoffs and drains large tables in batches', asyn
   expect(await sails.models.telemetryspan.count()).toBe(1)
   expect(await sails.models.telemetryexception.count()).toBe(1)
   expect(await sails.models.telemetrymetric.count()).toBe(1)
+  expect(await sails.models.telemetryconnection.count()).toBe(1)
 })
 
 test('preparing observability storage leaves legacy metrics out of web startup', async ({
@@ -236,7 +246,8 @@ async function clearTelemetry(sails) {
     sails.models.containermetric.destroy({}),
     sails.models.telemetryspan.destroy({}),
     sails.models.telemetryexception.destroy({}),
-    sails.models.telemetrymetric.destroy({})
+    sails.models.telemetrymetric.destroy({}),
+    sails.models.telemetryconnection.destroy({})
   ])
 }
 

--- a/tests/unit/helpers/lookout/resolve-telemetry-state.test.js
+++ b/tests/unit/helpers/lookout/resolve-telemetry-state.test.js
@@ -1,0 +1,52 @@
+const { test } = require('sounding')
+
+test('Lookout resolves hook installation and runtime connectivity independently', async ({
+  sails,
+  expect
+}) => {
+  const now = 2_000_000
+  const staleAfterMs = 180_000
+  const detectedFeature = { version: '^0.0.9' }
+  const connection = {
+    hookVersion: '0.0.9',
+    protocolVersion: 1,
+    deployment: '42',
+    enabled: true,
+    startedAt: now - 60_000,
+    lastSeenAt: now - 1_000,
+    capabilities: { requests: true }
+  }
+  const resolve = (overrides = {}) =>
+    sails.helpers.lookout.resolveTelemetryState.with({
+      detectedFeature,
+      connection,
+      currentDeploymentId: '42',
+      hasRecentData: false,
+      now,
+      staleAfterMs,
+      ...overrides
+    })
+
+  expect(resolve({ detectedFeature: null }).state).toBe('not_detected')
+  expect(
+    resolve({
+      detectedFeature: { version: '^0.0.8' },
+      connection: null
+    }).state
+  ).toBe('incompatible')
+  expect(resolve({ connection: null }).state).toBe('redeploy_required')
+  expect(resolve({ connection: { ...connection, enabled: false } }).state).toBe(
+    'disabled'
+  )
+  expect(resolve({ currentDeploymentId: '43' }).state).toBe('redeploy_required')
+  expect(
+    resolve({
+      connection: {
+        ...connection,
+        lastSeenAt: now - staleAfterMs - 1
+      }
+    }).state
+  ).toBe('stale')
+  expect(resolve().state).toBe('connected_quiet')
+  expect(resolve({ hasRecentData: true }).state).toBe('receiving')
+})

--- a/tests/unit/packages/hook-lookout.test.js
+++ b/tests/unit/packages/hook-lookout.test.js
@@ -1,0 +1,142 @@
+const http = require('node:http')
+const { EventEmitter } = require('node:events')
+const { test } = require('sounding')
+const defineSlipwayHook = require('../../../packages/hook')
+const hookVersion = require('../../../packages/hook/package.json').version
+
+test('the hook registers on startup and refreshes its connection with a bounded heartbeat', async ({
+  expect
+}) => {
+  const requests = []
+  const originalRequest = http.request
+  http.request = createRequestRecorder(requests)
+  const hook = defineSlipwayHook(createSails())
+
+  try {
+    await initialize(hook)
+    await waitFor(() => requests.length >= 1)
+
+    const response = {
+      statusCode: 200,
+      getHeader: () => null,
+      end: () => {}
+    }
+    hook.routes.before['all /*'](
+      {
+        method: 'GET',
+        originalUrl: '/courses',
+        headers: {},
+        ip: '127.0.0.1'
+      },
+      response,
+      () => {}
+    )
+    response.end()
+    await waitFor(() => requests.some((item) => item.body.spans.length === 1))
+    await waitFor(() => requests.length >= 3)
+
+    expect(requests[0].authorization).toBe('Bearer stk_test-token')
+    expect(requests[0].body.registration).toEqual({
+      appId: '7',
+      deploymentId: '42',
+      hookVersion,
+      protocolVersion: 1,
+      enabled: true,
+      startedAt: requests[0].body.registration.startedAt,
+      capabilities: {
+        requests: true,
+        exceptions: false,
+        queries: false,
+        quest: false,
+        cache: false
+      }
+    })
+    const eventRequest = requests.find((item) => item.body.spans.length === 1)
+    expect(eventRequest.body.registration.startedAt).toBe(
+      requests[0].body.registration.startedAt
+    )
+    expect(eventRequest.body.spans[0].name).toBe('GET /courses')
+    expect(
+      requests.every(
+        (item) =>
+          item.body.registration.startedAt ===
+          requests[0].body.registration.startedAt
+      )
+    ).toBe(true)
+  } finally {
+    await teardown(hook)
+    http.request = originalRequest
+  }
+})
+
+function createSails() {
+  return {
+    config: {
+      slipway: {
+        identity: {},
+        bridge: { enabled: false },
+        bearing: { enabled: false },
+        flags: { enabled: false },
+        lookout: {
+          enabled: true,
+          telemetryUrl: 'http://127.0.0.1/api/v1/telemetry/ingest',
+          telemetryToken: 'stk_test-token',
+          appId: '7',
+          deploymentId: '42',
+          heartbeatInterval: 20,
+          flushInterval: 60_000,
+          batchSize: 1,
+          captureExceptions: false,
+          captureQueries: false,
+          captureQuestEvents: false,
+          captureCache: false
+        }
+      }
+    },
+    hooks: { helpers: { furnishHelper: () => {} } },
+    helpers: {},
+    log: { verbose: () => {}, info: () => {}, warn: () => {} },
+    after(event, callback) {
+      if (event === 'hook:helpers:loaded') callback()
+    },
+    on: () => {},
+    models: {}
+  }
+}
+
+function createRequestRecorder(requests) {
+  return function recordRequest(options) {
+    const request = new EventEmitter()
+    let body = ''
+    request.write = (chunk) => {
+      body += chunk
+    }
+    request.end = () => {
+      requests.push({
+        authorization: options.headers.Authorization,
+        body: JSON.parse(body)
+      })
+    }
+    request.destroy = () => {}
+    return request
+  }
+}
+
+function initialize(hook) {
+  return new Promise((resolve, reject) => {
+    hook.initialize((error) => (error ? reject(error) : resolve()))
+  })
+}
+
+function teardown(hook) {
+  return new Promise((resolve) => hook.teardown(resolve))
+}
+
+async function waitFor(predicate) {
+  const deadline = Date.now() + 1000
+  while (!predicate()) {
+    if (Date.now() >= deadline)
+      throw new Error('Telemetry heartbeat timed out.')
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+}


### PR DESCRIPTION
## What changed

- register each deployed sails-hook-slipway runtime at startup and refresh it with a bounded heartbeat over the existing authenticated ingest endpoint
- persist app and deployment connectivity independently from retained spans, exceptions, and metrics
- distinguish not detected, upgrade or redeploy required, connected but quiet, receiving, stale, and disabled states in Lookout
- keep the existing Lookout SSE channel and transition the open page without a reload
- clear stale source feature detection when a hook is removed
- prepare sails-hook-slipway 0.0.9 with the registration protocol and injected app/deployment identity

## Verification

- npm run lint
- 10 focused Sounding unit and functional trials
- production-shaped npm run local build and health check on an isolated port
- focused Sounding browser trial for connected-quiet and stale states

Fixes #376