### PR TITLE
feat(ui): adopt Klean Alert for operational notices

### DIFF
--- a/assets/js/components/UpdateModal.vue
+++ b/assets/js/components/UpdateModal.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { ref, watch, onUnmounted } from 'vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
+import Alert from '@/components/ui/alert/Alert.vue'
 import { useEventSource } from '@/composables/sse'
 
 const props = defineProps({
@@ -347,8 +348,9 @@ function formatDate(dateString) {
 
             <!-- Ready State -->
             <div v-else class="space-y-4">
-              <div
-                class="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800/50 dark:bg-amber-950/30"
+              <Alert
+                role="note"
+                class="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-inherit dark:border-amber-800/50 dark:bg-amber-950/30"
               >
                 <svg
                   class="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400"
@@ -366,7 +368,7 @@ function formatDate(dateString) {
                 <p class="text-sm text-amber-800 dark:text-amber-200">
                   Slipway will briefly go offline during the update.
                 </p>
-              </div>
+              </Alert>
               <div class="flex items-center justify-end space-x-3">
                 <button
                   @click="emit('close')"

--- a/assets/js/components/content/MarkdownEditor.vue
+++ b/assets/js/components/content/MarkdownEditor.vue
@@ -8,6 +8,7 @@ import FileHandler from '@tiptap/extension-file-handler'
 import Placeholder from '@tiptap/extension-placeholder'
 import { Markdown } from '@tiptap/markdown'
 import DOMPurify from 'dompurify'
+import Alert from '@/components/ui/alert/Alert.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import {
   inspectMarkdown,
@@ -561,7 +562,7 @@ defineExpose({
     ]"
     :aria-label="isField ? undefined : 'Content editor'"
   >
-    <div
+    <Alert
       v-if="mode === 'source' && shouldShowCompatibilityWarning"
       :data-test="testHandle('source-warning')"
       role="note"
@@ -595,7 +596,7 @@ defineExpose({
           Unsupported constructs: {{ issueLabels }}
         </p>
       </div>
-    </div>
+    </Alert>
 
     <div
       v-show="mode === 'visual'"

--- a/assets/js/components/ui/alert/Alert.vue
+++ b/assets/js/components/ui/alert/Alert.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+defineProps({
+  as: { type: [String, Object, Function], default: 'div' }
+})
+
+const attrs = useAttrs()
+const element = ref()
+
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <component
+    :is="as"
+    ref="element"
+    v-bind="forwardedAttrs"
+    data-slot="alert"
+    :class="
+      twMerge(
+        'relative w-full rounded-md bg-gray-100 p-4 text-sm text-gray-950 dark:bg-gray-900 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </component>
+</template>

--- a/assets/js/pages/projects/bearing.vue
+++ b/assets/js/pages/projects/bearing.vue
@@ -12,6 +12,7 @@ import {
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
+import Alert from '@/components/ui/alert/Alert.vue'
 import { useQueryState } from '@/composables/useQueryState'
 
 defineOptions({ layout: AppLayout })
@@ -379,10 +380,10 @@ function handleViewKeydown(event, index) {
           </button>
         </div>
 
-        <div
+        <Alert
           v-if="form.enabled && !hookDetected"
-          class="mt-8 rounded-xl bg-amber-50 px-4 py-3 dark:bg-amber-950/30"
-          role="status"
+          class="mt-8 rounded-xl bg-amber-50 px-4 py-3 text-inherit dark:bg-amber-950/30"
+          role="note"
         >
           <p class="text-sm font-medium text-amber-900 dark:text-amber-200">
             Update sails-hook-slipway, then redeploy this app.
@@ -391,7 +392,7 @@ function handleViewKeydown(event, index) {
             Public pages can be prepared now. The compatible hook will add the
             signed-in participant handshake and optional in-app widget.
           </p>
-        </div>
+        </Alert>
 
         <div
           ref="tablist"

--- a/assets/js/pages/projects/bridge-access.vue
+++ b/assets/js/pages/projects/bridge-access.vue
@@ -4,6 +4,7 @@ import { computed, inject, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import Alert from '@/components/ui/alert/Alert.vue'
 
 defineOptions({
   layout: AppLayout
@@ -266,10 +267,11 @@ function timeAgo(timestamp) {
           </div>
         </div>
 
-        <section
+        <Alert
           v-if="app.bridgeEnabled && !hookDetected"
+          as="section"
           class="mt-8 rounded-lg bg-amber-50 px-4 py-3 dark:bg-amber-950/30"
-          role="status"
+          role="note"
           data-test="bridge-hook-warning"
         >
           <p class="text-sm font-medium text-amber-900 dark:text-amber-200">
@@ -279,7 +281,7 @@ function timeAgo(timestamp) {
             The hook adds the secure <code>/bridge</code> entry point. Existing
             dashboard Bridge tools continue to work while you update.
           </p>
-        </section>
+        </Alert>
 
         <section
           v-else-if="app.bridgeEnabled"

--- a/assets/js/pages/projects/deployment.vue
+++ b/assets/js/pages/projects/deployment.vue
@@ -6,6 +6,7 @@ import Breadcrumb from '@/components/Breadcrumb.vue'
 import DeploymentOutcome from '@/components/DeploymentOutcome.vue'
 import LogViewer from '@/components/LogViewer.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
+import Alert from '@/components/ui/alert/Alert.vue'
 import { useEventSource } from '@/composables/sse'
 
 defineOptions({
@@ -528,11 +529,12 @@ function executeRollback() {
         </div>
 
         <!-- Failure summary remains visible even when the pipeline failed before logs started. -->
-        <section
+        <Alert
           v-if="deployment.errorMessage && deployment.status !== 'cancelled'"
-          role="alert"
+          as="section"
+          data-test="deployment-failure-summary"
           aria-labelledby="deployment-error-title"
-          class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 dark:border-red-900/60 dark:bg-red-950/30"
+          class="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-inherit dark:border-red-900/60 dark:bg-red-950/30"
         >
           <div class="flex items-start gap-3">
             <svg
@@ -567,7 +569,7 @@ function executeRollback() {
               </p>
             </div>
           </div>
-        </section>
+        </Alert>
 
         <!-- Log Viewer -->
         <div

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -13,6 +13,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
+import Alert from '@/components/ui/alert/Alert.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
@@ -1331,8 +1332,10 @@ onBeforeUnmount(() => {
           v-if="checklist && checklist.length > 0 && !checklistAllGood"
           class="mb-10"
         >
-          <div
-            class="rounded-lg border border-amber-200 bg-amber-50/50 dark:border-amber-900/50 dark:bg-amber-950/20"
+          <Alert
+            data-test="deployment-checklist"
+            role="note"
+            class="rounded-lg border border-amber-200 bg-amber-50/50 p-0 text-base text-inherit dark:border-amber-900/50 dark:bg-amber-950/20"
           >
             <div class="flex items-center gap-2 px-4 py-3">
               <svg
@@ -1359,10 +1362,10 @@ onBeforeUnmount(() => {
                 {{ checklistWarnings.length }}
               </span>
             </div>
-            <div
+            <ul
               class="divide-y divide-amber-200/50 border-t border-amber-200/50 dark:divide-amber-900/30 dark:border-amber-900/30"
             >
-              <div
+              <li
                 v-for="item in checklist"
                 :key="item.key"
                 class="flex items-start justify-between gap-3 px-4 py-2.5"
@@ -1424,14 +1427,15 @@ onBeforeUnmount(() => {
                 </div>
                 <button
                   v-if="item.action"
+                  type="button"
                   @click="handleChecklistAction(item.action)"
                   class="shrink-0 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-700 hover:bg-amber-100 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-400 dark:hover:bg-amber-900/50"
                 >
                   {{ item.action.label }}
                 </button>
-              </div>
-            </div>
-          </div>
+              </li>
+            </ul>
+          </Alert>
         </div>
 
         <!-- Accordion: Apps, Services, Env Vars -->
@@ -1539,6 +1543,8 @@ onBeforeUnmount(() => {
                   </div>
                   <div class="relative">
                     <button
+                      type="button"
+                      :data-test="`app-actions-${appItem.slug}`"
                       @click.stop="
                         appMenuOpen =
                           appMenuOpen === appItem.id ? null : appItem.id
@@ -1565,6 +1571,7 @@ onBeforeUnmount(() => {
                     >
                       <div
                         v-if="appMenuOpen === appItem.id"
+                        :data-test="`app-action-menu-${appItem.slug}`"
                         @click.stop
                         class="absolute right-0 top-full z-20 mt-1 w-56 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
                       >
@@ -1584,10 +1591,11 @@ onBeforeUnmount(() => {
                             :disabled="deployingAppId === appItem.id"
                             @deploy="deployApp(appItem)"
                           />
-                          <div
+                          <Alert
                             v-else
-                            role="alert"
-                            class="rounded-md bg-amber-50 p-3 dark:bg-amber-950/30"
+                            data-test="deployment-source-required"
+                            role="note"
+                            class="bg-amber-50 p-3 text-inherit dark:bg-amber-950/30"
                           >
                             <p
                               class="text-xs font-medium text-amber-900 dark:text-amber-200"
@@ -1605,7 +1613,7 @@ onBeforeUnmount(() => {
                             >
                               Repository settings
                             </Link>
-                          </div>
+                          </Alert>
                         </div>
                         <!-- Actions -->
                         <div

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -17,6 +17,7 @@ import HelmResultViewer from '@/components/HelmResultViewer.vue'
 import HelmScratchpadTabs from '@/components/HelmScratchpadTabs.vue'
 import HelmWorkspaceLibrary from '@/components/HelmWorkspaceLibrary.vue'
 import HelmWriteGuardDialog from '@/components/HelmWriteGuardDialog.vue'
+import Alert from '@/components/ui/alert/Alert.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import { useHelmScratchpads } from '@/composables/useHelmScratchpads'
 import { helmEditorDiagnostic } from '@/lib/helmResult'
@@ -992,13 +993,15 @@ watch(code, () => {
     />
 
     <!-- Not running warning -->
-    <div
+    <Alert
       v-if="!isRunning"
-      class="border-t border-amber-200 bg-amber-50 px-4 py-3 dark:border-amber-900/50 dark:bg-amber-900/10"
+      data-test="helm-not-running-notice"
+      role="note"
+      class="rounded-none border-t border-amber-200 bg-amber-50 px-4 py-3 text-inherit dark:border-amber-900/50 dark:bg-amber-900/10"
     >
       <p class="text-center text-sm text-amber-700 dark:text-amber-400">
         App not running. Deploy first to use Helm.
       </p>
-    </div>
+    </Alert>
   </div>
 </template>

--- a/tests/e2e/pages/projects/alert.test.js
+++ b/tests/e2e/pages/projects/alert.test.js
@@ -1,0 +1,178 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('sounding')
+
+const capturePhase = process.env.ALERT_SCREENSHOT_PHASE || 'after'
+const captureFollowupOnly = process.env.ALERT_FOLLOWUP_ONLY === '1'
+const screenshotRoot = path.resolve(
+  `.tmp/screenshots/issue-441-alert/${capturePhase}`
+)
+
+test(
+  'deployment notices preserve their visual and semantic contracts with Klean Alert',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'alert-visual-contract',
+          name: 'Alert visual contract',
+          failure:
+            'The container started, but the health check could not reach /health after 30 seconds. Review the configured health path and confirm the application listens on the assigned port before deploying again.'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const deployment = current.deployments.failed
+    const environmentPath = `/projects/${project.slug}/environments/${environment.slug}?apps=1`
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'stopped',
+      containerId: null,
+      containerName: null
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+
+    if (captureFollowupOnly) {
+      await page.raw.setViewportSize({ width: 1440, height: 1000 })
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.goto(
+        `/projects/${project.slug}/environments/${environment.slug}/helm?appSlug=${app.slug}`
+      )
+      const helmNotice = page.raw.locator(
+        '[data-test="helm-not-running-notice"]'
+      )
+      await expect(helmNotice).toBeVisible()
+      await helmNotice.screenshot({
+        path: path.join(screenshotRoot, 'helm-not-running-light.png')
+      })
+      expect(page).toHaveNoJavascriptErrors()
+      return
+    }
+
+    await page.goto(environmentPath)
+
+    const checklist = page.raw.locator('[data-test="deployment-checklist"]')
+    await expect(checklist).toBeVisible()
+    await expect(checklist).toContainText('Deployment checklist')
+    await expect(checklist).toContainText('Generate')
+    expect(await checklist.locator('ul > li').count()).toBe(2)
+    await checklist.screenshot({
+      path: path.join(screenshotRoot, 'checklist-desktop-light.png')
+    })
+
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await checklist.screenshot({
+      path: path.join(screenshotRoot, 'checklist-desktop-dark.png')
+    })
+
+    await page.raw.setViewportSize({ width: 390, height: 844 })
+    await checklist.screenshot({
+      path: path.join(screenshotRoot, 'checklist-mobile-dark.png')
+    })
+
+    await page.raw.setViewportSize({ width: 1440, height: 1000 })
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+
+    let checklistSaveRequests = 0
+    const countChecklistSave = (request) => {
+      if (
+        request.method() === 'PATCH' &&
+        new URL(request.url()).pathname ===
+          `/api/v1/projects/${project.slug}/environments/${environment.slug}`
+      ) {
+        checklistSaveRequests += 1
+      }
+    }
+    page.raw.on('request', countChecklistSave)
+    const checklistSaveFinished = page.raw.waitForResponse(
+      (response) =>
+        response.request().method() === 'PATCH' &&
+        new URL(response.url()).pathname ===
+          `/api/v1/projects/${project.slug}/environments/${environment.slug}`
+    )
+    await checklist.getByRole('button', { name: 'Generate' }).click()
+    await checklistSaveFinished
+    page.raw.off('request', countChecklistSave)
+    expect(checklistSaveRequests).toBe(1)
+
+    const appActions = page.raw.locator(`[data-test="app-actions-${app.slug}"]`)
+    await appActions.focus()
+    await appActions.press('Enter')
+
+    const sourceRequired = page.raw.locator(
+      '[data-test="deployment-source-required"]'
+    )
+    await expect(sourceRequired).toBeVisible()
+    await expect(sourceRequired).toContainText('Deployment source required')
+    await expect(
+      sourceRequired.getByRole('link', { name: 'Repository settings' })
+    ).toHaveAttribute(
+      'href',
+      `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/settings`
+    )
+    await page.raw
+      .locator(`[data-test="app-action-menu-${app.slug}"]`)
+      .screenshot({
+        path: path.join(screenshotRoot, 'source-required-menu-light.png')
+      })
+
+    if (capturePhase === 'after') {
+      expect(await checklist.getAttribute('data-slot')).toBe('alert')
+      expect(await sourceRequired.getAttribute('data-slot')).toBe('alert')
+      expect(await checklist.getAttribute('role')).toBe('note')
+      expect(await sourceRequired.getAttribute('role')).toBe('note')
+    }
+
+    await page.goto(`/projects/${project.slug}/deployments/${deployment.id}`)
+    const failureSummary = page.raw.locator(
+      '[data-test="deployment-failure-summary"]'
+    )
+    await expect(failureSummary).toBeVisible()
+    await expect(failureSummary).toContainText('Deployment failed')
+    await expect(failureSummary).toContainText(
+      'The container started, but the health check could not reach /health'
+    )
+    await failureSummary.screenshot({
+      path: path.join(screenshotRoot, 'failure-summary-light.png')
+    })
+
+    if (capturePhase === 'after') {
+      expect(await failureSummary.getAttribute('data-slot')).toBe('alert')
+      expect(await failureSummary.getAttribute('role')).toBe(null)
+      expect(await failureSummary.evaluate((element) => element.tagName)).toBe(
+        'SECTION'
+      )
+    }
+
+    await page.goto(
+      `/projects/${project.slug}/environments/${environment.slug}/helm?appSlug=${app.slug}`
+    )
+    const helmNotice = page.raw.locator('[data-test="helm-not-running-notice"]')
+    await expect(helmNotice).toBeVisible()
+    await expect(helmNotice).toContainText(
+      'App not running. Deploy first to use Helm.'
+    )
+    await helmNotice.screenshot({
+      path: path.join(screenshotRoot, 'helm-not-running-light.png')
+    })
+
+    if (capturePhase === 'after') {
+      expect(await helmNotice.getAttribute('data-slot')).toBe('alert')
+      expect(await helmNotice.getAttribute('role')).toBe('note')
+    }
+
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)


### PR DESCRIPTION
## Summary

- install the source-owned Klean UI `Alert` from `sailscastshq/klean-ui@a57bab6`
- migrate the deployment checklist, source-required guidance, and failure summary without changing their application-owned anatomy or styling
- migrate genuine shallow notices in Markdown Editor, Helm, Bearing, Bridge, and the update modal
- render checklist entries as a native list and choose roles from the real server-rendered lifecycle
- add focused Sounding coverage for actions, durable links, keyboard access, conditional visibility, native semantics, and Alert source adoption

## Alert audit

Migrated as shallow notices:

- Markdown compatibility guidance
- Helm app-not-running guidance
- Bearing hook compatibility guidance
- Bridge hook compatibility guidance
- pre-update downtime guidance

Kept separate by design:

- field and dialog validation remain field feedback
- update failure recovery remains Error State
- transient action feedback remains Toast
- badges, status dots, destructive rows, log coloring, and ordinary update-page prose remain their existing patterns

## Semantics

- static and server-rendered supporting guidance uses `role="note"`
- the deployment failure remains a native `section` labelled by `deployment-error-title`
- the server-rendered failure does not use `role="alert"`, avoiding an assertive re-announcement after Inertia reload
- the repository settings destination remains a real Inertia link

## Visual acceptance

The Sounding browser trial captured identical before/after data and routes for:

- checklist: desktop light, desktop dark, and narrow mobile dark
- source-required application menu
- long wrapping deployment failure
- Helm operational notice

All six image comparisons preserve dimensions and report **0 changed pixels**.

## Verification

- `npm run lint`
- `npm run check:consistency`
- focused Alert Sounding browser trial
- Markdown editor unit trials
- Bearing and Bridge functional trials
- existing deployment failure, Bearing, and Bridge browser trials
- installed Alert matches the formatted Klean registry source exactly
- no runtime Klean dependency, config file, theme API, severity variant, compound anatomy, or barrel file

The full unit lane reached 296 passing trials before one Sails lift timeout contaminated the shared SQLite adapter and cascaded into unrelated failures. The first failure and a representative downstream file both pass cleanly in isolation; GitHub CI runs from a fresh process.

Fixes #441
