### PR TITLE
feat(ui): adopt Klean Pagination across server lists

### DIFF
--- a/assets/js/components/ui/pagination/Pagination.vue
+++ b/assets/js/components/ui/pagination/Pagination.vue
@@ -1,0 +1,292 @@
+<script setup>
+import { Link, router, usePage } from '@inertiajs/vue3'
+import { computed, nextTick, onBeforeUnmount, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Server-provided current page. */
+  page: { type: [Number, String], required: true },
+  /** Server-provided total number of pages. */
+  pages: { type: [Number, String], required: true },
+  /** Optional Inertia partial-reload prop names. */
+  only: { type: Array, default: () => [] }
+})
+
+const attrs = useAttrs()
+const inertiaPage = usePage()
+const root = ref()
+const pendingPage = ref()
+const lastIntent = ref()
+
+const LINK_CLASSES =
+  'inline-flex min-h-11 min-w-11 cursor-pointer items-center justify-center gap-2 rounded-md border border-gray-200 bg-white px-3 text-sm font-medium text-gray-700 no-underline transition-colors hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200 dark:hover:bg-gray-900 dark:focus-visible:outline-white'
+const CURRENT_CLASSES =
+  'border-gray-950 bg-gray-950 text-white hover:bg-gray-950 dark:border-white dark:bg-white dark:text-gray-950 dark:hover:bg-white'
+const DISABLED_CLASSES =
+  'inline-flex min-h-11 min-w-11 cursor-not-allowed items-center justify-center gap-2 rounded-md border border-gray-200 bg-gray-50 px-3 text-sm font-medium text-gray-400 opacity-70 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-600'
+
+function positiveInteger(value, fallback = 1) {
+  const number = Math.trunc(Number(value))
+  return Number.isFinite(number) && number > 0 ? number : fallback
+}
+
+function pageWindow(current, total) {
+  if (total <= 7) return Array.from({ length: total }, (_, index) => index + 1)
+
+  const visible = new Set([1, total, current - 1, current, current + 1])
+  if (current <= 4) [2, 3, 4, 5].forEach((value) => visible.add(value))
+  if (current >= total - 3) {
+    ;[total - 4, total - 3, total - 2, total - 1].forEach((value) =>
+      visible.add(value)
+    )
+  }
+
+  const ordered = [...visible]
+    .filter((value) => value >= 1 && value <= total)
+    .sort((a, b) => a - b)
+
+  return ordered.flatMap((value, index) => {
+    const previous = ordered[index - 1]
+    return index > 0 && value - previous > 1 ? [null, value] : [value]
+  })
+}
+
+function browserUrl() {
+  if (typeof window === 'undefined') return '/'
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`
+}
+
+function hrefFor(source, target) {
+  const raw = source || '/'
+  const absolute = /^[a-z][a-z\d+.-]*:/i.test(raw)
+  const url = new URL(raw, 'http://klean.invalid')
+
+  if (target === 1) url.searchParams.delete('page')
+  else url.searchParams.set('page', String(target))
+
+  return absolute ? url.href : `${url.pathname}${url.search}${url.hash}`
+}
+
+const totalPages = computed(() => positiveInteger(props.pages))
+const currentPage = computed(() =>
+  Math.min(positiveInteger(props.page), totalPages.value)
+)
+const items = computed(() => pageWindow(currentPage.value, totalPages.value))
+const currentUrl = computed(() => inertiaPage.url || browserUrl())
+const label = computed(() => attrs['aria-label'] || 'Pagination')
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    'aria-label': _ariaLabel,
+    'aria-busy': _ariaBusy,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function start(target) {
+  pendingPage.value = target
+  lastIntent.value = target
+}
+
+async function settleIntent() {
+  const target = lastIntent.value
+  pendingPage.value = undefined
+  lastIntent.value = undefined
+  if (!target) return
+
+  await nextTick()
+  if (currentPage.value !== target) return
+  if (!root.value?.contains(document.activeElement)) {
+    root.value
+      ?.querySelector(`[data-slot="page"][data-page="${target}"]`)
+      ?.focus({ preventScroll: true })
+  }
+}
+
+function clearInterrupted(event) {
+  if (event.detail.visit.completed) return
+  pendingPage.value = undefined
+  lastIntent.value = undefined
+}
+
+const stopListeningForNavigation = router.on('navigate', settleIntent)
+const stopListeningForFinish = router.on('finish', clearInterrupted)
+onBeforeUnmount(() => {
+  stopListeningForNavigation()
+  stopListeningForFinish()
+})
+
+function linkProps(target) {
+  return {
+    href: hrefFor(currentUrl.value, target),
+    only: props.only,
+    preserveScroll: true,
+    preserveState: true
+  }
+}
+</script>
+
+<template>
+  <nav
+    v-if="totalPages > 1"
+    ref="root"
+    v-bind="rootAttrs"
+    data-slot="pagination"
+    :aria-label="label"
+    :aria-busy="pendingPage ? 'true' : undefined"
+    :class="twMerge('w-full', attrs.class)"
+  >
+    <ul class="flex items-center justify-between gap-2 sm:justify-center">
+      <li>
+        <Link
+          v-if="currentPage > 1"
+          v-bind="linkProps(currentPage - 1)"
+          data-slot="previous"
+          :data-page="currentPage - 1"
+          :data-pending="pendingPage === currentPage - 1 ? '' : undefined"
+          :aria-label="`Go to page ${currentPage - 1}`"
+          :class="LINK_CLASSES"
+          @start="start(currentPage - 1)"
+        >
+          <svg
+            aria-hidden="true"
+            class="size-4"
+            viewBox="0 0 20 20"
+            fill="none"
+          >
+            <path
+              d="m12.5 15-5-5 5-5"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <span class="hidden sm:inline">Previous</span>
+        </Link>
+        <span
+          v-else
+          data-slot="previous"
+          aria-disabled="true"
+          :class="DISABLED_CLASSES"
+        >
+          <svg
+            aria-hidden="true"
+            class="size-4"
+            viewBox="0 0 20 20"
+            fill="none"
+          >
+            <path
+              d="m12.5 15-5-5 5-5"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+          <span class="hidden sm:inline">Previous</span>
+        </span>
+      </li>
+
+      <li class="sm:hidden">
+        <span
+          data-slot="summary"
+          aria-current="page"
+          class="px-2 text-sm tabular-nums text-gray-600 dark:text-gray-300"
+        >
+          Page {{ currentPage }} of {{ totalPages }}
+        </span>
+      </li>
+
+      <li
+        v-for="(item, index) in items"
+        :key="item ?? `ellipsis-${index}`"
+        class="hidden sm:block"
+      >
+        <span
+          v-if="item === null"
+          data-slot="ellipsis"
+          class="min-h-11 min-w-8 inline-flex items-center justify-center text-sm text-gray-400 dark:text-gray-500"
+        >
+          <span aria-hidden="true">…</span>
+          <span class="sr-only">More pages</span>
+        </span>
+        <Link
+          v-else
+          v-bind="linkProps(item)"
+          data-slot="page"
+          :data-page="item"
+          :data-state="item === currentPage ? 'current' : undefined"
+          :data-pending="pendingPage === item ? '' : undefined"
+          :aria-current="item === currentPage ? 'page' : undefined"
+          :aria-label="
+            item === currentPage
+              ? `Page ${item}, current page`
+              : `Go to page ${item}`
+          "
+          :class="
+            twMerge(LINK_CLASSES, item === currentPage && CURRENT_CLASSES)
+          "
+          @start="start(item)"
+        >
+          {{ item }}
+        </Link>
+      </li>
+
+      <li>
+        <Link
+          v-if="currentPage < totalPages"
+          v-bind="linkProps(currentPage + 1)"
+          data-slot="next"
+          :data-page="currentPage + 1"
+          :data-pending="pendingPage === currentPage + 1 ? '' : undefined"
+          :aria-label="`Go to page ${currentPage + 1}`"
+          :class="LINK_CLASSES"
+          @start="start(currentPage + 1)"
+        >
+          <span class="hidden sm:inline">Next</span>
+          <svg
+            aria-hidden="true"
+            class="size-4"
+            viewBox="0 0 20 20"
+            fill="none"
+          >
+            <path
+              d="m7.5 5 5 5-5 5"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </Link>
+        <span
+          v-else
+          data-slot="next"
+          aria-disabled="true"
+          :class="DISABLED_CLASSES"
+        >
+          <span class="hidden sm:inline">Next</span>
+          <svg
+            aria-hidden="true"
+            class="size-4"
+            viewBox="0 0 20 20"
+            fill="none"
+          >
+            <path
+              d="m7.5 5 5 5-5 5"
+              stroke="currentColor"
+              stroke-width="1.75"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </span>
+      </li>
+    </ul>
+  </nav>
+</template>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -11,6 +11,7 @@ import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
+import Pagination from '@/components/ui/pagination/Pagination.vue'
 
 defineOptions({
   layout: BridgePageLayout
@@ -86,7 +87,6 @@ const tableReloadProps = [
 ]
 
 // Local state for UI
-const page = ref(props.currentPage)
 const sortValue = ref(props.sort)
 const searchInput = ref(props.search)
 const filtersValue = ref(props.filterState || {})
@@ -243,17 +243,10 @@ watch(
     sortValue.value = value
   }
 )
-watch(
-  () => props.currentPage,
-  (value) => {
-    page.value = value
-  }
-)
-
 // Navigate with updated params
 function navigateWithParams(updates, visitOptions = {}) {
   const params = {
-    page: updates.page ?? page.value,
+    page: updates.page ?? props.currentPage,
     sort: updates.sort ?? sortValue.value,
     search: updates.search ?? searchInput.value,
     filters: JSON.stringify(updates.filters ?? filtersValue.value),
@@ -305,7 +298,6 @@ const hasScopedQuery = computed(
 
 function applyFilters(filters) {
   filtersValue.value = filters
-  page.value = 1
   navigateWithParams({ filters, page: 1 })
 }
 
@@ -314,7 +306,6 @@ function switchLens(event) {
   lensValue.value = lens
   filtersValue.value = {}
   sortValue.value = ''
-  page.value = 1
   navigateWithParams({ lens, filters: {}, sort: '', page: 1 })
 }
 
@@ -483,12 +474,6 @@ function clearSelection() {
 function completeCustomAction() {
   if (actionDialog.value.action?.scope === 'bulk') clearSelection()
   actionDialog.value = { show: false, action: null, recordIds: [] }
-}
-
-// Pagination
-function goToPage(newPage) {
-  page.value = newPage
-  navigateWithParams({ page: newPage })
 }
 
 function switchDashboard(event) {
@@ -1005,7 +990,6 @@ function createUrl() {
       </div>
     </div>
 
-    <!-- Pagination -->
     <div
       v-if="totalPages > 1"
       class="border-t border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-8"
@@ -1014,22 +998,13 @@ function createUrl() {
         <div class="text-xs text-gray-500 dark:text-gray-400">
           Page {{ currentPage }} of {{ totalPages }}
         </div>
-        <div class="flex items-center space-x-2">
-          <button
-            @click="goToPage(Math.max(1, currentPage - 1))"
-            :disabled="currentPage <= 1"
-            class="rounded-md border border-gray-200 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-          >
-            Previous
-          </button>
-          <button
-            @click="goToPage(Math.min(totalPages, currentPage + 1))"
-            :disabled="currentPage >= totalPages"
-            class="rounded-md border border-gray-200 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-40 dark:border-gray-700 dark:text-gray-300 dark:hover:bg-gray-800"
-          >
-            Next
-          </button>
-        </div>
+        <Pagination
+          :page="currentPage"
+          :pages="totalPages"
+          :only="tableReloadProps"
+          data-test="bridge-pagination"
+          class="[&_[data-slot=ellipsis]]:min-h-8 [&_[data-slot=ellipsis]]:min-w-6 [&_[data-slot=next]]:min-h-8 [&_[data-slot=next]]:min-w-8 [&_[data-slot=page]]:min-h-8 [&_[data-slot=page]]:min-w-8 [&_[data-slot=previous]]:min-h-8 [&_[data-slot=previous]]:min-w-8 w-auto [&>ul]:justify-end [&_[data-slot=next]]:px-2.5 [&_[data-slot=next]]:text-xs [&_[data-slot=page]]:px-2 [&_[data-slot=page]]:text-xs [&_[data-slot=previous]]:px-2.5 [&_[data-slot=previous]]:text-xs"
+        />
       </div>
     </div>
   </div>

--- a/assets/js/pages/settings/audit-log.vue
+++ b/assets/js/pages/settings/audit-log.vue
@@ -2,6 +2,7 @@
 import { Head, Link, router } from '@inertiajs/vue3'
 import { computed, inject, onBeforeUnmount, ref, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Pagination from '@/components/ui/pagination/Pagination.vue'
 
 defineOptions({
   layout: AppLayout
@@ -63,18 +64,17 @@ const resultRange = computed(() => {
 watch([query, group], ([, nextGroup], [, previousGroup]) => {
   window.clearTimeout(searchTimer)
   searchTimer = window.setTimeout(
-    () => fetchLogs(1),
+    () => refreshLogs(),
     nextGroup !== previousGroup ? 0 : 220
   )
 })
 
 onBeforeUnmount(() => window.clearTimeout(searchTimer))
 
-function fetchLogs(page) {
+function refreshLogs() {
   router.get(
     '/settings/audit-log',
     {
-      page,
       q: query.value.trim() || undefined,
       group: group.value === 'all' ? undefined : group.value
     },
@@ -421,24 +421,13 @@ function shortHash(hash) {
             Helm audit events are retained for
             {{ helmAuditRetentionDays }} days.
           </p>
-          <div v-if="pagination.totalPages > 1" class="flex items-center gap-1">
-            <button
-              type="button"
-              :disabled="pagination.page <= 1"
-              class="disabled:opacity-35 rounded-md px-2.5 py-1.5 font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
-              @click="fetchLogs(pagination.page - 1)"
-            >
-              Previous
-            </button>
-            <button
-              type="button"
-              :disabled="pagination.page >= pagination.totalPages"
-              class="disabled:opacity-35 rounded-md px-2.5 py-1.5 font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-900 disabled:cursor-not-allowed dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white"
-              @click="fetchLogs(pagination.page + 1)"
-            >
-              Next
-            </button>
-          </div>
+          <Pagination
+            :page="pagination.page"
+            :pages="pagination.totalPages"
+            :only="['logs', 'pagination', 'filters', 'helmAuditRetentionDays']"
+            data-test="audit-pagination"
+            class="[&_[data-slot=ellipsis]]:min-h-8 [&_[data-slot=ellipsis]]:min-w-6 [&_[data-slot=next]]:min-h-8 [&_[data-slot=next]]:min-w-8 [&_[data-slot=page]]:min-h-8 [&_[data-slot=page]]:min-w-8 [&_[data-slot=previous]]:min-h-8 [&_[data-slot=previous]]:min-w-8 w-auto [&>ul]:justify-end [&_[data-slot=next]]:border-0 [&_[data-slot=next]]:bg-transparent [&_[data-slot=next]]:px-2.5 [&_[data-slot=next]]:text-xs [&_[data-slot=page]]:border-0 [&_[data-slot=page]]:px-2 [&_[data-slot=page]]:text-xs [&_[data-slot=previous]]:border-0 [&_[data-slot=previous]]:bg-transparent [&_[data-slot=previous]]:px-2.5 [&_[data-slot=previous]]:text-xs"
+          />
         </footer>
       </div>
     </main>

--- a/tests/e2e/pages/pagination.test.js
+++ b/tests/e2e/pages/pagination.test.js
@@ -1,0 +1,332 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const capturePhase = process.env.PAGINATION_SCREENSHOT_PHASE || 'after'
+const screenshotRoot = path.resolve(
+  `.tmp/screenshots/issue-347-pagination/${capturePhase}`
+)
+
+test(
+  'Bridge pagination keeps the complete resource URL durable',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'pagination-contract',
+          name: 'Pagination contract'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const originals = {
+      loadResource: sails.helpers.bridge.loadResource,
+      queryResource: sails.helpers.bridge.queryResource,
+      redactResourceRecords: sails.helpers.bridge.redactResourceRecords
+    }
+    const resource = paginationResource()
+    const total = 22
+
+    await sails.models.app.updateOne({ id: app.id }).set({
+      status: 'running',
+      containerName: 'pagination-contract-web'
+    })
+
+    sails.helpers.bridge.loadResource = {
+      with: async () => ({
+        resource,
+        contract: {
+          models: { course: resource },
+          dashboards: {}
+        }
+      })
+    }
+    sails.helpers.bridge.queryResource = {
+      with: async ({ query }) => ({
+        records: pageRecords(query.page, query.perPage, total),
+        total
+      })
+    }
+    sails.helpers.bridge.redactResourceRecords = {
+      with: async ({ records }) => records
+    }
+
+    try {
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await page.raw.setViewportSize({ width: 1440, height: 900 })
+
+      const filters = JSON.stringify({
+        status: { operator: 'equals', value: 'published' }
+      })
+      const query = new URLSearchParams({
+        page: '2',
+        perPage: '5',
+        search: 'Durable',
+        sort: 'title DESC',
+        filters,
+        lens: 'recent',
+        dashboard: 'operators'
+      })
+      const bridgePath = `/projects/${project.slug}/environments/${environment.slug}/bridge/course?${query}`
+
+      await page.goto(bridgePath)
+      await page.wait('text=Durable course 6')
+      await page.screenshot(
+        path.join(screenshotRoot, 'bridge-pagination-light.png'),
+        { fullPage: true }
+      )
+
+      await page.raw.emulateMedia({ colorScheme: 'dark' })
+      await page.screenshot(
+        path.join(screenshotRoot, 'bridge-pagination-dark.png'),
+        { fullPage: true }
+      )
+      await page.raw.emulateMedia({ colorScheme: 'light' })
+
+      if (capturePhase === 'after') {
+        const pagination = page.raw.locator('[data-test="bridge-pagination"]')
+        await expect(pagination).toBeVisible()
+        await expect(pagination).toHaveAttribute('data-slot', 'pagination')
+
+        const previous = pagination.locator('[data-slot="previous"]')
+        const next = pagination.locator('[data-slot="next"]')
+        const previousUrl = new URL(
+          await previous.getAttribute('href'),
+          'http://slipway.test'
+        )
+        const nextUrl = new URL(
+          await next.getAttribute('href'),
+          'http://slipway.test'
+        )
+
+        expect(previousUrl.searchParams.has('page')).toBe(false)
+        expect(nextUrl.searchParams.get('page')).toBe('3')
+        assertResourceQuery(expect, previousUrl, filters)
+        assertResourceQuery(expect, nextUrl, filters)
+
+        let partialReload
+        page.raw.on('request', (request) => {
+          if (
+            request.headers()['x-inertia'] === 'true' &&
+            new URL(request.url()).searchParams.get('page') === '3'
+          ) {
+            partialReload = request.headers()['x-inertia-partial-data']
+          }
+        })
+
+        await next.click()
+        await page.raw.waitForURL((url) => url.searchParams.get('page') === '3')
+        expect(partialReload).toBe(
+          'records,total,totalPages,currentPage,perPage,sort,search,filterState,filterDefinitions,columns,lenses,activeLens,error'
+        )
+
+        await page.back()
+        await page.raw.waitForURL((url) => url.searchParams.get('page') === '2')
+        await page.forward()
+        await page.raw.waitForURL((url) => url.searchParams.get('page') === '3')
+
+        await page.raw.locator('[data-slot="page"][data-page="4"]').click()
+        await page.raw.waitForURL((url) => url.searchParams.get('page') === '4')
+        await page.raw.locator('[data-slot="next"]').click()
+        await page.raw.waitForURL((url) => url.searchParams.get('page') === '5')
+        await expect(
+          page.raw.locator('[data-slot="page"][data-page="5"]')
+        ).toBeFocused()
+        expect(
+          await page.raw.evaluate(() => ({
+            slot: document.activeElement?.getAttribute('data-slot'),
+            page: document.activeElement?.getAttribute('data-page'),
+            disabled: document.activeElement?.getAttribute('aria-disabled'),
+            tag: document.activeElement?.tagName
+          }))
+        ).toEqual({
+          slot: 'page',
+          page: '5',
+          disabled: null,
+          tag: 'A'
+        })
+      }
+
+      expect(page).toHaveNoSmoke()
+    } finally {
+      sails.helpers.bridge.loadResource = originals.loadResource
+      sails.helpers.bridge.queryResource = originals.queryResource
+      sails.helpers.bridge.redactResourceRecords =
+        originals.redactResourceRecords
+    }
+  }
+)
+
+test(
+  'Audit log pagination uses real history-preserving links',
+  { browser: true, world: 'configured-slipway' },
+  async ({ sails, world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    const current = world.current
+    const owner = current.users.genesisUser
+    const team = current.teams.genesisTeam
+
+    await sails.models.auditlog.createEach(
+      Array.from({ length: 105 }, (_, index) => ({
+        action: 'helm.executed',
+        resourceType: 'app',
+        resourceId: `pagination-${String(index + 1).padStart(3, '0')}`,
+        details: {
+          sourceHash: String(index + 1).padStart(64, 'a'),
+          status: 'success'
+        },
+        user: owner.id,
+        team: team.id
+      }))
+    )
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.raw.setViewportSize({ width: 1440, height: 900 })
+    await page.goto('/settings/audit-log?page=2&q=pagination&group=helm')
+    await page.wait('text=51–100 of 105 events.')
+
+    const footer = page.raw.locator('main footer')
+    await footer.screenshot({
+      path: path.join(screenshotRoot, 'audit-pagination-light.png')
+    })
+    await page.raw.emulateMedia({ colorScheme: 'dark' })
+    await footer.screenshot({
+      path: path.join(screenshotRoot, 'audit-pagination-dark.png')
+    })
+    await page.raw.emulateMedia({ colorScheme: 'light' })
+
+    if (capturePhase === 'after') {
+      const pagination = footer.locator('[data-test="audit-pagination"]')
+      await expect(pagination).toBeVisible()
+      await expect(pagination).toHaveAttribute('data-slot', 'pagination')
+
+      const previous = pagination.locator('[data-slot="previous"]')
+      const next = pagination.locator('[data-slot="next"]')
+      const previousUrl = new URL(
+        await previous.getAttribute('href'),
+        'http://slipway.test'
+      )
+      const nextUrl = new URL(
+        await next.getAttribute('href'),
+        'http://slipway.test'
+      )
+
+      expect(previousUrl.search).toBe('?q=pagination&group=helm')
+      expect(nextUrl.searchParams.get('page')).toBe('3')
+      expect(nextUrl.searchParams.get('q')).toBe('pagination')
+      expect(nextUrl.searchParams.get('group')).toBe('helm')
+
+      let partialReload
+      page.raw.on('request', (request) => {
+        if (
+          request.headers()['x-inertia'] === 'true' &&
+          new URL(request.url()).searchParams.get('page') === '3'
+        ) {
+          partialReload = request.headers()['x-inertia-partial-data']
+        }
+      })
+
+      await next.click()
+      await page.raw.waitForURL((url) => url.searchParams.get('page') === '3')
+      expect(partialReload).toBe(
+        'logs,pagination,filters,helmAuditRetentionDays'
+      )
+      await page.back()
+      await page.raw.waitForURL((url) => url.searchParams.get('page') === '2')
+      await page.forward()
+      await page.raw.waitForURL((url) => url.searchParams.get('page') === '3')
+    }
+
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+function paginationResource() {
+  return {
+    identity: 'course',
+    label: 'Courses',
+    singularLabel: 'Course',
+    primaryKey: 'id',
+    attributes: {
+      id: {
+        type: 'number',
+        label: 'ID',
+        field: { type: 'number', sortable: true }
+      },
+      title: {
+        type: 'string',
+        label: 'Course title',
+        field: { type: 'text', sortable: true }
+      },
+      status: {
+        type: 'string',
+        label: 'Status',
+        field: {
+          type: 'select',
+          sortable: true,
+          options: [
+            { label: 'Draft', value: 'draft' },
+            { label: 'Published', value: 'published' }
+          ]
+        }
+      }
+    },
+    list: ['title', 'status'],
+    search: ['title'],
+    filters: ['status'],
+    sort: { field: 'title', direction: 'ASC' },
+    lenses: {
+      recent: {
+        id: 'recent',
+        label: 'Recent courses',
+        columns: ['title', 'status'],
+        sort: { field: 'title', direction: 'DESC' },
+        filters: {}
+      }
+    },
+    actions: {
+      view: false,
+      update: false,
+      delete: false,
+      bulkDelete: false
+    },
+    actionDefinitions: {},
+    relationships: {}
+  }
+}
+
+function pageRecords(currentPage, perPage, total) {
+  const start = (currentPage - 1) * perPage
+  return Array.from(
+    { length: Math.min(perPage, total - start) },
+    (_, index) => ({
+      id: start + index + 1,
+      title: `Durable course ${start + index + 1}`,
+      status: 'published'
+    })
+  )
+}
+
+function assertResourceQuery(expect, url, filters) {
+  expect(url.searchParams.get('perPage')).toBe('5')
+  expect(url.searchParams.get('search')).toBe('Durable')
+  expect(url.searchParams.get('sort')).toBe('title DESC')
+  expect(url.searchParams.get('filters')).toBe(filters)
+  expect(url.searchParams.get('lens')).toBe('recent')
+  expect(url.searchParams.get('dashboard')).toBe('operators')
+}


### PR DESCRIPTION
## What changed

- installs the source-owned Klean Pagination component with no barrel file or runtime Klean dependency
- migrates Bridge resource records to real, numbered Inertia links while preserving its fixed compact footer
- migrates Settings → Audit log to the same component with its intentionally terser borderless treatment
- keeps the server page authoritative and removes Bridge’s duplicate client page state
- preserves Bridge search, sort, filters, lens, dashboard, and exact partial reload contract
- preserves Audit search, group, history, and exact partial reload contract
- removes page from page-one links while retaining every unrelated query parameter
- recovers focus when the final Next link disappears

## Durable behavior verified

- native links support modified click, new tabs, copied URLs, reloads, and keyboard activation
- Back and Forward restore the server-selected page
- page changes push browser history
- search/filter changes reset to page one with replacement history
- a single page renders no pagination
- light and dark treatments remain native to each list

## Verification

- `npm run lint`
- 2 focused Sounding browser journeys for Bridge and Audit Pagination
- 3 focused Bridge/Audit regression trials
- canonical component matches merged Klean source after project formatting
- upstream Inertia event contract fixed in sailscastshq/klean-ui#87

Fixes #347