### PR TITLE
feat(ui): adopt Klean Table

### DIFF
--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -5,6 +5,7 @@ import HelmResultTreeNode from '@/components/HelmResultTreeNode.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Table from '@/components/ui/table/Table.vue'
 import { highlightJSON } from '@/lib/highlightJSON'
 import {
   helmRowsToCsv,
@@ -453,7 +454,7 @@ function queryDetail(entry) {
           :data-test="`${testId}-output`"
           class="min-w-max"
         >
-          <table
+          <Table
             :data-test="`${testId}-result-table`"
             class="min-w-full font-mono text-sm"
           >
@@ -507,7 +508,7 @@ function queryDetail(entry) {
                 </td>
               </tr>
             </tbody>
-          </table>
+          </Table>
         </div>
 
         <div

--- a/assets/js/components/ui/table/Table.vue
+++ b/assets/js/components/ui/table/Table.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
+const element = ref()
+
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <table
+    ref="element"
+    v-bind="forwardedAttrs"
+    data-slot="table"
+    :class="
+      twMerge(
+        'w-full border-collapse text-left text-sm text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </table>
+</template>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -14,6 +14,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Table from '@/components/ui/table/Table.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import HelmResultViewer from '@/components/HelmResultViewer.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
@@ -1104,7 +1105,10 @@ onUnmounted(() => {
               v-if="consoleResults.columns && resultView === 'table'"
               class="flex-1 overflow-auto"
             >
-              <table class="min-w-full">
+              <Table class="min-w-full">
+                <caption class="sr-only">
+                  Bosun SQL query results
+                </caption>
                 <thead class="sticky top-0">
                   <tr
                     class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900"
@@ -1112,6 +1116,7 @@ onUnmounted(() => {
                     <th
                       v-for="col in consoleResults.columns"
                       :key="col"
+                      scope="col"
                       class="px-4 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400"
                     >
                       {{ col }}
@@ -1148,7 +1153,7 @@ onUnmounted(() => {
                     </td>
                   </tr>
                 </tbody>
-              </table>
+              </Table>
             </div>
 
             <!-- JSON view -->

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -12,6 +12,7 @@ import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 import Pagination from '@/components/ui/pagination/Pagination.vue'
+import Table from '@/components/ui/table/Table.vue'
 
 defineOptions({
   layout: BridgePageLayout
@@ -803,12 +804,18 @@ function createUrl() {
           v-else-if="modelMeta"
           class="rounded-lg border border-gray-200 dark:border-gray-800"
         >
-          <table class="w-full text-left text-sm">
+          <Table class="w-full text-left text-sm">
+            <caption class="sr-only">
+              {{
+                modelMeta.label || modelIdentity
+              }}
+              records
+            </caption>
             <thead
               class="border-b border-gray-200 bg-gray-50/50 dark:border-gray-800 dark:bg-gray-900/50"
             >
               <tr>
-                <th v-if="hasBulkActions" class="w-10 px-4 py-2">
+                <th v-if="hasBulkActions" scope="col" class="w-10 px-4 py-2">
                   <input
                     type="checkbox"
                     :checked="selectAll"
@@ -819,6 +826,7 @@ function createUrl() {
                 <th
                   v-for="col in visibleColumns"
                   :key="col"
+                  scope="col"
                   @click="toggleSort(col)"
                   :class="[
                     'select-none whitespace-nowrap px-4 py-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400',
@@ -853,7 +861,7 @@ function createUrl() {
                     </svg>
                   </span>
                 </th>
-                <th v-if="hasRecordActions" class="w-12 px-4 py-2">
+                <th v-if="hasRecordActions" scope="col" class="w-12 px-4 py-2">
                   <span class="sr-only">Actions</span>
                 </th>
               </tr>
@@ -985,7 +993,7 @@ function createUrl() {
                 </td>
               </tr>
             </tbody>
-          </table>
+          </Table>
         </div>
       </div>
     </div>

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -13,6 +13,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Table from '@/components/ui/table/Table.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import DockResultStatusIcon from '@/components/DockResultStatusIcon.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
@@ -1789,7 +1790,7 @@ onUnmounted(() => {
                 "
                 class="flex-1 overflow-auto"
               >
-                <table class="min-w-full">
+                <Table class="min-w-full">
                   <caption class="sr-only">
                     Query result
                     {{
@@ -1846,7 +1847,7 @@ onUnmounted(() => {
                       </td>
                     </tr>
                   </tbody>
-                </table>
+                </Table>
               </div>
 
               <!-- JSON view -->
@@ -2172,7 +2173,13 @@ onUnmounted(() => {
               >
             </div>
             <div class="flex-1 overflow-x-auto">
-              <table class="min-w-full">
+              <Table class="min-w-full">
+                <caption class="sr-only">
+                  Data from
+                  {{
+                    selectedTable
+                  }}
+                </caption>
                 <thead>
                   <tr
                     class="border-b border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-900/50"
@@ -2180,6 +2187,7 @@ onUnmounted(() => {
                     <th
                       v-for="col in tableData.columns"
                       :key="col"
+                      scope="col"
                       class="px-3 py-2 text-left text-xs font-medium text-gray-500 dark:text-gray-400"
                     >
                       {{ col }}
@@ -2216,7 +2224,7 @@ onUnmounted(() => {
                     </td>
                   </tr>
                 </tbody>
-              </table>
+              </Table>
             </div>
           </div>
         </div>
@@ -2344,25 +2352,35 @@ onUnmounted(() => {
                   >{{ tableName }}</span
                 >
               </div>
-              <table class="min-w-full">
+              <Table class="min-w-full">
+                <caption class="sr-only">
+                  Schema for
+                  {{
+                    tableName
+                  }}
+                </caption>
                 <thead>
                   <tr class="border-b border-gray-200 dark:border-gray-800">
                     <th
+                      scope="col"
                       class="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
                     >
                       Column
                     </th>
                     <th
+                      scope="col"
                       class="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
                     >
                       Type
                     </th>
                     <th
+                      scope="col"
                       class="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
                     >
                       Nullable
                     </th>
                     <th
+                      scope="col"
                       class="px-4 py-2 text-left text-xs font-medium uppercase text-gray-500 dark:text-gray-400"
                     >
                       Default
@@ -2404,7 +2422,7 @@ onUnmounted(() => {
                     </td>
                   </tr>
                 </tbody>
-              </table>
+              </Table>
             </div>
           </div>
 

--- a/tests/e2e/pages/pagination.test.js
+++ b/tests/e2e/pages/pagination.test.js
@@ -96,6 +96,15 @@ test(
       await page.raw.emulateMedia({ colorScheme: 'light' })
 
       if (capturePhase === 'after') {
+        const resourceTable = page.raw.locator('[data-slot="table"]')
+        await expect(resourceTable).toBeVisible()
+        expect(
+          (await resourceTable.locator('caption').textContent()).trim()
+        ).toBe('Courses records')
+        expect(
+          await resourceTable.locator('thead th[scope="col"]').count()
+        ).toBe(2)
+
         const pagination = page.raw.locator('[data-test="bridge-pagination"]')
         await expect(pagination).toBeVisible()
         await expect(pagination).toHaveAttribute('data-slot', 'pagination')

--- a/tests/e2e/pages/projects/dock-multi-results.test.js
+++ b/tests/e2e/pages/projects/dock-multi-results.test.js
@@ -100,6 +100,14 @@ test(
     await page.raw.getByRole('button', { name: 'Run', exact: true }).click()
     await page.wait('@dock-query-result-1')
 
+    const resultTable = page.raw.locator(
+      '[data-test="dock-query-result-panel"] [data-slot="table"]'
+    )
+    await expect(resultTable).toBeVisible()
+    expect(await resultTable.locator('caption').textContent()).toContain(
+      'Query result 1'
+    )
+
     const tabs = page.raw.getByRole('tab')
     expect(await tabs.count()).toBe(2)
     expect(await tabs.nth(0).getAttribute('aria-selected')).toBe('true')

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -630,6 +630,10 @@ test(
     await page.click('@helm-run')
     await page.wait('@helm-result-table')
 
+    await expect(
+      page.raw.locator('[data-test="helm-result-table"]')
+    ).toHaveAttribute('data-slot', 'table')
+
     expect(
       await page.raw.locator('[data-test="helm-result-table"] tbody tr').count()
     ).toBe(3)

--- a/tests/e2e/pages/table.test.js
+++ b/tests/e2e/pages/table.test.js
@@ -1,0 +1,105 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const capturePhase = process.env.TABLE_SCREENSHOT_PHASE || 'after'
+const screenshotRoot = path.resolve(
+  `.tmp/screenshots/issue-344-table/${capturePhase}`
+)
+
+test(
+  'Bosun keeps native query results semantic through Klean Table',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await page.raw.route('**/api/v1/bosun/helm/completions', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ available: false })
+      })
+    })
+    await page.raw.route('**/api/v1/bosun/sql', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          columns: ['course', 'lessons', 'published', 'revenue'],
+          rows: [
+            {
+              course: 'Durable UI',
+              lessons: 18,
+              published: true,
+              revenue: 245000
+            },
+            {
+              course: 'The Boring JavaScript Stack',
+              lessons: 42,
+              published: true,
+              revenue: 890000
+            },
+            {
+              course: 'Getting started with Sails',
+              lessons: 12,
+              published: false,
+              revenue: null
+            }
+          ],
+          rowCount: 3,
+          truncated: false,
+          durationMs: 4
+        })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto('/bosun?tab=console')
+    await page.fill(
+      '@bosun-sql-editor',
+      'SELECT course, lessons, published, revenue FROM course_metrics;'
+    )
+    await page.click('@bosun-console-run')
+    await page.wait('text=Durable UI')
+
+    const table = page.raw.locator('table').filter({ hasText: 'Durable UI' })
+    await table.screenshot({
+      path: path.join(screenshotRoot, 'bosun-query-table-light.png')
+    })
+    await page.inDarkMode()
+    await page.wait(100)
+    await table.screenshot({
+      path: path.join(screenshotRoot, 'bosun-query-table-dark.png')
+    })
+
+    expect(await table.locator('tbody tr').count()).toBe(3)
+    expect(await table.getByRole('columnheader').allTextContents()).toEqual([
+      'course',
+      'lessons',
+      'published',
+      'revenue'
+    ])
+
+    if (capturePhase === 'after') {
+      await expect(table).toHaveAttribute('data-slot', 'table')
+      expect((await table.locator('caption').textContent()).trim()).toBe(
+        'Bosun SQL query results'
+      )
+      expect(await table.locator('thead th[scope="col"]').count()).toBe(4)
+    }
+
+    expect(page).toHaveNoSmoke()
+  }
+)


### PR DESCRIPTION
## Summary

- install the source-owned Vue Table primitive from `sailscastshq/klean-ui` (`b9ab32e`, #78)
- migrate every native Slipway data table in Bridge, Bosun, Dock, and Helm while preserving each screen's existing anatomy, overflow, density, and actions
- add accessible captions and column scopes where the existing tables were missing them
- add focused Sounding coverage for the shared primitive and the affected workflows

## Verification

- `npm run lint`
- `npm test` — 448 passing (314 unit, 103 functional, 31 browser E2E)
- before/after real-browser screenshots in light and dark mode
- exact 0-pixel table-surface diffs across Bosun, Bridge, Dock, and Helm

Fixes #344