### PR TITLE
fix(services): pin legacy Redis latest images

### DIFF
--- a/api/helpers/docker/inspect-running-service-image.js
+++ b/api/helpers/docker/inspect-running-service-image.js
@@ -5,6 +5,10 @@ const {
   findSupportedLine,
   getPolicy
 } = require('../../lib/service-image-policy')
+const {
+  discoverServiceVersion,
+  getRuntimeVersionCommand
+} = require('../../lib/service-version-discovery')
 
 const execFileAsync = promisify(execFile)
 
@@ -45,7 +49,18 @@ module.exports = {
     ])
     const image = images[0]
     const policy = getPolicy(type)
-    const detectedVersion = detectVersion(type, containerDetails, image)
+    const runtimeOutput = await inspectRuntimeVersion(
+      dockerPath,
+      type,
+      containerName
+    )
+    const versionDiscovery = discoverServiceVersion({
+      type,
+      runtimeOutput,
+      container: containerDetails,
+      image
+    })
+    const detectedVersion = versionDiscovery.detectedVersion
     const version = findSupportedLine(type, detectedVersion)
     const imageReference =
       image?.RepoDigests?.find((digest) =>
@@ -58,12 +73,32 @@ module.exports = {
     return {
       version,
       detectedVersion,
+      versionDetectionSource: versionDiscovery.source,
       imageReference,
       imageId: image?.Id || containerDetails.Image,
       repoDigest: image?.RepoDigests?.[0] || null,
       configuredImage: containerDetails.Config?.Image || null,
       inspectedAt: Date.now()
     }
+  }
+}
+
+async function inspectRuntimeVersion(dockerPath, type, containerName) {
+  const command = getRuntimeVersionCommand(type)
+  if (!command) return null
+
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      dockerPath,
+      ['exec', containerName, ...command],
+      {
+        timeout: 5000,
+        maxBuffer: 64 * 1024
+      }
+    )
+    return [stdout, stderr].filter(Boolean).join('\n')
+  } catch {
+    return null
   }
 }
 
@@ -86,36 +121,4 @@ async function inspect(dockerPath, args) {
     error.code = 'SERVICE_CONTAINER_IMAGE_NOT_FOUND'
     throw error
   }
-}
-
-function detectVersion(type, container, image) {
-  const env = Object.fromEntries(
-    (image?.Config?.Env || [])
-      .map((entry) => entry.split(/=(.*)/s))
-      .filter(([key, value]) => key && value !== undefined)
-  )
-
-  const envKeys = {
-    postgresql: ['PG_MAJOR', 'PG_VERSION'],
-    mysql: ['MYSQL_VERSION', 'MYSQL_MAJOR'],
-    redis: ['REDIS_VERSION'],
-    mongodb: ['MONGO_VERSION', 'MONGO_MAJOR']
-  }
-
-  for (const key of envKeys[type] || []) {
-    const numeric = env[key]?.match(/\d+(?:\.\d+){0,2}/)?.[0]
-    if (numeric) return numeric
-  }
-
-  const configuredTag = container.Config?.Image?.match(/:([^:@]+)$/)?.[1]
-  if (configuredTag && configuredTag !== 'latest') {
-    return configuredTag
-  }
-
-  for (const repoTag of image?.RepoTags || []) {
-    const tag = repoTag.match(/:([^:@]+)$/)?.[1]
-    if (tag && tag !== 'latest') return tag
-  }
-
-  return null
 }

--- a/api/helpers/service/migrate-legacy-versions.js
+++ b/api/helpers/service/migrate-legacy-versions.js
@@ -1,3 +1,5 @@
+const LEGACY_VERSION_RESOLUTION_SCHEMA = 1
+
 module.exports = {
   friendlyName: 'Migrate legacy service versions',
 
@@ -10,7 +12,9 @@ module.exports = {
     const services = await Service.find()
     const candidates = services.filter(
       (service) =>
-        service.version === 'latest' ||
+        (service.version === 'latest' &&
+          service.imageMetadata?.versionResolution?.schemaVersion !==
+            LEGACY_VERSION_RESOLUTION_SCHEMA) ||
         !service.imageReference ||
         !service.imageMetadata
     )
@@ -29,28 +33,42 @@ module.exports = {
             containerName: service.containerName
           })
 
-        if (service.version === 'latest' && !inspected.version) {
-          result.unresolved += 1
-          sails.log.warn(
-            `Could not determine the pinned version for legacy service ${service.name}; leaving it unresolved.`
-          )
-          continue
-        }
+        const resolvedVersion =
+          service.version === 'latest' ? inspected.version : service.version
+        const versionResolved = Boolean(
+          resolvedVersion && resolvedVersion !== 'latest'
+        )
 
         await Service.updateOne({ id: service.id }).set({
-          version:
-            service.version === 'latest' ? inspected.version : service.version,
+          version: resolvedVersion || service.version,
           imageReference: inspected.imageReference,
           imageMetadata: {
+            ...(service.imageMetadata || {}),
             source: 'running-container',
             migratedAt: Date.now(),
             configuredImage: inspected.configuredImage,
             detectedVersion: inspected.detectedVersion,
+            versionDetectionSource: inspected.versionDetectionSource,
             imageId: inspected.imageId,
-            repoDigest: inspected.repoDigest
+            repoDigest: inspected.repoDigest,
+            versionResolution: {
+              schemaVersion: LEGACY_VERSION_RESOLUTION_SCHEMA,
+              status: versionResolved ? 'resolved' : 'unresolved',
+              source:
+                service.version === 'latest'
+                  ? inspected.versionDetectionSource
+                  : 'stored-version'
+            }
           }
         })
         result.migrated += 1
+
+        if (!versionResolved) {
+          result.unresolved += 1
+          sails.log.warn(
+            `Pinned the immutable image for legacy service ${service.name}, but could not determine its version.`
+          )
+        }
       } catch (error) {
         result.unresolved += 1
         sails.log.warn(

--- a/api/lib/service-image-policy.js
+++ b/api/lib/service-image-policy.js
@@ -2,6 +2,7 @@ const SERVICE_IMAGE_POLICY = Object.freeze({
   postgresql: Object.freeze({
     label: 'PostgreSQL',
     repository: 'postgres',
+    versionLineSegments: 1,
     defaultVersion: '17',
     versions: Object.freeze([
       version('17', {
@@ -16,6 +17,7 @@ const SERVICE_IMAGE_POLICY = Object.freeze({
   mysql: Object.freeze({
     label: 'MySQL',
     repository: 'mysql',
+    versionLineSegments: 2,
     defaultVersion: '8.4',
     versions: Object.freeze([
       version('8.4', {
@@ -30,6 +32,7 @@ const SERVICE_IMAGE_POLICY = Object.freeze({
   redis: Object.freeze({
     label: 'Redis',
     repository: 'redis',
+    versionLineSegments: 2,
     defaultVersion: '7.2',
     versions: Object.freeze([
       version('7.2', {
@@ -42,6 +45,7 @@ const SERVICE_IMAGE_POLICY = Object.freeze({
   mongodb: Object.freeze({
     label: 'MongoDB',
     repository: 'mongo',
+    versionLineSegments: 2,
     defaultVersion: '8.0',
     versions: Object.freeze([
       version('8.0', {
@@ -176,12 +180,15 @@ function findSupportedLine(type, detectedVersion) {
   const numeric = String(detectedVersion).match(/\d+(?:\.\d+){0,2}/)?.[0]
   if (!numeric) return null
 
-  return (
+  const supportedLine =
     policy.versions.find(
       (entry) =>
         numeric === entry.version || numeric.startsWith(`${entry.version}.`)
-    )?.version || numeric
-  )
+    )?.version || null
+
+  if (supportedLine) return supportedLine
+
+  return numeric.split('.').slice(0, policy.versionLineSegments).join('.')
 }
 
 function policyError(message) {

--- a/api/lib/service-version-discovery.js
+++ b/api/lib/service-version-discovery.js
@@ -1,0 +1,111 @@
+const RUNTIME_VERSION_COMMANDS = Object.freeze({
+  redis: Object.freeze(['redis-server', '--version'])
+})
+
+const ENV_VERSION_KEYS = Object.freeze({
+  postgresql: Object.freeze(['PG_MAJOR', 'PG_VERSION']),
+  mysql: Object.freeze(['MYSQL_VERSION', 'MYSQL_MAJOR']),
+  redis: Object.freeze(['REDIS_VERSION']),
+  mongodb: Object.freeze(['MONGO_VERSION', 'MONGO_MAJOR'])
+})
+
+function getRuntimeVersionCommand(type) {
+  return RUNTIME_VERSION_COMMANDS[type] || null
+}
+
+function discoverServiceVersion({ type, runtimeOutput, container, image }) {
+  const runtimeVersion = detectRuntimeVersion(type, runtimeOutput)
+  if (runtimeVersion) {
+    return {
+      detectedVersion: runtimeVersion,
+      source: 'runtime-command'
+    }
+  }
+
+  const env = collectEnvironment(container, image)
+  for (const key of ENV_VERSION_KEYS[type] || []) {
+    const version = extractNumericVersion(env[key])
+    if (version) {
+      return {
+        detectedVersion: version,
+        source: `image-env:${key}`
+      }
+    }
+  }
+
+  if (type === 'redis') {
+    const downloadVersion = extractRedisDownloadVersion(env.REDIS_DOWNLOAD_URL)
+    if (downloadVersion) {
+      return {
+        detectedVersion: downloadVersion,
+        source: 'image-env:REDIS_DOWNLOAD_URL'
+      }
+    }
+  }
+
+  const configuredTag = extractTag(container?.Config?.Image)
+  if (configuredTag) {
+    return {
+      detectedVersion: configuredTag,
+      source: 'configured-image-tag'
+    }
+  }
+
+  for (const repoTag of image?.RepoTags || []) {
+    const tag = extractTag(repoTag)
+    if (tag) {
+      return {
+        detectedVersion: tag,
+        source: 'repository-tag'
+      }
+    }
+  }
+
+  return {
+    detectedVersion: null,
+    source: null
+  }
+}
+
+function detectRuntimeVersion(type, output) {
+  if (type !== 'redis' || !output) return null
+
+  const versionMatch = String(output).match(
+    /(?:^|\s)(?:v(?:ersion)?=?)\s*(\d+(?:\.\d+){1,2})(?:\s|$)/i
+  )
+  return versionMatch?.[1] || null
+}
+
+function collectEnvironment(container, image) {
+  return Object.fromEntries(
+    [...(image?.Config?.Env || []), ...(container?.Config?.Env || [])]
+      .map((entry) => String(entry).split(/=(.*)/s))
+      .filter(([key, value]) => key && value !== undefined)
+  )
+}
+
+function extractRedisDownloadVersion(value) {
+  if (!value) return null
+
+  return (
+    String(value).match(
+      /\/refs\/tags\/v?(\d+(?:\.\d+){1,2})\.tar\.gz(?:$|[?#])/i
+    )?.[1] || null
+  )
+}
+
+function extractNumericVersion(value) {
+  return String(value || '').match(/\d+(?:\.\d+){0,2}/)?.[0] || null
+}
+
+function extractTag(reference) {
+  const tag = String(reference || '').match(/:([^:@]+)$/)?.[1]
+  if (!tag || tag.toLowerCase() === 'latest') return null
+
+  return extractNumericVersion(tag)
+}
+
+module.exports = {
+  discoverServiceVersion,
+  getRuntimeVersionCommand
+}

--- a/assets/js/pages/projects/service-settings.vue
+++ b/assets/js/pages/projects/service-settings.vue
@@ -382,6 +382,12 @@ const serviceTypeLabel = {
               >
                 Custom version outside the tested matrix
               </span>
+              <span
+                v-else-if="service.imageReference"
+                class="text-amber-700 dark:text-amber-400"
+              >
+                Immutable image pinned; version line unknown
+              </span>
               <span v-else class="text-amber-700 dark:text-amber-400">
                 Legacy version has not been resolved from Docker
               </span>

--- a/tests/unit/helpers/service/service-version-lifecycle.test.js
+++ b/tests/unit/helpers/service/service-version-lifecycle.test.js
@@ -112,6 +112,127 @@ test(
 )
 
 test(
+  'legacy Redis latest records resolve once and retain their running service',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'legacy-redis-service',
+          name: 'Legacy Redis Service'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'cache',
+      type: 'redis',
+      version: 'latest',
+      status: 'running',
+      containerId: 'running-redis-container',
+      containerName: 'slipway-legacy-redis-service-production-cache',
+      imageMetadata: {
+        volumeName: 'slipway-legacy-redis-service-cache-data'
+      }
+    })
+    const originalInspect = sails.helpers.docker.inspectRunningServiceImage
+
+    const inspectExisting = async () => ({
+      version: '8.4',
+      detectedVersion: '8.4.0',
+      versionDetectionSource: 'runtime-command',
+      imageReference: 'redis@sha256:running',
+      imageId: 'sha256:running',
+      repoDigest: 'redis@sha256:running',
+      configuredImage: 'redis:latest'
+    })
+    inspectExisting.with = inspectExisting
+    sails.helpers.docker.inspectRunningServiceImage = inspectExisting
+
+    try {
+      const first = await sails.helpers.service.migrateLegacyVersions()
+      const second = await sails.helpers.service.migrateLegacyVersions()
+      const updated = await sails.models.service.findOne({ id: service.id })
+
+      expect(first.migrated).toBe(1)
+      expect(first.unresolved).toBe(0)
+      expect(second.migrated).toBe(0)
+      expect(second.unresolved).toBe(0)
+      expect(updated.version).toBe('8.4')
+      expect(updated.imageReference).toBe('redis@sha256:running')
+      expect(updated.containerId).toBe('running-redis-container')
+      expect(updated.containerName).toBe(service.containerName)
+      expect(updated.status).toBe('running')
+      expect(updated.imageMetadata.volumeName).toBe(
+        'slipway-legacy-redis-service-cache-data'
+      )
+      expect(updated.imageMetadata.versionResolution.status).toBe('resolved')
+      expect(updated.imageMetadata.versionDetectionSource).toBe(
+        'runtime-command'
+      )
+    } finally {
+      sails.helpers.docker.inspectRunningServiceImage = originalInspect
+    }
+  }
+)
+
+test(
+  'legacy services retain an immutable image when the version stays unknown',
+  {
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'unknown-legacy-service',
+          name: 'Unknown Legacy Service'
+        }
+      }
+    }
+  },
+  async ({ sails, world, expect }) => {
+    const service = await world.create('service').with({
+      environment: world.current.environments.production.id,
+      name: 'cache',
+      type: 'redis',
+      version: 'latest',
+      status: 'running',
+      containerName: 'slipway-unknown-legacy-service-production-cache'
+    })
+    const originalInspect = sails.helpers.docker.inspectRunningServiceImage
+
+    const inspectExisting = async () => ({
+      version: null,
+      detectedVersion: null,
+      versionDetectionSource: null,
+      imageReference: 'redis@sha256:unknown-version',
+      imageId: 'sha256:unknown-version',
+      repoDigest: 'redis@sha256:unknown-version',
+      configuredImage: 'redis:latest'
+    })
+    inspectExisting.with = inspectExisting
+    sails.helpers.docker.inspectRunningServiceImage = inspectExisting
+
+    try {
+      const first = await sails.helpers.service.migrateLegacyVersions()
+      const second = await sails.helpers.service.migrateLegacyVersions()
+      const updated = await sails.models.service.findOne({ id: service.id })
+
+      expect(first.migrated).toBe(1)
+      expect(first.unresolved).toBe(1)
+      expect(second.migrated).toBe(0)
+      expect(second.unresolved).toBe(0)
+      expect(updated.version).toBe('latest')
+      expect(updated.imageReference).toBe('redis@sha256:unknown-version')
+      expect(updated.imageMetadata.versionResolution.status).toBe('unresolved')
+    } finally {
+      sails.helpers.docker.inspectRunningServiceImage = originalInspect
+    }
+  }
+)
+
+test(
   'a deliberate major upgrade backs up, restores, and retains recovery state',
   {
     world: {

--- a/tests/unit/services/service-version-discovery.test.js
+++ b/tests/unit/services/service-version-discovery.test.js
@@ -1,0 +1,59 @@
+const { test } = require('sounding')
+
+const { findSupportedLine } = require('../../../api/lib/service-image-policy')
+const {
+  discoverServiceVersion,
+  getRuntimeVersionCommand
+} = require('../../../api/lib/service-version-discovery')
+
+test('Redis version discovery survives current and legacy official images', ({
+  expect
+}) => {
+  expect(getRuntimeVersionCommand('redis')).toEqual([
+    'redis-server',
+    '--version'
+  ])
+
+  const runtime = discoverServiceVersion({
+    type: 'redis',
+    runtimeOutput: 'Redis server v=8.4.0 sha=00000000:0 malloc=jemalloc',
+    container: { Config: { Image: 'redis:latest' } },
+    image: {
+      Config: {
+        Env: [
+          'REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.3.0.tar.gz'
+        ]
+      },
+      RepoTags: ['redis:latest']
+    }
+  })
+  expect(runtime.detectedVersion).toBe('8.4.0')
+  expect(runtime.source).toBe('runtime-command')
+  expect(findSupportedLine('redis', runtime.detectedVersion)).toBe('8.4')
+
+  const currentImage = discoverServiceVersion({
+    type: 'redis',
+    container: { Config: { Image: 'redis:latest' } },
+    image: {
+      Config: {
+        Env: [
+          'REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.4.0.tar.gz'
+        ]
+      },
+      RepoTags: ['redis:latest']
+    }
+  })
+  expect(currentImage.detectedVersion).toBe('8.4.0')
+  expect(currentImage.source).toBe('image-env:REDIS_DOWNLOAD_URL')
+
+  const legacyImage = discoverServiceVersion({
+    type: 'redis',
+    container: { Config: { Image: 'redis:latest' } },
+    image: {
+      Config: { Env: ['REDIS_VERSION=7.2.5'] },
+      RepoTags: ['redis:latest']
+    }
+  })
+  expect(legacyImage.detectedVersion).toBe('7.2.5')
+  expect(legacyImage.source).toBe('image-env:REDIS_VERSION')
+})


### PR DESCRIPTION
## What changed

- discover Redis versions from a bounded read-only runtime command, then fall back to both legacy `REDIS_VERSION` and modern `REDIS_DOWNLOAD_URL` image metadata;
- normalize detected patch releases to the service's major/minor version line;
- persist the immutable Docker digest even when a semantic version cannot be identified;
- preserve existing container, volume, and image provenance metadata during the legacy backfill;
- mark completed resolution attempts so the startup backfill is idempotent and quiet;
- distinguish a safely pinned image with an unknown version from a completely unresolved service in the settings UI.

## Why

Modern official `redis:latest` images no longer expose `REDIS_VERSION`. Slipway therefore failed to classify legacy Redis containers and discarded the valid immutable digest Docker had already returned. Operators saw `Redis latest`, `Image: Not resolved`, and a legacy warning on every startup even though the running container was inspectable.

The repair is read-only with respect to Redis. It does not recreate or restart the container, alter the data volume, change credentials, or move the service to Slipway's current default version.

## Verification

- focused Redis and service lifecycle trials: 7 passed;
- complete Sounding unit lane: 317 passed;
- Prettier and `git diff --check` pass.

Fixes #455
