### PR TITLE
feat(ui): standardize action menus with Klean

### DIFF
--- a/assets/js/components/ActionMenu.vue
+++ b/assets/js/components/ActionMenu.vue
@@ -1,6 +1,7 @@
 <script setup>
-import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { computed, useId } from 'vue'
 import { Link } from '@inertiajs/vue3'
+import Menu from '@/components/ui/menu/Menu.vue'
 
 const props = defineProps({
   items: {
@@ -29,38 +30,13 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['select'])
-const root = ref(null)
-const trigger = ref(null)
-const menu = ref(null)
-const open = ref(false)
-
-async function toggle(event) {
-  if (props.disabled) return
-  open.value = !open.value
-  if (open.value && event?.detail === 0) {
-    await nextTick()
-    menu.value?.querySelector('[role="menuitem"]')?.focus()
-  }
-}
-
-async function openFromTrigger(position) {
-  if (props.disabled) return
-  open.value = true
-  await nextTick()
-  const items = menu.value?.querySelectorAll('[role="menuitem"]')
-  const item = position === 'last' ? items?.[items.length - 1] : items?.[0]
-  item?.focus()
-}
-
-function close({ restoreFocus = false } = {}) {
-  if (!open.value) return
-  open.value = false
-  if (restoreFocus) nextTick(() => trigger.value?.focus())
-}
+const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+const menuId = `action-menu-${generatedId}`
+const menuPlacement = computed(() =>
+  props.placement === 'top' ? 'top-end' : 'bottom-end'
+)
 
 function select(item) {
-  trigger.value?.focus()
-  close()
   emit('select', item)
 }
 
@@ -72,64 +48,17 @@ function itemClasses(item) {
       : 'text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800'
   ]
 }
-
-function handleKeydown(event) {
-  const items = Array.from(
-    menu.value?.querySelectorAll('[role="menuitem"]:not(:disabled)') || []
-  )
-  const currentIndex = items.indexOf(document.activeElement)
-
-  if (event.key === 'Escape') {
-    event.preventDefault()
-    close({ restoreFocus: true })
-    return
-  }
-
-  let nextIndex
-  if (event.key === 'ArrowDown') {
-    nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
-  } else if (event.key === 'ArrowUp') {
-    nextIndex =
-      currentIndex < 0
-        ? items.length - 1
-        : (currentIndex - 1 + items.length) % items.length
-  } else if (event.key === 'Home') {
-    nextIndex = 0
-  } else if (event.key === 'End') {
-    nextIndex = items.length - 1
-  } else {
-    return
-  }
-
-  event.preventDefault()
-  items[nextIndex]?.focus()
-}
-
-function handlePointerDown(event) {
-  if (!root.value?.contains(event.target)) close()
-}
-
-onMounted(() => document.addEventListener('pointerdown', handlePointerDown))
-onUnmounted(() =>
-  document.removeEventListener('pointerdown', handlePointerDown)
-)
 </script>
 
 <template>
-  <div v-if="items.length > 0" ref="root" class="relative">
+  <div v-if="items.length > 0" class="relative">
     <button
-      ref="trigger"
       type="button"
       :disabled="disabled"
+      :popovertarget="menuId"
       :data-test="`${testId}-trigger`"
       class="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 disabled:cursor-not-allowed disabled:opacity-40 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
       :aria-label="label"
-      aria-haspopup="menu"
-      :aria-expanded="open"
-      @click.stop="toggle"
-      @keydown.down.prevent="openFromTrigger('first')"
-      @keydown.up.prevent="openFromTrigger('last')"
-      @keydown.escape.prevent="close({ restoreFocus: true })"
     >
       <svg
         class="h-4 w-4"
@@ -148,23 +77,18 @@ onUnmounted(() =>
       </svg>
     </button>
 
-    <div
-      v-if="open"
-      ref="menu"
-      role="menu"
+    <Menu
+      :id="menuId"
+      :aria-label="label"
+      :placement="menuPlacement"
+      :offset="4"
       :data-test="testId"
-      :class="[
-        'min-w-44 absolute right-0 z-30 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900',
-        placement === 'top' ? 'bottom-full mb-1' : 'top-full mt-1'
-      ]"
-      @click.stop
-      @keydown="handleKeydown"
+      class="min-w-44 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
     >
       <template v-for="item in items" :key="item.key">
         <Link
           v-if="item.href && !item.disabled"
           :href="item.href"
-          role="menuitem"
           :data-test="`${testId}-${item.key}`"
           :class="itemClasses(item)"
           @click="select(item)"
@@ -174,7 +98,6 @@ onUnmounted(() =>
         <button
           v-else
           type="button"
-          role="menuitem"
           :disabled="item.disabled"
           :data-test="`${testId}-${item.key}`"
           :class="itemClasses(item)"
@@ -183,6 +106,6 @@ onUnmounted(() =>
           {{ item.label }}
         </button>
       </template>
-    </div>
+    </Menu>
   </div>
 </template>

--- a/assets/js/components/bridge/BridgeWorkspaceSidebar.vue
+++ b/assets/js/components/bridge/BridgeWorkspaceSidebar.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { Link, usePage } from '@inertiajs/vue3'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { computed, ref } from 'vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 
 const props = defineProps({
   app: Object,
@@ -12,7 +13,6 @@ defineEmits(['navigate'])
 
 const page = usePage()
 const search = ref('')
-const actorMenuOpen = ref(false)
 const normalizedBasePath = computed(() => props.basePath || '/bridge')
 const currentUrl = computed(() => page.url || normalizedBasePath.value)
 const currentPath = computed(() => currentUrl.value.split('?')[0])
@@ -62,24 +62,6 @@ function isResourceActive(identity) {
   const path = resourceUrl(identity)
   return currentPath.value === path || currentPath.value.startsWith(`${path}/`)
 }
-
-function closeActorMenu() {
-  actorMenuOpen.value = false
-}
-
-function handleEscapeKey(event) {
-  if (event.key === 'Escape') closeActorMenu()
-}
-
-onMounted(() => {
-  document.addEventListener('click', closeActorMenu)
-  document.addEventListener('keydown', handleEscapeKey)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', closeActorMenu)
-  document.removeEventListener('keydown', handleEscapeKey)
-})
 </script>
 
 <template>
@@ -233,21 +215,15 @@ onUnmounted(() => {
     </nav>
 
     <div class="relative px-3 py-3">
-      <Transition
-        enter-active-class="transition ease-out duration-100"
-        enter-from-class="transform opacity-0 scale-95"
-        enter-to-class="transform opacity-100 scale-100"
-        leave-active-class="transition ease-in duration-75"
-        leave-from-class="transform opacity-100 scale-100"
-        leave-to-class="transform opacity-0 scale-95"
+      <Menu
+        id="bridge-actor-menu"
+        aria-label="Bridge account actions"
+        placement="top-start"
+        :offset="4"
+        class="w-52 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+        data-test="bridge-actor-menu"
       >
-        <div
-          v-if="actorMenuOpen"
-          id="bridge-actor-menu"
-          class="absolute bottom-full left-3 right-3 z-20 mb-1 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-          data-test="bridge-actor-menu"
-          @click.stop
-        >
+        <div class="contents">
           <div
             class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 dark:text-gray-300"
           >
@@ -273,7 +249,10 @@ onUnmounted(() => {
               Role
             </span>
           </div>
-          <div class="my-1 border-t border-gray-100 dark:border-gray-800"></div>
+          <div
+            role="separator"
+            class="my-1 border-t border-gray-100 dark:border-gray-800"
+          ></div>
           <a
             href="https://docs.sailscasts.com/slipway/bridge"
             target="_blank"
@@ -313,15 +292,13 @@ onUnmounted(() => {
             <span>Sponsor Slipway</span>
           </a>
         </div>
-      </Transition>
+      </Menu>
 
       <button
         type="button"
+        popovertarget="bridge-actor-menu"
         class="flex w-full items-center space-x-3 rounded-md px-2 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-200/50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-200"
-        aria-controls="bridge-actor-menu"
-        :aria-expanded="actorMenuOpen"
         data-test="bridge-actor-menu-button"
-        @click.stop="actorMenuOpen = !actorMenuOpen"
       >
         <span
           class="bg-brand flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-medium text-white"
@@ -335,10 +312,7 @@ onUnmounted(() => {
           {{ actor.email || actorName }}
         </span>
         <svg
-          :class="[
-            'h-4 w-4 shrink-0 text-gray-400 transition-transform duration-150',
-            actorMenuOpen ? 'rotate-180' : ''
-          ]"
+          class="h-4 w-4 shrink-0 text-gray-400"
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"

--- a/assets/js/components/ui/menu/Menu.vue
+++ b/assets/js/components/ui/menu/Menu.vue
@@ -1,0 +1,427 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+import Popover from '../popover/Popover.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Matches the native button's `popovertarget`. */
+  id: { type: String, default: undefined },
+  /** Framework-native controlled state. Omit for native uncontrolled use. */
+  open: { type: Boolean, default: undefined },
+  /** Initial state when `open` is not controlled. */
+  defaultOpen: { type: Boolean, default: false },
+  /** Preferred logical placement. Collision handling may flip it. */
+  placement: { type: String, default: 'bottom-start' },
+  /** Space in pixels between the invoker and menu. */
+  offset: { type: Number, default: 8 }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const popover = ref()
+const internalOpen = ref(props.defaultOpen)
+const activeInvoker = ref()
+const isControlled = computed(() => props.open !== undefined)
+const isOpen = computed(() =>
+  isControlled.value ? props.open : internalOpen.value
+)
+const menuAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    tabindex: _tabindex,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+const menuClasses = computed(() => twMerge('min-w-40 p-1', attrs.class))
+const TABBABLE_SELECTOR =
+  'a[href], button, input, select, textarea, [tabindex], [contenteditable="true"]'
+
+let interactionRoot
+let itemObserver
+let pendingFocus = 'first'
+let restoreOnClose = false
+let tabExitPending = false
+let tabExitTarget
+let typeahead = ''
+let typeaheadTimer
+
+function contentElement() {
+  const exposed = popover.value?.content
+  return exposed?.value ?? exposed
+}
+
+function eventPath(event) {
+  return event.composedPath?.() ?? [event.target]
+}
+
+function invokers() {
+  const content = contentElement()
+  const root = content?.getRootNode?.() ?? document
+
+  return [...(root.querySelectorAll?.('[popovertarget]') ?? [])].filter(
+    (element) => element.getAttribute('popovertarget') === content?.id
+  )
+}
+
+function syncInvokerSemantics() {
+  for (const invoker of invokers()) {
+    invoker.setAttribute('aria-haspopup', 'menu')
+  }
+}
+
+function matchingInvoker(event) {
+  const id = contentElement()?.id
+  return eventPath(event).find(
+    (element) => element?.getAttribute?.('popovertarget') === id
+  )
+}
+
+function rememberInvoker(event) {
+  const invoker = matchingInvoker(event)
+  if (invoker) activeInvoker.value = invoker
+}
+
+function restoreInvokerFocus() {
+  const invoker = activeInvoker.value?.isConnected
+    ? activeInvoker.value
+    : invokers()[0]
+  invoker?.focus?.({ preventScroll: true })
+}
+
+function tabStopsOutsideMenu(root, content) {
+  return [...(root.querySelectorAll?.(TABBABLE_SELECTOR) ?? [])].filter(
+    (element) =>
+      !content?.contains(element) &&
+      element.tabIndex >= 0 &&
+      !element.matches(':disabled') &&
+      !element.closest('[hidden], [inert]')
+  )
+}
+
+function adjacentTabStop(backward) {
+  const content = contentElement()
+  const invoker = activeInvoker.value?.isConnected
+    ? activeInvoker.value
+    : invokers()[0]
+  let anchor = invoker
+  let root = content?.getRootNode?.() ?? document
+
+  while (anchor && root) {
+    const stops = tabStopsOutsideMenu(root, content)
+    const current = stops.indexOf(anchor)
+    let target
+
+    if (current >= 0) {
+      target = stops[current + (backward ? -1 : 1)]
+    } else {
+      const candidates = stops.filter((element) => {
+        const relation = anchor.compareDocumentPosition(element)
+        return backward ? Boolean(relation & 2) : Boolean(relation & 4)
+      })
+      target = backward ? candidates.at(-1) : candidates[0]
+    }
+
+    if (target) return target
+    if (!root.host) return undefined
+    anchor = root.host
+    root = anchor.getRootNode?.()
+  }
+
+  return undefined
+}
+
+function completeTabExit() {
+  if (tabExitTarget?.isConnected) {
+    tabExitTarget.focus({ preventScroll: true })
+  } else {
+    const root = contentElement()?.getRootNode?.() ?? document
+    root.activeElement?.blur?.()
+  }
+
+  tabExitTarget = undefined
+  tabExitPending = false
+}
+
+function itemRole(element) {
+  return ['menuitem', 'menuitemcheckbox', 'menuitemradio'].includes(
+    element.getAttribute('role')
+  )
+}
+
+function menuItems() {
+  const content = contentElement()
+  if (!content) return []
+
+  for (const element of content.querySelectorAll('button, a[href]')) {
+    if (!element.hasAttribute('role')) element.setAttribute('role', 'menuitem')
+  }
+
+  const items = [
+    ...content.querySelectorAll(
+      '[role="menuitem"], [role="menuitemcheckbox"], [role="menuitemradio"]'
+    )
+  ].filter((element) => element.closest('[role="menu"]') === content)
+
+  for (const item of items) item.tabIndex = -1
+  return items
+}
+
+function itemIsDisabled(item) {
+  return (
+    item.matches(':disabled') ||
+    item.getAttribute('aria-disabled') === 'true' ||
+    item.hidden ||
+    item.closest('[hidden]') !== null
+  )
+}
+
+function enabledItems() {
+  return menuItems().filter((item) => !itemIsDisabled(item))
+}
+
+function focusedElement() {
+  return (
+    contentElement()?.getRootNode?.().activeElement ?? document.activeElement
+  )
+}
+
+function focusItem(item) {
+  if (!item) return
+  for (const candidate of menuItems()) candidate.tabIndex = -1
+  item.tabIndex = 0
+  item.focus({ preventScroll: true })
+}
+
+function focusEdge(edge = 'first') {
+  const items = enabledItems()
+  const item = edge === 'last' ? items.at(-1) : items[0]
+  if (item) focusItem(item)
+  else contentElement()?.focus({ preventScroll: true })
+}
+
+function clearTypeahead() {
+  typeahead = ''
+  clearTimeout(typeaheadTimer)
+  typeaheadTimer = undefined
+}
+
+function normalizedText(item) {
+  return (item.getAttribute('aria-label') ?? item.textContent ?? '')
+    .trim()
+    .toLocaleLowerCase()
+}
+
+function handleTypeahead(event) {
+  if (
+    event.key.length !== 1 ||
+    event.key === ' ' ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  clearTimeout(typeaheadTimer)
+  typeahead += event.key.toLocaleLowerCase()
+  typeaheadTimer = setTimeout(clearTypeahead, 500)
+
+  const items = enabledItems()
+  if (!items.length) return true
+  const current = items.indexOf(focusedElement())
+  const ordered = [...items.slice(current + 1), ...items.slice(0, current + 1)]
+  let match = ordered.find((item) => normalizedText(item).startsWith(typeahead))
+
+  if (!match && new Set(typeahead).size === 1) {
+    typeahead = typeahead.at(-1)
+    match = ordered.find((item) => normalizedText(item).startsWith(typeahead))
+  }
+
+  if (match) focusItem(match)
+  return true
+}
+
+function requestOpen(nextOpen) {
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+}
+
+function openMenu(edge = 'first') {
+  pendingFocus = edge
+  if (isOpen.value) focusEdge(edge)
+  else requestOpen(true)
+}
+
+function closeMenu({ restoreFocus = false } = {}) {
+  restoreOnClose ||= restoreFocus
+  if (isOpen.value) requestOpen(false)
+  else if (restoreOnClose) {
+    restoreOnClose = false
+    nextTick(restoreInvokerFocus)
+  }
+}
+
+function handlePopoverOpen(nextOpen) {
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+}
+
+function handleInvokerKeydown(event) {
+  const invoker = matchingInvoker(event)
+  if (!invoker || invoker.matches(':disabled')) return
+  activeInvoker.value = invoker
+
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault()
+    openMenu(event.key === 'ArrowUp' ? 'last' : 'first')
+  }
+}
+
+function itemFromEvent(event) {
+  const content = contentElement()
+  return eventPath(event).find(
+    (element) =>
+      element?.nodeType === Node.ELEMENT_NODE &&
+      itemRole(element) &&
+      element.closest?.('[role="menu"]') === content
+  )
+}
+
+function handleClick(event) {
+  const item = itemFromEvent(event)
+  if (!item) return
+
+  if (itemIsDisabled(item)) {
+    event.preventDefault()
+    event.stopImmediatePropagation()
+    return
+  }
+
+  closeMenu({ restoreFocus: true })
+}
+
+function handleKeydown(event) {
+  const items = enabledItems()
+  const currentIndex = items.indexOf(focusedElement())
+  let nextIndex
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    closeMenu({ restoreFocus: true })
+    return
+  }
+
+  if (event.key === 'Tab') {
+    event.preventDefault()
+    clearTypeahead()
+    restoreOnClose = false
+    tabExitTarget = adjacentTabStop(event.shiftKey)
+    tabExitPending = true
+    closeMenu()
+    return
+  }
+
+  if (event.key === 'ArrowDown') {
+    nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
+  } else if (event.key === 'ArrowUp') {
+    nextIndex =
+      currentIndex < 0
+        ? items.length - 1
+        : (currentIndex - 1 + items.length) % items.length
+  } else if (event.key === 'Home') {
+    nextIndex = 0
+  } else if (event.key === 'End') {
+    nextIndex = items.length - 1
+  } else if (handleTypeahead(event)) {
+    return
+  } else {
+    return
+  }
+
+  if (!items.length) return
+  event.preventDefault()
+  focusItem(items[nextIndex])
+}
+
+watch(
+  isOpen,
+  async (nextOpen) => {
+    await nextTick()
+    syncInvokerSemantics()
+
+    if (nextOpen) {
+      focusEdge(pendingFocus)
+      pendingFocus = 'first'
+      return
+    }
+
+    clearTypeahead()
+    menuItems()
+    if (tabExitPending) completeTabExit()
+    else if (restoreOnClose) restoreInvokerFocus()
+    restoreOnClose = false
+  },
+  { flush: 'post' }
+)
+
+onMounted(async () => {
+  await nextTick()
+  const content = contentElement()
+  interactionRoot = content?.getRootNode?.() ?? document
+  interactionRoot.addEventListener('keydown', handleInvokerKeydown)
+  interactionRoot.addEventListener('click', rememberInvoker, true)
+  syncInvokerSemantics()
+  menuItems()
+
+  if (typeof MutationObserver !== 'undefined' && content) {
+    itemObserver = new MutationObserver(menuItems)
+    itemObserver.observe(content, { childList: true, subtree: true })
+  }
+
+  if (isOpen.value) focusEdge(pendingFocus)
+})
+
+onBeforeUnmount(() => {
+  clearTypeahead()
+  itemObserver?.disconnect()
+  interactionRoot?.removeEventListener('keydown', handleInvokerKeydown)
+  interactionRoot?.removeEventListener('click', rememberInvoker, true)
+})
+
+defineExpose({ close: closeMenu, open: openMenu })
+</script>
+
+<template>
+  <Popover
+    ref="popover"
+    v-bind="menuAttrs"
+    :id="id"
+    :open="isOpen"
+    :placement="placement"
+    :offset="offset"
+    role="menu"
+    tabindex="-1"
+    data-slot="menu"
+    :class="menuClasses"
+    @update:open="handlePopoverOpen"
+    @click.capture="handleClick"
+    @keydown="handleKeydown"
+  >
+    <slot :open="isOpen" :close="closeMenu" />
+  </Popover>
+</template>

--- a/assets/js/components/ui/popover/Popover.vue
+++ b/assets/js/components/ui/popover/Popover.vue
@@ -1,0 +1,362 @@
+<script setup>
+import {
+  autoUpdate,
+  computePosition,
+  flip,
+  offset as floatingOffset,
+  shift
+} from '@floating-ui/dom'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  useId,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Matches the native button's `popovertarget`. */
+  id: { type: String, default: undefined },
+  /** Framework-native controlled state. Omit for native uncontrolled use. */
+  open: { type: Boolean, default: undefined },
+  /** Initial state when `open` is not controlled. */
+  defaultOpen: { type: Boolean, default: false },
+  /** Element or element id used only for floating-surface positioning. */
+  anchor: { type: [String, Object], default: undefined },
+  /** Preferred logical placement. Collision handling may flip it. */
+  placement: {
+    type: String,
+    default: 'bottom-start',
+    validator: (value) =>
+      [
+        'top',
+        'top-start',
+        'top-end',
+        'right',
+        'right-start',
+        'right-end',
+        'bottom',
+        'bottom-start',
+        'bottom-end',
+        'left',
+        'left-start',
+        'left-end'
+      ].includes(value)
+  },
+  /** Space in pixels between the invoker and floating surface. */
+  offset: { type: Number, default: 8 }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const generatedId = useId()
+const content = ref()
+const activeInvoker = ref()
+const internalOpen = ref(props.defaultOpen)
+const nativePopover = ref(false)
+const resolvedPlacement = ref(props.placement)
+const positionStyle = ref({
+  position: 'fixed',
+  inset: 'auto',
+  left: '0px',
+  top: '0px'
+})
+let cleanupPosition = () => {}
+
+const isControlled = computed(() => props.open !== undefined)
+const isOpen = computed(() =>
+  isControlled.value ? props.open : internalOpen.value
+)
+const contentId = computed(
+  () =>
+    props.id ?? `klean-popover-${generatedId.replace(/[^a-zA-Z0-9_-]/g, '')}`
+)
+const contentAttrs = computed(() => {
+  const {
+    class: _class,
+    style: _style,
+    hidden: _hidden,
+    popover: _popover,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+const contentClasses = computed(() =>
+  twMerge(
+    [
+      'z-50 m-0 w-max max-w-[calc(100vw-1rem)] rounded-md border border-gray-200 bg-white p-4 text-gray-950 shadow-lg outline-none',
+      'dark:border-gray-700 dark:bg-gray-950 dark:text-white'
+    ],
+    attrs.class
+  )
+)
+const dataSlot = computed(() => attrs['data-slot'] ?? 'popover-content')
+
+function invokers() {
+  const root = content.value?.getRootNode?.() ?? document
+
+  return [...(root.querySelectorAll?.('[popovertarget]') ?? [])].filter(
+    (element) => element.getAttribute('popovertarget') === contentId.value
+  )
+}
+
+function eventPath(event) {
+  return event.composedPath?.() ?? [event.target]
+}
+
+function resolveInvoker(candidate) {
+  if (candidate?.isConnected) {
+    activeInvoker.value = candidate
+  }
+
+  if (!activeInvoker.value?.isConnected) {
+    activeInvoker.value = invokers()[0]
+  }
+
+  return activeInvoker.value
+}
+
+function resolveAnchor() {
+  if (typeof props.anchor === 'string') {
+    const root = content.value?.getRootNode?.() ?? document
+    const element =
+      root.getElementById?.(props.anchor) ??
+      document.getElementById(props.anchor)
+
+    if (element?.isConnected) return element
+  } else if (props.anchor?.isConnected) {
+    return props.anchor
+  }
+
+  return resolveInvoker()
+}
+
+function syncInvokerAria() {
+  for (const invoker of invokers()) {
+    invoker.setAttribute('aria-controls', contentId.value)
+    invoker.setAttribute('aria-expanded', String(isOpen.value))
+  }
+}
+
+function popoverIsShowing() {
+  if (!content.value || !nativePopover.value) return false
+
+  try {
+    return content.value.matches(':popover-open')
+  } catch {
+    return false
+  }
+}
+
+function syncNativePopover() {
+  if (!content.value || !nativePopover.value) return
+
+  const showing = popoverIsShowing()
+
+  try {
+    if (isOpen.value && !showing) {
+      content.value.showPopover({ source: resolveInvoker() })
+    } else if (!isOpen.value && showing) {
+      content.value.hidePopover()
+    }
+  } catch {
+    // A rapid native toggle can briefly make the requested state redundant.
+  }
+}
+
+function setOpen(nextOpen, { restoreFocus = false } = {}) {
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+
+  nextTick(() => {
+    syncInvokerAria()
+    syncNativePopover()
+
+    const invoker = resolveInvoker()
+    if (!nextOpen && restoreFocus && invoker?.isConnected) {
+      invoker.focus({ preventScroll: true })
+    }
+  })
+}
+
+function close({ restoreFocus = isOpen.value } = {}) {
+  setOpen(false, { restoreFocus })
+}
+
+function open(source) {
+  resolveInvoker(source)
+  setOpen(true)
+}
+
+function handleNativeToggle(event) {
+  const nextOpen = event.newState === 'open'
+  const shouldRestoreFocus =
+    !nextOpen && event.source?.getAttribute?.('popovertargetaction') === 'hide'
+  if (nextOpen) resolveInvoker(event.source)
+  if (nextOpen === isOpen.value) return
+
+  if (!isControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+  syncInvokerAria()
+
+  if (isControlled.value) nextTick(syncNativePopover)
+
+  if (shouldRestoreFocus) {
+    nextTick(() => {
+      const invoker = resolveInvoker()
+      if (invoker?.isConnected) invoker.focus({ preventScroll: true })
+    })
+  }
+}
+
+function matchingInvokerFromEvent(event) {
+  const candidate = eventPath(event).find(
+    (element) => element?.getAttribute?.('popovertarget') === contentId.value
+  )
+  return candidate?.getAttribute('popovertarget') === contentId.value
+    ? candidate
+    : undefined
+}
+
+function handleFallbackInvokerClick(event) {
+  const invoker = matchingInvokerFromEvent(event)
+  if (!invoker) return
+
+  resolveInvoker(invoker)
+  const action = invoker.getAttribute('popovertargetaction') ?? 'toggle'
+
+  if (action === 'show') setOpen(true)
+  else if (action === 'hide') setOpen(false, { restoreFocus: true })
+  else setOpen(!isOpen.value)
+}
+
+function handleOutsidePointer(event) {
+  const path = eventPath(event)
+  const invoker = resolveInvoker()
+  const anchor = resolveAnchor()
+
+  if (
+    path.includes(content.value) ||
+    (invoker && (path.includes(invoker) || invoker.contains?.(event.target))) ||
+    (anchor && (path.includes(anchor) || anchor.contains?.(event.target))) ||
+    invokers().some(
+      (invoker) => path.includes(invoker) || invoker.contains(event.target)
+    )
+  ) {
+    return
+  }
+
+  setOpen(false)
+}
+
+function handleEscape(event) {
+  if (event.key !== 'Escape') return
+
+  if (nativePopover.value) {
+    const openPopovers = [...document.querySelectorAll(':popover-open')]
+    if (openPopovers.at(-1) !== content.value) return
+  }
+
+  event.preventDefault()
+  setOpen(false, { restoreFocus: true })
+}
+
+async function updatePosition() {
+  const anchor = resolveAnchor()
+  if (!isOpen.value || !anchor || !content.value) return
+
+  const { x, y, placement } = await computePosition(anchor, content.value, {
+    placement: props.placement,
+    strategy: 'fixed',
+    middleware: [floatingOffset(props.offset), flip(), shift({ padding: 8 })]
+  })
+
+  resolvedPlacement.value = placement
+  positionStyle.value = {
+    position: 'fixed',
+    inset: 'auto',
+    left: `${x}px`,
+    top: `${y}px`
+  }
+}
+
+function stopOpenEffects() {
+  cleanupPosition()
+  cleanupPosition = () => {}
+  document.removeEventListener('pointerdown', handleOutsidePointer, true)
+  document.removeEventListener('keydown', handleEscape)
+}
+
+async function syncOpenEffects() {
+  stopOpenEffects()
+  await nextTick()
+  syncInvokerAria()
+  syncNativePopover()
+
+  const anchor = resolveAnchor()
+  if (!isOpen.value || !anchor || !content.value) return
+
+  cleanupPosition = autoUpdate(anchor, content.value, updatePosition)
+
+  document.addEventListener('keydown', handleEscape)
+  document.addEventListener('pointerdown', handleOutsidePointer, true)
+}
+
+watch(
+  () => [
+    isOpen.value,
+    props.anchor,
+    props.placement,
+    props.offset,
+    activeInvoker.value
+  ],
+  syncOpenEffects,
+  { flush: 'post' }
+)
+
+onMounted(() => {
+  nativePopover.value =
+    typeof content.value?.showPopover === 'function' &&
+    typeof content.value?.hidePopover === 'function'
+  resolveInvoker()
+  syncInvokerAria()
+
+  if (!nativePopover.value) {
+    document.addEventListener('click', handleFallbackInvokerClick)
+  }
+
+  syncOpenEffects()
+})
+
+onBeforeUnmount(() => {
+  stopOpenEffects()
+  document.removeEventListener('click', handleFallbackInvokerClick)
+})
+
+defineExpose({ content, close, open })
+</script>
+
+<template>
+  <div
+    ref="content"
+    v-bind="contentAttrs"
+    :id="contentId"
+    popover="auto"
+    :hidden="!nativePopover && !isOpen"
+    :data-slot="dataSlot"
+    :data-state="isOpen ? 'open' : 'closed'"
+    :data-placement="resolvedPlacement"
+    :class="contentClasses"
+    :style="[positionStyle, attrs.style]"
+    @toggle="handleNativeToggle"
+  >
+    <slot :open="isOpen" :close="close" />
+  </div>
+</template>

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -9,6 +9,7 @@ import UpdateModal from '@/components/UpdateModal.vue'
 import DeploymentToast from '@/components/DeploymentToast.vue'
 import ServiceActionToast from '@/components/ServiceActionToast.vue'
 import CommandPalette from '@/components/CommandPalette.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import { createToast } from '@/composables/toast'
 import { useFlashToast } from '@/composables/flash-toast'
 import {
@@ -73,10 +74,6 @@ provide('toggleMobileMenu', toggleMobileMenu)
 provide('toggleSidebar', toggleSidebar)
 provide('sidebarCollapsed', sidebarCollapsed)
 
-// Team dropdown state
-const teamDropdownOpen = ref(false)
-const userDropdownOpen = ref(false)
-
 // Get user's teams (current team + owned teams)
 const userTeams = computed(() => {
   if (!loggedInUser) return []
@@ -96,7 +93,6 @@ const userTeams = computed(() => {
 })
 
 function switchTeam(teamId) {
-  teamDropdownOpen.value = false
   router.post(
     '/switch-team',
     { teamId },
@@ -112,59 +108,38 @@ function switchTeam(teamId) {
 }
 
 function createNewTeam() {
-  teamDropdownOpen.value = false
   router.visit('/teams/create')
 }
 
 function logout() {
-  userDropdownOpen.value = false
   deploymentFavicon.reset()
   router.delete('/logout')
 }
 
-function closeUserMenuAndMobileMenu() {
-  userDropdownOpen.value = false
+function handleMobileProfileClick() {
   closeMobileMenu()
 }
 
-function handleMobileProfileClick() {
-  closeUserMenuAndMobileMenu()
-}
-
 function handleMobileSettingsClick() {
-  closeUserMenuAndMobileMenu()
+  closeMobileMenu()
 }
 
 function openUpdateModalFromMobileMenu() {
-  closeUserMenuAndMobileMenu()
+  closeMobileMenu()
   showUpdateModal.value = true
 }
 
 function openCommandPaletteFromMobileMenu() {
-  closeUserMenuAndMobileMenu()
+  closeMobileMenu()
   openCommandPalette()
 }
 
 function openUpdateModalFromUserMenu() {
-  userDropdownOpen.value = false
   showUpdateModal.value = true
 }
 
 function openCommandPaletteFromUserMenu() {
-  userDropdownOpen.value = false
   openCommandPalette()
-}
-
-function closeAllDropdowns() {
-  teamDropdownOpen.value = false
-  userDropdownOpen.value = false
-}
-
-// Handle escape key to close dropdowns
-function handleEscapeKey(e) {
-  if (e.key === 'Escape') {
-    closeAllDropdowns()
-  }
 }
 
 // Toast system
@@ -243,8 +218,6 @@ onMounted(() => {
     sidebarCollapsed.value = saved === 'true'
   }
 
-  // Listen for escape key to close dropdowns
-  document.addEventListener('keydown', handleEscapeKey)
   document.addEventListener('visibilitychange', acknowledgeDeploymentFavicon)
   window.addEventListener('focus', acknowledgeDeploymentFavicon)
   window.addEventListener('pagehide', deploymentFavicon.reset)
@@ -253,7 +226,6 @@ onMounted(() => {
 onUnmounted(() => {
   disconnectDeploymentStream()
   deploymentFavicon.destroy()
-  document.removeEventListener('keydown', handleEscapeKey)
   document.removeEventListener('visibilitychange', acknowledgeDeploymentFavicon)
   window.removeEventListener('focus', acknowledgeDeploymentFavicon)
   window.removeEventListener('pagehide', deploymentFavicon.reset)
@@ -261,10 +233,7 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <div
-    class="flex h-screen overflow-hidden bg-white dark:bg-gray-950"
-    @click="closeAllDropdowns"
-  >
+  <div class="flex h-screen overflow-hidden bg-white dark:bg-gray-950">
     <!-- Mobile Menu Backdrop -->
     <Transition
       enter-active-class="transition-opacity duration-300"
@@ -299,7 +268,7 @@ onUnmounted(() => {
           <div class="relative min-w-0 flex-1">
             <button
               data-test="mobile-team-selector"
-              @click.stop="teamDropdownOpen = !teamDropdownOpen"
+              popovertarget="mobile-team-menu"
               class="flex w-full min-w-0 items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
             >
               <div class="flex min-w-0 flex-1 items-center space-x-2">
@@ -323,10 +292,7 @@ onUnmounted(() => {
                 >
               </div>
               <svg
-                :class="[
-                  'h-4 w-4 shrink-0 text-gray-400 transition-transform dark:text-gray-500',
-                  teamDropdownOpen ? 'rotate-180' : ''
-                ]"
+                class="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -340,19 +306,14 @@ onUnmounted(() => {
               </svg>
             </button>
             <!-- Team Dropdown -->
-            <Transition
-              enter-active-class="transition ease-out duration-100"
-              enter-from-class="transform opacity-0 scale-95"
-              enter-to-class="transform opacity-100 scale-100"
-              leave-active-class="transition ease-in duration-75"
-              leave-from-class="transform opacity-100 scale-100"
-              leave-to-class="transform opacity-0 scale-95"
+            <Menu
+              id="mobile-team-menu"
+              aria-label="Switch team"
+              placement="bottom-start"
+              :offset="4"
+              class="w-64 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
             >
-              <div
-                v-if="teamDropdownOpen"
-                @click.stop
-                class="absolute left-0 top-full z-20 mt-1 w-full rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-              >
+              <div class="contents">
                 <div
                   class="px-3 py-1.5 text-xs font-medium text-gray-400 dark:text-gray-500"
                 >
@@ -398,6 +359,7 @@ onUnmounted(() => {
                   </svg>
                 </button>
                 <div
+                  role="separator"
                   class="my-1 border-t border-gray-100 dark:border-gray-800"
                 ></div>
                 <button
@@ -420,7 +382,7 @@ onUnmounted(() => {
                   <span>Create team</span>
                 </button>
               </div>
-            </Transition>
+            </Menu>
           </div>
           <button
             data-test="mobile-menu-close"
@@ -560,7 +522,7 @@ onUnmounted(() => {
         <!-- User Profile Dropdown (Mobile) -->
         <div class="relative px-3 py-3">
           <button
-            @click.stop="userDropdownOpen = !userDropdownOpen"
+            popovertarget="mobile-user-menu"
             class="flex w-full items-center space-x-3 rounded-md px-3 py-2.5 text-sm text-gray-600 transition-colors hover:bg-gray-200/50 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-200"
           >
             <span
@@ -586,19 +548,14 @@ onUnmounted(() => {
             </svg>
           </button>
           <!-- User Dropdown -->
-          <Transition
-            enter-active-class="transition ease-out duration-100"
-            enter-from-class="transform opacity-0 scale-95"
-            enter-to-class="transform opacity-100 scale-100"
-            leave-active-class="transition ease-in duration-75"
-            leave-from-class="transform opacity-100 scale-100"
-            leave-to-class="transform opacity-0 scale-95"
+          <Menu
+            id="mobile-user-menu"
+            aria-label="Account actions"
+            placement="top-start"
+            :offset="4"
+            class="w-64 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
           >
-            <div
-              v-if="userDropdownOpen"
-              @click.stop
-              class="absolute bottom-full left-3 right-3 z-20 mb-1 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-            >
+            <div class="contents">
               <Link
                 href="/profile"
                 @click="handleMobileProfileClick"
@@ -688,6 +645,7 @@ onUnmounted(() => {
                 >
               </button>
               <div
+                role="separator"
                 class="my-1 border-t border-gray-100 dark:border-gray-800"
               ></div>
               <a
@@ -743,6 +701,7 @@ onUnmounted(() => {
                 Sponsor Slipway
               </a>
               <div
+                role="separator"
                 class="my-1 border-t border-gray-100 dark:border-gray-800"
               ></div>
               <button
@@ -765,7 +724,7 @@ onUnmounted(() => {
                 Sign out
               </button>
             </div>
-          </Transition>
+          </Menu>
         </div>
       </aside>
     </Transition>
@@ -783,7 +742,7 @@ onUnmounted(() => {
         <div class="relative min-w-0 flex-1">
           <button
             data-test="desktop-team-selector"
-            @click.stop="teamDropdownOpen = !teamDropdownOpen"
+            popovertarget="desktop-team-menu"
             class="flex w-full min-w-0 items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
           >
             <img
@@ -805,10 +764,7 @@ onUnmounted(() => {
               >{{ loggedInUser.team?.name || 'Team' }}</span
             >
             <svg
-              :class="[
-                'h-4 w-4 shrink-0 text-gray-400 transition-transform dark:text-gray-500',
-                teamDropdownOpen ? 'rotate-180' : ''
-              ]"
+              class="h-4 w-4 shrink-0 text-gray-400 dark:text-gray-500"
               fill="none"
               stroke="currentColor"
               viewBox="0 0 24 24"
@@ -822,19 +778,14 @@ onUnmounted(() => {
             </svg>
           </button>
           <!-- Team Dropdown -->
-          <Transition
-            enter-active-class="transition ease-out duration-100"
-            enter-from-class="transform opacity-0 scale-95"
-            enter-to-class="transform opacity-100 scale-100"
-            leave-active-class="transition ease-in duration-75"
-            leave-from-class="transform opacity-100 scale-100"
-            leave-to-class="transform opacity-0 scale-95"
+          <Menu
+            id="desktop-team-menu"
+            aria-label="Switch team"
+            placement="bottom-start"
+            :offset="4"
+            class="w-52 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
           >
-            <div
-              v-if="teamDropdownOpen"
-              @click.stop
-              class="absolute left-0 top-full z-20 mt-1 w-full rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-            >
+            <div class="contents">
               <div
                 class="px-3 py-1.5 text-xs font-medium text-gray-400 dark:text-gray-500"
               >
@@ -880,6 +831,7 @@ onUnmounted(() => {
                 </svg>
               </button>
               <div
+                role="separator"
                 class="my-1 border-t border-gray-100 dark:border-gray-800"
               ></div>
               <button
@@ -902,7 +854,7 @@ onUnmounted(() => {
                 <span>Create team</span>
               </button>
             </div>
-          </Transition>
+          </Menu>
         </div>
       </div>
 
@@ -1019,7 +971,8 @@ onUnmounted(() => {
       <!-- User Profile Dropdown (Desktop) -->
       <div class="relative px-3 py-3">
         <button
-          @click.stop="userDropdownOpen = !userDropdownOpen"
+          data-test="desktop-user-menu-button"
+          popovertarget="desktop-user-menu"
           class="flex w-full items-center space-x-3 rounded-md px-2 py-2 text-sm text-gray-500 transition-colors hover:bg-gray-200/50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800/50 dark:hover:text-gray-200"
         >
           <span
@@ -1045,22 +998,16 @@ onUnmounted(() => {
           </svg>
         </button>
         <!-- User Dropdown -->
-        <Transition
-          enter-active-class="transition ease-out duration-100"
-          enter-from-class="transform opacity-0 scale-95"
-          enter-to-class="transform opacity-100 scale-100"
-          leave-active-class="transition ease-in duration-75"
-          leave-from-class="transform opacity-100 scale-100"
-          leave-to-class="transform opacity-0 scale-95"
+        <Menu
+          id="desktop-user-menu"
+          aria-label="Account actions"
+          placement="top-start"
+          :offset="4"
+          class="w-52 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
         >
-          <div
-            v-if="userDropdownOpen"
-            @click.stop
-            class="absolute bottom-full left-3 right-3 z-20 mb-1 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-          >
+          <div class="contents">
             <Link
               href="/profile"
-              @click="userDropdownOpen = false"
               class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
             >
               <svg
@@ -1080,7 +1027,6 @@ onUnmounted(() => {
             </Link>
             <Link
               href="/settings"
-              @click="userDropdownOpen = false"
               class="flex w-full items-center gap-2 px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
             >
               <svg
@@ -1147,6 +1093,7 @@ onUnmounted(() => {
               >
             </button>
             <div
+              role="separator"
               class="my-1 border-t border-gray-100 dark:border-gray-800"
             ></div>
             <a
@@ -1202,6 +1149,7 @@ onUnmounted(() => {
               Sponsor Slipway
             </a>
             <div
+              role="separator"
               class="my-1 border-t border-gray-100 dark:border-gray-800"
             ></div>
             <button
@@ -1224,7 +1172,7 @@ onUnmounted(() => {
               Sign out
             </button>
           </div>
-        </Transition>
+        </Menu>
       </div>
     </aside>
 

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -15,6 +15,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Table from '@/components/ui/table/Table.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import HelmResultViewer from '@/components/HelmResultViewer.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
@@ -104,7 +105,6 @@ const consoleError = ref(null)
 const consoleLoading = ref(false)
 const queryHistory = ref([])
 const resultView = ref('table')
-const showExportMenu = ref(false)
 
 // ─── Migrate state ───
 const diff = ref(null)
@@ -421,7 +421,6 @@ function downloadFile(content, filename, mimeType) {
 
 function exportAction(fn) {
   fn()
-  showExportMenu.value = false
 }
 
 async function fetchDiff() {
@@ -766,15 +765,7 @@ function activityTypeColor(type) {
   )
 }
 
-// Close menus on click outside
-function handleClickOutside(e) {
-  if (showExportMenu.value && !e.target.closest('[data-export-menu]')) {
-    showExportMenu.value = false
-  }
-}
-
 onMounted(() => {
-  document.addEventListener('click', handleClickOutside)
   window.addEventListener('focus', loadHelmCompletionMetadata)
   loadHelmCompletionMetadata()
   if (activeTab.value === 'activity') {
@@ -791,7 +782,6 @@ onBeforeUnmount(() => {
 
 onUnmounted(() => {
   helmCompletionRequestSequence++
-  document.removeEventListener('click', handleClickOutside)
   window.removeEventListener('focus', loadHelmCompletionMetadata)
 })
 </script>
@@ -1317,12 +1307,12 @@ onUnmounted(() => {
               </button>
             </Tooltip>
             <!-- Export dropdown -->
-            <div class="relative" data-export-menu>
+            <div class="relative">
               <Tooltip text="Download" placement="top">
                 <button
                   type="button"
                   aria-label="Download query results"
-                  @click="showExportMenu = !showExportMenu"
+                  popovertarget="bosun-export-menu"
                   class="rounded p-1.5 text-gray-500 hover:bg-gray-200 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-200"
                 >
                   <svg
@@ -1340,9 +1330,12 @@ onUnmounted(() => {
                   </svg>
                 </button>
               </Tooltip>
-              <div
-                v-if="showExportMenu"
-                class="absolute bottom-full right-0 z-10 mb-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+              <Menu
+                id="bosun-export-menu"
+                aria-label="Export query results"
+                placement="top-end"
+                :offset="4"
+                class="w-40 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
               >
                 <button
                   @click="exportAction(copyAsJSON)"
@@ -1357,6 +1350,7 @@ onUnmounted(() => {
                   Copy as CSV
                 </button>
                 <div
+                  role="separator"
                   class="my-1 border-t border-gray-200 dark:border-gray-700"
                 ></div>
                 <button
@@ -1371,7 +1365,7 @@ onUnmounted(() => {
                 >
                   Download CSV
                 </button>
-              </div>
+              </Menu>
             </div>
           </div>
         </template>

--- a/assets/js/pages/dashboard/index.vue
+++ b/assets/js/pages/dashboard/index.vue
@@ -1,8 +1,9 @@
 <script setup>
 import { Link, Head, useForm } from '@inertiajs/vue3'
-import { inject, ref, computed, onMounted, onUnmounted } from 'vue'
+import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 
 defineOptions({
   layout: AppLayout
@@ -19,7 +20,6 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const searchQuery = ref('')
-const openMenuId = ref(null)
 const copiedSlug = ref(null)
 
 const filteredProjects = computed(() => {
@@ -54,16 +54,6 @@ function timeAgo(date) {
   return 'just now'
 }
 
-function toggleMenu(e, projectId) {
-  e.preventDefault()
-  e.stopPropagation()
-  openMenuId.value = openMenuId.value === projectId ? null : projectId
-}
-
-function closeMenu() {
-  openMenuId.value = null
-}
-
 function copySlug(e, slug) {
   e.preventDefault()
   e.stopPropagation()
@@ -72,7 +62,6 @@ function copySlug(e, slug) {
   setTimeout(() => {
     copiedSlug.value = null
   }, 2000)
-  closeMenu()
 }
 
 const deletingProject = ref(null)
@@ -85,7 +74,6 @@ function deleteProject(e, project) {
   e.stopPropagation()
   deletingProject.value = project
   deleteProjectForm.reset()
-  closeMenu()
 }
 
 function executeDeleteProject() {
@@ -101,21 +89,6 @@ function cancelDeleteProject() {
   deleteProjectForm.reset()
   deletingProject.value = null
 }
-
-// Close menu when clicking outside
-function handleClickOutside(e) {
-  if (openMenuId.value && !e.target.closest('.relative')) {
-    closeMenu()
-  }
-}
-
-onMounted(() => {
-  document.addEventListener('click', handleClickOutside)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', handleClickOutside)
-})
 </script>
 <template>
   <Head title="Projects | Slipway"></Head>
@@ -397,7 +370,10 @@ onUnmounted(() => {
                 <!-- Actions Menu -->
                 <div class="relative">
                   <button
-                    @click="toggleMenu($event, project.id)"
+                    type="button"
+                    :popovertarget="`project-actions-${project.id}`"
+                    :data-test="`project-actions-${project.slug}`"
+                    :aria-label="`Actions for ${project.name}`"
                     class="rounded p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
                   >
                     <svg
@@ -411,9 +387,12 @@ onUnmounted(() => {
                     </svg>
                   </button>
                   <!-- Dropdown -->
-                  <div
-                    v-if="openMenuId === project.id"
-                    class="absolute right-0 z-10 mt-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+                  <Menu
+                    :id="`project-actions-${project.id}`"
+                    :aria-label="`Actions for ${project.name}`"
+                    placement="bottom-end"
+                    :offset="4"
+                    class="w-40 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
                   >
                     <Link
                       :href="`/projects/${project.slug}/settings`"
@@ -476,6 +455,7 @@ onUnmounted(() => {
                       Copy slug
                     </button>
                     <div
+                      role="separator"
                       class="my-1 border-t border-gray-200 dark:border-gray-700"
                     ></div>
                     <button
@@ -497,7 +477,7 @@ onUnmounted(() => {
                       </svg>
                       Delete
                     </button>
-                  </div>
+                  </Menu>
                 </div>
               </div>
             </div>

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -18,6 +18,7 @@ import CodeEditor from '@/components/CodeEditor.vue'
 import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
 import ReleaseFlagMenu from '@/components/ReleaseFlagMenu.vue'
 import Switch from '@/components/ui/switch/Switch.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import { useToast } from '@/composables/toast'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
@@ -142,19 +143,16 @@ async function stopApp() {
 }
 
 async function handleRestartAppClick() {
-  moreMenuOpen.value = false
   await restartApp()
 }
 
 async function handleStopAppClick() {
-  moreMenuOpen.value = false
   await stopApp()
 }
 
 // --- Domain display ---
 const domainDropdownOpen = ref(false)
 const copiedText = ref(null)
-const moreMenuOpen = ref(false)
 
 const accessUrls = computed(() => props.app.accessUrls || [])
 
@@ -171,7 +169,6 @@ function copyToClipboard(text) {
 
 function closeAllDropdowns() {
   domainDropdownOpen.value = false
-  moreMenuOpen.value = false
 }
 
 // --- Custom domain ---
@@ -182,7 +179,6 @@ const domainModalOpen = ref(false)
 function openDomainModal() {
   newDomain.value = props.environment.domain || ''
   domainModalOpen.value = true
-  moreMenuOpen.value = false
 }
 
 function closeDomainModal() {
@@ -1111,9 +1107,7 @@ onBeforeUnmount(() => {
                 type="button"
                 data-test="app-more-menu"
                 aria-label="Open app actions"
-                aria-haspopup="true"
-                :aria-expanded="moreMenuOpen"
-                @click.stop="moreMenuOpen = !moreMenuOpen"
+                popovertarget="app-more-actions"
                 class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
               >
                 <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
@@ -1123,19 +1117,14 @@ onBeforeUnmount(() => {
                 </svg>
               </button>
               <!-- Dropdown -->
-              <Transition
-                enter-active-class="transition ease-out duration-100"
-                enter-from-class="transform opacity-0 scale-95"
-                enter-to-class="transform opacity-100 scale-100"
-                leave-active-class="transition ease-in duration-75"
-                leave-from-class="transform opacity-100 scale-100"
-                leave-to-class="transform opacity-0 scale-95"
+              <Menu
+                id="app-more-actions"
+                aria-label="App actions"
+                placement="bottom-end"
+                :offset="4"
+                class="w-48 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
               >
-                <div
-                  v-if="moreMenuOpen"
-                  @click.stop
-                  class="absolute right-0 top-full z-20 mt-1 w-48 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-                >
+                <div class="contents">
                   <!-- Platform tools -->
                   <div
                     v-if="app.status === 'running'"
@@ -1408,7 +1397,7 @@ onBeforeUnmount(() => {
                     </Link>
                   </div>
                 </div>
-              </Transition>
+              </Menu>
             </div>
             <span
               :class="[

--- a/assets/js/pages/projects/bridge-access.vue
+++ b/assets/js/pages/projects/bridge-access.vue
@@ -5,6 +5,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import Alert from '@/components/ui/alert/Alert.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 
 defineOptions({
   layout: AppLayout
@@ -21,7 +22,6 @@ const props = defineProps({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
-const openMenu = ref(null)
 const revoking = ref(null)
 const disabling = ref(false)
 const resending = ref(null)
@@ -69,7 +69,6 @@ function setEnabled(enabled) {
 }
 
 function changeRole(grant, role) {
-  openMenu.value = null
   if (grant.role === role) return
   router.patch(
     `${accessPath.value}/${grant.id}`,
@@ -79,7 +78,6 @@ function changeRole(grant, role) {
 }
 
 function resend(grant) {
-  openMenu.value = null
   resending.value = grant.id
   router.post(
     `${accessPath.value}/invitations`,
@@ -97,7 +95,6 @@ function resend(grant) {
 }
 
 function confirmRevoke(grant) {
-  openMenu.value = null
   revoking.value = grant
 }
 
@@ -113,10 +110,6 @@ function revoke() {
 function disableBridge() {
   setEnabled(false)
   disabling.value = false
-}
-
-function closeMenus() {
-  openMenu.value = null
 }
 
 function statusLabel(grant) {
@@ -169,7 +162,7 @@ function timeAgo(timestamp) {
 
 <template>
   <Head :title="`Bridge access - ${app.name} | Slipway`"></Head>
-  <div class="flex h-full flex-col" @click="closeMenus">
+  <div class="flex h-full flex-col">
     <header
       class="flex items-center justify-between border-b border-gray-200 py-4 pl-4 pr-4 dark:border-gray-800 sm:pr-8"
     >
@@ -449,10 +442,7 @@ function timeAgo(timestamp) {
                   type="button"
                   class="rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-900 dark:hover:text-gray-200"
                   :aria-label="`Manage ${grant.email}`"
-                  :aria-expanded="openMenu === grant.id"
-                  @click.stop="
-                    openMenu = openMenu === grant.id ? null : grant.id
-                  "
+                  :popovertarget="`bridge-access-actions-${grant.id}`"
                 >
                   <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                     <circle cx="6" cy="12" r="1.5" />
@@ -460,10 +450,12 @@ function timeAgo(timestamp) {
                     <circle cx="18" cy="12" r="1.5" />
                   </svg>
                 </button>
-                <div
-                  v-if="openMenu === grant.id"
-                  class="absolute right-0 top-full z-20 mt-1 w-44 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-800 dark:bg-gray-900"
-                  @click.stop
+                <Menu
+                  :id="`bridge-access-actions-${grant.id}`"
+                  :aria-label="`Manage ${grant.email}`"
+                  placement="bottom-end"
+                  :offset="4"
+                  class="w-44 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-800 dark:bg-gray-900"
                 >
                   <p
                     class="px-3 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-gray-400"
@@ -508,7 +500,7 @@ function timeAgo(timestamp) {
                   >
                     Revoke access
                   </button>
-                </div>
+                </Menu>
               </div>
             </article>
           </div>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -13,6 +13,7 @@ import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 import Pagination from '@/components/ui/pagination/Pagination.vue'
 import Table from '@/components/ui/table/Table.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 
 defineOptions({
   layout: BridgePageLayout
@@ -96,7 +97,6 @@ const selectedIds = ref(new Set())
 const selectAll = ref(false)
 const deleteModal = ref({ show: false, recordId: null })
 const bulkDeleteModal = ref({ show: false })
-const openActionMenu = ref(null)
 const actionDialog = ref({ show: false, action: null, recordIds: [] })
 
 const hasRecordActions = computed(() => {
@@ -161,55 +161,12 @@ function actionLabel(record) {
   return String(title || displayIdentifier(record[props.modelMeta.primaryKey]))
 }
 
-function toggleActionMenu(record) {
-  const key = recordKey(record)
-  openActionMenu.value = openActionMenu.value === key ? null : key
-}
-
-function closeActionMenu() {
-  openActionMenu.value = null
-}
-
-function handleActionMenuKeydown(event) {
-  const items = Array.from(
-    event.currentTarget.querySelectorAll('[role="menuitem"]')
-  )
-  const currentIndex = items.indexOf(document.activeElement)
-
-  if (event.key === 'Escape') {
-    event.preventDefault()
-    closeActionMenu()
-    event.currentTarget.previousElementSibling?.focus()
-    return
-  }
-
-  let nextIndex
-  if (event.key === 'ArrowDown') {
-    nextIndex = currentIndex < 0 ? 0 : (currentIndex + 1) % items.length
-  } else if (event.key === 'ArrowUp') {
-    nextIndex =
-      currentIndex < 0
-        ? items.length - 1
-        : (currentIndex - 1 + items.length) % items.length
-  } else if (event.key === 'Home') {
-    nextIndex = 0
-  } else if (event.key === 'End') {
-    nextIndex = items.length - 1
-  } else {
-    return
-  }
-
-  event.preventDefault()
-  items[nextIndex]?.focus()
-}
-
 // Forms for delete actions
 const deleteForm = useForm({})
 const bulkDeleteForm = useForm({ ids: [] })
 const quickActionForm = useForm({})
 
 function openDeleteModal(record) {
-  closeActionMenu()
   deleteModal.value = {
     show: true,
     recordId: record[props.modelMeta.primaryKey],
@@ -509,11 +466,7 @@ function createUrl() {
   ></Head>
   <ToastContainer :toasts="toasts" @dismiss="dismiss" />
 
-  <div
-    class="flex h-full flex-col"
-    @click="closeActionMenu"
-    @keydown.esc="closeActionMenu"
-  >
+  <div class="flex h-full flex-col">
     <BridgePageHeader
       v-if="hostBridgeOrigin"
       :project="project"
@@ -890,7 +843,7 @@ function createUrl() {
               class="divide-y divide-gray-200 bg-white dark:divide-gray-800 dark:bg-gray-950"
             >
               <tr
-                v-for="(record, recordIndex) in records"
+                v-for="record in records"
                 :key="record[modelMeta.primaryKey]"
                 class="group hover:bg-gray-50 dark:hover:bg-gray-900/30"
               >
@@ -933,9 +886,9 @@ function createUrl() {
                       type="button"
                       class="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
                       :aria-label="`Actions for ${actionLabel(record)}`"
-                      aria-haspopup="menu"
-                      :aria-expanded="openActionMenu === recordKey(record)"
-                      @click="toggleActionMenu(record)"
+                      :popovertarget="`bridge-record-actions-${recordKey(
+                        record
+                      )}`"
                     >
                       <svg
                         class="h-4 w-4"
@@ -949,16 +902,12 @@ function createUrl() {
                       </svg>
                     </button>
 
-                    <div
-                      v-if="openActionMenu === recordKey(record)"
-                      role="menu"
-                      :class="[
-                        'absolute right-0 z-20 w-36 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900',
-                        recordIndex >= records.length - 2
-                          ? 'bottom-full mb-1'
-                          : 'top-full mt-1'
-                      ]"
-                      @keydown="handleActionMenuKeydown"
+                    <Menu
+                      :id="`bridge-record-actions-${recordKey(record)}`"
+                      :aria-label="`Actions for ${actionLabel(record)}`"
+                      placement="bottom-end"
+                      :offset="4"
+                      class="w-36 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
                     >
                       <Link
                         v-if="modelMeta.actions?.view !== false"
@@ -966,7 +915,6 @@ function createUrl() {
                         prefetch
                         role="menuitem"
                         class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
-                        @click="closeActionMenu"
                       >
                         View record
                       </Link>
@@ -976,7 +924,6 @@ function createUrl() {
                         prefetch
                         role="menuitem"
                         class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
-                        @click="closeActionMenu"
                       >
                         Edit record
                       </Link>
@@ -988,7 +935,7 @@ function createUrl() {
                       >
                         Delete record
                       </button>
-                    </div>
+                    </Menu>
                   </div>
                 </td>
               </tr>

--- a/assets/js/pages/projects/content-editor.vue
+++ b/assets/js/pages/projects/content-editor.vue
@@ -1,10 +1,11 @@
 <script setup>
 import { Link, Head, useForm } from '@inertiajs/vue3'
-import { computed, inject, onMounted, onUnmounted, ref, watch } from 'vue'
+import { computed, inject, ref, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
@@ -30,7 +31,6 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 // State
 const deleteModalOpen = ref(false)
 const showSaveMenu = ref(false)
-const saveMenuRoot = ref(null)
 
 // Content (initialized from props)
 const fileType = ref(props.content?.fileType || 'markdown')
@@ -216,26 +216,6 @@ function updateEditorMode(nextMode) {
 function updateEditorCompatibility(nextCompatibility) {
   editorCompatibility.value = nextCompatibility
 }
-
-// Click outside handler
-function handleClickOutside(e) {
-  if (
-    showSaveMenu.value &&
-    saveMenuRoot.value &&
-    !saveMenuRoot.value.contains(e.target)
-  ) {
-    showSaveMenu.value = false
-  }
-}
-
-// Initialize
-onMounted(() => {
-  document.addEventListener('click', handleClickOutside)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', handleClickOutside)
-})
 
 // Keyboard shortcuts
 function handleKeydown(e) {
@@ -500,7 +480,7 @@ function handleKeydown(e) {
         </Tooltip>
 
         <!-- Split Save Button -->
-        <div ref="saveMenuRoot" class="relative flex">
+        <div class="relative flex">
           <button
             type="button"
             @click="saveContent(false)"
@@ -524,9 +504,7 @@ function handleKeydown(e) {
             data-test="content-save-menu-toggle"
             type="button"
             aria-label="Open save options"
-            :aria-expanded="showSaveMenu"
-            aria-controls="content-save-menu"
-            @click="showSaveMenu = !showSaveMenu"
+            popovertarget="content-save-menu"
             :disabled="saveForm.processing || saveForm.validating"
             class="rounded-r-md border-l border-gray-700 bg-gray-900 px-2 py-1.5 text-white hover:bg-gray-800 disabled:opacity-50 dark:border-gray-300 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
           >
@@ -546,11 +524,14 @@ function handleKeydown(e) {
             </svg>
           </button>
           <!-- Dropdown -->
-          <div
-            v-if="showSaveMenu"
+          <Menu
+            v-model:open="showSaveMenu"
             id="content-save-menu"
             data-test="content-save-menu"
-            class="absolute right-0 top-full z-10 mt-1 w-64 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+            aria-label="Save options"
+            placement="bottom-end"
+            :offset="4"
+            class="w-64 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
           >
             <button
               type="button"
@@ -583,7 +564,7 @@ function handleKeydown(e) {
                 saveForm.errors.appSlug
               }}
             </p>
-          </div>
+          </Menu>
         </div>
       </div>
     </div>

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -14,6 +14,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Table from '@/components/ui/table/Table.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import DockResultStatusIcon from '@/components/DockResultStatusIcon.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
@@ -983,25 +984,17 @@ function downloadFile(content, filename, mimeType) {
   }, 100)
 }
 
-// Close all dropdowns on click outside
+// The schema filter is a form popover rather than an action menu.
 const handleClickOutside = (e) => {
-  if (showExportMenu.value && !e.target.closest('[ref="exportDropdown"]')) {
-    showExportMenu.value = false
-  }
   if (schemaFilterOpen.value && !e.target.closest('[data-schema-filter]')) {
     schemaFilterOpen.value = false
   }
-  if (exportDropdownOpen.value && !e.target.closest('[data-export-dropdown]')) {
-    exportDropdownOpen.value = false
-  }
 }
 
-// Handle escape key to close menus
+// Klean Menu owns Escape for action menus; this remains for form surfaces.
 function handleEscapeKey(e) {
   if (e.key === 'Escape') {
-    showExportMenu.value = false
     schemaFilterOpen.value = false
-    exportDropdownOpen.value = false
     if (showImportModal.value && !importLoading.value) {
       closeImportModal()
     }
@@ -2032,7 +2025,7 @@ onUnmounted(() => {
                     placement="top"
                   >
                     <button
-                      @click="showExportMenu = !showExportMenu"
+                      popovertarget="dock-query-export-menu"
                       :aria-label="
                         resultView === 'json' ? 'Download JSON' : 'Download CSV'
                       "
@@ -2053,9 +2046,13 @@ onUnmounted(() => {
                       </svg>
                     </button>
                   </Tooltip>
-                  <div
-                    v-if="showExportMenu"
-                    class="absolute bottom-full right-0 z-10 mb-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+                  <Menu
+                    v-model:open="showExportMenu"
+                    id="dock-query-export-menu"
+                    aria-label="Download query results"
+                    placement="top-end"
+                    :offset="4"
+                    class="w-40 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
                   >
                     <button
                       @click="downloadQueryResultAsJSON"
@@ -2069,7 +2066,7 @@ onUnmounted(() => {
                     >
                       Download as CSV
                     </button>
-                  </div>
+                  </Menu>
                 </div>
               </div>
             </div>
@@ -2673,11 +2670,8 @@ onUnmounted(() => {
               :aria-label="
                 exportLoading ? 'Exporting database' : 'Export database'
               "
-              @click.stop="
-                exportLoading
-                  ? undefined
-                  : (exportDropdownOpen = !exportDropdownOpen)
-              "
+              popovertarget="dock-database-export-menu"
+              :disabled="exportLoading"
               :aria-disabled="exportLoading"
               :class="[
                 'flex h-8 w-8 items-center justify-center rounded-md transition-colors',
@@ -2705,9 +2699,13 @@ onUnmounted(() => {
             </button>
           </Tooltip>
           <!-- Export dropdown -->
-          <div
-            v-if="exportDropdownOpen"
-            class="absolute bottom-full right-0 z-50 mb-2 w-44 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+          <Menu
+            v-model:open="exportDropdownOpen"
+            id="dock-database-export-menu"
+            aria-label="Export database"
+            placement="top-end"
+            :offset="8"
+            class="w-44 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
           >
             <button
               @click="exportDatabase('full')"
@@ -2766,7 +2764,7 @@ onUnmounted(() => {
               </svg>
               Data only
             </button>
-          </div>
+          </Menu>
         </div>
 
         <!-- Import button -->

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -15,6 +15,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Alert from '@/components/ui/alert/Alert.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import ConfigVariableMenu from '@/components/ConfigVariableMenu.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
@@ -271,13 +272,11 @@ async function stopSingleApp(appItem) {
 function openAddAppFromMoreMenu() {
   appsOpen.value = true
   addAppOpen.value = true
-  moreMenuOpen.value = false
 }
 
 function openAddServiceFromMoreMenu() {
   servicesOpen.value = true
   addServiceOpen.value = true
-  moreMenuOpen.value = false
 }
 
 async function handleRestartSingleApp(appItem) {
@@ -423,8 +422,6 @@ function copyToClipboard(text) {
 }
 
 function closeAllDropdowns() {
-  moreMenuOpen.value = false
-  serviceMenuOpen.value = null
   appMenuOpen.value = null
   repoDropdownOpen.value = false
 }
@@ -628,7 +625,6 @@ const creatingService = ref(false)
 const deletingServiceId = ref(null)
 const deletingService = ref(false)
 const purgeServiceData = ref(false)
-const serviceMenuOpen = ref(null)
 const stoppingServiceId = ref(null)
 const startingServiceId = ref(null)
 const revealedServiceUrls = ref(new Set())
@@ -737,22 +733,12 @@ async function createService() {
   }
 }
 
-function toggleServiceMenu(serviceId) {
-  serviceMenuOpen.value = serviceMenuOpen.value === serviceId ? null : serviceId
-}
-
-function closeServiceMenu() {
-  serviceMenuOpen.value = null
-}
-
 function confirmDeleteService(service) {
-  serviceMenuOpen.value = null
   purgeServiceData.value = false
   deletingServiceId.value = service.id
 }
 
 async function stopService(service) {
-  serviceMenuOpen.value = null
   stoppingServiceId.value = service.id
 
   const actionId = startAction({
@@ -776,7 +762,6 @@ async function stopService(service) {
 }
 
 async function startService(service) {
-  serviceMenuOpen.value = null
   startingServiceId.value = service.id
 
   const actionId = startAction({
@@ -1054,8 +1039,6 @@ function handleChecklistAction(action) {
   }
 }
 
-const moreMenuOpen = ref(false)
-
 // Handle escape key to close dropdowns
 function handleEscapeKey(e) {
   if (e.key === 'Escape') {
@@ -1229,7 +1212,9 @@ onBeforeUnmount(() => {
             <!-- More menu -->
             <div class="relative">
               <button
-                @click.stop="moreMenuOpen = !moreMenuOpen"
+                type="button"
+                aria-label="Environment actions"
+                popovertarget="environment-actions"
                 class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
               >
                 <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
@@ -1239,19 +1224,14 @@ onBeforeUnmount(() => {
                 </svg>
               </button>
               <!-- Dropdown -->
-              <Transition
-                enter-active-class="transition ease-out duration-100"
-                enter-from-class="transform opacity-0 scale-95"
-                enter-to-class="transform opacity-100 scale-100"
-                leave-active-class="transition ease-in duration-75"
-                leave-from-class="transform opacity-100 scale-100"
-                leave-to-class="transform opacity-0 scale-95"
+              <Menu
+                id="environment-actions"
+                aria-label="Environment actions"
+                placement="bottom-end"
+                :offset="4"
+                class="w-48 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
               >
-                <div
-                  v-if="moreMenuOpen"
-                  @click.stop
-                  class="absolute right-0 top-full z-20 mt-1 w-48 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-                >
+                <div class="contents">
                   <div
                     class="border-b border-gray-100 pb-1 dark:border-gray-800"
                   >
@@ -1322,7 +1302,7 @@ onBeforeUnmount(() => {
                     </Link>
                   </div>
                 </div>
-              </Transition>
+              </Menu>
             </div>
           </div>
         </div>
@@ -2037,7 +2017,7 @@ onBeforeUnmount(() => {
                 </svg>
               </button>
             </div>
-            <div v-show="servicesOpen" @click="closeServiceMenu">
+            <div v-show="servicesOpen">
               <div v-if="services.length > 0" class="space-y-1 px-4 pb-3">
                 <div
                   v-for="service in services"
@@ -2109,7 +2089,9 @@ onBeforeUnmount(() => {
                       <!-- Service actions menu -->
                       <div class="relative">
                         <button
-                          @click.stop="toggleServiceMenu(service.id)"
+                          type="button"
+                          :aria-label="`Actions for ${service.name}`"
+                          :popovertarget="`service-actions-${service.id}`"
                           class="rounded p-1 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
                         >
                           <svg
@@ -2122,10 +2104,12 @@ onBeforeUnmount(() => {
                             />
                           </svg>
                         </button>
-                        <div
-                          v-if="serviceMenuOpen === service.id"
-                          @click.stop
-                          class="absolute right-0 z-20 mt-1 w-36 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+                        <Menu
+                          :id="`service-actions-${service.id}`"
+                          :aria-label="`Actions for ${service.name}`"
+                          placement="bottom-end"
+                          :offset="4"
+                          class="w-36 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
                         >
                           <button
                             v-if="service.status === 'running'"
@@ -2233,7 +2217,7 @@ onBeforeUnmount(() => {
                             </svg>
                             Delete
                           </button>
-                        </div>
+                        </Menu>
                       </div>
                     </div>
                   </div>

--- a/assets/js/pages/projects/service.vue
+++ b/assets/js/pages/projects/service.vue
@@ -7,6 +7,7 @@ import Breadcrumb from '@/components/Breadcrumb.vue'
 import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
 import LogViewer from '@/components/LogViewer.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 
 defineOptions({
   layout: AppLayout
@@ -28,7 +29,6 @@ const sidebarCollapsed = inject('sidebarCollapsed')
 // State
 const logLines = ref([])
 const logsOpen = ref(true)
-const menuOpen = ref(false)
 const stopping = ref(false)
 const restarting = ref(false)
 const serviceStatus = ref(props.service.status)
@@ -150,8 +150,6 @@ const {
 async function stopService() {
   if (stopping.value) return
   stopping.value = true
-  menuOpen.value = false
-
   const actionId = startAction({
     serviceName: serviceName.value,
     serviceType: props.service.type,
@@ -186,8 +184,6 @@ async function stopService() {
 async function restartService() {
   if (restarting.value) return
   restarting.value = true
-  menuOpen.value = false
-
   // Use 'starting' if stopped, 'restarting' if running
   const actionType =
     serviceStatus.value === 'stopped' || serviceStatus.value === 'failed'
@@ -230,7 +226,6 @@ async function restartService() {
 
 function clearLogs() {
   logLines.value = []
-  menuOpen.value = false
 }
 
 function copyUrl() {
@@ -304,8 +299,6 @@ function handleNameKeydown(e) {
 }
 
 function handleClickOutside(e) {
-  if (menuOpen.value && !e.target.closest('.menu-container'))
-    menuOpen.value = false
   if (editingName.value && !e.target.closest('.name-editor'))
     cancelEditingName()
 }
@@ -576,9 +569,11 @@ onUnmounted(() => {
 
           <div class="flex items-center space-x-2">
             <!-- More menu -->
-            <div class="menu-container relative">
+            <div class="relative">
               <button
-                @click.stop="menuOpen = !menuOpen"
+                type="button"
+                :popovertarget="`service-actions-${service.id}`"
+                :aria-label="`Actions for ${serviceName}`"
                 class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
               >
                 <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
@@ -587,19 +582,14 @@ onUnmounted(() => {
                   <circle cx="12" cy="18" r="1.5" />
                 </svg>
               </button>
-              <Transition
-                enter-active-class="transition ease-out duration-100"
-                enter-from-class="transform opacity-0 scale-95"
-                enter-to-class="transform opacity-100 scale-100"
-                leave-active-class="transition ease-in duration-75"
-                leave-from-class="transform opacity-100 scale-100"
-                leave-to-class="transform opacity-0 scale-95"
+              <Menu
+                :id="`service-actions-${service.id}`"
+                :aria-label="`Actions for ${serviceName}`"
+                placement="bottom-end"
+                :offset="4"
+                class="w-40 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
               >
-                <div
-                  v-if="menuOpen"
-                  @click.stop
-                  class="absolute right-0 top-full z-20 mt-1 w-40 rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-                >
+                <div class="contents">
                   <button
                     v-if="serviceStatus === 'running'"
                     @click="stopService"
@@ -693,7 +683,7 @@ onUnmounted(() => {
                     Clear logs
                   </button>
                 </div>
-              </Transition>
+              </Menu>
             </div>
 
             <!-- Status badge -->

--- a/assets/js/pages/settings/api-keys.vue
+++ b/assets/js/pages/settings/api-keys.vue
@@ -3,6 +3,7 @@ import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
@@ -27,17 +28,6 @@ const filtered = computed(() => {
   )
 })
 
-// Actions menu
-const openMenu = ref(null)
-
-function toggleMenu(tokenId) {
-  openMenu.value = openMenu.value === tokenId ? null : tokenId
-}
-
-function closeMenu() {
-  openMenu.value = null
-}
-
 // Rename
 const renamingId = ref(null)
 const renameForm = useForm({ name: '' })
@@ -50,7 +40,6 @@ function startRename(token) {
   renamingId.value = token.id
   renameForm.name = token.name
   renameForm.clearErrors()
-  openMenu.value = null
 }
 
 function submitRename(tokenId) {
@@ -74,7 +63,6 @@ const deletingId = ref(null)
 
 function confirmDelete(token) {
   deletingId.value = token.id
-  openMenu.value = null
 }
 
 function executeDelete() {
@@ -111,7 +99,7 @@ function timeAgo(date) {
 </script>
 <template>
   <Head title="CLI Tokens | Slipway"></Head>
-  <div class="flex h-full flex-col" @click="closeMenu">
+  <div class="flex h-full flex-col">
     <!-- Header -->
     <div
       class="flex items-center justify-between border-b border-gray-200 py-4 pl-4 pr-4 dark:border-gray-800 sm:pl-4 sm:pr-8"
@@ -390,7 +378,9 @@ function timeAgo(date) {
               <div class="col-span-1 flex justify-end">
                 <div class="relative">
                   <button
-                    @click.stop="toggleMenu(token.id)"
+                    type="button"
+                    :popovertarget="`cli-token-actions-${token.id}`"
+                    :aria-label="`Actions for ${token.name}`"
                     class="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
                   >
                     <svg
@@ -405,12 +395,15 @@ function timeAgo(date) {
                   </button>
 
                   <!-- Dropdown menu -->
-                  <div
-                    v-if="openMenu === token.id"
-                    class="absolute right-0 z-10 mt-1 w-36 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+                  <Menu
+                    :id="`cli-token-actions-${token.id}`"
+                    :aria-label="`Actions for ${token.name}`"
+                    placement="bottom-end"
+                    :offset="4"
+                    class="w-36 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
                   >
                     <button
-                      @click.stop="startRename(token)"
+                      @click="startRename(token)"
                       class="flex w-full items-center px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
                     >
                       <svg
@@ -429,7 +422,7 @@ function timeAgo(date) {
                       Rename
                     </button>
                     <button
-                      @click.stop="confirmDelete(token)"
+                      @click="confirmDelete(token)"
                       class="flex w-full items-center px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
                     >
                       <svg
@@ -447,7 +440,7 @@ function timeAgo(date) {
                       </svg>
                       Delete
                     </button>
-                  </div>
+                  </Menu>
                 </div>
               </div>
             </div>

--- a/assets/js/pages/settings/team.vue
+++ b/assets/js/pages/settings/team.vue
@@ -3,6 +3,7 @@ import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, watch, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import Menu from '@/components/ui/menu/Menu.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
@@ -80,17 +81,6 @@ onUnmounted(() => {
   document.removeEventListener('keydown', handleInviteKeydown)
 })
 
-// Actions menu
-const openMenu = ref(null)
-
-function toggleMenu(memberId) {
-  openMenu.value = openMenu.value === memberId ? null : memberId
-}
-
-function closeMenu() {
-  openMenu.value = null
-}
-
 // Role change
 const roleMemberId = ref(null)
 const roleForm = useForm({ role: 'member' }).withPrecognition(
@@ -99,7 +89,6 @@ const roleForm = useForm({ role: 'member' }).withPrecognition(
 )
 
 function changeRole(member, newRole) {
-  openMenu.value = null
   roleMemberId.value = member.id
   roleForm.role = newRole
   roleForm.validate('role', {
@@ -116,7 +105,6 @@ const removingMember = ref(null)
 
 function confirmRemove(member) {
   removingMember.value = member
-  openMenu.value = null
 }
 
 function executeRemove() {
@@ -161,7 +149,7 @@ function timeAgo(date) {
 </script>
 <template>
   <Head :title="`Team Members | ${team.name} | Slipway`"></Head>
-  <div class="flex h-full flex-col" @click="closeMenu">
+  <div class="flex h-full flex-col">
     <!-- Header -->
     <div
       class="flex items-center justify-between border-b border-gray-200 py-4 pl-4 pr-4 dark:border-gray-800 sm:pl-4 sm:pr-8"
@@ -396,7 +384,9 @@ function timeAgo(date) {
                   class="relative"
                 >
                   <button
-                    @click.stop="toggleMenu(member.id)"
+                    type="button"
+                    :popovertarget="`team-member-actions-${member.id}`"
+                    :aria-label="`Actions for ${member.fullName}`"
                     class="rounded-md p-1 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-800 dark:hover:text-gray-300"
                   >
                     <svg
@@ -411,33 +401,36 @@ function timeAgo(date) {
                   </button>
 
                   <!-- Dropdown menu -->
-                  <div
-                    v-if="openMenu === member.id"
-                    class="absolute right-0 z-10 mt-1 w-40 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+                  <Menu
+                    :id="`team-member-actions-${member.id}`"
+                    :aria-label="`Actions for ${member.fullName}`"
+                    placement="bottom-end"
+                    :offset="4"
+                    class="w-40 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
                   >
                     <template v-if="isOwner">
                       <button
                         v-if="member.teamRole === 'member'"
-                        @click.stop="changeRole(member, 'admin')"
+                        @click="changeRole(member, 'admin')"
                         class="flex w-full items-center px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
                       >
                         Make admin
                       </button>
                       <button
                         v-if="member.teamRole === 'admin'"
-                        @click.stop="changeRole(member, 'member')"
+                        @click="changeRole(member, 'member')"
                         class="flex w-full items-center px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
                       >
                         Make member
                       </button>
                     </template>
                     <button
-                      @click.stop="confirmRemove(member)"
+                      @click="confirmRemove(member)"
                       class="flex w-full items-center px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20"
                     >
                       Remove
                     </button>
-                  </div>
+                  </Menu>
                 </div>
               </div>
             </div>

--- a/tests/e2e/pages/deployment-favicon.test.js
+++ b/tests/e2e/pages/deployment-favicon.test.js
@@ -83,11 +83,8 @@ test(
     await acknowledgeFavicon(page)
     expect(await waitForFavicon(page, 'idle')).toBe('/images/favicon.svg')
 
-    await page.raw
-      .getByText(current.users.genesisUser.email, { exact: true })
-      .locator('..')
-      .click()
-    await page.raw.getByRole('button', { name: 'Sign out' }).click()
+    await page.raw.locator('[data-test="desktop-user-menu-button"]').click()
+    await page.raw.getByRole('menuitem', { name: 'Sign out' }).click()
 
     expect(await waitForFavicon(page, 'idle')).toBe('/images/favicon.svg')
     expect(page).toHaveNoJavascriptErrors()

--- a/tests/e2e/pages/dropdown-menu.test.js
+++ b/tests/e2e/pages/dropdown-menu.test.js
@@ -1,0 +1,109 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const capturePhase = process.env.MENU_SCREENSHOT_PHASE || 'after'
+const screenshotRoot = path.resolve(
+  `.tmp/screenshots/issue-340-dropdown-menu/${capturePhase}`
+)
+
+test(
+  'project actions preserve their visual contract with Klean Menu',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'klean-menu-contract',
+          name: 'Klean menu contract'
+        }
+      }
+    }
+  },
+  async ({ world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto('/')
+
+    const project = world.current.projects.deploymentTarget
+    const trigger = page.raw.locator(
+      `[data-test="project-actions-${project.slug}"]`
+    )
+
+    await trigger.click()
+    const menu = page.raw.getByText('Copy slug', { exact: true }).locator('..')
+    await expect(menu).toBeVisible()
+    await page.wait(100)
+
+    await page.screenshot(
+      path.join(screenshotRoot, 'project-actions-desktop-light.png'),
+      { animations: 'disabled' }
+    )
+
+    await page.inDarkMode()
+    await page.wait(100)
+    await page.screenshot(
+      path.join(screenshotRoot, 'project-actions-desktop-dark.png'),
+      { animations: 'disabled' }
+    )
+
+    if (capturePhase === 'after') {
+      await expect(menu).toHaveAttribute('data-slot', 'menu')
+      await expect(menu).toHaveAttribute('role', 'menu')
+      await expect(trigger).toHaveAttribute('aria-haspopup', 'menu')
+
+      await page.key('c')
+      expect(
+        await page.raw.evaluate(() =>
+          document.activeElement?.textContent.trim()
+        )
+      ).toBe('Copy slug')
+
+      await page.key('Escape')
+      await expect(menu).toBeHidden()
+      expect(
+        await page.raw.evaluate(() => document.activeElement?.dataset.test)
+      ).toBe(`project-actions-${project.slug}`)
+
+      const teamTrigger = page.raw.locator(
+        '[data-test="desktop-team-selector"]'
+      )
+      await teamTrigger.click()
+      const teamMenu = page.raw.locator('#desktop-team-menu')
+      await expect(teamMenu).toBeVisible()
+      await expect(teamMenu).toHaveAttribute('data-slot', 'menu')
+      await page.key('Escape')
+      await expect(teamMenu).toBeHidden()
+      expect(
+        await page.raw.evaluate(() => document.activeElement?.dataset.test)
+      ).toBe('desktop-team-selector')
+
+      const userTrigger = page.raw.locator(
+        '[data-test="desktop-user-menu-button"]'
+      )
+      await userTrigger.click()
+      const userMenu = page.raw.locator('#desktop-user-menu')
+      await expect(userMenu).toBeVisible()
+      await expect(userMenu).toHaveAttribute('data-slot', 'menu')
+      await page.key('Escape')
+      await expect(userMenu).toBeHidden()
+    }
+
+    expect(page).toHaveNoSmoke()
+  }
+)

--- a/tests/e2e/pages/projects/bridge-access.test.js
+++ b/tests/e2e/pages/projects/bridge-access.test.js
@@ -39,7 +39,7 @@ test(
       await page.goto(appPath)
       await page.click('@app-more-menu')
 
-      const bridgeLink = page.raw.getByRole('link', {
+      const bridgeLink = page.raw.getByRole('menuitem', {
         name: 'Bridge',
         exact: true
       })


### PR DESCRIPTION
## Summary

- add the source-owned Klean Menu and Popover primitives with direct imports and no barrel files
- replace true hand-built action menus across Slipway while preserving their existing visual treatment
- leave selectors and form-like popovers on their purpose-built interaction patterns
- cover keyboard navigation, typeahead, Escape focus restoration, Bridge actions, and Dock results with Sounding

## Verification

- npm run lint
- npm run test:unit (317 passed)
- npx sounding test tests/e2e/pages/dropdown-menu.test.js --test-concurrency=1
- npx sounding test tests/e2e/pages/projects/bridge-access.test.js tests/e2e/pages/projects/bridge-resource-contract.test.js tests/e2e/pages/projects/dock-multi-results.test.js --test-concurrency=1
- captured matching before and after screenshots in light and dark mode

Closes #340
