### PR TITLE
feat(ui): adopt Klean Avatar for team identity

### DIFF
--- a/assets/js/components/ui/avatar/Avatar.vue
+++ b/assets/js/components/ui/avatar/Avatar.vue
@@ -1,0 +1,106 @@
+<script setup>
+import { computed, ref, useAttrs, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  src: { type: String, default: '' },
+  alt: { type: String, required: true }
+})
+
+const attrs = useAttrs()
+const element = ref()
+const failed = ref(false)
+
+const BASE_CLASSES =
+  'inline-flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-full bg-gray-100 object-cover text-sm font-medium text-gray-700 select-none dark:bg-gray-800 dark:text-gray-300'
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    onError: _onError,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const fallbackAttrs = computed(() => {
+  const {
+    loading: _loading,
+    decoding: _decoding,
+    crossorigin: _crossorigin,
+    referrerpolicy: _referrerpolicy,
+    fetchpriority: _fetchpriority,
+    sizes: _sizes,
+    srcset: _srcset,
+    usemap: _usemap,
+    ismap: _ismap,
+    onLoad: _onLoad,
+    ...rest
+  } = forwardedAttrs.value
+  return rest
+})
+
+const hasCallerFallbackSemantics = computed(() =>
+  ['role', 'aria-label', 'aria-hidden'].some((name) => name in attrs)
+)
+
+const fallbackSemantics = computed(() => {
+  if (hasCallerFallbackSemantics.value) return {}
+  if (props.alt) return { role: 'img', 'aria-label': props.alt }
+  return { 'aria-hidden': 'true' }
+})
+
+const finalFallbackAttrs = computed(() => ({
+  ...fallbackAttrs.value,
+  ...fallbackSemantics.value
+}))
+
+watch(
+  () => props.src,
+  () => {
+    failed.value = false
+  },
+  { flush: 'sync' }
+)
+
+function handleError(event) {
+  failed.value = true
+
+  const listener = attrs.onError
+  if (Array.isArray(listener)) {
+    for (const callback of listener) callback(event)
+  } else if (typeof listener === 'function') {
+    listener(event)
+  }
+}
+
+defineExpose({ element })
+</script>
+
+<template>
+  <img
+    v-if="props.src && !failed"
+    ref="element"
+    v-bind="forwardedAttrs"
+    data-slot="avatar"
+    data-state="image"
+    :src="props.src"
+    :alt="props.alt"
+    :class="twMerge(BASE_CLASSES, attrs.class)"
+    @error="handleError"
+  />
+  <span
+    v-else
+    ref="element"
+    v-bind="finalFallbackAttrs"
+    data-slot="avatar"
+    data-state="fallback"
+    :class="twMerge(BASE_CLASSES, attrs.class)"
+  >
+    <slot />
+  </span>
+</template>

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -9,6 +9,7 @@ import UpdateModal from '@/components/UpdateModal.vue'
 import DeploymentToast from '@/components/DeploymentToast.vue'
 import ServiceActionToast from '@/components/ServiceActionToast.vue'
 import CommandPalette from '@/components/CommandPalette.vue'
+import Avatar from '@/components/ui/avatar/Avatar.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
 import { createToast } from '@/composables/toast'
 import { useFlashToast } from '@/composables/flash-toast'
@@ -272,18 +273,14 @@ onUnmounted(() => {
               class="flex w-full min-w-0 items-center justify-between gap-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
             >
               <div class="flex min-w-0 flex-1 items-center space-x-2">
-                <img
-                  v-if="loggedInUser.team?.logoUrl"
-                  :src="loggedInUser.team.logoUrl"
+                <Avatar
+                  data-test="mobile-current-team-avatar"
+                  :src="loggedInUser.team?.logoUrl || ''"
                   alt=""
-                  class="h-6 w-6 shrink-0 rounded object-cover"
-                />
-                <span
-                  v-else
-                  class="bg-brand flex h-6 w-6 shrink-0 items-center justify-center rounded text-xs font-medium text-white"
+                  class="bg-brand h-6 w-6 rounded object-cover text-xs font-medium text-white"
                 >
                   {{ loggedInUser.team?.name?.charAt(0)?.toUpperCase() || 'T' }}
-                </span>
+                </Avatar>
                 <span
                   data-test="mobile-team-name"
                   class="truncate font-medium"
@@ -330,18 +327,13 @@ onUnmounted(() => {
                       : 'text-gray-600 dark:text-gray-400'
                   ]"
                 >
-                  <img
-                    v-if="team.logoUrl"
+                  <Avatar
                     :src="team.logoUrl"
                     alt=""
-                    class="h-5 w-5 rounded object-cover"
-                  />
-                  <span
-                    v-else
-                    class="bg-brand flex h-5 w-5 items-center justify-center rounded text-[10px] font-medium text-white"
+                    class="bg-brand h-5 w-5 rounded object-cover text-[10px] font-medium text-white"
                   >
                     {{ team.name?.charAt(0)?.toUpperCase() }}
-                  </span>
+                  </Avatar>
                   <span class="flex-1 truncate">{{ team.name }}</span>
                   <svg
                     v-if="team.id === loggedInUser.team?.id"
@@ -745,18 +737,14 @@ onUnmounted(() => {
             popovertarget="desktop-team-menu"
             class="flex w-full min-w-0 items-center space-x-2 rounded-md px-2 py-1.5 text-sm text-gray-700 hover:bg-gray-200 dark:text-gray-200 dark:hover:bg-gray-800"
           >
-            <img
-              v-if="loggedInUser.team?.logoUrl"
-              :src="loggedInUser.team.logoUrl"
+            <Avatar
+              data-test="desktop-current-team-avatar"
+              :src="loggedInUser.team?.logoUrl || ''"
               alt=""
-              class="h-6 w-6 shrink-0 rounded object-cover"
-            />
-            <span
-              v-else
-              class="bg-brand flex h-6 w-6 shrink-0 items-center justify-center rounded text-xs font-medium text-white"
+              class="bg-brand h-6 w-6 rounded object-cover text-xs font-medium text-white"
             >
               {{ loggedInUser.team?.name?.charAt(0)?.toUpperCase() || 'T' }}
-            </span>
+            </Avatar>
             <span
               data-test="desktop-team-name"
               class="min-w-0 flex-1 truncate text-left font-medium"
@@ -802,18 +790,13 @@ onUnmounted(() => {
                     : 'text-gray-600 dark:text-gray-400'
                 ]"
               >
-                <img
-                  v-if="team.logoUrl"
+                <Avatar
                   :src="team.logoUrl"
                   alt=""
-                  class="h-5 w-5 rounded object-cover"
-                />
-                <span
-                  v-else
-                  class="bg-brand flex h-5 w-5 items-center justify-center rounded text-[10px] font-medium text-white"
+                  class="bg-brand h-5 w-5 rounded object-cover text-[10px] font-medium text-white"
                 >
                   {{ team.name?.charAt(0)?.toUpperCase() }}
-                </span>
+                </Avatar>
                 <span class="flex-1 truncate">{{ team.name }}</span>
                 <svg
                   v-if="team.id === loggedInUser.team?.id"

--- a/assets/js/pages/settings/team-profile.vue
+++ b/assets/js/pages/settings/team-profile.vue
@@ -3,6 +3,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
+import Avatar from '@/components/ui/avatar/Avatar.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
@@ -264,22 +265,19 @@ const initials = computed(() => {
             <div class="flex items-center gap-4">
               <!-- Logo preview -->
               <div class="relative">
-                <div
-                  v-if="logoPreview"
-                  class="h-16 w-16 overflow-hidden rounded-lg border border-gray-200 dark:border-gray-700"
-                >
-                  <img
-                    :src="logoPreview"
-                    alt="Team logo"
-                    class="h-full w-full object-cover"
-                  />
-                </div>
-                <div
-                  v-else
-                  class="bg-brand flex h-16 w-16 items-center justify-center rounded-lg text-xl font-semibold text-white"
+                <Avatar
+                  data-test="team-profile-avatar"
+                  :src="logoPreview"
+                  :alt="`${props.team.name} team logo`"
+                  :class="[
+                    'bg-brand h-16 w-16 rounded-lg object-cover text-xl font-semibold text-white',
+                    logoPreview
+                      ? 'border border-gray-200 dark:border-gray-700'
+                      : ''
+                  ]"
                 >
                   {{ initials }}
-                </div>
+                </Avatar>
                 <!-- Uploading overlay -->
                 <div
                   v-if="uploading"

--- a/tests/e2e/pages/team-avatar.test.js
+++ b/tests/e2e/pages/team-avatar.test.js
@@ -1,0 +1,168 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const capturePhase = process.env.AVATAR_SCREENSHOT_PHASE || 'after'
+const screenshotRoot = path.resolve(
+  `.tmp/screenshots/issue-454-klean-avatar/${capturePhase}`
+)
+const teamLogo = `data:image/svg+xml;base64,${Buffer.from(
+  `
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+    <rect width="128" height="128" rx="24" fill="#111827"/>
+    <path d="M34 69c10 0 16-6 20-17 4 11 10 17 20 17 8 0 15-4 20-11-2 23-14 36-40 36S16 81 14 58c5 7 12 11 20 11Z" fill="#38bdf8"/>
+    <circle cx="54" cy="38" r="8" fill="#f8fafc"/>
+    <circle cx="74" cy="38" r="8" fill="#f8fafc"/>
+  </svg>
+`
+).toString('base64')}`
+
+test(
+  'team identity preserves its visual contract with Klean Avatar',
+  { browser: true, world: 'configured-slipway' },
+  async ({ sails, world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+    const current = world.current
+
+    await prepareTeams({ sails, world })
+    await preventUpdateCheck(page)
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto('/')
+
+    const trigger = page.raw.locator('[data-test="desktop-team-selector"]')
+    await trigger.click()
+    await expect(page.raw.locator('#desktop-team-menu')).toBeVisible()
+    await page.wait(100)
+    await captureDesktop('desktop-team-menu-light.png', page)
+
+    await page.inDarkMode()
+    await page.wait(100)
+    await captureDesktop('desktop-team-menu-dark.png', page)
+
+    await page.inLightMode()
+    await page.goto('/settings/team-profile')
+    await page.wait(100)
+    await page.screenshot(path.join(screenshotRoot, 'team-profile-light.png'), {
+      animations: 'disabled'
+    })
+
+    await sails.models.team
+      .updateOne({ id: current.teams.genesisTeam.id })
+      .set({
+        logoUrl: '/images/avatar-that-does-not-exist.svg'
+      })
+    await page.goto('/')
+    await trigger.click()
+    await page.wait(100)
+    await captureDesktop('broken-image-fallback-light.png', page)
+
+    if (capturePhase === 'after') {
+      await expect(
+        page.raw.locator('[data-test="desktop-current-team-avatar"]')
+      ).toHaveAttribute('data-slot', 'avatar')
+      await expect(
+        page.raw.locator('[data-test="desktop-current-team-avatar"] img')
+      ).toBeHidden()
+      await expect(
+        page.raw
+          .locator('[data-test="desktop-current-team-avatar"]')
+          .getByText('N', { exact: true })
+      ).toBeVisible()
+    }
+
+    if (capturePhase === 'after') {
+      expect(page).toHaveNoSmoke()
+    }
+  }
+)
+
+test(
+  'team identity remains compact in the mobile drawer',
+  { browser: true, world: 'configured-slipway' },
+  async ({ sails, world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+    const current = world.current
+
+    await prepareTeams({ sails, world })
+    await preventUpdateCheck(page)
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.resize(390, 844)
+    await page.inLightMode()
+    await page.goto('/')
+
+    await page.raw.locator('button.md\\:hidden').first().click()
+    const trigger = page.raw.locator('[data-test="mobile-team-selector"]')
+    await trigger.click()
+    await expect(page.raw.locator('#mobile-team-menu')).toBeVisible()
+    await page.wait(100)
+    await page.screenshot(
+      path.join(screenshotRoot, 'mobile-team-menu-light.png'),
+      { animations: 'disabled' }
+    )
+
+    await page.inDarkMode()
+    await page.wait(100)
+    await page.screenshot(
+      path.join(screenshotRoot, 'mobile-team-menu-dark.png'),
+      { animations: 'disabled' }
+    )
+
+    if (capturePhase === 'after') {
+      await expect(
+        page.raw.locator('[data-test="mobile-current-team-avatar"]')
+      ).toHaveAttribute('data-slot', 'avatar')
+    }
+
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+async function prepareTeams({ sails, world }) {
+  const current = world.current
+
+  await sails.models.team.updateOne({ id: current.teams.genesisTeam.id }).set({
+    name: 'Northstar Labs',
+    logoUrl: teamLogo
+  })
+  await world.create('team').with({
+    name: 'Quiet Current',
+    slug: `${current.key}-quiet-current`,
+    owner: current.users.genesisUser.id,
+    logoUrl: ''
+  })
+}
+
+async function preventUpdateCheck(page) {
+  await page.raw.route('**/api/v1/system/check-update', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ updateAvailable: false })
+    })
+  })
+  await page.raw.route(
+    '**/images/avatar-that-does-not-exist.svg',
+    async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'image/svg+xml',
+        body: 'not an image'
+      })
+    }
+  )
+}
+
+async function captureDesktop(fileName, page) {
+  await page.raw.screenshot({
+    path: path.join(screenshotRoot, fileName),
+    animations: 'disabled',
+    clip: { x: 0, y: 0, width: 430, height: 520 }
+  })
+}


### PR DESCRIPTION
## What changed

- add Klean Avatar as source-owned Slipway UI code
- replace five repeated image-or-initial branches across mobile, desktop, team lists, and the team profile
- preserve Slipway's existing sizes, shapes, colors, and upload overlay
- recover failed image sources to team initials
- keep decorative avatars silent and give the standalone team preview an informative accessible name

## Visual contract

Matched before-and-after captures cover:

- desktop team menu in light and dark mode
- mobile team menu in light and dark mode
- team profile logo preview
- failed-image recovery

The five normal captures preserve the existing layout. The failed-image capture intentionally changes from a broken image to the team's initial.

## Verification

- 14 focused Sounding trials pass
- team switching and team-profile mutation coverage pass
- menu integration coverage passes
- Avatar image, fallback, and source-failure coverage passes
- Prettier and `git diff --check` pass

Closes #454
