### PR TITLE
feat(ui): adopt Klean Select across Slipway

### DIFF
--- a/assets/js/components/ConfigVariableMenu.vue
+++ b/assets/js/components/ConfigVariableMenu.vue
@@ -1,4 +1,6 @@
 <script setup>
+import Select from '@/components/ui/select/Select.vue'
+
 const props = defineProps({
   variableKey: { type: String, required: true },
   metadata: { type: Object, required: true }
@@ -73,29 +75,31 @@ function toggleDetails(event) {
           <span class="text-xs font-medium text-gray-700 dark:text-gray-300"
             >Value type</span
           >
-          <select
-            :value="metadata.kind"
-            @change="update('kind', $event.target.value)"
+          <Select
+            :model-value="metadata.kind"
+            :options="[
+              { value: 'secret', label: 'Secret' },
+              { value: 'plain', label: 'Plain config' }
+            ]"
+            @change="update('kind', $event)"
             class="mt-1 block w-full rounded-md border-0 bg-gray-50 px-2 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-800 dark:focus:ring-gray-600"
-          >
-            <option value="secret">Secret</option>
-            <option value="plain">Plain config</option>
-          </select>
+          />
         </label>
 
         <label class="block">
           <span class="text-xs font-medium text-gray-700 dark:text-gray-300"
             >Preview environments</span
           >
-          <select
-            :value="metadata.previewPolicy"
-            @change="update('previewPolicy', $event.target.value)"
+          <Select
+            :model-value="metadata.previewPolicy"
+            :options="[
+              { value: 'omit', label: 'Omit' },
+              { value: 'inherit', label: 'Inherit' },
+              { value: 'randomize', label: 'Generate a new value' }
+            ]"
+            @change="update('previewPolicy', $event)"
             class="mt-1 block w-full rounded-md border-0 bg-gray-50 px-2 py-1.5 text-sm text-gray-900 ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-950 dark:text-white dark:ring-gray-800 dark:focus:ring-gray-600"
-          >
-            <option value="omit">Omit</option>
-            <option value="inherit">Inherit</option>
-            <option value="randomize">Generate a new value</option>
-          </select>
+          />
           <span
             data-test="config-preview-policy-description"
             class="mt-1 block text-xs leading-5 text-gray-500 dark:text-gray-400"

--- a/assets/js/components/LogViewer.vue
+++ b/assets/js/components/LogViewer.vue
@@ -9,6 +9,7 @@ import {
   serializeLogEvents
 } from '@/lib/log-viewer.mjs'
 import Spinner from '@/components/SlipwaySpinner.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 
 const props = defineProps({
@@ -268,30 +269,18 @@ function segmentClass(type) {
       <div class="order-2 ml-auto flex items-center gap-1 sm:order-3">
         <label class="relative">
           <span class="sr-only">Filter logs by severity</span>
-          <select
+          <Select
             v-model="level"
+            :options="[
+              { value: 'all', label: `All · ${events.length}` },
+              ...LOG_LEVELS.map((value) => ({
+                value,
+                label: `${levelLabel(value)} · ${levelCounts[value]}`
+              }))
+            ]"
             data-test="log-level-filter"
             class="h-10 appearance-none border-0 border-b border-dashed border-gray-300 bg-transparent py-0 pl-2 pr-7 font-sans text-xs text-gray-700 outline-none focus:border-sky-500 focus:ring-0 dark:border-zinc-700 dark:text-zinc-300 dark:focus:border-sky-400"
-          >
-            <option value="all">All · {{ events.length }}</option>
-            <option v-for="value in LOG_LEVELS" :key="value" :value="value">
-              {{ levelLabel(value) }} · {{ levelCounts[value] }}
-            </option>
-          </select>
-          <svg
-            aria-hidden="true"
-            class="pointer-events-none absolute right-1.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-500 dark:text-zinc-500"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="m7 10 5 5 5-5"
-            />
-          </svg>
+          />
         </label>
 
         <Tooltip

--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -3,6 +3,7 @@ import { router } from '@inertiajs/vue3'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
 import BridgeRelationshipSelect from '@/components/bridge/BridgeRelationshipSelect.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Switch from '@/components/ui/switch/Switch.vue'
 import {
   bridgeFieldType,
@@ -851,30 +852,27 @@ function defaultPlaceholder(fieldType) {
         @blur="handleBlur"
       />
 
-      <select
+      <Select
         v-else-if="type === 'select'"
         :id="fieldId"
-        :value="modelValue"
+        :model-value="modelValue"
+        :options="[
+          { value: '', label: 'Select…' },
+          ...options.map((option) => ({
+            value: option.value,
+            label: option.label,
+            disabled: option.disabled
+          }))
+        ]"
         :disabled="field.readOnly"
         :required="attribute.required"
         :aria-invalid="visibleError ? 'true' : undefined"
         :aria-describedby="describedBy"
         :data-test="`${fieldId}-input`"
         :class="inputClass"
-        @change="update(options[$event.target.selectedIndex - 1]?.value ?? '')"
+        @change="update"
         @blur="handleBlur"
-      >
-        <option value="">Select…</option>
-        <option
-          v-for="option in options"
-          :key="`${typeof option.value}:${String(option.value)}`"
-          :value="String(option.value)"
-          :disabled="option.disabled"
-          :selected="Object.is(option.value, modelValue)"
-        >
-          {{ option.label }}
-        </option>
-      </select>
+      />
 
       <BridgeRelationshipSelect
         v-else-if="type === 'belongsTo'"

--- a/assets/js/components/bridge/BridgeFilterMenu.vue
+++ b/assets/js/components/bridge/BridgeFilterMenu.vue
@@ -1,6 +1,7 @@
 <script setup>
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 import BridgeRelationshipSelect from '@/components/bridge/BridgeRelationshipSelect.vue'
+import Select from '@/components/ui/select/Select.vue'
 
 const props = defineProps({
   definitions: {
@@ -307,19 +308,17 @@ onBeforeUnmount(() => {
             >
               {{ definition.label }}
             </label>
-            <select
+            <Select
               :id="fieldId(definition, 'operator')"
               v-model="draft[definition.field].operator"
+              :options="
+                definition.operators.map((operator) => ({
+                  value: operator,
+                  label: operatorLabel(operator)
+                }))
+              "
               class="border-0 bg-transparent py-0 pl-1 pr-5 text-right text-xs text-gray-500 focus:ring-0 dark:bg-gray-900 dark:text-gray-400"
-            >
-              <option
-                v-for="operator in definition.operators"
-                :key="operator"
-                :value="operator"
-              >
-                {{ operatorLabel(operator) }}
-              </option>
-            </select>
+            />
           </div>
 
           <div v-if="supportsValue(definition)">
@@ -372,35 +371,34 @@ onBeforeUnmount(() => {
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500"
             />
 
-            <select
+            <Select
               v-else-if="definition.type === 'boolean'"
               :id="fieldId(definition, 'value')"
               v-model="draft[definition.field].value"
+              :options="[
+                { value: '', label: 'Choose…' },
+                { value: 'true', label: 'Yes' },
+                { value: 'false', label: 'No' }
+              ]"
               :aria-label="`${definition.label} value`"
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-0 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-            >
-              <option value="">Choose…</option>
-              <option value="true">Yes</option>
-              <option value="false">No</option>
-            </select>
+            />
 
-            <select
+            <Select
               v-else-if="definition.type === 'select'"
               :id="fieldId(definition, 'value')"
               v-model="draft[definition.field].value"
+              :options="[
+                { value: '', label: 'Choose…' },
+                ...(definition.options || []).map((option) => ({
+                  value: option.value,
+                  label: option.label,
+                  disabled: option.disabled
+                }))
+              ]"
               :aria-label="`${definition.label} value`"
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-0 dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-            >
-              <option value="">Choose…</option>
-              <option
-                v-for="option in definition.options || []"
-                :key="String(option.value)"
-                :value="option.value"
-                :disabled="option.disabled"
-              >
-                {{ option.label }}
-              </option>
-            </select>
+            />
 
             <BridgeRelationshipSelect
               v-else-if="definition.type === 'belongsTo'"

--- a/assets/js/components/ui/select/Select.vue
+++ b/assets/js/components/ui/select/Select.vue
@@ -1,0 +1,612 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  useId,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+import Popover from '../popover/Popover.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Framework-native controlled value. Omit for uncontrolled use. */
+  modelValue: { default: undefined },
+  /** Initial value when `modelValue` is not controlled. */
+  defaultValue: { default: undefined },
+  /** Fixed choices in the form `{ value, label, disabled?, group? }`. */
+  options: { type: Array, default: () => [] },
+  /** Text shown when no option is selected. */
+  placeholder: { type: String, default: 'Select an option' },
+  /** Native form field name. */
+  name: { type: String, default: undefined },
+  /** Native and accessible required state. */
+  required: { type: Boolean, default: false },
+  /** Prevents opening and selection. */
+  disabled: { type: Boolean, default: false },
+  /** Stable control ID. */
+  id: { type: String, default: undefined },
+  /** Framework-native controlled popup state. */
+  open: { type: Boolean, default: undefined },
+  /** Initial popup state when `open` is not controlled. */
+  defaultOpen: { type: Boolean, default: false },
+  /** Preferred logical placement. Collision handling may flip it. */
+  placement: { type: String, default: 'bottom-start' },
+  /** Space in pixels between the trigger and popup. */
+  offset: { type: Number, default: 4 }
+})
+
+const emit = defineEmits(['update:modelValue', 'update:open', 'change', 'blur'])
+const attrs = useAttrs()
+const generatedId = useId()
+const root = ref()
+const trigger = ref()
+const popover = ref()
+const internalValue = ref(props.defaultValue)
+const internalOpen = ref(props.defaultOpen)
+const highlightedIndex = ref(-1)
+const triggerWidth = ref(0)
+
+const isValueControlled = computed(() => props.modelValue !== undefined)
+const value = computed(() =>
+  isValueControlled.value ? props.modelValue : internalValue.value
+)
+const isOpenControlled = computed(() => props.open !== undefined)
+const isOpen = computed(() =>
+  isOpenControlled.value ? props.open : internalOpen.value
+)
+const controlId = computed(
+  () => props.id ?? `klean-select-${generatedId.replace(/[^a-zA-Z0-9_-]/g, '')}`
+)
+const contentId = computed(() => `${controlId.value}-content`)
+const listboxId = computed(() => `${controlId.value}-listbox`)
+const triggerClasses = computed(() =>
+  twMerge(
+    'flex min-h-11 w-full cursor-pointer items-center justify-between gap-3 rounded-md border border-gray-300 bg-white px-3 py-2 text-left text-base text-gray-950 shadow-sm outline-none transition-colors duration-150 hover:border-gray-400 focus-visible:border-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:bg-gray-100 disabled:text-gray-500 aria-invalid:border-red-600 aria-invalid:focus-visible:outline-red-600 dark:border-gray-700 dark:bg-gray-950 dark:text-white dark:hover:border-gray-600 dark:focus-visible:border-white dark:focus-visible:outline-white dark:disabled:bg-gray-900 dark:disabled:text-gray-500 dark:aria-invalid:border-red-500 dark:aria-invalid:focus-visible:outline-red-500 motion-reduce:transition-none',
+    attrs.class
+  )
+)
+const forwardedTriggerAttrs = computed(() => {
+  const {
+    class: _class,
+    style: _style,
+    id: _id,
+    role: _role,
+    type: _type,
+    disabled: _disabled,
+    name: _name,
+    required: _required,
+    value: _value,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+const selectedIndex = computed(() =>
+  props.options.findIndex((option) => Object.is(option.value, value.value))
+)
+const selectedOption = computed(() => props.options[selectedIndex.value])
+const serializedValue = computed(() => {
+  const current = value.value
+  return ['string', 'number', 'boolean'].includes(typeof current)
+    ? String(current)
+    : ''
+})
+const groupedOptions = computed(() => {
+  const groups = new Map()
+
+  props.options.forEach((option, index) => {
+    const label = option.group ?? null
+    if (!groups.has(label)) groups.set(label, [])
+    groups.get(label).push({ option, index })
+  })
+
+  return [...groups].map(([label, entries]) => ({ label, entries }))
+})
+const activeDescendant = computed(() =>
+  isOpen.value && highlightedIndex.value >= 0
+    ? optionId(highlightedIndex.value)
+    : undefined
+)
+
+let form
+let resizeObserver
+let typeahead = ''
+let typeaheadTimer
+let closeTimer
+let pendingEdge = 'selected'
+let suppressNativeReopen = false
+
+function optionId(index) {
+  return `${controlId.value}-option-${index}`
+}
+
+function optionIsDisabled(index) {
+  return Boolean(props.options[index]?.disabled)
+}
+
+function enabledIndexes() {
+  return props.options
+    .map((option, index) => ({ option, index }))
+    .filter(({ option }) => !option.disabled)
+    .map(({ index }) => index)
+}
+
+function initialHighlight(edge = 'selected') {
+  const enabled = enabledIndexes()
+  if (!enabled.length) return -1
+
+  if (
+    edge === 'selected' &&
+    selectedIndex.value >= 0 &&
+    !optionIsDisabled(selectedIndex.value)
+  ) {
+    return selectedIndex.value
+  }
+
+  return edge === 'last' ? enabled.at(-1) : enabled[0]
+}
+
+function syncTriggerWidth() {
+  triggerWidth.value = trigger.value?.getBoundingClientRect().width ?? 0
+}
+
+async function revealHighlighted() {
+  await nextTick()
+  if (highlightedIndex.value < 0) return
+
+  const content = popover.value?.content?.value ?? popover.value?.content
+  content
+    ?.querySelector?.(`[data-option-index="${highlightedIndex.value}"]`)
+    ?.scrollIntoView?.({ block: 'nearest' })
+}
+
+function requestOpen(nextOpen) {
+  if (!isOpenControlled.value) internalOpen.value = nextOpen
+  emit('update:open', nextOpen)
+}
+
+function handlePopoverOpen(nextOpen) {
+  if (suppressNativeReopen && nextOpen) {
+    requestOpen(false)
+    const content = popover.value?.content?.value ?? popover.value?.content
+    try {
+      content?.hidePopover?.()
+    } catch {
+      // The controlled state still closes the fallback surface.
+    }
+    return
+  }
+
+  requestOpen(nextOpen)
+}
+
+function openSelect(edge = 'selected') {
+  if (props.disabled) return
+  suppressNativeReopen = false
+  pendingEdge = edge
+  syncTriggerWidth()
+
+  if (isOpen.value) {
+    highlightedIndex.value = initialHighlight(edge)
+    revealHighlighted()
+  } else {
+    popover.value?.open(trigger.value)
+  }
+}
+
+function closeSelect({ restoreFocus = false } = {}) {
+  suppressNativeReopen = true
+  requestOpen(false)
+
+  const finishClose = () => {
+    requestOpen(false)
+    const content = popover.value?.content?.value ?? popover.value?.content
+    if (typeof content?.hidePopover === 'function') {
+      try {
+        content.hidePopover()
+      } catch {
+        // The controlled state still closes the fallback surface.
+      }
+    }
+
+    if (restoreFocus) {
+      nextTick(() => trigger.value?.focus({ preventScroll: true }))
+    }
+  }
+
+  clearTimeout(closeTimer)
+  closeTimer = setTimeout(finishClose, 0)
+}
+
+function clearTypeahead() {
+  typeahead = ''
+  clearTimeout(typeaheadTimer)
+  typeaheadTimer = undefined
+}
+
+function normalizedLabel(option) {
+  return String(option?.label ?? '')
+    .trim()
+    .toLocaleLowerCase()
+}
+
+function findTypeaheadMatch(text) {
+  const enabled = enabledIndexes()
+  if (!enabled.length) return -1
+
+  const current = isOpen.value
+    ? enabled.indexOf(highlightedIndex.value)
+    : enabled.indexOf(selectedIndex.value)
+  const ordered = [
+    ...enabled.slice(current + 1),
+    ...enabled.slice(0, current + 1)
+  ]
+
+  return (
+    ordered.find((index) =>
+      normalizedLabel(props.options[index]).startsWith(text)
+    ) ?? -1
+  )
+}
+
+function handleTypeahead(event) {
+  if (
+    event.key.length !== 1 ||
+    event.key === ' ' ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey
+  ) {
+    return false
+  }
+
+  event.preventDefault()
+  clearTimeout(typeaheadTimer)
+  typeahead += event.key.toLocaleLowerCase()
+  typeaheadTimer = setTimeout(clearTypeahead, 500)
+
+  let match = findTypeaheadMatch(typeahead)
+  if (match < 0 && new Set(typeahead).size === 1) {
+    typeahead = typeahead.at(-1)
+    match = findTypeaheadMatch(typeahead)
+  }
+
+  if (match < 0) return true
+  if (isOpen.value) {
+    highlightedIndex.value = match
+    revealHighlighted()
+  } else {
+    choose(match, { close: false })
+  }
+  return true
+}
+
+function moveHighlight(step) {
+  const enabled = enabledIndexes()
+  if (!enabled.length) return
+  const current = enabled.indexOf(highlightedIndex.value)
+  const next =
+    current < 0
+      ? step > 0
+        ? 0
+        : enabled.length - 1
+      : (current + step + enabled.length) % enabled.length
+  highlightedIndex.value = enabled[next]
+  revealHighlighted()
+}
+
+function choose(index, { close = true } = {}) {
+  const option = props.options[index]
+  if (!option || option.disabled || props.disabled) return
+
+  if (!isValueControlled.value) internalValue.value = option.value
+  emit('update:modelValue', option.value)
+  emit('change', option.value, option)
+  highlightedIndex.value = index
+  clearTypeahead()
+
+  if (close) closeSelect({ restoreFocus: true })
+}
+
+function handleKeydown(event) {
+  if (props.disabled) return
+
+  if (!isOpen.value) {
+    if (['Enter', ' ', 'ArrowDown', 'ArrowUp'].includes(event.key)) {
+      event.preventDefault()
+      openSelect(event.key === 'ArrowUp' ? 'last' : 'selected')
+      return
+    }
+
+    handleTypeahead(event)
+    return
+  }
+
+  if (event.key === 'Escape') {
+    event.preventDefault()
+    event.stopPropagation()
+    closeSelect({ restoreFocus: true })
+  } else if (event.key === 'Tab') {
+    clearTypeahead()
+    closeSelect()
+  } else if (event.key === 'ArrowDown') {
+    event.preventDefault()
+    moveHighlight(1)
+  } else if (event.key === 'ArrowUp') {
+    event.preventDefault()
+    moveHighlight(-1)
+  } else if (event.key === 'Home') {
+    event.preventDefault()
+    highlightedIndex.value = initialHighlight('first')
+    revealHighlighted()
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    highlightedIndex.value = initialHighlight('last')
+    revealHighlighted()
+  } else if (['Enter', ' '].includes(event.key)) {
+    event.preventDefault()
+    if (highlightedIndex.value >= 0) choose(highlightedIndex.value)
+  } else {
+    handleTypeahead(event)
+  }
+}
+
+function handleTriggerClick() {
+  suppressNativeReopen = false
+  if (!isOpen.value) pendingEdge = 'selected'
+  syncTriggerWidth()
+}
+
+function handleFormReset() {
+  if (!isValueControlled.value) internalValue.value = props.defaultValue
+  if (isOpen.value) closeSelect()
+}
+
+watch(
+  isOpen,
+  async (nextOpen) => {
+    clearTypeahead()
+    if (!nextOpen) {
+      highlightedIndex.value = -1
+      return
+    }
+
+    highlightedIndex.value = initialHighlight(pendingEdge)
+    pendingEdge = 'selected'
+    syncTriggerWidth()
+    await revealHighlighted()
+  },
+  { flush: 'post' }
+)
+
+watch(
+  () => props.options,
+  () => {
+    if (!isOpen.value) return
+    highlightedIndex.value = initialHighlight('selected')
+    revealHighlighted()
+  },
+  { deep: true }
+)
+
+onMounted(() => {
+  form = root.value?.closest?.('form')
+  form?.addEventListener('reset', handleFormReset)
+
+  if (typeof ResizeObserver !== 'undefined' && trigger.value) {
+    resizeObserver = new ResizeObserver(syncTriggerWidth)
+    resizeObserver.observe(trigger.value)
+  }
+
+  syncTriggerWidth()
+})
+
+onBeforeUnmount(() => {
+  clearTypeahead()
+  clearTimeout(closeTimer)
+  resizeObserver?.disconnect()
+  form?.removeEventListener('reset', handleFormReset)
+})
+
+defineExpose({
+  close: closeSelect,
+  focus: (options) => trigger.value?.focus(options),
+  open: openSelect,
+  trigger
+})
+</script>
+
+<template>
+  <span
+    ref="root"
+    data-slot="select"
+    :data-state="isOpen ? 'open' : 'closed'"
+    :data-placeholder="selectedOption ? undefined : ''"
+    :data-disabled="disabled ? '' : undefined"
+    :data-invalid="
+      attrs['aria-invalid'] === true || attrs['aria-invalid'] === 'true'
+        ? ''
+        : undefined
+    "
+    class="relative grid w-full"
+  >
+    <button
+      ref="trigger"
+      v-bind="forwardedTriggerAttrs"
+      :id="controlId"
+      type="button"
+      role="combobox"
+      :disabled="disabled"
+      :popovertarget="contentId"
+      popovertargetaction="toggle"
+      :aria-expanded="String(isOpen)"
+      :aria-controls="listboxId"
+      aria-haspopup="listbox"
+      :aria-activedescendant="activeDescendant"
+      :aria-required="required || undefined"
+      data-slot="select-trigger"
+      :data-state="isOpen ? 'open' : 'closed'"
+      :data-placeholder="selectedOption ? undefined : ''"
+      :class="triggerClasses"
+      :style="attrs.style"
+      @click="handleTriggerClick"
+      @keydown="handleKeydown"
+      @blur="emit('blur', $event)"
+    >
+      <span
+        data-slot="select-value"
+        :class="
+          selectedOption
+            ? 'truncate'
+            : 'truncate text-gray-500 dark:text-gray-400'
+        "
+      >
+        <slot v-if="selectedOption" name="value" :option="selectedOption">
+          {{ selectedOption.label }}
+        </slot>
+        <template v-else>{{ placeholder }}</template>
+      </span>
+
+      <span
+        data-slot="select-icon"
+        class="shrink-0 text-gray-500 dark:text-gray-400"
+      >
+        <slot name="icon" :open="isOpen">
+          <svg
+            aria-hidden="true"
+            viewBox="0 0 20 20"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.8"
+            class="size-4"
+          >
+            <path
+              d="m6 8 4 4 4-4"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        </slot>
+      </span>
+    </button>
+
+    <input
+      v-if="name"
+      type="hidden"
+      :name="name"
+      :value="serializedValue"
+      :disabled="disabled"
+      :form="attrs.form"
+    />
+
+    <Popover
+      ref="popover"
+      :id="contentId"
+      :open="isOpen"
+      :placement="placement"
+      :offset="offset"
+      data-slot="select-content"
+      class="max-h-72 overflow-hidden p-1"
+      :style="triggerWidth ? { minWidth: `${triggerWidth}px` } : undefined"
+      @update:open="handlePopoverOpen"
+    >
+      <div
+        :id="listboxId"
+        role="listbox"
+        :aria-labelledby="
+          attrs['aria-label']
+            ? undefined
+            : attrs['aria-labelledby'] ?? controlId
+        "
+        :aria-label="
+          attrs['aria-label'] ? `${attrs['aria-label']} options` : undefined
+        "
+        data-slot="select-listbox"
+        class="max-h-68 overflow-y-auto overscroll-contain outline-none"
+      >
+        <template v-if="options.length">
+          <div
+            v-for="(group, groupIndex) in groupedOptions"
+            :key="group.label ?? `ungrouped-${groupIndex}`"
+            :role="group.label ? 'group' : undefined"
+            :aria-label="group.label || undefined"
+            data-slot="select-group"
+          >
+            <p
+              v-if="group.label"
+              data-slot="select-group-label"
+              class="px-3 py-2 text-xs font-medium text-gray-500 dark:text-gray-400"
+            >
+              {{ group.label }}
+            </p>
+
+            <div
+              v-for="{ option, index } in group.entries"
+              :id="optionId(index)"
+              :key="index"
+              role="option"
+              :aria-label="String(option.label)"
+              :aria-selected="String(index === selectedIndex)"
+              :aria-disabled="option.disabled || undefined"
+              data-slot="select-option"
+              :data-option-index="index"
+              :data-highlighted="index === highlightedIndex ? '' : undefined"
+              :data-selected="index === selectedIndex ? '' : undefined"
+              :data-disabled="option.disabled ? '' : undefined"
+              class="min-h-11 data-highlighted:bg-gray-100 data-highlighted:text-gray-950 data-disabled:cursor-not-allowed data-disabled:opacity-40 dark:data-highlighted:bg-white/10 dark:data-highlighted:text-white flex cursor-pointer items-center justify-between gap-3 rounded px-3 py-2 text-sm text-gray-700 outline-none dark:text-gray-200"
+              @pointermove="!option.disabled && (highlightedIndex = index)"
+              @pointerdown.prevent
+              @click="choose(index)"
+            >
+              <span class="min-w-0 flex-1 truncate">
+                <slot
+                  name="option"
+                  :option="option"
+                  :selected="index === selectedIndex"
+                  :highlighted="index === highlightedIndex"
+                >
+                  {{ option.label }}
+                </slot>
+              </span>
+
+              <span
+                data-slot="select-indicator"
+                class="size-5 grid shrink-0 place-items-center"
+                aria-hidden="true"
+              >
+                <svg
+                  v-if="index === selectedIndex"
+                  viewBox="0 0 20 20"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  class="size-4"
+                >
+                  <path
+                    d="m5 10 3 3 7-7"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                  />
+                </svg>
+              </span>
+            </div>
+          </div>
+        </template>
+
+        <div
+          v-else
+          data-slot="select-empty"
+          class="px-3 py-6 text-center text-sm text-gray-500 dark:text-gray-400"
+        >
+          <slot name="empty">No options available.</slot>
+        </div>
+      </div>
+    </Popover>
+  </span>
+</template>

--- a/assets/js/pages/bearing/feedback.vue
+++ b/assets/js/pages/bearing/feedback.vue
@@ -3,6 +3,7 @@ import { Head, InfiniteScroll, router, useForm } from '@inertiajs/vue3'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import SelectMenu from '@/components/SelectMenu.vue'
 import ShareLinkButton from '@/components/ShareLinkButton.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import { useBearingRealtime } from '@/composables/useBearingRealtime'
 import { useFormDraft } from '@/composables/useFormDraft'
@@ -1127,20 +1128,18 @@ function shortDate(value) {
                 >
                   Category
                 </span>
-                <select
+                <Select
                   v-model="categoryFilter"
+                  :options="[
+                    { value: 'all', label: 'All categories' },
+                    ...categories.map((category) => ({
+                      value: category.key,
+                      label: category.label
+                    }))
+                  ]"
                   data-test="bearing-feedback-category-filter"
                   class="focus:border-brand min-h-11 mt-1 w-full border-0 border-b border-dashed border-gray-300 bg-transparent px-0 text-sm focus:ring-0 dark:border-gray-700"
-                >
-                  <option value="all">All categories</option>
-                  <option
-                    v-for="category in categories"
-                    :key="category.key"
-                    :value="category.key"
-                  >
-                    {{ category.label }}
-                  </option>
-                </select>
+                />
               </label>
 
               <label class="mt-5 block">
@@ -1149,18 +1148,11 @@ function shortDate(value) {
                 >
                   Status
                 </span>
-                <select
+                <Select
                   v-model="statusFilter"
+                  :options="statusOptions"
                   class="min-h-12 mt-1 w-full border-0 border-b border-dashed border-gray-300 bg-transparent px-0 text-sm focus:border-gray-950 focus:ring-0 dark:border-gray-700 dark:focus:border-white"
-                >
-                  <option
-                    v-for="status in statusOptions"
-                    :key="status.value"
-                    :value="status.value"
-                  >
-                    {{ status.label }}
-                  </option>
-                </select>
+                />
               </label>
 
               <fieldset class="mt-7">

--- a/assets/js/pages/projects/app-settings.vue
+++ b/assets/js/pages/projects/app-settings.vue
@@ -4,6 +4,7 @@ import { ref, computed, inject, onMounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import { useToast } from '@/composables/toast'
@@ -536,16 +537,17 @@ async function deleteApp() {
             >
               Route path
             </label>
-            <select
+            <Select
               id="routePath"
               v-model="routePathChoice"
+              :options="[
+                { value: '/', label: '/ (root)' },
+                { value: '/api', label: '/api' },
+                { value: '/admin', label: '/admin' },
+                { value: 'none', label: 'None (worker)' }
+              ]"
               class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:text-white"
-            >
-              <option value="/">/ (root)</option>
-              <option value="/api">/api</option>
-              <option value="/admin">/admin</option>
-              <option value="none">None (worker)</option>
-            </select>
+            />
             <p class="mt-1 text-xs text-gray-400 dark:text-gray-500">
               URL prefix this app handles. Choose "None" for background workers.
             </p>
@@ -833,20 +835,18 @@ async function deleteApp() {
                         >Loading branches...</span
                       >
                     </div>
-                    <select
+                    <Select
                       v-else-if="branches.length > 0"
-                      :value="selectedBranch"
-                      @change="selectBranch($event.target.value)"
+                      :model-value="selectedBranch"
+                      :options="
+                        branches.map((branch) => ({
+                          value: branch.name,
+                          label: branch.name
+                        }))
+                      "
+                      @change="selectBranch"
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:text-white"
-                    >
-                      <option
-                        v-for="b in branches"
-                        :key="b.name"
-                        :value="b.name"
-                      >
-                        {{ b.name }}
-                      </option>
-                    </select>
+                    />
                     <p
                       v-else
                       class="py-1.5 text-sm text-gray-500 dark:text-gray-400"

--- a/assets/js/pages/projects/bearing.vue
+++ b/assets/js/pages/projects/bearing.vue
@@ -13,6 +13,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
 import Alert from '@/components/ui/alert/Alert.vue'
+import Select from '@/components/ui/select/Select.vue'
 import { useQueryState } from '@/composables/useQueryState'
 
 defineOptions({ layout: AppLayout })
@@ -659,17 +660,18 @@ function handleViewKeydown(event, index) {
                 </div>
                 <label class="shrink-0">
                   <span class="sr-only">Status for {{ item.title }}</span>
-                  <select
-                    :value="item.status"
+                  <Select
+                    :model-value="item.status"
+                    :options="[
+                      { value: 'reviewing', label: 'Reviewing' },
+                      { value: 'planned', label: 'Planned' },
+                      { value: 'in_progress', label: 'In progress' },
+                      { value: 'shipped', label: 'Shipped' },
+                      { value: 'closed', label: 'Closed' }
+                    ]"
                     class="min-h-10 rounded-lg border-0 bg-gray-50 px-3 text-sm focus:ring-2 focus:ring-gray-400 dark:bg-gray-900"
-                    @change="moveFeedback(item, $event.target.value)"
-                  >
-                    <option value="reviewing">Reviewing</option>
-                    <option value="planned">Planned</option>
-                    <option value="in_progress">In progress</option>
-                    <option value="shipped">Shipped</option>
-                    <option value="closed">Closed</option>
-                  </select>
+                    @change="moveFeedback(item, $event)"
+                  />
                 </label>
               </div>
             </article>

--- a/assets/js/pages/projects/bridge-access.vue
+++ b/assets/js/pages/projects/bridge-access.vue
@@ -6,6 +6,7 @@ import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import Alert from '@/components/ui/alert/Alert.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
+import Select from '@/components/ui/select/Select.vue'
 
 defineOptions({
   layout: AppLayout
@@ -365,16 +366,17 @@ function timeAgo(timestamp) {
               <label for="bridge-invite-role" class="sr-only">
                 Bridge role
               </label>
-              <select
+              <Select
                 id="bridge-invite-role"
                 v-model="inviteForm.role"
+                :options="[
+                  { value: 'viewer', label: 'Viewer' },
+                  { value: 'editor', label: 'Editor' },
+                  { value: 'administrator', label: 'Administrator' }
+                ]"
                 :disabled="!app.bridgeEnabled || inviteForm.processing"
                 class="min-h-10 w-full rounded-lg border border-gray-200 bg-white px-3 text-sm text-gray-700 outline-none focus:border-gray-400 focus:ring-2 focus:ring-gray-100 disabled:cursor-not-allowed disabled:bg-gray-50 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-200 dark:focus:border-gray-600 dark:focus:ring-gray-900 dark:disabled:bg-gray-900"
-              >
-                <option value="viewer">Viewer</option>
-                <option value="editor">Editor</option>
-                <option value="administrator">Administrator</option>
-              </select>
+              />
             </div>
             <button
               type="submit"

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -12,6 +12,7 @@ import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 import Pagination from '@/components/ui/pagination/Pagination.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Table from '@/components/ui/table/Table.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
 
@@ -259,8 +260,7 @@ function applyFilters(filters) {
   navigateWithParams({ filters, page: 1 })
 }
 
-function switchLens(event) {
-  const lens = event.target.value
+function switchLens(lens) {
   lensValue.value = lens
   filtersValue.value = {}
   sortValue.value = ''
@@ -434,9 +434,9 @@ function completeCustomAction() {
   actionDialog.value = { show: false, action: null, recordIds: [] }
 }
 
-function switchDashboard(event) {
+function switchDashboard(dashboard) {
   navigateWithParams(
-    { dashboard: event.target.value, page: 1 },
+    { dashboard, page: 1 },
     { only: ['activeDashboard', 'error'], replace: true }
   )
 }
@@ -629,19 +629,21 @@ function createUrl() {
             placeholder="Search records..."
             class="w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:border-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 dark:focus:border-gray-600 sm:w-64"
           />
-          <select
+          <Select
             v-if="lenses?.length > 0"
-            :value="lensValue"
+            :model-value="lensValue"
+            :options="[
+              { value: allRecordsLensValue, label: 'All records' },
+              ...lenses.map((lens) => ({
+                value: lens.id,
+                label: lens.label
+              }))
+            ]"
             aria-label="Saved view"
             class="rounded-md border-0 bg-transparent py-1 pl-2 pr-7 text-sm text-gray-600 focus:ring-1 focus:ring-gray-300 dark:bg-gray-950 dark:text-gray-300 dark:focus:ring-gray-700"
             data-test="bridge-lens-select"
             @change="switchLens"
-          >
-            <option :value="allRecordsLensValue">All records</option>
-            <option v-for="lens in lenses" :key="lens.id" :value="lens.id">
-              {{ lens.label }}
-            </option>
-          </select>
+          />
           <BridgeFilterMenu
             v-if="Object.keys(filterDefinitions || {}).length > 0"
             :definitions="filterDefinitions"
@@ -675,21 +677,19 @@ function createUrl() {
           </Transition>
         </div>
         <div class="flex items-center space-x-4">
-          <select
+          <Select
             v-if="dashboards?.length > 1"
-            :value="activeDashboard?.id"
+            :model-value="activeDashboard?.id"
+            :options="
+              dashboards.map((dashboard) => ({
+                value: dashboard.id,
+                label: dashboard.label
+              }))
+            "
             @change="switchDashboard"
             aria-label="Bridge dashboard"
             class="rounded-md border-0 bg-transparent py-1 pl-2 pr-7 text-sm text-gray-600 focus:ring-1 focus:ring-gray-300 dark:bg-gray-950 dark:text-gray-300 dark:focus:ring-gray-700"
-          >
-            <option
-              v-for="dashboard in dashboards"
-              :key="dashboard.id"
-              :value="dashboard.id"
-            >
-              {{ dashboard.label }}
-            </option>
-          </select>
+          />
           <span
             v-if="total > 0"
             class="text-xs text-gray-500 dark:text-gray-400"

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -4,6 +4,7 @@ import { computed, ref } from 'vue'
 import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 
 defineOptions({
@@ -77,8 +78,7 @@ function refresh() {
   router.reload({ only: ['models', 'modelsError', 'activeDashboard'] })
 }
 
-function switchDashboard(event) {
-  const id = event.target.value
+function switchDashboard(id) {
   router.get(bridgeBasePath.value, id ? { dashboard: id } : {}, {
     preserveState: true,
     preserveScroll: true,
@@ -98,21 +98,19 @@ function switchDashboard(event) {
       :breadcrumbs="[{ label: 'bridge' }]"
     >
       <template #actions>
-        <select
+        <Select
           v-if="dashboards?.length > 1"
-          :value="activeDashboard?.id"
+          :model-value="activeDashboard?.id"
+          :options="
+            dashboards.map((dashboard) => ({
+              value: dashboard.id,
+              label: dashboard.label
+            }))
+          "
           @change="switchDashboard"
           aria-label="Bridge dashboard"
           class="rounded-md border-0 bg-transparent py-1 pl-2 pr-7 text-sm text-gray-600 focus:ring-1 focus:ring-gray-300 dark:bg-gray-950 dark:text-gray-300 dark:focus:ring-gray-700"
-        >
-          <option
-            v-for="dashboard in dashboards"
-            :key="dashboard.id"
-            :value="dashboard.id"
-          >
-            {{ dashboard.label }}
-          </option>
-        </select>
+        />
         <Tooltip
           v-if="appRunning && (modelList.length > 0 || activeDashboard)"
           text="Refresh Bridge"

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -13,6 +13,7 @@ import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Table from '@/components/ui/table/Table.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
@@ -1152,19 +1153,17 @@ onUnmounted(() => {
           v-if="databaseService && hasMultipleServices"
           class="relative hidden sm:block"
         >
-          <select
-            :value="databaseService.id"
-            @change="switchService($event.target.value)"
+          <Select
+            :model-value="databaseService.id"
+            :options="
+              availableServices.map((service) => ({
+                value: service.id,
+                label: service.name
+              }))
+            "
+            @change="switchService"
             class="focus:border-brand appearance-none border-b border-dashed border-gray-300 bg-transparent py-1 pl-1 pr-6 text-sm text-gray-600 focus:outline-none dark:border-gray-600 dark:text-gray-400"
-          >
-            <option
-              v-for="svc in availableServices"
-              :key="svc.id"
-              :value="svc.id"
-            >
-              {{ svc.name }}
-            </option>
-          </select>
+          />
           <svg
             class="pointer-events-none absolute right-0 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-gray-400"
             fill="none"

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -14,6 +14,7 @@ import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import SlideToDeploy from '@/components/SlideToDeploy.vue'
 import Alert from '@/components/ui/alert/Alert.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
@@ -1739,15 +1740,16 @@ onBeforeUnmount(() => {
                         {{ createAppForm.errors.healthPath }}
                       </p>
                     </div>
-                    <select
+                    <Select
                       v-model="createAppRoutePath"
+                      :options="[
+                        { value: '/', label: '/ (root)' },
+                        { value: '/api', label: '/api' },
+                        { value: '/admin', label: '/admin' },
+                        { value: 'none', label: 'None (worker)' }
+                      ]"
                       class="focus:border-brand rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-                    >
-                      <option value="/">/ (root)</option>
-                      <option value="/api">/api</option>
-                      <option value="/admin">/admin</option>
-                      <option value="none">None (worker)</option>
-                    </select>
+                    />
                   </div>
 
                   <!-- GitHub repo picker -->
@@ -1808,20 +1810,18 @@ onBeforeUnmount(() => {
                         <span class="text-xs text-gray-500 dark:text-gray-400"
                           >Deploy branch</span
                         >
-                        <select
+                        <Select
                           v-if="branches.length > 0"
-                          :value="selectedBranch"
-                          @change="selectBranch($event.target.value)"
+                          :model-value="selectedBranch"
+                          :options="
+                            branches.map((branch) => ({
+                              value: branch.name,
+                              label: branch.name
+                            }))
+                          "
+                          @change="selectBranch"
                           class="focus:border-brand rounded-md border border-gray-200 bg-white px-2 py-1 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-                        >
-                          <option
-                            v-for="b in branches"
-                            :key="b.name"
-                            :value="b.name"
-                          >
-                            {{ b.name }}
-                          </option>
-                        </select>
+                        />
                         <span v-else-if="loadingBranches" role="status">
                           <Spinner class="h-4 w-4 text-gray-400" />
                           <span class="sr-only"
@@ -2391,35 +2391,29 @@ onBeforeUnmount(() => {
                       class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 font-mono text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:flex-1"
                       @keydown.enter="createService"
                     />
-                    <select
+                    <Select
                       v-model="newServiceType"
+                      :options="serviceTypes"
                       class="focus:border-brand rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-                    >
-                      <option
-                        v-for="st in serviceTypes"
-                        :key="st.value"
-                        :value="st.value"
-                      >
-                        {{ st.label }}
-                      </option>
-                    </select>
-                    <select
+                    />
+                    <Select
                       v-if="!customServiceVersion"
                       v-model="newServiceVersion"
+                      :options="[
+                        ...(selectedServicePolicy?.versions || []).map(
+                          (entry) => ({
+                            value: entry.version,
+                            label: `${entry.version}${
+                              entry.recommended ? ' · recommended' : ''
+                            }`
+                          })
+                        ),
+                        { value: '__custom__', label: 'Custom version…' }
+                      ]"
                       aria-label="Service version"
                       class="focus:border-brand rounded-md border border-gray-200 bg-white px-2 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
                       @change="handleServiceVersionChange"
-                    >
-                      <option
-                        v-for="entry in selectedServicePolicy?.versions || []"
-                        :key="entry.version"
-                        :value="entry.version"
-                      >
-                        {{ entry.version
-                        }}{{ entry.recommended ? ' · recommended' : '' }}
-                      </option>
-                      <option value="__custom__">Custom version…</option>
-                    </select>
+                    />
                     <div v-else class="flex items-center gap-2">
                       <input
                         v-model="newServiceVersion"

--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -3,6 +3,7 @@ import { Link, Head, router } from '@inertiajs/vue3'
 import { inject, ref, computed, watch, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
+import Select from '@/components/ui/select/Select.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import { useQueryState } from '@/composables/useQueryState'
 import { useEventSource } from '@/composables/sse'
@@ -1676,17 +1677,18 @@ async function copyToken() {
                   </button>
                 </div>
                 <!-- Status filter -->
-                <select
-                  :value="requestStatusFilter"
-                  @change="requestStatusFilter = $event.target.value"
+                <Select
+                  :model-value="requestStatusFilter"
+                  :options="[
+                    { value: '', label: 'Any status' },
+                    { value: '2xx', label: '2xx' },
+                    { value: '3xx', label: '3xx' },
+                    { value: '4xx', label: '4xx' },
+                    { value: '5xx', label: '5xx' }
+                  ]"
+                  @change="requestStatusFilter = $event"
                   class="rounded border border-gray-200 bg-white px-1.5 py-0.5 text-[10px] font-medium text-gray-600 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-400"
-                >
-                  <option value="">Any status</option>
-                  <option value="2xx">2xx</option>
-                  <option value="3xx">3xx</option>
-                  <option value="4xx">4xx</option>
-                  <option value="5xx">5xx</option>
-                </select>
+                />
                 <!-- Search -->
                 <div class="relative">
                   <svg

--- a/assets/js/pages/settings/audit-log.vue
+++ b/assets/js/pages/settings/audit-log.vue
@@ -3,6 +3,7 @@ import { Head, Link, router } from '@inertiajs/vue3'
 import { computed, inject, onBeforeUnmount, ref, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Pagination from '@/components/ui/pagination/Pagination.vue'
+import Select from '@/components/ui/select/Select.vue'
 
 defineOptions({
   layout: AppLayout
@@ -272,14 +273,15 @@ function shortHash(hash) {
             </label>
             <label>
               <span class="sr-only">Filter audit events</span>
-              <select
+              <Select
                 v-model="group"
+                :options="[
+                  { value: 'all', label: 'All events' },
+                  { value: 'helm', label: 'Helm' }
+                ]"
                 data-test="audit-group"
                 class="rounded-md border-0 bg-gray-50 py-2 pl-3 pr-8 text-sm text-gray-700 outline-none ring-1 ring-inset ring-gray-200 focus:ring-gray-400 dark:bg-gray-900 dark:text-gray-300 dark:ring-gray-800 dark:focus:ring-gray-600"
-              >
-                <option value="all">All events</option>
-                <option value="helm">Helm</option>
-              </select>
+              />
             </label>
           </div>
         </div>

--- a/assets/js/pages/settings/git.vue
+++ b/assets/js/pages/settings/git.vue
@@ -3,6 +3,7 @@ import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
+import Select from '@/components/ui/select/Select.vue'
 import { useToast } from '@/composables/toast'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
@@ -722,15 +723,17 @@ jobs:
                   class="block text-sm font-medium text-gray-700 dark:text-gray-300"
                   >Scope (optional)</label
                 >
-                <select
+                <Select
                   v-model="newToken.projectId"
+                  :options="[
+                    { value: '', label: 'All projects' },
+                    ...projects.map((project) => ({
+                      value: project.id,
+                      label: project.name
+                    }))
+                  ]"
                   class="focus:border-brand mt-1 w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-transparent dark:text-white"
-                >
-                  <option value="">All projects</option>
-                  <option v-for="p in projects" :key="p.id" :value="p.id">
-                    {{ p.name }}
-                  </option>
-                </select>
+                />
               </div>
 
               <div class="flex justify-end space-x-3 pt-2">

--- a/assets/js/pages/settings/team.vue
+++ b/assets/js/pages/settings/team.vue
@@ -4,6 +4,7 @@ import { inject, ref, computed, watch, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
+import Select from '@/components/ui/select/Select.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
@@ -534,13 +535,14 @@ function timeAgo(date) {
                     class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400"
                     >Role</label
                   >
-                  <select
+                  <Select
                     v-model="inviteForm.role"
+                    :options="[
+                      { value: 'member', label: 'Member' },
+                      { value: 'admin', label: 'Admin' }
+                    ]"
                     class="focus:border-brand w-full rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
-                  >
-                    <option value="member">Member</option>
-                    <option value="admin">Admin</option>
-                  </select>
+                  />
                 </div>
                 <div class="flex justify-end space-x-3">
                   <button

--- a/assets/js/pages/settings/uploads.vue
+++ b/assets/js/pages/settings/uploads.vue
@@ -2,6 +2,7 @@
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Select from '@/components/ui/select/Select.vue'
 import { useToast } from '@/composables/toast'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
@@ -766,8 +767,15 @@ const providers = [
                   class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400"
                   >Backup Interval</label
                 >
-                <select
+                <Select
                   v-model="scheduleForm.backupSchedule.intervalHours"
+                  :options="[
+                    { value: 6, label: 'Every 6 hours' },
+                    { value: 12, label: 'Every 12 hours' },
+                    { value: 24, label: 'Every 24 hours' },
+                    { value: 48, label: 'Every 48 hours' },
+                    { value: 168, label: 'Weekly' }
+                  ]"
                   :aria-invalid="
                     scheduleForm.invalid('backupSchedule.intervalHours')
                   "
@@ -783,13 +791,7 @@ const providers = [
                       $event
                     )
                   "
-                >
-                  <option :value="6">Every 6 hours</option>
-                  <option :value="12">Every 12 hours</option>
-                  <option :value="24">Every 24 hours</option>
-                  <option :value="48">Every 48 hours</option>
-                  <option :value="168">Weekly</option>
-                </select>
+                />
                 <p
                   v-if="scheduleForm.errors['backupSchedule.intervalHours']"
                   class="mt-1 text-sm text-red-600 dark:text-red-400"
@@ -802,8 +804,14 @@ const providers = [
                   class="mb-1 block text-xs font-medium text-gray-500 dark:text-gray-400"
                   >Retention</label
                 >
-                <select
+                <Select
                   v-model="scheduleForm.backupSchedule.retentionCount"
+                  :options="[
+                    { value: 5, label: 'Keep last 5' },
+                    { value: 10, label: 'Keep last 10' },
+                    { value: 20, label: 'Keep last 20' },
+                    { value: 50, label: 'Keep last 50' }
+                  ]"
                   :aria-invalid="
                     scheduleForm.invalid('backupSchedule.retentionCount')
                   "
@@ -819,12 +827,7 @@ const providers = [
                       $event
                     )
                   "
-                >
-                  <option :value="5">Keep last 5</option>
-                  <option :value="10">Keep last 10</option>
-                  <option :value="20">Keep last 20</option>
-                  <option :value="50">Keep last 50</option>
-                </select>
+                />
                 <p
                   v-if="scheduleForm.errors['backupSchedule.retentionCount']"
                   class="mt-1 text-sm text-red-600 dark:text-red-400"

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -567,9 +567,8 @@ test(
       )
       await page.raw.emulateMedia({ colorScheme: 'light' })
       await page.raw.locator('#bridge-filter-title-value').fill('production')
-      await page.raw
-        .locator('#bridge-filter-published-value')
-        .selectOption('true')
+      await page.raw.locator('#bridge-filter-published-value').click()
+      await page.raw.getByRole('option', { name: 'Yes', exact: true }).click()
       await page.raw.locator('#bridge-filter-creator-value').click()
       await page.wait('text=Ada Lovelace')
       await page.screenshot(
@@ -605,9 +604,10 @@ test(
         { fullPage: true }
       )
 
+      await page.raw.locator('[data-test="bridge-lens-select"]').click()
       await page.raw
-        .locator('[data-test="bridge-lens-select"]')
-        .selectOption('recent')
+        .getByRole('option', { name: 'Recently active', exact: true })
+        .click()
       await page.raw.waitForURL(
         (url) => url.searchParams.get('lens') === 'recent'
       )
@@ -623,9 +623,10 @@ test(
         { fullPage: true }
       )
       await page.raw.emulateMedia({ colorScheme: 'light' })
+      await page.raw.locator('[data-test="bridge-lens-select"]').click()
       await page.raw
-        .locator('[data-test="bridge-lens-select"]')
-        .selectOption('')
+        .getByRole('option', { name: 'All records', exact: true })
+        .click()
       await page.raw.waitForURL((url) => !url.searchParams.has('lens'))
 
       const resourceActionsButton = page.raw.getByRole('button', {

--- a/tests/e2e/pages/projects/log-viewer.test.js
+++ b/tests/e2e/pages/projects/log-viewer.test.js
@@ -100,14 +100,22 @@ test(
       path: path.resolve('.tmp/issue-434-log-viewer-desktop-dark.png')
     })
 
-    await viewer.locator('[data-test="log-level-filter"]').selectOption('error')
+    await viewer.locator('[data-test="log-level-filter"]').click()
+    await page.raw.getByRole('option', { name: /^Errors ·/ }).click()
+    expect(
+      await viewer
+        .locator('[data-test="log-level-filter"]')
+        .getAttribute('aria-expanded')
+    ).toBe('false')
     expect(await viewer.locator('[data-test="log-event"]').count()).toBe(1)
     await expect(page).toSee('Timeout.<anonymous>')
     await viewer.screenshot({
       path: path.resolve('.tmp/issue-434-log-viewer-error-filter.png')
     })
 
-    await viewer.locator('[data-test="log-level-filter"]').selectOption('all')
+    await page.raw.getByRole('listbox').waitFor({ state: 'hidden' })
+    await viewer.locator('[data-test="log-level-filter"]').click()
+    await page.raw.getByRole('option', { name: 'All · 5', exact: true }).click()
 
     await page.raw.evaluate(() => {
       const stream = window.__slipwayTestEventSources.find((candidate) =>


### PR DESCRIPTION
## What changed

- install the copied-source Klean Select and use it for all 27 current select controls across Bridge, Bearing, Lookout, environment settings, logs, and team settings
- preserve typed values, disabled and required states, blur validation, dynamic option lists, compact caller styling, and existing test hooks
- harden rapid option selection so a late native popover event cannot reopen a menu after the choice is committed
- update browser trials to exercise visible combobox and option behavior instead of native `selectOption()` calls

## Verification

- `npm run lint`
- `node_modules/.bin/sounding test --file tests/e2e/pages/projects/log-viewer.test.js --file tests/e2e/pages/projects/bridge-resource-contract.test.js --test-concurrency=1 --compact`
- local browser verification: PostgreSQL → Redis updates the dependent version picker to `7.2 · recommended`, closes the menu, and reopens cleanly
- captured matching before/after screenshots under `.tmp/screenshots/issue-331-select/`

Closes #331