### PR TITLE
feat(ui): adopt Klean Textarea across Slipway

### DIFF
--- a/assets/js/components/ReleaseFlagMenu.vue
+++ b/assets/js/components/ReleaseFlagMenu.vue
@@ -1,4 +1,5 @@
 <script setup>
+import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
 import { ref, watch } from 'vue'
 
@@ -84,12 +85,12 @@ function remove(event) {
         class="mt-3 block text-xs font-medium text-gray-700 dark:text-gray-300"
       >
         Allowlist
-        <textarea
+        <Textarea
           v-model="targets"
           rows="3"
           class="mt-1 w-full resize-none border-b border-gray-200 bg-transparent py-1.5 font-mono text-xs font-normal text-gray-900 placeholder-gray-400 focus:border-gray-500 focus:outline-none dark:border-gray-700 dark:text-white"
           placeholder="user:42&#10;account:acme"
-        ></textarea>
+        />
       </label>
       <p class="mt-1 text-[11px] leading-4 text-gray-400">
         One user, account, tenant, or team per line.

--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -1,4 +1,5 @@
 <script setup>
+import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
 import { router } from '@inertiajs/vue3'
 import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
@@ -921,7 +922,7 @@ function defaultPlaceholder(fieldType) {
         @compatibility-change="richTextCompatibility = $event"
       />
 
-      <textarea
+      <Textarea
         v-else-if="['textarea', 'richtext'].includes(type)"
         :id="fieldId"
         :value="modelValue"
@@ -936,7 +937,7 @@ function defaultPlaceholder(fieldType) {
         style="field-sizing: content"
         @input="update($event.target.value)"
         @blur="handleBlur"
-      ></textarea>
+      />
 
       <textarea
         v-else-if="type === 'json'"

--- a/assets/js/components/ui/textarea/Textarea.vue
+++ b/assets/js/components/ui/textarea/Textarea.vue
@@ -1,0 +1,64 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  modelValue: { type: [String, Number], default: undefined }
+})
+const emit = defineEmits(['update:modelValue', 'input'])
+const attrs = useAttrs()
+const element = ref()
+let composing = false
+
+const resolvedValue = computed(() => props.modelValue ?? attrs.value)
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    value: _value,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function commitValue(event) {
+  emit('update:modelValue', event.target.value)
+}
+
+function updateValue(event) {
+  if (!composing) commitValue(event)
+  emit('input', event)
+}
+
+function finishComposition(event) {
+  composing = false
+  commitValue(event)
+}
+
+defineExpose({
+  element,
+  focus: (options) => element.value?.focus(options),
+  select: () => element.value?.select()
+})
+</script>
+
+<template>
+  <textarea
+    ref="element"
+    v-bind="forwardedAttrs"
+    :value="resolvedValue"
+    data-slot="textarea"
+    :class="
+      twMerge(
+        ['disabled:cursor-not-allowed motion-reduce:transition-none'],
+        attrs.class
+      )
+    "
+    @compositionstart="composing = true"
+    @compositionend="finishComposition"
+    @input="updateValue"
+  />
+</template>

--- a/assets/js/pages/bearing/feedback.vue
+++ b/assets/js/pages/bearing/feedback.vue
@@ -1,4 +1,5 @@
 <script setup>
+import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
 import { Head, InfiniteScroll, router, useForm } from '@inertiajs/vue3'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
@@ -832,14 +833,14 @@ function shortDate(value) {
 
               <label class="mt-3 block" for="bearing-feedback-details">
                 <span class="sr-only">Details (optional)</span>
-                <textarea
+                <Textarea
                   id="bearing-feedback-details"
                   v-model="form.details"
                   rows="2"
                   maxlength="5000"
                   placeholder="Add details (optional)"
                   class="bearing-feedback-composer-field w-full resize-none border-0 bg-transparent p-0 text-sm leading-6 text-gray-700 caret-gray-950 placeholder:text-gray-300 dark:text-gray-300 dark:caret-white dark:placeholder:text-gray-600"
-                ></textarea>
+                />
               </label>
 
               <div

--- a/assets/js/pages/projects/new.vue
+++ b/assets/js/pages/projects/new.vue
@@ -1,4 +1,5 @@
 <script setup>
+import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
 import { useForm, Head, Link } from '@inertiajs/vue3'
 import { inject } from 'vue'
@@ -186,7 +187,7 @@ const sidebarCollapsed = inject('sidebarCollapsed')
               {{ form.errors.name }}
             </p>
 
-            <textarea
+            <Textarea
               id="description"
               v-model="form.description"
               placeholder="A brief description about your project"
@@ -198,7 +199,7 @@ const sidebarCollapsed = inject('sidebarCollapsed')
               "
               @blur="validateOnBlur('description', $event)"
               @input="revalidateWhenInvalid('description')"
-            ></textarea>
+            />
             <p
               v-if="form.errors.description"
               id="project-description-error"

--- a/assets/js/pages/projects/settings.vue
+++ b/assets/js/pages/projects/settings.vue
@@ -1,4 +1,5 @@
 <script setup>
+import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref } from 'vue'
@@ -269,7 +270,7 @@ function openDeleteProject() {
             >
               Description
             </label>
-            <textarea
+            <Textarea
               id="description"
               v-model="form.description"
               placeholder="A brief description about your project"
@@ -281,7 +282,7 @@ function openDeleteProject() {
               "
               @blur="validateProjectOnBlur('description', $event)"
               @input="revalidateProjectWhenInvalid('description')"
-            ></textarea>
+            />
             <p
               v-if="form.errors.description"
               id="project-description-error"


### PR DESCRIPTION
## Summary

- add a locally owned native-first Klean Textarea with IME-safe v-model, composed input events, and native focus/select access
- migrate five ordinary multiline fields while keeping Bridge JSON, content JSON, and Markdown source editors semantically separate
- remove the registry auto-grow and forced resize behavior so every existing Slipway sizing recipe remains caller-owned

## Verification

- create-project before/after screenshots are pixel-identical
- browser verification preserves newline values, data-slot semantics, and caller-owned field sizing
- npm run lint
- focused Bridge browser trial covering multiline/rich-text fallback, validation, long content, and light/dark mode (passed)

Closes #333