### PR TITLE
feat(ui): adopt Klean Checkbox across Slipway

### DIFF
--- a/assets/js/components/ui/checkbox/Checkbox.vue
+++ b/assets/js/components/ui/checkbox/Checkbox.vue
@@ -1,0 +1,133 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  onUpdated,
+  ref,
+  useAttrs
+} from 'vue'
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  indeterminate: { type: Boolean, default: false }
+})
+const emit = defineEmits(['change'])
+const model = defineModel({ default: false })
+const attrs = useAttrs()
+const element = ref()
+const checked = ref(false)
+let form
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    type: _type,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-disabled': _dataDisabled,
+    'data-invalid': _dataInvalid,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const disabled = computed(
+  () => attrs.disabled !== undefined && attrs.disabled !== false
+)
+const invalid = computed(
+  () => attrs['aria-invalid'] === true || attrs['aria-invalid'] === 'true'
+)
+const state = computed(() =>
+  props.indeterminate
+    ? 'indeterminate'
+    : checked.value
+    ? 'checked'
+    : 'unchecked'
+)
+
+function applyElementState() {
+  if (!element.value) return
+  element.value.indeterminate = props.indeterminate
+  checked.value = element.value.checked
+}
+
+function valuesMatch(left, right) {
+  return Object.is(left, right)
+}
+
+function resetModelFromElement() {
+  if (!element.value) return
+
+  const nextChecked = element.value.checked
+  const current = model.value
+  const inputValue = attrs.value ?? 'on'
+
+  if (Array.isArray(current)) {
+    const index = current.findIndex((item) => valuesMatch(item, inputValue))
+    if (nextChecked && index === -1) model.value = [...current, inputValue]
+    if (!nextChecked && index !== -1) {
+      model.value = current.filter((_, itemIndex) => itemIndex !== index)
+    }
+  } else if (current instanceof Set) {
+    const next = new Set(current)
+    if (nextChecked) next.add(inputValue)
+    else next.delete(inputValue)
+    model.value = next
+  } else {
+    model.value = nextChecked
+      ? attrs['true-value'] ?? true
+      : attrs['false-value'] ?? false
+  }
+
+  checked.value = nextChecked
+}
+
+function handleReset() {
+  queueMicrotask(resetModelFromElement)
+}
+
+function handleChange(event) {
+  nextTick(() => {
+    applyElementState()
+    emit('change', event)
+  })
+}
+
+onMounted(() => {
+  applyElementState()
+  element.value.defaultChecked = element.value.checked
+  form = element.value.form
+  form?.addEventListener('reset', handleReset)
+})
+
+onUpdated(applyElementState)
+
+onBeforeUnmount(() => {
+  form?.removeEventListener('reset', handleReset)
+})
+
+defineExpose({
+  element,
+  focus: (options) => element.value?.focus(options)
+})
+</script>
+
+<template>
+  <input
+    ref="element"
+    v-model="model"
+    v-bind="forwardedAttrs"
+    type="checkbox"
+    data-slot="checkbox"
+    :data-state="state"
+    :data-disabled="disabled ? '' : undefined"
+    :data-invalid="invalid ? '' : undefined"
+    :class="[
+      'disabled:cursor-not-allowed motion-reduce:transition-none',
+      attrs.class
+    ]"
+    @change="handleChange"
+  />
+</template>

--- a/assets/js/pages/dashboard/index.vue
+++ b/assets/js/pages/dashboard/index.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
@@ -541,9 +542,8 @@ function cancelDeleteProject() {
     >
       <template #form>
         <label class="mt-4 flex cursor-pointer items-start gap-3">
-          <input
+          <Checkbox
             v-model="deleteProjectForm.purgeData"
-            type="checkbox"
             class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
           />
           <span>

--- a/assets/js/pages/projects/app-settings.vue
+++ b/assets/js/pages/projects/app-settings.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, router, usePage, useForm } from '@inertiajs/vue3'
 import { ref, computed, inject, onMounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
@@ -1066,9 +1067,8 @@ async function deleteApp() {
     >
       <template #form>
         <label class="mt-4 flex cursor-pointer items-start gap-3">
-          <input
+          <Checkbox
             v-model="purgeAppData"
-            type="checkbox"
             class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
           />
           <span class="text-sm text-gray-700 dark:text-gray-300">

--- a/assets/js/pages/projects/bearing.vue
+++ b/assets/js/pages/projects/bearing.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Head, router, useForm } from '@inertiajs/vue3'
 import {
   computed,
@@ -803,9 +804,8 @@ function handleViewKeydown(event, index) {
                   :key="item.publicId"
                   class="has-[:checked]:bg-gray-950 has-[:checked]:text-white dark:has-[:checked]:bg-white dark:has-[:checked]:text-gray-950 cursor-pointer rounded-full bg-gray-50 px-3 py-2 text-xs dark:bg-gray-900"
                 >
-                  <input
+                  <Checkbox
                     v-model="updateForm.feedbackIds"
-                    type="checkbox"
                     class="sr-only"
                     :value="item.publicId"
                   />

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, watch } from 'vue'
 import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
@@ -770,9 +771,9 @@ function createUrl() {
             >
               <tr>
                 <th v-if="hasBulkActions" scope="col" class="w-10 px-4 py-2">
-                  <input
-                    type="checkbox"
-                    :checked="selectAll"
+                  <Checkbox
+                    :model-value="selectAll"
+                    :indeterminate="selectedIds.size > 0 && !selectAll"
                     @change="toggleSelectAll"
                     class="h-3.5 w-3.5 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                   />
@@ -849,9 +850,8 @@ function createUrl() {
                 class="group hover:bg-gray-50 dark:hover:bg-gray-900/30"
               >
                 <td v-if="hasBulkActions" class="px-4 py-2">
-                  <input
-                    type="checkbox"
-                    :checked="selectedIds.has(record[modelMeta.primaryKey])"
+                  <Checkbox
+                    :model-value="selectedIds.has(record[modelMeta.primaryKey])"
                     @change="toggleSelect(record[modelMeta.primaryKey])"
                     class="h-3.5 w-3.5 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                   />

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head } from '@inertiajs/vue3'
 import {
   inject,
@@ -2298,9 +2299,8 @@ onUnmounted(() => {
                   :key="tableName"
                   class="flex cursor-pointer items-center gap-2 px-3 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-800"
                 >
-                  <input
-                    type="checkbox"
-                    :checked="selectedSchemaTables.has(tableName)"
+                  <Checkbox
+                    :model-value="selectedSchemaTables.has(tableName)"
                     @change="toggleSchemaTable(tableName)"
                     class="h-3.5 w-3.5 rounded border-gray-300 text-gray-900 focus:ring-0 focus:ring-offset-0 dark:border-gray-600 dark:bg-gray-800"
                   />
@@ -2547,9 +2547,8 @@ onUnmounted(() => {
                       : 'border-gray-200 bg-white text-gray-500 hover:border-gray-300 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400 dark:hover:border-gray-600'
                   "
                 >
-                  <input
-                    type="checkbox"
-                    :checked="selectedModels.has(model)"
+                  <Checkbox
+                    :model-value="selectedModels.has(model)"
                     @change="toggleModel(model)"
                     class="sr-only"
                   />

--- a/assets/js/pages/projects/environment-settings.vue
+++ b/assets/js/pages/projects/environment-settings.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
@@ -379,9 +380,8 @@ function openDeleteEnvironment() {
     >
       <template #form>
         <label class="mt-4 flex cursor-pointer items-start gap-3">
-          <input
+          <Checkbox
             v-model="purgeData"
-            type="checkbox"
             class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
           />
           <span>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import {
   inject,
@@ -2738,9 +2739,8 @@ onBeforeUnmount(() => {
     >
       <template #form>
         <label class="mt-4 flex cursor-pointer items-start gap-3">
-          <input
+          <Checkbox
             v-model="purgeServiceData"
-            type="checkbox"
             class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
           />
           <span class="text-sm text-gray-700 dark:text-gray-300">

--- a/assets/js/pages/projects/settings.vue
+++ b/assets/js/pages/projects/settings.vue
@@ -1,6 +1,7 @@
 <script setup>
 import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
@@ -346,8 +347,7 @@ function openDeleteProject() {
           <div class="mt-6 space-y-4">
             <!-- Enable toggle -->
             <label class="flex items-center space-x-3">
-              <input
-                type="checkbox"
+              <Checkbox
                 v-model="deployForm.autoDeploy"
                 @change="saveDeploySettings"
                 class="text-brand focus:ring-brand h-4 w-4 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-900"
@@ -500,9 +500,8 @@ function openDeleteProject() {
     >
       <template #form>
         <label class="mt-4 flex cursor-pointer items-start gap-3">
-          <input
+          <Checkbox
             v-model="deleteProjectForm.purgeData"
-            type="checkbox"
             class="mt-0.5 h-4 w-4 rounded border-gray-300 text-red-600 focus:ring-red-500 dark:border-gray-600 dark:bg-gray-800"
           />
           <span>

--- a/assets/js/pages/settings/notifications.vue
+++ b/assets/js/pages/settings/notifications.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
@@ -427,8 +428,7 @@ const categoryIcons = {
                         {{ event.description }}
                       </p>
                     </div>
-                    <input
-                      type="checkbox"
+                    <Checkbox
                       v-model="form[event.model]"
                       class="accent-brand text-brand focus:ring-brand h-4 w-4 rounded border-gray-300 dark:border-gray-600 dark:bg-gray-900"
                     />


### PR DESCRIPTION
Closes #336

## What changed
- add a class-first, native Klean Checkbox primitive with boolean, collection, indeterminate, and form-reset behavior
- migrate every real Slipway checkbox while keeping provider controls on Switch
- preserve existing light/dark styling, hidden chip controls, destructive confirmations, and caller-owned classes

## Verification
- before/after project settings screenshots are byte-for-byte identical
- focused Sounding Bridge browser trial passes bulk selection and partial selection
- focused Sounding Bearing browser trials pass collection-backed feedback chips
- focused Sounding settings trial passes inline validation in light and dark mode
- npm run lint
- git diff --check