### PR TITLE
feat(ui): adopt Klean Radio across Slipway

### DIFF
--- a/assets/js/components/HelmSnippetDialog.vue
+++ b/assets/js/components/HelmSnippetDialog.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Radio from '@/components/ui/radio/Radio.vue'
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
@@ -205,9 +206,8 @@ function handleKeydown(event) {
                         : 'border-gray-200 hover:border-gray-300 dark:border-gray-700 dark:hover:border-gray-600'
                     ]"
                   >
-                    <input
+                    <Radio
                       v-model="scope"
-                      type="radio"
                       name="snippet-scope"
                       :value="option.value"
                       class="sr-only"

--- a/assets/js/components/ui/radio/Radio.vue
+++ b/assets/js/components/ui/radio/Radio.vue
@@ -1,0 +1,111 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs
+} from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const model = defineModel()
+const emit = defineEmits(['change'])
+const attrs = useAttrs()
+const element = ref()
+let form
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    type: _type,
+    checked: _checked,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-disabled': _dataDisabled,
+    'data-invalid': _dataInvalid,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const disabled = computed(
+  () => attrs.disabled !== undefined && attrs.disabled !== false
+)
+const invalid = computed(
+  () => attrs['aria-invalid'] === true || attrs['aria-invalid'] === 'true'
+)
+
+function inputValue() {
+  if (!element.value) return undefined
+  return Object.prototype.hasOwnProperty.call(element.value, '_value')
+    ? element.value._value
+    : element.value.value
+}
+
+const checked = computed(() => Object.is(model.value, attrs.value ?? 'on'))
+
+function groupHasCheckedRadio() {
+  if (!element.value) return false
+  const root = element.value.form ?? element.value.getRootNode()
+  const controls =
+    element.value.form?.elements ??
+    root?.querySelectorAll?.('input[type="radio"]') ??
+    []
+
+  return Array.from(controls).some(
+    (control) =>
+      control.type === 'radio' &&
+      control.name === element.value.name &&
+      control.form === element.value.form &&
+      control.checked
+  )
+}
+
+function resetModelFromElement() {
+  if (element.value.checked) model.value = inputValue()
+  else if (!groupHasCheckedRadio()) model.value = undefined
+}
+
+function handleReset() {
+  queueMicrotask(resetModelFromElement)
+}
+
+function handleChange(event) {
+  nextTick(() => emit('change', event))
+}
+
+onMounted(() => {
+  element.value.defaultChecked = element.value.checked
+  form = element.value.form
+  form?.addEventListener('reset', handleReset)
+})
+
+onBeforeUnmount(() => {
+  form?.removeEventListener('reset', handleReset)
+})
+
+defineExpose({
+  element,
+  focus: (options) => element.value?.focus(options)
+})
+</script>
+
+<template>
+  <input
+    ref="element"
+    v-model="model"
+    v-bind="forwardedAttrs"
+    type="radio"
+    data-slot="radio"
+    :data-state="checked ? 'checked' : 'unchecked'"
+    :data-disabled="disabled ? '' : undefined"
+    :data-invalid="invalid ? '' : undefined"
+    :class="[
+      'disabled:cursor-not-allowed motion-reduce:transition-none',
+      attrs.class
+    ]"
+    @change="handleChange"
+  />
+</template>

--- a/assets/js/pages/bearing/feedback.vue
+++ b/assets/js/pages/bearing/feedback.vue
@@ -1,6 +1,7 @@
 <script setup>
 import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
+import Radio from '@/components/ui/radio/Radio.vue'
 import { Head, InfiniteScroll, router, useForm } from '@inertiajs/vue3'
 import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 import SelectMenu from '@/components/SelectMenu.vue'
@@ -1177,10 +1178,9 @@ function shortDate(value) {
                         : 'bg-gray-50/70 text-gray-500 hover:bg-gray-100 dark:bg-gray-900/60 dark:text-gray-400 dark:hover:bg-gray-900'
                     "
                   >
-                    <input
+                    <Radio
                       v-model="sort"
                       class="sr-only"
-                      type="radio"
                       name="mobile-feedback-sort"
                       :value="option.value"
                     />

--- a/assets/js/pages/projects/bearing.vue
+++ b/assets/js/pages/projects/bearing.vue
@@ -1,6 +1,7 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
 import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
+import Radio from '@/components/ui/radio/Radio.vue'
 import { Head, router, useForm } from '@inertiajs/vue3'
 import {
   computed,
@@ -984,10 +985,9 @@ function handleViewKeydown(event, index) {
                     : 'bg-gray-50 text-gray-950 hover:bg-gray-100 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800'
                 ]"
               >
-                <input
+                <Radio
                   v-model="form.allowAnonymousParticipation"
                   class="sr-only"
-                  type="radio"
                   name="bearing-participation"
                   :value="false"
                 />
@@ -1025,10 +1025,9 @@ function handleViewKeydown(event, index) {
                     : 'bg-gray-50 text-gray-950 hover:bg-gray-100 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800'
                 ]"
               >
-                <input
+                <Radio
                   v-model="form.allowAnonymousParticipation"
                   class="sr-only"
-                  type="radio"
                   name="bearing-participation"
                   :value="true"
                 />

--- a/assets/js/pages/settings/uploads.vue
+++ b/assets/js/pages/settings/uploads.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Radio from '@/components/ui/radio/Radio.vue'
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
@@ -368,10 +369,10 @@ const providers = [
               ]"
             >
               <div class="flex items-center space-x-3">
-                <input
-                  type="radio"
+                <Radio
                   :value="p.id"
                   v-model="selectedProvider"
+                  name="storage-provider"
                   @change="onProviderChange"
                   class="text-brand focus:ring-brand h-4 w-4 border-gray-300 dark:border-gray-600"
                 />


### PR DESCRIPTION
Closes #337

## What changed
- add a class-first native Klean Radio primitive with form-reset and caller-owned styling
- migrate storage providers, Helm scope, Bearing participation, and Bearing mobile sort choices
- add the missing shared storage-provider group name so native keyboard grouping is explicit
- preserve existing card shells, URL-owned filter state, and light/dark recipes

## Verification
- captured untouched light-mode before and dark-mode after screenshots
- exercised provider selection and mutual exclusion in the local browser
- focused Sounding Bearing browser trials pass
- focused Sounding storage/settings validation trials pass
- npm run lint
- git diff --check