### PR TITLE
feat(ui): adopt Klean Tabs across Slipway

### DIFF
--- a/assets/js/components/HelmScratchpadTabs.vue
+++ b/assets/js/components/HelmScratchpadTabs.vue
@@ -18,7 +18,6 @@ const props = defineProps({
 })
 
 const emit = defineEmits([
-  'activate',
   'close',
   'create',
   'duplicate',
@@ -27,7 +26,6 @@ const emit = defineEmits([
   'save'
 ])
 
-const tabRefs = ref([])
 const renamingId = ref('')
 const renameValue = ref('')
 const renameInput = ref(null)
@@ -92,26 +90,6 @@ function createScratchpad() {
   if (props.disabled || !props.canCreate) return
   emit('create')
 }
-
-function handleTabKeydown(event, index) {
-  let nextIndex = index
-  if (event.key === 'ArrowRight') {
-    nextIndex = (index + 1) % props.tabs.length
-  } else if (event.key === 'ArrowLeft') {
-    nextIndex = (index - 1 + props.tabs.length) % props.tabs.length
-  } else if (event.key === 'Home') {
-    nextIndex = 0
-  } else if (event.key === 'End') {
-    nextIndex = props.tabs.length - 1
-  } else {
-    return
-  }
-
-  event.preventDefault()
-  const tab = props.tabs[nextIndex]
-  emit('activate', tab)
-  nextTick(() => tabRefs.value[nextIndex]?.focus())
-}
 </script>
 
 <template>
@@ -120,8 +98,7 @@ function handleTabKeydown(event, index) {
     class="min-h-9 flex shrink-0 items-center gap-2 bg-white px-3 py-0.5 dark:bg-gray-950"
   >
     <div
-      role="tablist"
-      aria-label="Helm scratchpads"
+      data-slot="tabs-list"
       class="flex min-w-0 flex-1 items-center gap-3 overflow-x-auto"
     >
       <template v-for="(tab, index) in tabs" :key="tab.id">
@@ -140,13 +117,10 @@ function handleTabKeydown(event, index) {
         <button
           v-else
           :id="`helm-scratchpad-${tab.id}-tab`"
-          :ref="(element) => (tabRefs[index] = element)"
           type="button"
-          role="tab"
+          :data-value="tab.id"
           :data-test="`helm-scratchpad-${index}`"
-          :aria-selected="tab.id === activeId"
           aria-controls="helm-scratchpad-panel"
-          :tabindex="tab.id === activeId ? 0 : -1"
           :disabled="disabled"
           :title="helmScratchpadTargetTitle(tab.target)"
           :class="[
@@ -155,9 +129,7 @@ function handleTabKeydown(event, index) {
               ? 'font-medium text-gray-900 dark:text-white'
               : 'text-gray-400 hover:text-gray-700 dark:text-gray-500 dark:hover:text-gray-300'
           ]"
-          @click="emit('activate', tab)"
           @dblclick="beginRename(tab)"
-          @keydown="handleTabKeydown($event, index)"
         >
           <span class="truncate">{{ tab.name }}</span>
           <span

--- a/assets/js/components/HelmWorkspaceLibrary.vue
+++ b/assets/js/components/HelmWorkspaceLibrary.vue
@@ -6,6 +6,7 @@ import ConfirmModal from '@/components/ConfirmModal.vue'
 import HelmSnippetDialog from '@/components/HelmSnippetDialog.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Tabs from '@/components/ui/tabs/Tabs.vue'
 import ToastContainer from '@/components/ToastContainer.vue'
 
 const props = defineProps({
@@ -366,45 +367,22 @@ function dismissToast(id) {
   toasts.value = toasts.value.filter((toast) => toast.id !== id)
 }
 
-function handleLibraryTabKeydown(event, index) {
-  let nextIndex = index
-  if (event.key === 'ArrowRight') {
-    nextIndex = (index + 1) % libraryTabs.value.length
-  } else if (event.key === 'ArrowLeft') {
-    nextIndex =
-      (index - 1 + libraryTabs.value.length) % libraryTabs.value.length
-  } else if (event.key === 'Home') {
-    nextIndex = 0
-  } else if (event.key === 'End') {
-    nextIndex = libraryTabs.value.length - 1
-  } else {
-    return
-  }
-
-  event.preventDefault()
-  const nextTab = libraryTabs.value[nextIndex]
-  emit('update:tab', nextTab.key)
-  window.requestAnimationFrame(() => {
-    document.getElementById(`helm-library-${nextTab.key}-tab`)?.focus()
-  })
-}
-
 defineExpose({ refreshHistory, openSnippetDialog })
 </script>
 
 <template>
-  <section
+  <Tabs
+    as="section"
+    :model-value="tab"
+    aria-label="Helm library"
     data-test="helm-library"
     class="flex max-h-[17rem] min-h-0 shrink-0 flex-col border-t border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-950"
+    @change="emit('update:tab', $event)"
   >
     <header class="flex shrink-0 items-center gap-2 px-3 py-2">
-      <div
-        class="flex shrink-0 items-center gap-0.5"
-        role="tablist"
-        aria-label="Helm library"
-      >
+      <div data-slot="tabs-list" class="flex shrink-0 items-center gap-0.5">
         <Tooltip
-          v-for="(item, index) in libraryTabs"
+          v-for="item in libraryTabs"
           :key="item.key"
           :text="`${item.label} · ${item.countLabel}`"
           placement="top"
@@ -412,11 +390,9 @@ defineExpose({ refreshHistory, openSnippetDialog })
           <button
             :id="`helm-library-${item.key}-tab`"
             type="button"
-            role="tab"
+            :data-value="item.key"
             aria-controls="helm-library-panel"
             :aria-label="`${item.label}, ${item.countLabel}`"
-            :aria-selected="tab === item.key"
-            :tabindex="tab === item.key ? 0 : -1"
             :data-test="`helm-library-${item.key}`"
             :class="[
               'flex h-7 w-7 items-center justify-center rounded-md outline-none transition-colors focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-gray-400 motion-reduce:transition-none dark:focus-visible:ring-gray-600',
@@ -424,8 +400,6 @@ defineExpose({ refreshHistory, openSnippetDialog })
                 ? 'bg-gray-200/80 text-gray-900 dark:bg-gray-800 dark:text-white'
                 : 'text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300'
             ]"
-            @click="emit('update:tab', item.key)"
-            @keydown="handleLibraryTabKeydown($event, index)"
           >
             <svg
               v-if="item.key === 'history'"
@@ -551,8 +525,8 @@ defineExpose({ refreshHistory, openSnippetDialog })
 
     <div
       id="helm-library-panel"
-      role="tabpanel"
-      :aria-labelledby="`helm-library-${tab}-tab`"
+      data-slot="tab-panel"
+      :data-value="tab"
       class="min-h-0 flex-1 overflow-y-auto"
     >
       <div
@@ -715,7 +689,7 @@ defineExpose({ refreshHistory, openSnippetDialog })
         are never saved.
       </p>
     </footer>
-  </section>
+  </Tabs>
 
   <HelmSnippetDialog
     :show="snippetDialog.show"

--- a/assets/js/components/ui/tabs/Tabs.vue
+++ b/assets/js/components/ui/tabs/Tabs.vue
@@ -1,0 +1,429 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  useId,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Root element. Use `nav` when the children are route destinations. */
+  as: {
+    type: String,
+    default: 'div',
+    validator: (value) => ['div', 'nav', 'section'].includes(value)
+  },
+  /** Framework-native controlled value. Omit for uncontrolled use. */
+  modelValue: { type: String, default: undefined },
+  /** Initial value when `modelValue` is not controlled. */
+  defaultValue: { type: String, default: undefined },
+  /** Arrow-key direction. */
+  orientation: {
+    type: String,
+    default: 'horizontal',
+    validator: (value) => ['horizontal', 'vertical'].includes(value)
+  },
+  /** Whether moving focus also selects a tab. */
+  activation: {
+    type: String,
+    default: 'automatic',
+    validator: (value) => ['automatic', 'manual'].includes(value)
+  }
+})
+
+const emit = defineEmits(['update:modelValue', 'change'])
+const attrs = useAttrs()
+const componentId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+const root = ref()
+const internalValue = ref(props.defaultValue)
+const isControlled = computed(() => props.modelValue !== undefined)
+const value = computed(() =>
+  isControlled.value ? props.modelValue : internalValue.value
+)
+const rootAttrs = computed(() => {
+  const { class: _class, role: _role, ...rest } = attrs
+  if (props.as !== 'nav') {
+    delete rest['aria-label']
+    delete rest['aria-labelledby']
+  }
+  return rest
+})
+const rootClasses = computed(() => twMerge(attrs.class))
+
+let observer
+let previousValues = []
+let lastFocusedValue
+let syncing = false
+
+function listElement() {
+  if (root.value?.matches('nav')) return root.value
+  return [
+    ...(root.value?.querySelectorAll('[data-slot="tabs-list"]') ?? [])
+  ].find(belongsToThisTabs)
+}
+
+function tabValue(element) {
+  return element?.getAttribute('data-value') ?? ''
+}
+
+function belongsToThisTabs(element) {
+  return element.closest('[data-slot="tabs"]') === root.value
+}
+
+function triggers() {
+  const list = listElement()
+  if (!list) return []
+  return [
+    ...list.querySelectorAll('button[data-value], a[href][data-value]')
+  ].filter(belongsToThisTabs)
+}
+
+function mode(elements = triggers()) {
+  if (!elements.length) return 'empty'
+  if (props.as === 'nav') {
+    return elements.every((element) => element.matches('a[href]'))
+      ? 'navigation'
+      : 'mixed'
+  }
+  if (elements.every((element) => element.matches('button'))) return 'panels'
+  if (elements.every((element) => element.matches('a[href]'))) {
+    return 'navigation'
+  }
+  return 'mixed'
+}
+
+function tabs() {
+  return triggers().filter((trigger) => trigger.matches('button'))
+}
+
+function panels() {
+  if (!root.value) return []
+  return [
+    ...root.value.querySelectorAll('[data-slot="tab-panel"][data-value]')
+  ].filter(belongsToThisTabs)
+}
+
+function mutationTouchesTabs(record) {
+  const target =
+    record.target instanceof Element
+      ? record.target
+      : record.target.parentElement
+  if (target?.closest('[data-slot="tabs"]') !== root.value) return false
+
+  const list = listElement()
+  if (record.type === 'attributes') {
+    return (
+      target === list ||
+      target.matches('[data-slot="tab-panel"][data-value]') ||
+      (list?.contains(target) &&
+        target.matches('button[data-value], a[href][data-value]'))
+    )
+  }
+
+  if (target === list) return true
+  return [...record.addedNodes, ...record.removedNodes].some((node) => {
+    if (!(node instanceof Element)) return false
+    if (node.matches('[data-slot="tabs"]')) return false
+
+    const candidates = [
+      ...(node.matches(
+        '[data-slot="tabs-list"], [data-slot="tab-panel"][data-value]'
+      )
+        ? [node]
+        : []),
+      ...node.querySelectorAll(
+        '[data-slot="tabs-list"], [data-slot="tab-panel"][data-value]'
+      )
+    ]
+    return candidates.some(belongsToThisTabs)
+  })
+}
+
+function disabled(tab) {
+  return tab.disabled || tab.getAttribute('aria-disabled') === 'true'
+}
+
+function enabledTabs() {
+  return tabs().filter((tab) => !disabled(tab))
+}
+
+function tabFor(candidate) {
+  return tabs().find((tab) => tabValue(tab) === candidate)
+}
+
+function panelFor(candidate) {
+  return panels().find((panel) => tabValue(panel) === candidate)
+}
+
+function fallbackValue(current) {
+  const available = enabledTabs()
+  if (!available.length) return undefined
+
+  const oldIndex = previousValues.indexOf(current)
+  const index = oldIndex < 0 ? 0 : Math.min(oldIndex, available.length - 1)
+  return tabValue(available[index])
+}
+
+function requestValue(nextValue, { user = false } = {}) {
+  if (!nextValue || nextValue === value.value) return
+  if (!isControlled.value) internalValue.value = nextValue
+  emit('update:modelValue', nextValue)
+  if (user) emit('change', nextValue)
+  nextTick(sync)
+}
+
+function generatedPairId(candidate, index) {
+  const slug = candidate.replace(/[^a-zA-Z0-9_-]/g, '-') || String(index)
+  return `klean-tabs-${componentId}-${slug}-${index}`
+}
+
+function setAttribute(element, name, nextValue) {
+  if (element.getAttribute(name) !== nextValue) {
+    element.setAttribute(name, nextValue)
+  }
+}
+
+function syncList(list, currentMode) {
+  if (!list) return
+  const isRoot = list === root.value
+  if (!isRoot) list.setAttribute('data-slot', 'tabs-list')
+  list.setAttribute('data-mode', currentMode)
+  list.setAttribute('data-orientation', props.orientation)
+  if (!isRoot && attrs['aria-label'])
+    list.setAttribute('aria-label', attrs['aria-label'])
+  if (!isRoot && attrs['aria-labelledby'])
+    list.setAttribute('aria-labelledby', attrs['aria-labelledby'])
+}
+
+function syncNavigation(list, links) {
+  if (list.getAttribute('role') === 'tablist') list.removeAttribute('role')
+  list.removeAttribute('aria-orientation')
+
+  const current = value.value
+  const currentLink = links.find((link) => tabValue(link) === current)
+  const markedLink = links.find(
+    (link) => link.getAttribute('aria-current') === 'page'
+  )
+  const selected = currentLink ?? (!isControlled.value ? markedLink : undefined)
+
+  if (!isControlled.value && selected && tabValue(selected) !== current) {
+    internalValue.value = tabValue(selected)
+  }
+
+  links.forEach((link) => {
+    const active = link === selected
+    link.setAttribute('data-slot', 'tab')
+    link.setAttribute('data-mode', 'navigation')
+    link.setAttribute('data-state', active ? 'active' : 'inactive')
+    link.setAttribute('data-orientation', props.orientation)
+    if (link.getAttribute('role') === 'tab') link.removeAttribute('role')
+    link.removeAttribute('aria-selected')
+    link.removeAttribute('aria-controls')
+    if (active) setAttribute(link, 'aria-current', 'page')
+    else if (link.getAttribute('aria-current') === 'page') {
+      link.removeAttribute('aria-current')
+    }
+  })
+}
+
+function sync() {
+  if (!root.value || syncing) return
+  syncing = true
+
+  const list = listElement()
+  const allTriggers = triggers()
+  const currentMode = mode(allTriggers)
+  root.value.setAttribute('data-mode', currentMode)
+  syncList(list, currentMode)
+
+  if (currentMode === 'navigation') {
+    syncNavigation(list, allTriggers)
+    previousValues = []
+    syncing = false
+    return
+  }
+
+  if (currentMode !== 'panels') {
+    syncing = false
+    return
+  }
+
+  const allTabs = tabs()
+  const allPanels = panels()
+  const current = value.value
+  const currentTab = tabFor(current)
+  const resolved = currentTab ? current : fallbackValue(current)
+
+  if (resolved && resolved !== current) {
+    if (!isControlled.value) internalValue.value = resolved
+    else emit('update:modelValue', resolved)
+  }
+
+  if (list) {
+    list.setAttribute('role', 'tablist')
+    list.setAttribute('aria-orientation', props.orientation)
+  }
+
+  allTabs.forEach((tab, index) => {
+    const candidate = tabValue(tab)
+    const panel = panelFor(candidate)
+    const pairId = generatedPairId(candidate, index)
+    const selected = candidate === resolved
+
+    if (!tab.hasAttribute('type')) tab.setAttribute('type', 'button')
+    tab.setAttribute('role', 'tab')
+    tab.setAttribute('data-slot', 'tab')
+    tab.setAttribute('data-mode', 'panels')
+    tab.setAttribute('data-state', selected ? 'active' : 'inactive')
+    tab.setAttribute('data-orientation', props.orientation)
+    tab.setAttribute('aria-selected', String(selected))
+    tab.tabIndex = selected ? 0 : -1
+    if (!tab.id) tab.id = `${pairId}-tab`
+    const panelId =
+      panel?.id || tab.getAttribute('aria-controls') || `${pairId}-panel`
+    tab.setAttribute('aria-controls', panelId)
+
+    if (panel) {
+      if (!panel.id) panel.id = panelId
+      panel.setAttribute('role', 'tabpanel')
+      panel.setAttribute('data-slot', 'tab-panel')
+      panel.setAttribute('data-state', selected ? 'active' : 'inactive')
+      panel.setAttribute('data-orientation', props.orientation)
+      panel.setAttribute('aria-labelledby', tab.id)
+      if (panel.hidden === selected) panel.hidden = !selected
+      if (!panel.hasAttribute('tabindex')) panel.tabIndex = 0
+    }
+  })
+
+  allPanels.forEach((panel) => {
+    if (tabFor(tabValue(panel))) return
+    if (!panel.hidden) panel.hidden = true
+  })
+
+  const shouldRestoreFocus =
+    lastFocusedValue === current && current && !tabFor(current) && resolved
+  previousValues = allTabs.map(tabValue)
+  syncing = false
+
+  if (shouldRestoreFocus) {
+    nextTick(() => tabFor(resolved)?.focus({ preventScroll: true }))
+  }
+}
+
+function reveal(tab) {
+  tab.scrollIntoView?.({ block: 'nearest', inline: 'nearest' })
+}
+
+function focusTab(tab) {
+  if (!tab) return
+  tab.focus({ preventScroll: true })
+  reveal(tab)
+  if (props.activation === 'automatic') {
+    requestValue(tabValue(tab), { user: true })
+  }
+}
+
+function eventTab(event) {
+  const candidate = event.target.closest?.('button[data-value]')
+  return candidate && listElement()?.contains(candidate) ? candidate : undefined
+}
+
+function handleClick(event) {
+  const tab = eventTab(event)
+  if (!tab || disabled(tab)) return
+  lastFocusedValue = tabValue(tab)
+  requestValue(tabValue(tab), { user: true })
+}
+
+function handleFocusIn(event) {
+  const tab = eventTab(event)
+  if (!tab || disabled(tab)) return
+  lastFocusedValue = tabValue(tab)
+}
+
+function handleKeydown(event) {
+  const tab = eventTab(event)
+  if (!tab || disabled(tab)) return
+  const available = enabledTabs()
+  const index = available.indexOf(tab)
+  let next
+
+  if (
+    (props.orientation === 'horizontal' && event.key === 'ArrowRight') ||
+    (props.orientation === 'vertical' && event.key === 'ArrowDown')
+  ) {
+    next = available[(index + 1) % available.length]
+  } else if (
+    (props.orientation === 'horizontal' && event.key === 'ArrowLeft') ||
+    (props.orientation === 'vertical' && event.key === 'ArrowUp')
+  ) {
+    next = available[(index - 1 + available.length) % available.length]
+  } else if (event.key === 'Home') {
+    next = available[0]
+  } else if (event.key === 'End') {
+    next = available.at(-1)
+  } else if (
+    props.activation === 'manual' &&
+    ['Enter', ' '].includes(event.key)
+  ) {
+    event.preventDefault()
+    requestValue(tabValue(tab), { user: true })
+    return
+  } else {
+    return
+  }
+
+  event.preventDefault()
+  focusTab(next)
+}
+
+onMounted(async () => {
+  await nextTick()
+  sync()
+  observer = new MutationObserver((records) => {
+    if (records.some(mutationTouchesTabs)) sync()
+  })
+  observer.observe(root.value, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: [
+      'data-value',
+      'disabled',
+      'aria-disabled',
+      'href',
+      'aria-current'
+    ]
+  })
+})
+
+watch(
+  () => [props.modelValue, props.orientation, props.activation],
+  () => nextTick(sync)
+)
+
+onBeforeUnmount(() => observer?.disconnect())
+</script>
+
+<template>
+  <component
+    :is="as"
+    v-bind="rootAttrs"
+    ref="root"
+    data-slot="tabs"
+    :data-orientation="orientation"
+    :class="rootClasses"
+    @click="handleClick"
+    @focusin="handleFocusIn"
+    @keydown="handleKeydown"
+  >
+    <slot />
+  </component>
+</template>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Tabs from '@/components/ui/tabs/Tabs.vue'
 import { Head, usePage } from '@inertiajs/vue3'
 import {
   ref,
@@ -789,7 +790,12 @@ onUnmounted(() => {
 
 <template>
   <Head title="Bosun | Slipway"></Head>
-  <div class="flex h-full flex-col">
+  <Tabs
+    :model-value="activeTab"
+    aria-label="Bosun sections"
+    class="flex h-full flex-col"
+    @change="onTabChange"
+  >
     <!-- Header -->
     <div
       class="flex items-center justify-between border-b border-gray-200 px-4 py-3 dark:border-gray-800 sm:px-6"
@@ -919,12 +925,13 @@ onUnmounted(() => {
 
     <!-- Tab bar (Dock-style pills with frosted glass) -->
     <div
+      data-slot="tabs-list"
       class="flex items-center space-x-1 border-b border-gray-200/50 bg-white/80 px-4 py-2 backdrop-blur-md dark:border-gray-800/50 dark:bg-gray-950/80 sm:px-6"
     >
       <button
         v-for="tab in tabs"
         :key="tab.id"
-        @click="onTabChange(tab.id)"
+        :data-value="tab.id"
         :class="[
           'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
           activeTab === tab.id
@@ -939,6 +946,8 @@ onUnmounted(() => {
     <!-- ═══ Console Tab (full-height layout matching Dock) ═══ -->
     <div
       v-if="activeTab === 'console'"
+      data-slot="tab-panel"
+      data-value="console"
       class="flex flex-1 flex-col overflow-hidden"
     >
       <!-- Editor -->
@@ -1380,7 +1389,11 @@ onUnmounted(() => {
     >
       <div class="mx-auto max-w-6xl">
         <!-- ═══ Overview Tab ═══ -->
-        <div v-if="activeTab === 'overview'">
+        <div
+          v-if="activeTab === 'overview'"
+          data-slot="tab-panel"
+          data-value="overview"
+        >
           <!-- Status line -->
           <div
             class="mb-6 flex flex-wrap items-center gap-3 rounded-lg border border-gray-200 bg-gray-50/50 px-4 py-3 dark:border-gray-800 dark:bg-gray-900/50"
@@ -1587,7 +1600,11 @@ onUnmounted(() => {
         </div>
 
         <!-- ═══ Environment Tab ═══ -->
-        <div v-if="activeTab === 'environment'">
+        <div
+          v-if="activeTab === 'environment'"
+          data-slot="tab-panel"
+          data-value="environment"
+        >
           <div class="mb-6">
             <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
               Instance Environment
@@ -1729,7 +1746,11 @@ onUnmounted(() => {
         </div>
 
         <!-- ═══ Migrate Tab ═══ -->
-        <div v-if="activeTab === 'migrate'">
+        <div
+          v-if="activeTab === 'migrate'"
+          data-slot="tab-panel"
+          data-value="migrate"
+        >
           <div
             class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
           >
@@ -2033,13 +2054,13 @@ onUnmounted(() => {
                     </span>
                     <span class="text-gray-500 dark:text-gray-400">
                       Current: {{ change.current.type }} ·
-                      {{ change.current.nullable ? 'nullable' : 'not null' }} ·
-                      default {{ change.current.defaultValue ?? 'none' }}
+                      {{ change.current.nullable ? 'nullable' : 'not null' }}
+                      · default {{ change.current.defaultValue ?? 'none' }}
                     </span>
                     <span class="text-gray-700 dark:text-gray-300">
                       Expected: {{ change.expected.type }} ·
-                      {{ change.expected.nullable ? 'nullable' : 'not null' }} ·
-                      default {{ change.expected.defaultValue ?? 'none' }}
+                      {{ change.expected.nullable ? 'nullable' : 'not null' }}
+                      · default {{ change.expected.defaultValue ?? 'none' }}
                     </span>
                   </div>
                   <p
@@ -2063,7 +2084,11 @@ onUnmounted(() => {
         </div>
 
         <!-- ═══ Activity Tab ═══ -->
-        <div v-if="activeTab === 'activity'">
+        <div
+          v-if="activeTab === 'activity'"
+          data-slot="tab-panel"
+          data-value="activity"
+        >
           <div class="mb-6 flex items-start justify-between">
             <div>
               <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
@@ -2237,5 +2262,5 @@ onUnmounted(() => {
       @cancel="showMigrateConfirm = false"
     />
     <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
-  </div>
+  </Tabs>
 </template>

--- a/assets/js/pages/projects/bearing.vue
+++ b/assets/js/pages/projects/bearing.vue
@@ -17,6 +17,7 @@ import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
 import Alert from '@/components/ui/alert/Alert.vue'
 import Select from '@/components/ui/select/Select.vue'
+import Tabs from '@/components/ui/tabs/Tabs.vue'
 import { useQueryState } from '@/composables/useQueryState'
 
 defineOptions({ layout: AppLayout })
@@ -248,29 +249,6 @@ onUnmounted(() => {
   window.removeEventListener('resize', revealSelectedTab)
   window.clearTimeout(copyResetTimer)
 })
-
-function handleViewKeydown(event, index) {
-  let nextIndex
-
-  if (event.key === 'ArrowRight') {
-    nextIndex = (index + 1) % navItems.length
-  } else if (event.key === 'ArrowLeft') {
-    nextIndex = (index - 1 + navItems.length) % navItems.length
-  } else if (event.key === 'Home') {
-    nextIndex = 0
-  } else if (event.key === 'End') {
-    nextIndex = navItems.length - 1
-  } else {
-    return
-  }
-
-  event.preventDefault()
-  const [view] = navItems[nextIndex]
-  selectView(view)
-  nextTick(() => {
-    document.getElementById(`bearing-tab-${view}`)?.focus()
-  })
-}
 </script>
 
 <template>
@@ -339,7 +317,11 @@ function handleViewKeydown(event, index) {
     <main
       class="flex-1 overflow-y-auto px-4 py-8 text-gray-950 dark:text-white sm:px-8 sm:py-12"
     >
-      <div class="mx-auto max-w-3xl">
+      <Tabs
+        v-model="selectedView"
+        aria-label="Bearing sections"
+        class="mx-auto max-w-3xl"
+      >
         <div
           class="flex flex-col gap-5 sm:flex-row sm:items-start sm:justify-between"
         >
@@ -400,27 +382,22 @@ function handleViewKeydown(event, index) {
 
         <div
           ref="tablist"
+          data-slot="tabs-list"
           class="mt-8 flex items-center gap-1 overflow-x-auto py-1"
-          role="tablist"
-          aria-label="Bearing sections"
         >
           <button
             v-for="(item, index) in navItems"
             :id="`bearing-tab-${item[0]}`"
             :key="item[0]"
             type="button"
-            role="tab"
-            :aria-selected="selectedView === item[0]"
+            :data-value="item[0]"
             :aria-controls="`bearing-panel-${item[0]}`"
-            :tabindex="selectedView === item[0] ? 0 : -1"
             :class="[
               'min-h-10 shrink-0 rounded-md px-3 py-1.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:focus-visible:ring-gray-600',
               selectedView === item[0]
                 ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
                 : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-gray-300'
             ]"
-            @click="selectView(item[0])"
-            @keydown="handleViewKeydown($event, index)"
           >
             {{ item[1] }}
           </button>
@@ -429,10 +406,9 @@ function handleViewKeydown(event, index) {
         <section
           v-if="selectedView === 'overview'"
           id="bearing-panel-overview"
+          data-slot="tab-panel"
+          data-value="overview"
           class="mt-10"
-          role="tabpanel"
-          aria-labelledby="bearing-tab-overview"
-          tabindex="0"
         >
           <div
             class="grid grid-cols-2 gap-3 min-[360px]:grid-cols-3 sm:grid-cols-5"
@@ -625,10 +601,9 @@ function handleViewKeydown(event, index) {
         <section
           v-else-if="selectedView === 'feedback'"
           id="bearing-panel-feedback"
+          data-slot="tab-panel"
+          data-value="feedback"
           class="mt-10"
-          role="tabpanel"
-          aria-labelledby="bearing-tab-feedback"
-          tabindex="0"
         >
           <div class="flex items-end justify-between gap-4">
             <div>
@@ -690,10 +665,9 @@ function handleViewKeydown(event, index) {
         <section
           v-else-if="selectedView === 'roadmap'"
           id="bearing-panel-roadmap"
+          data-slot="tab-panel"
+          data-value="roadmap"
           class="mt-10"
-          role="tabpanel"
-          aria-labelledby="bearing-tab-roadmap"
-          tabindex="0"
         >
           <div class="grid gap-4 lg:grid-cols-3">
             <section v-for="group in roadmapGroups" :key="group.status">
@@ -730,10 +704,9 @@ function handleViewKeydown(event, index) {
         <section
           v-else-if="selectedView === 'updates'"
           id="bearing-panel-updates"
+          data-slot="tab-panel"
+          data-value="updates"
           class="mt-10"
-          role="tabpanel"
-          aria-labelledby="bearing-tab-updates"
-          tabindex="0"
         >
           <form class="space-y-5" @submit.prevent="saveUpdate(false)">
             <div>
@@ -872,10 +845,9 @@ function handleViewKeydown(event, index) {
         <form
           v-else
           id="bearing-panel-settings"
+          data-slot="tab-panel"
+          data-value="settings"
           class="mt-10 space-y-12"
-          role="tabpanel"
-          aria-labelledby="bearing-tab-settings"
-          tabindex="0"
           @submit.prevent="save"
         >
           <section aria-labelledby="bearing-availability-heading">
@@ -1302,7 +1274,7 @@ function handleViewKeydown(event, index) {
             </p>
           </div>
         </form>
-      </div>
+      </Tabs>
     </main>
   </div>
 </template>

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -19,6 +19,7 @@ import Select from '@/components/ui/select/Select.vue'
 import Table from '@/components/ui/table/Table.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
+import Tabs from '@/components/ui/tabs/Tabs.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
 import DockResultStatusIcon from '@/components/DockResultStatusIcon.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
@@ -130,6 +131,10 @@ const queryResults = computed(() => {
 const activeQueryResult = computed(
   () => queryResults.value[activeQueryResultIndex.value] || null
 )
+const activeQueryResultTab = computed({
+  get: () => String(activeQueryResultIndex.value),
+  set: (value) => selectQueryResult(Number(value))
+})
 const hasMultipleQueryResults = computed(() => queryResults.value.length > 1)
 const hasOnlyCommandResults = computed(
   () =>
@@ -855,29 +860,6 @@ function selectQueryResult(index) {
   showExportMenu.value = false
 }
 
-function handleQueryResultKeydown(event, index) {
-  let nextIndex = index
-
-  if (event.key === 'ArrowRight') {
-    nextIndex = (index + 1) % queryResults.value.length
-  } else if (event.key === 'ArrowLeft') {
-    nextIndex =
-      (index - 1 + queryResults.value.length) % queryResults.value.length
-  } else if (event.key === 'Home') {
-    nextIndex = 0
-  } else if (event.key === 'End') {
-    nextIndex = queryResults.value.length - 1
-  } else {
-    return
-  }
-
-  event.preventDefault()
-  selectQueryResult(nextIndex)
-  nextTick(() => {
-    document.getElementById(`dock-query-result-tab-${nextIndex}`)?.focus()
-  })
-}
-
 function queryResultAriaLabel(result, index) {
   return `${index + 1}. ${
     result.statementPreview || result.commandTag || 'SQL statement'
@@ -1384,16 +1366,23 @@ onUnmounted(() => {
     </div>
 
     <!-- Database management UI (service selected) -->
-    <div v-else class="flex flex-1 flex-col overflow-hidden">
+    <Tabs
+      v-else
+      :model-value="activeTab"
+      aria-label="Database sections"
+      class="flex min-h-0 flex-1 flex-col overflow-hidden"
+      @change="switchTab"
+    >
       <!-- Tabs (hidden for Redis since it only has console) -->
       <div
-        v-if="validTabs.length > 1"
+        v-show="validTabs.length > 1"
+        data-slot="tabs-list"
         class="sticky top-0 z-10 flex items-center space-x-1 border-b border-gray-200/50 bg-white/80 px-4 py-2 backdrop-blur-md dark:border-gray-800/50 dark:bg-gray-950/80 sm:px-6"
       >
         <button
           v-for="tab in validTabs"
           :key="tab"
-          @click="switchTab(tab)"
+          :data-value="tab"
           :class="[
             'rounded-md px-3 py-1.5 text-sm font-medium capitalize transition-colors',
             activeTab === tab
@@ -1408,6 +1397,8 @@ onUnmounted(() => {
       <!-- Redis Console Tab -->
       <div
         v-if="activeTab === 'console' && isRedis"
+        data-slot="tab-panel"
+        data-value="console"
         class="flex flex-1 flex-col overflow-hidden"
       >
         <!-- Quick actions bar -->
@@ -1543,6 +1534,8 @@ onUnmounted(() => {
       <!-- SQL/MongoDB Console Tab -->
       <div
         v-if="activeTab === 'console' && !isRedis"
+        data-slot="tab-panel"
+        data-value="console"
         class="flex flex-1 flex-col overflow-hidden"
       >
         <!-- Editor -->
@@ -1702,22 +1695,24 @@ onUnmounted(() => {
           </section>
 
           <!-- Row-returning and mixed results -->
-          <div v-else-if="queryResult" class="flex h-full min-h-0 flex-col">
+          <Tabs
+            v-else-if="queryResult"
+            v-model="activeQueryResultTab"
+            aria-label="Query results"
+            class="flex h-full min-h-0 flex-col"
+          >
             <div
-              v-if="hasMultipleQueryResults"
-              role="tablist"
-              aria-label="Query results"
+              v-show="hasMultipleQueryResults"
+              data-slot="tabs-list"
               class="flex shrink-0 items-center gap-1 overflow-x-auto border-b border-gray-200 px-2 py-1.5 dark:border-gray-800"
             >
               <button
                 v-for="(result, index) in queryResults"
                 :id="`dock-query-result-tab-${index}`"
                 :key="index"
-                role="tab"
-                :aria-selected="index === activeQueryResultIndex"
+                :data-value="String(index)"
                 aria-controls="dock-query-result-panel"
                 :aria-label="queryResultAriaLabel(result, index)"
-                :tabindex="index === activeQueryResultIndex ? 0 : -1"
                 :data-test="`dock-query-result-${index + 1}`"
                 :title="result.statementSql"
                 :class="[
@@ -1726,8 +1721,6 @@ onUnmounted(() => {
                     ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
                     : 'text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-200'
                 ]"
-                @click="selectQueryResult(index)"
-                @keydown="handleQueryResultKeydown($event, index)"
               >
                 <DockResultStatusIcon :status="result.status" />
                 <span class="shrink-0 font-medium tabular-nums">{{
@@ -1746,12 +1739,8 @@ onUnmounted(() => {
             <div
               id="dock-query-result-panel"
               data-test="dock-query-result-panel"
-              role="tabpanel"
-              :aria-labelledby="
-                hasMultipleQueryResults
-                  ? `dock-query-result-tab-${activeQueryResultIndex}`
-                  : undefined
-              "
+              data-slot="tab-panel"
+              :data-value="activeQueryResultTab"
               class="flex min-h-0 flex-1 flex-col"
             >
               <!-- Table view -->
@@ -2050,7 +2039,7 @@ onUnmounted(() => {
                 </div>
               </div>
             </div>
-          </div>
+          </Tabs>
 
           <!-- Empty state -->
           <div
@@ -2065,6 +2054,8 @@ onUnmounted(() => {
       <!-- Tables / Collections Tab -->
       <div
         v-if="activeTab === 'tables' || activeTab === 'collections'"
+        data-slot="tab-panel"
+        :data-value="activeTab"
         class="flex flex-1 overflow-hidden"
       >
         <!-- Table list sidebar -->
@@ -2210,6 +2201,8 @@ onUnmounted(() => {
       <!-- Schema Tab -->
       <div
         v-if="activeTab === 'schema'"
+        data-slot="tab-panel"
+        data-value="schema"
         class="flex-1 overflow-auto p-4 sm:p-6"
       >
         <div
@@ -2418,6 +2411,8 @@ onUnmounted(() => {
       <!-- Migrate Tab -->
       <div
         v-if="activeTab === 'migrate'"
+        data-slot="tab-panel"
+        data-value="migrate"
         class="flex-1 overflow-auto p-4 sm:p-6"
       >
         <div
@@ -2617,7 +2612,7 @@ onUnmounted(() => {
           </div>
         </div>
       </div>
-    </div>
+    </Tabs>
 
     <!-- Bottom-right toolbar (migrate tab only, not for Redis) -->
     <div

--- a/assets/js/pages/projects/helm.vue
+++ b/assets/js/pages/projects/helm.vue
@@ -20,6 +20,7 @@ import HelmWriteGuardDialog from '@/components/HelmWriteGuardDialog.vue'
 import Alert from '@/components/ui/alert/Alert.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import Tabs from '@/components/ui/tabs/Tabs.vue'
 import { useHelmScratchpads } from '@/composables/useHelmScratchpads'
 import { helmEditorDiagnostic } from '@/lib/helmResult'
 import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
@@ -500,6 +501,11 @@ async function activateScratchpad(tab) {
   openScratchpadTarget(tab)
 }
 
+function activateScratchpadById(id) {
+  const tab = scratchpadTabs.value.find((item) => item.id === id)
+  if (tab) activateScratchpad(tab)
+}
+
 function openScratchpadTarget(tab = targetSwitch.value.tab) {
   if (!tab) return
   targetSwitch.value = { show: false, tab: null }
@@ -848,20 +854,26 @@ watch(code, () => {
       </div>
     </div>
 
-    <HelmScratchpadTabs
-      :tabs="scratchpadTabs"
-      :active-id="activeScratchpadId"
-      :current-target-key="currentTargetKey"
-      :disabled="running || inspectingSource"
-      :can-create="canCreateScratchpad"
-      @activate="activateScratchpad"
-      @create="createScratchpad"
-      @rename="scratchpads.rename"
-      @duplicate="duplicateScratchpad"
-      @move="(tab, offset) => scratchpads.move(tab.id, offset)"
-      @save="saveScratchpadAsSnippet"
-      @close="requestCloseScratchpad"
-    />
+    <Tabs
+      :model-value="activeScratchpadId"
+      aria-label="Helm scratchpads"
+      class="contents"
+      @change="activateScratchpadById"
+    >
+      <HelmScratchpadTabs
+        :tabs="scratchpadTabs"
+        :active-id="activeScratchpadId"
+        :current-target-key="currentTargetKey"
+        :disabled="running || inspectingSource"
+        :can-create="canCreateScratchpad"
+        @create="createScratchpad"
+        @rename="scratchpads.rename"
+        @duplicate="duplicateScratchpad"
+        @move="(tab, offset) => scratchpads.move(tab.id, offset)"
+        @save="saveScratchpadAsSnippet"
+        @close="requestCloseScratchpad"
+      />
+    </Tabs>
 
     <!-- Main content - Tinkerwell style -->
     <div

--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -5,6 +5,7 @@ import { inject, ref, computed, watch, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import Select from '@/components/ui/select/Select.vue'
+import Tabs from '@/components/ui/tabs/Tabs.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import { useQueryState } from '@/composables/useQueryState'
 import { useEventSource } from '@/composables/sse'
@@ -786,7 +787,11 @@ async function copyToken() {
 
     <!-- Content -->
     <div class="flex-1 overflow-y-auto px-4 py-6 sm:px-8 sm:py-8">
-      <div class="mx-auto max-w-5xl">
+      <Tabs
+        v-model="activeTab"
+        aria-label="Lookout sections"
+        class="mx-auto max-w-5xl"
+      >
         <!-- Header -->
         <div class="mb-6">
           <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
@@ -824,11 +829,11 @@ async function copyToken() {
 
         <!-- Tabs -->
         <div class="mb-6 border-b border-gray-200 dark:border-gray-800">
-          <nav class="-mb-px flex space-x-6">
+          <nav data-slot="tabs-list" class="-mb-px flex space-x-6">
             <button
               v-for="tab in tabs"
               :key="tab.id"
-              @click="activeTab = tab.id"
+              :data-value="tab.id"
               :class="[
                 'flex items-center space-x-1.5 border-b-2 pb-3 text-sm font-medium transition-colors',
                 activeTab === tab.id
@@ -852,7 +857,11 @@ async function copyToken() {
         </div>
 
         <!-- INFRASTRUCTURE TAB -->
-        <div v-if="activeTab === 'infrastructure'">
+        <div
+          v-if="activeTab === 'infrastructure'"
+          data-slot="tab-panel"
+          data-value="infrastructure"
+        >
           <!-- Empty state -->
           <div v-if="liveContainers.length === 0" class="py-20 text-center">
             <svg
@@ -1174,7 +1183,8 @@ async function copyToken() {
                                 memColor(container.metric.memoryPercent)
                               ]"
                             >
-                              {{ formatBytes(container.metric.memoryUsage) }} /
+                              {{ formatBytes(container.metric.memoryUsage) }}
+                              /
                               {{ formatBytes(container.metric.memoryLimit) }}
                             </span>
                           </div>
@@ -1515,7 +1525,11 @@ async function copyToken() {
         </div>
 
         <!-- REQUESTS TAB -->
-        <div v-if="activeTab === 'requests'">
+        <div
+          v-if="activeTab === 'requests'"
+          data-slot="tab-panel"
+          data-value="requests"
+        >
           <!-- Summary cards -->
           <div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
             <div
@@ -2030,7 +2044,11 @@ async function copyToken() {
         </div>
 
         <!-- EXCEPTIONS TAB -->
-        <div v-if="activeTab === 'exceptions'">
+        <div
+          v-if="activeTab === 'exceptions'"
+          data-slot="tab-panel"
+          data-value="exceptions"
+        >
           <!-- Summary -->
           <div class="mb-6 flex items-center justify-between">
             <div class="flex items-baseline space-x-3">
@@ -2165,7 +2183,11 @@ async function copyToken() {
         </div>
 
         <!-- QUERIES TAB -->
-        <div v-if="activeTab === 'queries'">
+        <div
+          v-if="activeTab === 'queries'"
+          data-slot="tab-panel"
+          data-value="queries"
+        >
           <div v-if="telemetry.queries.slow.length > 0">
             <h3
               class="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300"
@@ -2241,7 +2263,11 @@ async function copyToken() {
         </div>
 
         <!-- CACHE TAB -->
-        <div v-if="activeTab === 'cache'">
+        <div
+          v-if="activeTab === 'cache'"
+          data-slot="tab-panel"
+          data-value="cache"
+        >
           <!-- Summary cards -->
           <div class="mb-6 grid grid-cols-2 gap-4 sm:grid-cols-4">
             <div
@@ -2454,7 +2480,12 @@ async function copyToken() {
         </div>
 
         <!-- SETUP TAB (when no telemetry data) -->
-        <div v-if="activeTab === 'setup'" class="mx-auto max-w-lg py-8">
+        <div
+          v-if="activeTab === 'setup'"
+          data-slot="tab-panel"
+          data-value="setup"
+          class="mx-auto max-w-lg py-8"
+        >
           <div class="text-center">
             <div
               class="bg-brand/10 mx-auto flex h-12 w-12 items-center justify-center rounded-full"
@@ -2567,7 +2598,7 @@ async function copyToken() {
             </div>
           </div>
         </div>
-      </div>
+      </Tabs>
     </div>
   </div>
 </template>

--- a/tests/e2e/pages/projects/dock-multi-results.test.js
+++ b/tests/e2e/pages/projects/dock-multi-results.test.js
@@ -108,7 +108,9 @@ test(
       'Query result 1'
     )
 
-    const tabs = page.raw.getByRole('tab')
+    const tabs = page.raw
+      .getByRole('tablist', { name: 'Query results' })
+      .getByRole('tab')
     expect(await tabs.count()).toBe(2)
     expect(await tabs.nth(0).getAttribute('aria-selected')).toBe('true')
     await expect(page).toSee('24873')
@@ -127,7 +129,7 @@ test(
       .click()
     await page.wait(350)
 
-    await page.raw.getByRole('tab').nth(0).focus()
+    await tabs.nth(0).focus()
     await page.key('ArrowRight')
     expect(await tabs.nth(1).getAttribute('aria-selected')).toBe('true')
 


### PR DESCRIPTION
Closes #342

## What changed

- add the Klean Tabs primitive without a barrel file
- consolidate Bosun, Dock, Lookout, Bearing, and Helm operational tab sets
- cover nested Dock query results and dynamic Helm scratchpads/library tabs
- preserve page-owned URL state, Inertia behavior, lazy fetches, and existing visual styling
- remove duplicated click, arrow-key, Home/End, roving tabindex, and ARIA wiring
- scope the existing Dock trial to its nested Query results tablist now that primary Dock navigation is also semantic

## Verification

- `npm run lint`
- `sounding test tests/e2e/pages/projects/dock-multi-results.test.js --test-concurrency=1`
- `sounding test tests/e2e/pages/projects/lookout-telemetry-state.test.js tests/e2e/pages/projects/bearing.test.js --test-concurrency=1`
- `sounding test tests/e2e/pages/projects/helm.test.js --grep "named scratchpads|durable searchable history" --test-concurrency=1`
- browser-verified Bosun click and ArrowRight navigation, focus, ARIA linkage, active panel, and `?tab=` synchronization
- captured matching before/after Bosun screenshots; the migration is visually 1:1