### PR TITLE
feat(ui): adopt Klean Command for the command palette

### DIFF
--- a/assets/js/components/CommandPalette.vue
+++ b/assets/js/components/CommandPalette.vue
@@ -1,5 +1,5 @@
 <script setup>
-import Input from '@/components/ui/input/Input.vue'
+import Command from '@/components/ui/command/Command.vue'
 import {
   ref,
   computed,
@@ -15,16 +15,14 @@ import { useToast } from '@/composables/toast'
 import { fuzzySearch } from '@/lib/fuzzySearch'
 import { LOCAL_STORAGE_KEYS } from '@/lib/localStorageKeys'
 
-const { isOpen, history, register, unregister, getAll, execute, close } =
+const { isOpen, history, register, unregister, getAll, execute, open, close } =
   useCommandPalette()
 const toast = useToast()
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 
 const query = ref('')
-const selectedIndex = ref(0)
-const inputRef = ref(null)
-const resultsRef = ref(null)
+const commandRef = ref(null)
 const mode = ref('root')
 const parentCommand = ref(null)
 
@@ -540,76 +538,37 @@ const results = computed(() => {
   return groups
 })
 
-const flatResults = computed(() => Object.values(results.value).flat())
-
 // ─── Keyboard navigation ─────────────────────────────────────────────
 
-function handleKeydown(e) {
-  // Global: toggle palette
+function handleGlobalKeydown(e) {
   if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
     e.preventDefault()
     if (isOpen.value) {
       close()
     } else {
-      isOpen.value = true
+      open()
     }
-    return
-  }
-
-  if (!isOpen.value) return
-
-  switch (e.key) {
-    case 'ArrowDown':
-      e.preventDefault()
-      selectedIndex.value = Math.min(
-        selectedIndex.value + 1,
-        flatResults.value.length - 1
-      )
-      scrollToSelected()
-      break
-
-    case 'ArrowUp':
-      e.preventDefault()
-      selectedIndex.value = Math.max(selectedIndex.value - 1, 0)
-      scrollToSelected()
-      break
-
-    case 'Enter':
-      e.preventDefault()
-      if (flatResults.value[selectedIndex.value]) {
-        selectCommand(flatResults.value[selectedIndex.value])
-      }
-      break
-
-    case 'Escape':
-      e.preventDefault()
-      if (mode.value === 'submenu') {
-        mode.value = 'root'
-        parentCommand.value = null
-        query.value = ''
-      } else {
-        close()
-      }
-      break
-
-    case 'Backspace':
-      if (!query.value && mode.value === 'submenu') {
-        mode.value = 'root'
-        parentCommand.value = null
-      }
-      break
   }
 }
 
-function scrollToSelected() {
-  nextTick(() => {
-    const container = resultsRef.value
-    if (!container) return
-    const selected = container.querySelector('[data-selected="true"]')
-    if (selected) {
-      selected.scrollIntoView({ block: 'nearest' })
-    }
-  })
+function handleCommandKeydown(event) {
+  if (event.key !== 'Escape' || event.isComposing || event.keyCode === 229) {
+    return
+  }
+
+  event.preventDefault()
+  event.stopPropagation()
+  if (mode.value === 'submenu') {
+    returnToRootMode()
+  } else {
+    close()
+  }
+}
+
+function handleCommandBack(event) {
+  if (mode.value !== 'submenu') return
+  event.preventDefault()
+  returnToRootMode()
 }
 
 function selectCommand(cmd) {
@@ -626,7 +585,6 @@ function selectCommand(cmd) {
     mode.value = 'submenu'
     parentCommand.value = cmd
     query.value = ''
-    selectedIndex.value = 0
   } else {
     query.value = ''
     mode.value = 'root'
@@ -640,25 +598,20 @@ function selectCommand(cmd) {
 watch(isOpen, (open) => {
   if (open) {
     query.value = ''
-    selectedIndex.value = 0
     mode.value = 'root'
     parentCommand.value = null
-    nextTick(() => inputRef.value?.focus())
+    nextTick(() => commandRef.value?.focus())
   }
-})
-
-watch(query, () => {
-  selectedIndex.value = 0
 })
 
 // ─── Lifecycle ───────────────────────────────────────────────────────
 
 onMounted(() => {
-  document.addEventListener('keydown', handleKeydown)
+  document.addEventListener('keydown', handleGlobalKeydown)
 })
 
 onUnmounted(() => {
-  document.removeEventListener('keydown', handleKeydown)
+  document.removeEventListener('keydown', handleGlobalKeydown)
 })
 
 // ─── Icons ───────────────────────────────────────────────────────────
@@ -750,18 +703,29 @@ const icons = computed(() => ({
           leave-to-class="opacity-0 scale-95 translate-y-2"
           appear
         >
-          <div
-            class="relative w-full max-w-lg rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+          <Command
+            ref="commandRef"
+            :groups="results"
+            :query="query"
+            label="Slipway commands"
+            :placeholder="
+              mode === 'submenu'
+                ? parentCommand?.title + '...'
+                : 'Type a command or search...'
+            "
+            class="relative w-full max-w-lg rounded-xl border-gray-200 bg-white text-gray-950 shadow-2xl dark:border-gray-700 dark:bg-gray-900 dark:text-white [&_[data-slot=command-group-heading]]:text-gray-400 dark:[&_[data-slot=command-group-heading]]:text-gray-500 [&_[data-slot=command-input]:focus-visible]:outline-none [&_[data-slot=command-input]]:py-3.5 [&_[data-slot=command-input]]:text-sm [&_[data-slot=command-input]]:placeholder:text-gray-400 dark:[&_[data-slot=command-input]]:placeholder:text-gray-500 [&_[data-slot=command-item][data-destructive][data-highlighted]]:bg-red-50 dark:[&_[data-slot=command-item][data-destructive][data-highlighted]]:bg-red-950 [&_[data-slot=command-item][data-destructive]]:text-red-600 dark:[&_[data-slot=command-item][data-destructive]]:text-red-400 [&_[data-slot=command-item][data-highlighted]]:bg-gray-100 [&_[data-slot=command-item][data-highlighted]]:text-gray-900 dark:[&_[data-slot=command-item][data-highlighted]]:bg-gray-800 dark:[&_[data-slot=command-item][data-highlighted]]:text-white [&_[data-slot=command-item]]:rounded-lg [&_[data-slot=command-item]]:px-2.5 [&_[data-slot=command-item]]:text-gray-700 [&_[data-slot=command-item]]:transition-colors dark:[&_[data-slot=command-item]]:text-gray-300 [&_[data-slot=command-search]]:border-gray-100 dark:[&_[data-slot=command-search]]:border-gray-800"
+            @update:query="query = $event"
+            @select="selectCommand"
+            @keydown="handleCommandKeydown"
+            @back="handleCommandBack"
           >
-            <!-- Search input -->
-            <div
-              class="flex items-center border-b border-gray-100 px-4 dark:border-gray-800"
-            >
+            <template #prefix>
               <svg
-                class="h-4 w-4 shrink-0 text-gray-400"
+                class="mr-3 h-4 w-4 shrink-0 text-gray-400"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
+                aria-hidden="true"
               >
                 <path
                   stroke-linecap="round"
@@ -770,35 +734,23 @@ const icons = computed(() => ({
                   :d="icons.search"
                 />
               </svg>
-              <Input
-                ref="inputRef"
-                v-model="query"
-                type="text"
-                class="w-full bg-transparent px-3 py-3.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:text-white dark:placeholder-gray-500"
-                :placeholder="
-                  mode === 'submenu'
-                    ? parentCommand?.title + '...'
-                    : 'Type a command or search...'
-                "
-              />
+            </template>
+
+            <template #suffix>
               <kbd
                 class="hidden shrink-0 rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-400 dark:bg-gray-800 dark:text-gray-500 sm:inline"
               >
                 ESC
               </kbd>
-            </div>
+            </template>
 
-            <!-- Results -->
-            <div
-              ref="resultsRef"
-              class="max-h-72 overflow-y-auto overscroll-contain p-1.5"
-            >
-              <!-- Breadcrumb for submenu -->
+            <template #before>
               <div
                 v-if="mode === 'submenu'"
-                class="mb-1 flex items-center gap-1 px-2 py-1 text-xs text-gray-400 dark:text-gray-500"
+                class="mx-1.5 mt-1.5 flex items-center gap-1 px-2 py-1 text-xs text-gray-400 dark:text-gray-500"
               >
                 <button
+                  type="button"
                   @click="returnToRootMode"
                   class="hover:text-gray-600 dark:hover:text-gray-300"
                 >
@@ -821,155 +773,133 @@ const icons = computed(() => ({
                   parentCommand?.title
                 }}</span>
               </div>
+            </template>
 
-              <template v-for="(commands, group) in results" :key="group">
-                <div
-                  class="px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500"
-                >
-                  {{ group }}
-                </div>
-                <button
-                  v-for="cmd in commands"
-                  :key="cmd.id"
-                  @click="selectCommand(cmd)"
-                  @mouseenter="selectedIndex = flatResults.indexOf(cmd)"
-                  :data-selected="flatResults.indexOf(cmd) === selectedIndex"
-                  :class="[
-                    'flex w-full items-center gap-3 rounded-lg px-2.5 py-2 text-left text-sm transition-colors',
-                    cmd.destructive
-                      ? flatResults.indexOf(cmd) === selectedIndex
-                        ? 'bg-red-50 text-red-600 dark:bg-red-950 dark:text-red-400'
-                        : 'text-red-600 hover:bg-red-50 dark:text-red-400 dark:hover:bg-red-950/50'
-                      : flatResults.indexOf(cmd) === selectedIndex
-                      ? 'bg-gray-100 text-gray-900 dark:bg-gray-800 dark:text-white'
-                      : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/50'
-                  ]"
-                >
-                  <span
-                    :class="[
-                      'flex h-7 w-7 shrink-0 items-center justify-center rounded-md',
-                      cmd.destructive
-                        ? 'bg-red-50 dark:bg-red-950'
-                        : 'bg-gray-100 dark:bg-gray-800'
-                    ]"
-                  >
-                    <svg
-                      v-if="typeof icons[cmd.icon] === 'object'"
-                      :class="[
-                        'h-3.5 w-3.5',
-                        cmd.destructive
-                          ? 'text-red-500 dark:text-red-400'
-                          : 'text-gray-500 dark:text-gray-400'
-                      ]"
-                      fill="none"
-                      stroke="currentColor"
-                      :viewBox="icons[cmd.icon].viewBox"
-                    >
-                      <path
-                        v-for="(d, i) in icons[cmd.icon].paths"
-                        :key="i"
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="1"
-                        :d="d"
-                      />
-                    </svg>
-                    <svg
-                      v-else
-                      :class="[
-                        'h-3.5 w-3.5',
-                        cmd.destructive
-                          ? 'text-red-500 dark:text-red-400'
-                          : 'text-gray-500 dark:text-gray-400'
-                      ]"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="1.5"
-                        :d="icons[cmd.icon] || icons.folder"
-                      />
-                    </svg>
-                  </span>
-                  <span class="flex min-w-0 flex-1 flex-col">
-                    <span class="truncate">{{ cmd.title }}</span>
-                    <span
-                      v-if="cmd.subtitle"
-                      class="truncate text-xs text-gray-400 dark:text-gray-500"
-                      >{{ cmd.subtitle }}</span
-                    >
-                  </span>
-                  <svg
-                    v-if="cmd.children"
-                    class="h-3.5 w-3.5 shrink-0 text-gray-400"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                      stroke-width="2"
-                      :d="icons.chevronRight"
-                    />
-                  </svg>
-                </button>
-              </template>
-
-              <!-- Empty state -->
-              <div
-                v-if="!flatResults.length && query"
-                class="py-10 text-center"
+            <template #item="{ command: cmd }">
+              <span
+                :class="[
+                  'flex h-7 w-7 shrink-0 items-center justify-center rounded-md',
+                  cmd.destructive
+                    ? 'bg-red-50 dark:bg-red-950'
+                    : 'bg-gray-100 dark:bg-gray-800'
+                ]"
               >
                 <svg
-                  class="mx-auto h-6 w-6 text-gray-300 dark:text-gray-600"
+                  v-if="typeof icons[cmd.icon] === 'object'"
+                  :class="[
+                    'h-3.5 w-3.5',
+                    cmd.destructive
+                      ? 'text-red-500 dark:text-red-400'
+                      : 'text-gray-500 dark:text-gray-400'
+                  ]"
+                  fill="none"
+                  stroke="currentColor"
+                  :viewBox="icons[cmd.icon].viewBox"
+                  aria-hidden="true"
+                >
+                  <path
+                    v-for="(d, i) in icons[cmd.icon].paths"
+                    :key="i"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="1"
+                    :d="d"
+                  />
+                </svg>
+                <svg
+                  v-else
+                  :class="[
+                    'h-3.5 w-3.5',
+                    cmd.destructive
+                      ? 'text-red-500 dark:text-red-400'
+                      : 'text-gray-500 dark:text-gray-400'
+                  ]"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
+                  aria-hidden="true"
                 >
                   <path
                     stroke-linecap="round"
                     stroke-linejoin="round"
                     stroke-width="1.5"
-                    :d="icons.search"
+                    :d="icons[cmd.icon] || icons.folder"
                   />
                 </svg>
-                <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-                  No results for "{{ query }}"
-                </p>
-              </div>
-            </div>
+              </span>
+              <span class="flex min-w-0 flex-1 flex-col">
+                <span class="truncate">{{ cmd.title }}</span>
+                <span
+                  v-if="cmd.subtitle"
+                  class="truncate text-xs text-gray-400 dark:text-gray-500"
+                  >{{ cmd.subtitle }}</span
+                >
+              </span>
+              <svg
+                v-if="cmd.children"
+                class="h-3.5 w-3.5 shrink-0 text-gray-400"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  :d="icons.chevronRight"
+                />
+              </svg>
+            </template>
 
-            <!-- Footer -->
-            <div
-              class="flex items-center gap-4 border-t border-gray-100 px-4 py-2 text-[11px] text-gray-400 dark:border-gray-800 dark:text-gray-500"
-            >
-              <span class="flex items-center gap-1">
-                <kbd
-                  class="rounded bg-gray-100 px-1 py-0.5 font-mono dark:bg-gray-800"
-                  >&uarr;&darr;</kbd
-                >
-                navigate
-              </span>
-              <span class="flex items-center gap-1">
-                <kbd
-                  class="rounded bg-gray-100 px-1 py-0.5 font-mono dark:bg-gray-800"
-                  >&crarr;</kbd
-                >
-                select
-              </span>
-              <span class="flex items-center gap-1">
-                <kbd
-                  class="rounded bg-gray-100 px-1 py-0.5 font-mono dark:bg-gray-800"
-                  >esc</kbd
-                >
-                close
-              </span>
-            </div>
-          </div>
+            <template #empty>
+              <svg
+                class="mx-auto h-6 w-6 text-gray-300 dark:text-gray-600"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1.5"
+                  :d="icons.search"
+                />
+              </svg>
+              <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+                No results for "{{ query }}"
+              </p>
+            </template>
+
+            <template #footer>
+              <div
+                class="flex items-center gap-4 border-t border-gray-100 px-4 py-2 text-[11px] text-gray-400 dark:border-gray-800 dark:text-gray-500"
+              >
+                <span class="flex items-center gap-1">
+                  <kbd
+                    class="rounded bg-gray-100 px-1 py-0.5 font-mono dark:bg-gray-800"
+                    >&uarr;&darr;</kbd
+                  >
+                  navigate
+                </span>
+                <span class="flex items-center gap-1">
+                  <kbd
+                    class="rounded bg-gray-100 px-1 py-0.5 font-mono dark:bg-gray-800"
+                    >&crarr;</kbd
+                  >
+                  select
+                </span>
+                <span class="flex items-center gap-1">
+                  <kbd
+                    class="rounded bg-gray-100 px-1 py-0.5 font-mono dark:bg-gray-800"
+                    >esc</kbd
+                  >
+                  close
+                </span>
+              </div>
+            </template>
+          </Command>
         </Transition>
       </div>
     </Transition>

--- a/assets/js/components/ui/command/Command.vue
+++ b/assets/js/components/ui/command/Command.vue
@@ -1,0 +1,354 @@
+<script setup>
+import { computed, nextTick, ref, toRaw, useAttrs, useId, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+function normalize(value) {
+  return String(value ?? '')
+    .normalize('NFKD')
+    .toLocaleLowerCase()
+    .replace(/\p{Diacritic}/gu, '')
+}
+
+function defaultFilter(command, query) {
+  const needle = normalize(query).trim()
+  if (!needle) return true
+  return normalize(
+    [command.title, ...(command.keywords ?? [])].filter(Boolean).join(' ')
+  ).includes(needle)
+}
+
+const props = defineProps({
+  /** Flat command records. Klean filters and groups these by `group`. */
+  commands: { type: Array, default: () => [] },
+  /** Caller-filtered groups. Useful for ranked search, Recent, and nested flows. */
+  groups: { type: Object, default: undefined },
+  /** Framework-native controlled search query. Omit for uncontrolled use. */
+  query: { type: String, default: undefined },
+  /** Initial query when `query` is not controlled. */
+  defaultQuery: { type: String, default: '' },
+  /** Accessible name for the real search input. */
+  label: { type: String, default: 'Search commands' },
+  placeholder: { type: String, default: 'Type a command or search…' },
+  /** Boolean visibility predicate for flat `commands`. */
+  filter: { type: Function, default: undefined },
+  autofocus: { type: Boolean, default: false },
+  /** Stable base ID for the input/listbox relationship. */
+  id: { type: String, default: undefined }
+})
+
+const emit = defineEmits(['update:query', 'select', 'escape', 'back'])
+const attrs = useAttrs()
+const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+const root = ref()
+const input = ref()
+const internalQuery = ref(props.defaultQuery)
+const activeKey = ref()
+
+const isControlled = computed(() => props.query !== undefined)
+const currentQuery = computed(() =>
+  isControlled.value ? props.query : internalQuery.value
+)
+const controlId = computed(() => props.id ?? `klean-command-${generatedId}`)
+const inputId = computed(() => `${controlId.value}-input`)
+const listId = computed(() => `${controlId.value}-list`)
+
+const sourceGroups = computed(() => {
+  if (props.groups !== undefined) {
+    return Object.entries(props.groups).map(([heading, commands]) => ({
+      heading,
+      commands: Array.isArray(commands) ? commands : []
+    }))
+  }
+
+  const groups = new Map()
+  for (const command of props.commands) {
+    if (!(props.filter ?? defaultFilter)(command, currentQuery.value)) continue
+    const heading = command.group || 'Other'
+    if (!groups.has(heading)) groups.set(heading, [])
+    groups.get(heading).push(command)
+  }
+  return [...groups].map(([heading, commands]) => ({ heading, commands }))
+})
+
+const commandGroups = computed(() =>
+  sourceGroups.value
+    .map((group, groupIndex) => ({
+      heading: group.heading,
+      headingId: `${controlId.value}-group-${groupIndex}`,
+      entries: group.commands.map((command, commandIndex) => {
+        const identity = String(command.id ?? command.title ?? commandIndex)
+          .replace(/[^a-zA-Z0-9_-]/g, '-')
+          .replace(/-+/g, '-')
+        return {
+          command,
+          key: `${groupIndex}:${commandIndex}:${identity}`,
+          optionId: `${controlId.value}-option-${groupIndex}-${commandIndex}-${identity}`
+        }
+      })
+    }))
+    .filter((group) => group.entries.length)
+)
+const entries = computed(() =>
+  commandGroups.value.flatMap((group) => group.entries)
+)
+const enabledEntries = computed(() =>
+  entries.value.filter((entry) => !entry.command.disabled)
+)
+const activeEntry = computed(() =>
+  enabledEntries.value.find((entry) => entry.key === activeKey.value)
+)
+const rootClasses = computed(() =>
+  twMerge(
+    'w-full overflow-hidden rounded-lg border border-gray-200 bg-white text-gray-950 shadow-lg dark:border-gray-700 dark:bg-gray-950 dark:text-white',
+    attrs.class
+  )
+)
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    onKeydown: _onKeydown,
+    onKeyDown: _onKeyDown,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function setQuery(nextQuery) {
+  if (!isControlled.value) internalQuery.value = nextQuery
+  emit('update:query', nextQuery)
+}
+
+function revealActive() {
+  nextTick(() => {
+    if (!activeEntry.value) return
+    root.value
+      ?.querySelector?.(`[data-command-key="${activeEntry.value.key}"]`)
+      ?.scrollIntoView?.({ block: 'nearest' })
+  })
+}
+
+function setActive(key) {
+  if (!enabledEntries.value.some((entry) => entry.key === key)) return
+  activeKey.value = key
+}
+
+function move(step) {
+  const enabled = enabledEntries.value
+  if (!enabled.length) return
+  const current = enabled.findIndex((entry) => entry.key === activeKey.value)
+  const next =
+    current < 0
+      ? step > 0
+        ? 0
+        : enabled.length - 1
+      : (current + step + enabled.length) % enabled.length
+  activeKey.value = enabled[next].key
+  revealActive()
+}
+
+function moveTo(edge) {
+  const enabled = enabledEntries.value
+  if (!enabled.length) return
+  activeKey.value = edge === 'last' ? enabled.at(-1).key : enabled[0].key
+  revealActive()
+}
+
+function select(entry = activeEntry.value) {
+  if (!entry || entry.command.disabled) return
+  emit('select', toRaw(entry.command))
+}
+
+function handleInput(event) {
+  setQuery(event.currentTarget.value)
+}
+
+function handleKeydown(event) {
+  const listener = attrs.onKeydown ?? attrs.onKeyDown
+  for (const callback of Array.isArray(listener) ? listener : [listener]) {
+    callback?.(event)
+  }
+  if (event.defaultPrevented || event.isComposing || event.keyCode === 229) {
+    return
+  }
+
+  if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+    event.preventDefault()
+    move(event.key === 'ArrowDown' ? 1 : -1)
+  } else if (event.key === 'Home') {
+    event.preventDefault()
+    moveTo('first')
+  } else if (event.key === 'End') {
+    event.preventDefault()
+    moveTo('last')
+  } else if (event.key === 'Enter') {
+    if (!activeEntry.value) return
+    event.preventDefault()
+    select()
+  } else if (event.key === 'Escape') {
+    if (currentQuery.value) {
+      event.preventDefault()
+      event.stopPropagation()
+      setQuery('')
+    } else {
+      emit('escape', event)
+    }
+  } else if (event.key === 'Backspace' && !currentQuery.value) {
+    emit('back', event)
+  }
+}
+
+function handlePointermove(event, entry) {
+  if (entry.command.disabled || event.pointerType === 'touch') return
+  setActive(entry.key)
+}
+
+function handleMousedown(event) {
+  event.preventDefault()
+}
+
+function focus(options) {
+  input.value?.focus(options)
+}
+
+watch(
+  [enabledEntries, currentQuery],
+  ([enabled, query], previous = []) => {
+    const queryChanged = query !== previous[1]
+    if (
+      queryChanged ||
+      !enabled.some((entry) => entry.key === activeKey.value)
+    ) {
+      activeKey.value = enabled[0]?.key
+    }
+    revealActive()
+  },
+  { immediate: true, flush: 'post' }
+)
+
+defineExpose({ focus, clear: () => setQuery('') })
+</script>
+
+<template>
+  <div
+    v-bind="rootAttrs"
+    ref="root"
+    data-slot="command"
+    :data-state="entries.length ? 'results' : 'empty'"
+    :class="rootClasses"
+  >
+    <div
+      data-slot="command-search"
+      class="flex items-center border-b border-gray-200 px-4 dark:border-gray-800"
+    >
+      <slot name="prefix" />
+      <input
+        :id="inputId"
+        ref="input"
+        type="text"
+        role="combobox"
+        aria-autocomplete="list"
+        aria-expanded="true"
+        :aria-label="label"
+        :aria-controls="listId"
+        :aria-activedescendant="activeEntry?.optionId"
+        autocomplete="off"
+        :autofocus="autofocus"
+        :placeholder="placeholder"
+        :value="currentQuery"
+        data-slot="command-input"
+        class="min-h-11 w-full border-0 bg-transparent px-0 py-3 text-base text-gray-950 outline-none placeholder:text-gray-500 focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-gray-950 dark:text-white dark:placeholder:text-gray-400 dark:focus-visible:outline-white"
+        @input="handleInput"
+        @keydown="handleKeydown"
+      />
+      <slot name="suffix" />
+    </div>
+
+    <slot name="before" />
+
+    <div
+      :id="listId"
+      role="listbox"
+      :aria-label="`${label} results`"
+      data-slot="command-list"
+      class="max-h-72 overflow-y-auto overscroll-contain p-1.5"
+    >
+      <div
+        v-for="group in commandGroups"
+        :key="group.headingId"
+        role="group"
+        :aria-labelledby="group.headingId"
+        data-slot="command-group"
+      >
+        <div
+          :id="group.headingId"
+          data-slot="command-group-heading"
+          class="px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
+        >
+          {{ group.heading }}
+        </div>
+
+        <div
+          v-for="entry in group.entries"
+          :id="entry.optionId"
+          :key="entry.key"
+          role="option"
+          :aria-selected="entry.key === activeKey"
+          :aria-disabled="entry.command.disabled || undefined"
+          data-slot="command-item"
+          :data-command-key="entry.key"
+          :data-state="entry.key === activeKey ? 'active' : 'inactive'"
+          :data-highlighted="entry.key === activeKey ? '' : undefined"
+          :data-destructive="entry.command.destructive ? '' : undefined"
+          class="min-h-11 data-highlighted:bg-gray-100 data-highlighted:text-gray-950 dark:data-highlighted:bg-gray-800 dark:data-highlighted:text-white flex cursor-pointer select-none items-center gap-3 rounded-md px-3 py-2 text-sm outline-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+          @mousedown="handleMousedown"
+          @pointermove="handlePointermove($event, entry)"
+          @click="select(entry)"
+        >
+          <slot
+            name="item"
+            :command="entry.command"
+            :active="entry.key === activeKey"
+          >
+            <span class="flex min-w-0 flex-1 flex-col">
+              <span class="truncate">{{ entry.command.title }}</span>
+              <span
+                v-if="entry.command.subtitle"
+                class="truncate text-xs text-gray-500 dark:text-gray-400"
+              >
+                {{ entry.command.subtitle }}
+              </span>
+            </span>
+            <kbd
+              v-if="entry.command.shortcut"
+              aria-hidden="true"
+              class="ml-auto shrink-0 font-mono text-xs text-gray-500 dark:text-gray-400"
+            >
+              {{ entry.command.shortcut }}
+            </kbd>
+          </slot>
+        </div>
+      </div>
+    </div>
+
+    <div
+      data-slot="command-empty"
+      :class="
+        entries.length
+          ? 'sr-only'
+          : 'py-10 text-center text-sm text-gray-500 dark:text-gray-400'
+      "
+      role="status"
+      aria-atomic="true"
+    >
+      <slot v-if="!entries.length" name="empty" :query="currentQuery">
+        No matching command.
+      </slot>
+    </div>
+
+    <slot name="footer" />
+  </div>
+</template>

--- a/assets/js/composables/useCommandPalette.js
+++ b/assets/js/composables/useCommandPalette.js
@@ -1,4 +1,4 @@
-import { ref, provide, inject } from 'vue'
+import { ref, provide, inject, nextTick } from 'vue'
 import { LOCAL_STORAGE_KEYS } from '@/lib/localStorageKeys'
 
 const COMMAND_PALETTE_KEY = Symbol('commandPalette')
@@ -26,6 +26,7 @@ function saveHistory(history) {
 export function createCommandPalette() {
   const isOpen = ref(false)
   const history = ref(loadHistory())
+  let returnFocusTo = null
 
   function register(command) {
     commands.set(command.id, {
@@ -52,23 +53,33 @@ export function createCommandPalette() {
     ].slice(0, 10)
     saveHistory(history.value)
 
-    // Close palette
-    isOpen.value = false
+    close()
 
     // Run the action
     return command.action()
   }
 
-  function open() {
+  function open(trigger) {
+    const activeElement = trigger || document.activeElement
+    returnFocusTo =
+      activeElement instanceof HTMLElement && activeElement !== document.body
+        ? activeElement
+        : null
     isOpen.value = true
   }
 
   function close() {
     isOpen.value = false
+    const focusTarget = returnFocusTo
+    returnFocusTo = null
+    nextTick(() => {
+      if (focusTarget?.isConnected) focusTarget.focus()
+    })
   }
 
   function toggle() {
-    isOpen.value = !isOpen.value
+    if (isOpen.value) close()
+    else open()
   }
 
   const palette = {

--- a/tests/e2e/pages/command-palette.test.js
+++ b/tests/e2e/pages/command-palette.test.js
@@ -1,0 +1,138 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const capturePhase = process.env.COMMAND_SCREENSHOT_PHASE || 'after'
+const screenshotRoot = path.resolve(
+  `.tmp/screenshots/issue-343-command/${capturePhase}`
+)
+
+test(
+  'command palette preserves its visual and interaction contract with Klean Command',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    fs.mkdirSync(screenshotRoot, { recursive: true })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.inLightMode()
+    await page.goto('/')
+    await page.key('Control+k')
+
+    const input = page.raw.locator(
+      'input[placeholder="Type a command or search..."]'
+    )
+    await expect(input).toBeVisible()
+    await page.raw.mouse.move(720, 463)
+    await page.wait(100)
+    await page.screenshot(
+      path.join(screenshotRoot, 'command-palette-desktop-light.png'),
+      { animations: 'disabled' }
+    )
+
+    await page.inDarkMode()
+    await page.wait(100)
+    await page.screenshot(
+      path.join(screenshotRoot, 'command-palette-desktop-dark.png'),
+      { animations: 'disabled' }
+    )
+
+    await page.key('Escape')
+    await page.resize(390, 844)
+    await page.inLightMode()
+    await page.raw
+      .locator('button:visible')
+      .filter({
+        has: page.raw.locator('svg[viewBox="-0.5 -0.5 16 16"]')
+      })
+      .first()
+      .click()
+    await page.raw
+      .locator('button[popovertarget="mobile-user-menu"]:visible')
+      .click()
+    await page.raw
+      .locator('#mobile-user-menu')
+      .getByText('Search', { exact: true })
+      .click()
+    await expect(input).toBeVisible()
+    await page.wait(100)
+    await page.screenshot(
+      path.join(screenshotRoot, 'command-palette-mobile-light.png'),
+      { animations: 'disabled' }
+    )
+
+    await page.inDarkMode()
+    await page.wait(100)
+    await page.screenshot(
+      path.join(screenshotRoot, 'command-palette-mobile-dark.png'),
+      { animations: 'disabled' }
+    )
+
+    if (capturePhase === 'after') {
+      await expect(input).toHaveAttribute('role', 'combobox')
+      await expect(input).toHaveAttribute('aria-controls')
+      await expect(input).toHaveAttribute('aria-activedescendant')
+
+      await input.fill('Lookout')
+      await expect(
+        page.raw.getByRole('option', { name: /Go to Lookout/ })
+      ).toBeVisible()
+      await page.key('Enter')
+      await expect(
+        page.raw.getByText('Commands', { exact: true })
+      ).toBeVisible()
+      await page.key('Backspace')
+      await expect(page.raw.getByText('Commands', { exact: true })).toBeHidden()
+
+      await input.fill('nothing-can-match-this')
+      await expect(
+        page.raw.getByText('No results for "nothing-can-match-this"')
+      ).toBeVisible()
+
+      await input.fill('')
+      await page.key('End')
+      const lastActiveId = await input.getAttribute('aria-activedescendant')
+      await expect(page.raw.locator(`#${lastActiveId}`)).toBeInViewport()
+      await page.key('Home')
+      await page.key('Escape')
+      await expect(input).toBeHidden()
+
+      await page.resize(1440, 900)
+      const userMenuTrigger = page.raw.locator(
+        '[data-test="desktop-user-menu-button"]'
+      )
+      await userMenuTrigger.focus()
+      await page.key('Control+k')
+      await expect(input).toBeFocused()
+      await page.raw.evaluate(() => {
+        const commandInput = document.querySelector(
+          'input[placeholder="Type a command or search..."]'
+        )
+        commandInput.dispatchEvent(
+          new KeyboardEvent('keydown', {
+            key: 'Enter',
+            keyCode: 229,
+            bubbles: true,
+            cancelable: true
+          })
+        )
+      })
+      await expect(input).toBeVisible()
+      await page.key('Escape')
+      await expect(userMenuTrigger).toBeFocused()
+    }
+
+    expect(page).toHaveNoSmoke()
+  }
+)


### PR DESCRIPTION
## What changed

- add the Klean Command source directly with no barrel or runtime dependency
- keep Slipway routes, permissions, catalog, icons, history, nested flows, and visual treatment app-owned
- remove duplicate selection, keyboard navigation, IME, active-item, and scroll-reveal machinery from the app palette
- restore focus to the invoking control when the palette closes
- add one Sounding browser contract covering desktop, mobile, light, dark, nested navigation, empty results, IME, long-list reveal, Escape, and focus restoration

## Visual contract

Frozen before and after captures use identical routes, data, viewport, theme, pointer position, and open state. Pixel difference is limited to the blinking input caret:

- desktop light: 6 / 1,296,000 pixels
- desktop dark: 15 / 1,296,000 pixels
- mobile light: 6 / 329,160 pixels
- mobile dark: 16 / 329,160 pixels

## Verification

- npm run lint
- npm test — 455 passing
- focused Sounding browser trial — passing

Closes #343