### PR TITLE
fix: prevent child runtimes from automigrating

### DIFF
--- a/api/helpers/bridge/execute-in-container.js
+++ b/api/helpers/bridge/execute-in-container.js
@@ -229,6 +229,7 @@ const BOOT_ERROR_MARKER = ${JSON.stringify(BOOT_ERROR_MARKER)};
     sailsApp = require('sails');
     await new Promise((resolve, reject) => {
       sailsApp.load({
+        models: { migrate: 'safe' },
         hooks: {
           http: false,
           views: false,

--- a/api/helpers/dock/get-models.js
+++ b/api/helpers/dock/get-models.js
@@ -45,6 +45,7 @@ function buildIntrospectionCode() {
     sailsApp = require('sails');
     await new Promise((resolve, reject) => {
       sailsApp.load({
+        models: { migrate: 'safe' },
         hooks: { http: false, views: false, sockets: false, pubsub: false, grunt: false },
         log: { level: 'warn' }
       }, (err) => {

--- a/api/helpers/quest/list-jobs.js
+++ b/api/helpers/quest/list-jobs.js
@@ -138,7 +138,7 @@ function buildListJobsCode() {
     await new Promise((resolve, reject) => {
       sailsApp.load({
         environment: 'console',
-        environment: 'console',
+        models: { migrate: 'safe' },
         log: { level: 'silent' }
       }, (err) => {
         if (err) reject(err);

--- a/api/helpers/quest/pause-job.js
+++ b/api/helpers/quest/pause-job.js
@@ -31,6 +31,7 @@ module.exports = {
     await new Promise((resolve, reject) => {
       sailsApp.load({
         environment: 'console',
+        models: { migrate: 'safe' },
         log: { level: 'warn' }
       }, (err) => {
         if (err) reject(err);

--- a/api/helpers/quest/resume-job.js
+++ b/api/helpers/quest/resume-job.js
@@ -31,6 +31,7 @@ module.exports = {
     await new Promise((resolve, reject) => {
       sailsApp.load({
         environment: 'console',
+        models: { migrate: 'safe' },
         log: { level: 'warn' }
       }, (err) => {
         if (err) reject(err);

--- a/api/lib/helm-runtime.js
+++ b/api/lib/helm-runtime.js
@@ -509,9 +509,14 @@ async function helmSubprocessMain(options, createQueryTracer) {
       await new Promise((resolve, reject) => {
         sailsApp.load(
           {
-            environment: 'console',
+            // Keep the datastore and other environment-specific config from the
+            // app process that owns this container.  Not every app defines a
+            // separate `console` environment.
             bootstrap(done) {
               done()
+            },
+            models: {
+              migrate: 'safe'
             },
             hooks: {
               http: false,

--- a/tests/unit/helpers/bridge/execute-in-container.test.js
+++ b/tests/unit/helpers/bridge/execute-in-container.test.js
@@ -44,6 +44,7 @@ test('Bridge reuses one production worker for warm operations', async ({
       '-e'
     ])
     expect(argumentsPassedToDocker[7]).toContain('sailsApp.load')
+    expect(argumentsPassedToDocker[7]).toContain("migrate: 'safe'")
     expect(argumentsPassedToDocker[7]).toContain('http: false')
   } finally {
     restore()

--- a/tests/unit/helpers/helm/runtime.test.js
+++ b/tests/unit/helpers/helm/runtime.test.js
@@ -44,6 +44,19 @@ await Creator.find({
   expect(result.outputBytes).toBe(Buffer.byteLength(result.output))
 })
 
+test('Helm inherits the running app environment without allowing automigrations', async ({
+  expect
+}) => {
+  const prepared = helmRuntime.prepareSource('BusinessListing.count()')
+  const runner = helmRuntime.buildRunnerSource({
+    preparedSource: prepared.source,
+    finalExpression: prepared.finalExpression
+  })
+
+  expect(runner.includes("environment: 'console'")).toBe(false)
+  expect(runner).toContain("migrate: 'safe'")
+})
+
 test('Helm captures parser-backed inline inspections without changing expression values', async ({
   sails,
   expect

--- a/tests/unit/helpers/secondary-sails-runtimes.test.js
+++ b/tests/unit/helpers/secondary-sails-runtimes.test.js
@@ -1,0 +1,22 @@
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+const runtimeFiles = [
+  'api/helpers/dock/get-models.js',
+  'api/helpers/quest/list-jobs.js',
+  'api/helpers/quest/pause-job.js',
+  'api/helpers/quest/resume-job.js'
+]
+
+test('Slipway-owned secondary Sails lifts cannot run automigrations', async ({
+  expect
+}) => {
+  for (const file of runtimeFiles) {
+    const source = fs.readFileSync(path.resolve(file), 'utf8')
+
+    expect(source).toContain('sailsApp.load')
+    expect(source).toContain("migrate: 'safe'")
+  }
+})


### PR DESCRIPTION
## Summary

- let Helm inherit the environment and datastore of the running app container instead of forcing a potentially undefined console environment
- force every Slipway-owned secondary Sails lift to use the safe migration strategy
- preserve Helm's lightweight hook and bootstrap overrides while allowing explicit Waterline reads and writes
- remove the duplicated Quest environment option found during the child-runtime audit

## Root cause

Hagfish defines a console environment that imports production configuration. Pairlore does not, so Helm's forced console lift fell back to Pairlore's local SQLite datastore and base alter migration strategy rather than its running production datastore.

## Verification

- 16 focused Sounding trials pass
- generated Helm runtime inherits its container environment and contains migrate safe
- Bridge worker source explicitly contains migrate safe
- Dock and Quest child-runtime source is guarded by a focused regression trial
- npm run lint
- git diff --check

Closes #468