### PR TITLE
feat(ui): adopt the Klean application shell

### DIFF
--- a/assets/js/components/bridge/BridgeWorkspaceSidebar.vue
+++ b/assets/js/components/bridge/BridgeWorkspaceSidebar.vue
@@ -66,7 +66,7 @@ function isResourceActive(identity) {
 </script>
 
 <template>
-  <aside
+  <div
     class="flex h-full flex-col border-r border-gray-200 bg-gray-50 dark:border-gray-800 dark:bg-gray-950"
     data-test="bridge-workspace-sidebar"
   >
@@ -328,5 +328,5 @@ function isResourceActive(identity) {
         </svg>
       </button>
     </div>
-  </aside>
+  </div>
 </template>

--- a/assets/js/components/ui/dialog/Dialog.vue
+++ b/assets/js/components/ui/dialog/Dialog.vue
@@ -1,0 +1,246 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  id: { type: String, default: undefined },
+  open: { type: Boolean, default: undefined },
+  defaultOpen: { type: Boolean, default: false },
+  dismissible: { type: Boolean, default: true }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const dialog = ref()
+const internalOpen = ref(props.defaultOpen)
+const nativeOpen = ref(false)
+const isControlled = computed(() => props.open !== undefined)
+const desiredOpen = computed(() =>
+  isControlled.value ? props.open : internalOpen.value
+)
+const dialogAttrs = computed(() => {
+  const {
+    class: _class,
+    closedby: _closedby,
+    open: _open,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    onBeforetoggle: _onBeforetoggle,
+    onBeforeToggle: _onBeforeToggle,
+    onCancel: _onCancel,
+    onClick: _onClick,
+    onClose: _onClose,
+    onToggle: _onToggle,
+    ...rest
+  } = attrs
+
+  return rest
+})
+const dialogClasses = computed(() =>
+  twMerge(
+    [
+      'm-auto w-[calc(100vw-2rem)] max-w-lg overflow-hidden rounded-lg border border-gray-200 bg-white p-6 text-gray-950 shadow-xl outline-none',
+      'backdrop:bg-black/50',
+      'dark:border-gray-700 dark:bg-gray-950 dark:text-white'
+    ],
+    attrs.class
+  )
+)
+
+let commandRoot
+let previousDocumentOverflow = ''
+let scrollLocked = false
+let fallbackInvoker
+
+function callListener(listener, event) {
+  for (const callback of Array.isArray(listener) ? listener : [listener]) {
+    callback?.(event)
+  }
+}
+
+function lockScroll() {
+  if (scrollLocked || typeof document === 'undefined') return
+  previousDocumentOverflow = document.documentElement.style.overflow
+  document.documentElement.style.overflow = 'hidden'
+  scrollLocked = true
+}
+
+function unlockScroll() {
+  if (!scrollLocked || typeof document === 'undefined') return
+  document.documentElement.style.overflow = previousDocumentOverflow
+  scrollLocked = false
+}
+
+function observeNativeOpen(nextOpen) {
+  const shouldNotify = desiredOpen.value !== nextOpen
+  nativeOpen.value = nextOpen
+
+  if (!isControlled.value) internalOpen.value = nextOpen
+  if (nextOpen) lockScroll()
+  else unlockScroll()
+  if (shouldNotify) emit('update:open', nextOpen)
+}
+
+function showModal(source) {
+  const element = dialog.value
+  if (!element || element.open) return
+
+  fallbackInvoker = source
+  element.showModal()
+  observeNativeOpen(true)
+}
+
+function close(returnValue) {
+  const element = dialog.value
+  if (!element?.open) return
+
+  element.close(returnValue)
+  observeNativeOpen(false)
+}
+
+function requestClose(returnValue) {
+  const element = dialog.value
+  if (!element?.open) return
+
+  if (typeof element.requestClose === 'function') {
+    element.requestClose(returnValue)
+    return
+  }
+
+  const event = new Event('cancel', { cancelable: true })
+  if (element.dispatchEvent(event)) close(returnValue)
+}
+
+function handleBeforeToggle(event) {
+  callListener(attrs.onBeforetoggle ?? attrs.onBeforeToggle, event)
+}
+
+function handleToggle(event) {
+  observeNativeOpen(event.newState === 'open' || dialog.value?.open === true)
+  callListener(attrs.onToggle, event)
+}
+
+function handleCancel(event) {
+  if (!props.dismissible) event.preventDefault()
+  callListener(attrs.onCancel, event)
+}
+
+function handleClose(event) {
+  observeNativeOpen(false)
+
+  if (fallbackInvoker?.isConnected) {
+    fallbackInvoker.focus({ preventScroll: true })
+  }
+  fallbackInvoker = undefined
+  callListener(attrs.onClose, event)
+}
+
+function clickIsOutsideDialog(event) {
+  const rect = event.currentTarget.getBoundingClientRect()
+
+  return (
+    event.clientX < rect.left ||
+    event.clientX > rect.right ||
+    event.clientY < rect.top ||
+    event.clientY > rect.bottom
+  )
+}
+
+function handleClick(event) {
+  callListener(attrs.onClick, event)
+
+  if (
+    event.defaultPrevented ||
+    !props.dismissible ||
+    'closedBy' in event.currentTarget ||
+    event.target !== event.currentTarget ||
+    !clickIsOutsideDialog(event)
+  ) {
+    return
+  }
+
+  requestClose()
+}
+
+function commandButton(event) {
+  return (event.composedPath?.() ?? [event.target]).find(
+    (element) =>
+      element?.tagName === 'BUTTON' &&
+      element.getAttribute('commandfor') === props.id
+  )
+}
+
+function handleFallbackCommand(event) {
+  const button = commandButton(event)
+  if (!button || button.matches(':disabled')) return
+
+  const command = button.getAttribute('command')
+  if (command === 'show-modal') showModal(button)
+  else if (command === 'close') close(button.value)
+  else if (command === 'request-close') requestClose(button.value)
+}
+
+function supportsInvokerCommands() {
+  return (
+    typeof HTMLButtonElement !== 'undefined' &&
+    'commandForElement' in HTMLButtonElement.prototype
+  )
+}
+
+async function syncDesiredOpen() {
+  await nextTick()
+  const element = dialog.value
+  if (!element) return
+
+  if (desiredOpen.value && !element.open) showModal()
+  else if (!desiredOpen.value && element.open) close()
+  else observeNativeOpen(element.open)
+}
+
+watch(desiredOpen, syncDesiredOpen, { flush: 'post' })
+
+onMounted(() => {
+  commandRoot = dialog.value?.getRootNode?.() ?? document
+  if (!supportsInvokerCommands() && props.id) {
+    commandRoot.addEventListener('click', handleFallbackCommand)
+  }
+  syncDesiredOpen()
+})
+
+onBeforeUnmount(() => {
+  commandRoot?.removeEventListener('click', handleFallbackCommand)
+  if (dialog.value?.open) dialog.value.close()
+  unlockScroll()
+})
+
+defineExpose({ dialog, showModal, close, requestClose })
+</script>
+
+<template>
+  <dialog
+    ref="dialog"
+    v-bind="dialogAttrs"
+    :id="id"
+    :closedby="dismissible ? 'any' : 'none'"
+    data-slot="dialog"
+    :data-state="nativeOpen ? 'open' : 'closed'"
+    :class="dialogClasses"
+    @beforetoggle="handleBeforeToggle"
+    @toggle="handleToggle"
+    @cancel="handleCancel"
+    @close="handleClose"
+    @click="handleClick"
+  >
+    <slot />
+  </dialog>
+</template>

--- a/assets/js/components/ui/sheet/Sheet.vue
+++ b/assets/js/components/ui/sheet/Sheet.vue
@@ -1,0 +1,63 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+import Dialog from '../dialog/Dialog.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  id: { type: String, default: undefined },
+  open: { type: Boolean, default: undefined },
+  defaultOpen: { type: Boolean, default: false },
+  dismissible: { type: Boolean, default: true }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const sheet = ref()
+
+const BASE_CLASSES = [
+  'fixed inset-y-0 right-0 left-auto m-0 ml-auto h-dvh max-h-none w-[min(26rem,calc(100vw-1rem))] max-w-none translate-x-full overflow-hidden rounded-none border-y-0 border-r-0 border-l border-gray-200 bg-white p-0 text-gray-950 opacity-0 shadow-2xl outline-none',
+  'open:translate-x-0 open:opacity-100',
+  'transition-[display,overlay,opacity,transform] transition-discrete duration-200 ease-[cubic-bezier(0.22,1,0.36,1)]',
+  'starting:open:translate-x-full starting:open:opacity-0 motion-reduce:transition-none',
+  'backdrop:bg-black/50 starting:open:backdrop:bg-black/0',
+  'dark:border-gray-700 dark:bg-gray-950 dark:text-white'
+]
+
+const sheetAttrs = computed(() => {
+  const { class: _class, ...rest } = attrs
+  return rest
+})
+const sheetClasses = computed(() => twMerge(BASE_CLASSES, attrs.class))
+
+function showModal(source) {
+  sheet.value?.showModal(source)
+}
+
+function close(returnValue) {
+  sheet.value?.close(returnValue)
+}
+
+function requestClose(returnValue) {
+  sheet.value?.requestClose(returnValue)
+}
+
+defineExpose({ sheet, showModal, close, requestClose })
+</script>
+
+<template>
+  <Dialog
+    ref="sheet"
+    v-bind="sheetAttrs"
+    :id="props.id"
+    :open="props.open"
+    :default-open="props.defaultOpen"
+    :dismissible="props.dismissible"
+    data-klean-sheet=""
+    :class="sheetClasses"
+    @update:open="emit('update:open', $event)"
+  >
+    <slot />
+  </Dialog>
+</template>

--- a/assets/js/components/ui/sidebar/Sidebar.vue
+++ b/assets/js/components/ui/sidebar/Sidebar.vue
@@ -1,0 +1,156 @@
+<script setup>
+import { computed, onBeforeUnmount, onMounted, ref, useAttrs, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  id: { type: String, default: 'app-sidebar' },
+  open: { type: Boolean, default: undefined },
+  defaultOpen: { type: Boolean, default: true },
+  remember: { type: Boolean, default: true }
+})
+
+const emit = defineEmits(['update:open'])
+const attrs = useAttrs()
+const root = ref()
+const internalOpen = ref(props.defaultOpen)
+const restored = ref(false)
+const controlled = computed(() => props.open !== undefined)
+const visible = computed(() =>
+  controlled.value ? props.open : internalOpen.value
+)
+const storageKey = computed(() => `klean:sidebar:${props.id}:open`)
+
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-restored': _dataRestored,
+    'aria-hidden': _ariaHidden,
+    inert: _inert,
+    ...rest
+  } = attrs
+  return rest
+})
+
+const rootClasses = computed(() =>
+  twMerge(
+    'min-w-0 shrink-0 overflow-hidden transition-[width,opacity] duration-200 ease-out motion-reduce:transition-none',
+    attrs.class
+  )
+)
+
+function readRemembered() {
+  if (!props.remember || typeof window === 'undefined') return undefined
+  try {
+    const value = window.localStorage.getItem(storageKey.value)
+    if (value === 'true') return true
+    if (value === 'false') return false
+  } catch {
+    // Storage may be unavailable in private or constrained browser contexts.
+  }
+  return undefined
+}
+
+function rememberVisibility(next) {
+  if (!props.remember || typeof window === 'undefined') return
+  try {
+    window.localStorage.setItem(storageKey.value, String(next))
+  } catch {
+    // Visibility still works when persistence is unavailable.
+  }
+}
+
+function setOpen(next) {
+  const normalized = Boolean(next)
+  if (!controlled.value) internalOpen.value = normalized
+  emit('update:open', normalized)
+  rememberVisibility(normalized)
+}
+
+function show() {
+  setOpen(true)
+}
+
+function hide() {
+  setOpen(false)
+}
+
+function toggle() {
+  setOpen(!visible.value)
+}
+
+function restore() {
+  if (controlled.value) {
+    rememberVisibility(visible.value)
+    return
+  }
+  const remembered = readRemembered()
+  const next = remembered ?? props.defaultOpen
+  internalOpen.value = next
+  emit('update:open', next)
+}
+
+function handleStorage(event) {
+  if (
+    !props.remember ||
+    event.storageArea !== window.localStorage ||
+    event.key !== storageKey.value
+  ) {
+    return
+  }
+
+  if (event.newValue === 'true') {
+    if (!controlled.value) internalOpen.value = true
+    emit('update:open', true)
+  }
+  if (event.newValue === 'false') {
+    if (!controlled.value) internalOpen.value = false
+    emit('update:open', false)
+  }
+}
+
+onMounted(() => {
+  restore()
+  restored.value = true
+  window.addEventListener('storage', handleStorage)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('storage', handleStorage)
+})
+
+watch(
+  () => props.open,
+  (next) => {
+    if (restored.value && next !== undefined) rememberVisibility(next)
+  }
+)
+
+watch(
+  () => [props.id, props.remember],
+  () => {
+    if (restored.value) restore()
+  }
+)
+
+defineExpose({ root, show, hide, toggle })
+</script>
+
+<template>
+  <aside
+    ref="root"
+    v-bind="rootAttrs"
+    :id="props.id"
+    data-slot="sidebar"
+    :data-state="visible ? 'open' : 'closed'"
+    :data-restored="restored ? 'true' : 'false'"
+    :aria-hidden="visible ? undefined : 'true'"
+    :inert="visible ? undefined : ''"
+    :class="rootClasses"
+  >
+    <slot :open="visible" :show="show" :hide="hide" :toggle="toggle" />
+  </aside>
+</template>

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { Link, usePage, router } from '@inertiajs/vue3'
-import { computed, ref, provide, onMounted, onUnmounted } from 'vue'
+import { computed, ref, provide, onMounted, onUnmounted, watch } from 'vue'
 import { useEventSource } from '@/composables/sse'
 import { createDeploymentFaviconManager } from '@/lib/deployment-favicon.mjs'
 import ToastContainer from '@/components/ToastContainer.vue'
@@ -11,6 +11,8 @@ import ServiceActionToast from '@/components/ServiceActionToast.vue'
 import CommandPalette from '@/components/CommandPalette.vue'
 import Avatar from '@/components/ui/avatar/Avatar.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
+import Sheet from '@/components/ui/sheet/Sheet.vue'
+import Sidebar from '@/components/ui/sidebar/Sidebar.vue'
 import { createToast } from '@/composables/toast'
 import { useFlashToast } from '@/composables/flash-toast'
 import {
@@ -50,27 +52,53 @@ const isActive = (path) => {
 
 // Mobile menu state
 const mobileMenuOpen = ref(false)
+const mobileSheet = ref()
+let desktopMediaQuery
 
-const toggleMobileMenu = () => {
-  mobileMenuOpen.value = !mobileMenuOpen.value
+const toggleMobileMenu = (event) => {
+  if (mobileMenuOpen.value) {
+    mobileSheet.value?.close()
+    return
+  }
+
+  const invoker = event?.currentTarget ?? event
+  if (mobileSheet.value) mobileSheet.value.showModal(invoker)
+  else mobileMenuOpen.value = true
 }
 
 const closeMobileMenu = () => {
-  mobileMenuOpen.value = false
+  if (mobileSheet.value) mobileSheet.value.close()
+  else mobileMenuOpen.value = false
 }
 
-// Desktop sidebar collapsed state (persisted in localStorage)
-const sidebarCollapsed = ref(false)
+function handleMobileNavigation(event) {
+  if (event.target.closest('a')) closeMobileMenu()
+}
 
-const toggleSidebar = () => {
-  sidebarCollapsed.value = !sidebarCollapsed.value
-  localStorage.setItem(
+function handleDesktopViewport(event) {
+  if (event.matches) closeMobileMenu()
+}
+
+function legacySidebarDefault() {
+  if (typeof window === 'undefined') return true
+  const saved = readLocalStorageValue(
     LOCAL_STORAGE_KEYS.sidebarCollapsed,
-    String(sidebarCollapsed.value)
+    LEGACY_LOCAL_STORAGE_KEYS.sidebarCollapsed
   )
+  return saved !== 'true'
 }
 
-// Provide toggle functions to child components
+// Preserve the established page contract while Klean owns the durable state.
+const desktopSidebar = ref()
+const sidebarOpen = ref(true)
+const sidebarCollapsed = computed(() => !sidebarOpen.value)
+const defaultSidebarOpen = legacySidebarDefault()
+
+const toggleSidebar = () => desktopSidebar.value?.toggle()
+const updateSidebarOpen = (open) => {
+  sidebarOpen.value = open
+}
+
 provide('toggleMobileMenu', toggleMobileMenu)
 provide('toggleSidebar', toggleSidebar)
 provide('sidebarCollapsed', sidebarCollapsed)
@@ -208,16 +236,9 @@ function acknowledgeDeploymentFavicon() {
   }
 }
 
-// Initialize on mount
 onMounted(() => {
-  // Restore sidebar state
-  const saved = readLocalStorageValue(
-    LOCAL_STORAGE_KEYS.sidebarCollapsed,
-    LEGACY_LOCAL_STORAGE_KEYS.sidebarCollapsed
-  )
-  if (saved !== null) {
-    sidebarCollapsed.value = saved === 'true'
-  }
+  desktopMediaQuery = window.matchMedia('(min-width: 768px)')
+  desktopMediaQuery.addEventListener('change', handleDesktopViewport)
 
   document.addEventListener('visibilitychange', acknowledgeDeploymentFavicon)
   window.addEventListener('focus', acknowledgeDeploymentFavicon)
@@ -225,45 +246,30 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  desktopMediaQuery?.removeEventListener('change', handleDesktopViewport)
   disconnectDeploymentStream()
   deploymentFavicon.destroy()
   document.removeEventListener('visibilitychange', acknowledgeDeploymentFavicon)
   window.removeEventListener('focus', acknowledgeDeploymentFavicon)
   window.removeEventListener('pagehide', deploymentFavicon.reset)
 })
+
+watch(() => page.url, closeMobileMenu)
 </script>
 
 <template>
   <div class="flex h-screen overflow-hidden bg-white dark:bg-gray-950">
-    <!-- Mobile Menu Backdrop -->
-    <Transition
-      enter-active-class="transition-opacity duration-300"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-active-class="transition-opacity duration-300"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
+    <!-- Mobile navigation is modal; desktop navigation remains a landmark. -->
+    <Sheet
+      v-if="loggedInUser"
+      id="primary-navigation-mobile"
+      ref="mobileSheet"
+      v-model:open="mobileMenuOpen"
+      aria-label="Primary navigation"
+      class="starting:open:-translate-x-full left-0 right-auto ml-0 mr-auto w-72 -translate-x-full flex-col border-none bg-gray-50 shadow-2xl open:flex dark:bg-gray-950 md:hidden"
+      @click="handleMobileNavigation"
     >
-      <div
-        v-if="mobileMenuOpen && loggedInUser"
-        class="fixed inset-0 z-40 bg-black/50 md:hidden"
-        @click="closeMobileMenu"
-      />
-    </Transition>
-
-    <!-- Mobile Menu Drawer -->
-    <Transition
-      enter-active-class="transition-transform duration-300 ease-out"
-      enter-from-class="-translate-x-full"
-      enter-to-class="translate-x-0"
-      leave-active-class="transition-transform duration-300 ease-in"
-      leave-from-class="translate-x-0"
-      leave-to-class="-translate-x-full"
-    >
-      <aside
-        v-if="mobileMenuOpen && loggedInUser"
-        class="fixed inset-y-0 left-0 z-50 flex w-72 flex-col bg-gray-50 dark:bg-gray-950 md:hidden"
-      >
+      <div class="contents">
         <!-- Header with Team Selector -->
         <div class="flex items-center justify-between px-3 py-4">
           <div class="relative min-w-0 flex-1">
@@ -718,16 +724,18 @@ onUnmounted(() => {
             </div>
           </Menu>
         </div>
-      </aside>
-    </Transition>
+      </div>
+    </Sheet>
 
     <!-- Desktop Sidebar -->
-    <aside
+    <Sidebar
       v-if="loggedInUser"
-      :class="[
-        'hidden flex-col border-r border-gray-200 bg-gray-50 transition-all duration-200 ease-out dark:border-gray-800 dark:bg-gray-950 md:flex',
-        sidebarCollapsed ? 'w-0 overflow-hidden border-r-0' : 'w-56'
-      ]"
+      id="primary-navigation"
+      ref="desktopSidebar"
+      :default-open="defaultSidebarOpen"
+      aria-label="Primary navigation"
+      class="hidden w-56 flex-col border-r border-gray-200 bg-gray-50 data-[state=closed]:w-0 data-[state=closed]:border-r-0 data-[state=closed]:opacity-0 dark:border-gray-800 dark:bg-gray-950 md:flex"
+      @update:open="updateSidebarOpen"
     >
       <!-- Team Selector + Collapse -->
       <div class="flex items-center justify-between px-3 py-4">
@@ -1157,7 +1165,7 @@ onUnmounted(() => {
           </div>
         </Menu>
       </div>
-    </aside>
+    </Sidebar>
 
     <!-- Main Content -->
     <main class="min-w-0 flex-1 overflow-y-auto bg-white dark:bg-gray-950">

--- a/assets/js/layouts/BridgeWorkspaceLayout.vue
+++ b/assets/js/layouts/BridgeWorkspaceLayout.vue
@@ -1,42 +1,72 @@
 <script setup>
 import { usePage } from '@inertiajs/vue3'
-import { onMounted, onUnmounted, provide, ref } from 'vue'
+import { computed, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import BridgeWorkspaceSidebar from '@/components/bridge/BridgeWorkspaceSidebar.vue'
+import Sheet from '@/components/ui/sheet/Sheet.vue'
+import Sidebar from '@/components/ui/sidebar/Sidebar.vue'
 
 const STORAGE_KEY = 'slipway:bridge-sidebar-collapsed'
 const page = usePage()
 const mobileMenuOpen = ref(false)
-const sidebarCollapsed = ref(false)
+const mobileSheet = ref()
+const desktopSidebar = ref()
+const sidebarOpen = ref(true)
+const sidebarCollapsed = computed(() => !sidebarOpen.value)
+let desktopMediaQuery
 
-function toggleMobileMenu() {
-  mobileMenuOpen.value = !mobileMenuOpen.value
+function toggleMobileMenu(event) {
+  if (mobileMenuOpen.value) {
+    mobileSheet.value?.close()
+    return
+  }
+
+  const invoker = event?.currentTarget ?? event
+  if (mobileSheet.value) mobileSheet.value.showModal(invoker)
+  else mobileMenuOpen.value = true
 }
 
 function closeMobileMenu() {
-  mobileMenuOpen.value = false
+  if (mobileSheet.value) mobileSheet.value.close()
+  else mobileMenuOpen.value = false
 }
 
 function toggleSidebar() {
-  sidebarCollapsed.value = !sidebarCollapsed.value
-  localStorage.setItem(STORAGE_KEY, String(sidebarCollapsed.value))
+  desktopSidebar.value?.toggle()
 }
 
-function handleKeydown(event) {
-  if (event.key === 'Escape') closeMobileMenu()
+function updateSidebarOpen(open) {
+  sidebarOpen.value = open
 }
+
+function legacySidebarDefault() {
+  if (typeof window === 'undefined') return true
+  try {
+    return window.localStorage.getItem(STORAGE_KEY) !== 'true'
+  } catch {
+    return true
+  }
+}
+
+function handleDesktopViewport(event) {
+  if (event.matches) closeMobileMenu()
+}
+
+const defaultSidebarOpen = legacySidebarDefault()
 
 provide('toggleMobileMenu', toggleMobileMenu)
 provide('toggleSidebar', toggleSidebar)
 provide('sidebarCollapsed', sidebarCollapsed)
 
 onMounted(() => {
-  sidebarCollapsed.value = localStorage.getItem(STORAGE_KEY) === 'true'
-  document.addEventListener('keydown', handleKeydown)
+  desktopMediaQuery = window.matchMedia('(min-width: 768px)')
+  desktopMediaQuery.addEventListener('change', handleDesktopViewport)
 })
 
 onUnmounted(() => {
-  document.removeEventListener('keydown', handleKeydown)
+  desktopMediaQuery?.removeEventListener('change', handleDesktopViewport)
 })
+
+watch(() => page.url, closeMobileMenu)
 </script>
 
 <template>
@@ -44,50 +74,37 @@ onUnmounted(() => {
     class="flex h-screen min-h-0 overflow-hidden bg-white text-gray-900 dark:bg-gray-950 dark:text-white"
     data-test="bridge-workspace"
   >
-    <Transition
-      enter-active-class="transition-opacity duration-300"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-active-class="transition-opacity duration-300"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
-      <button
-        v-if="mobileMenuOpen"
-        type="button"
-        class="fixed inset-0 z-40 bg-black/50 md:hidden"
-        aria-label="Close Bridge navigation"
-        @click="closeMobileMenu"
-      ></button>
-    </Transition>
-
-    <Transition
-      enter-active-class="transition-transform duration-300 ease-out"
-      enter-from-class="-translate-x-full"
-      enter-to-class="translate-x-0"
-      leave-active-class="transition-transform duration-300 ease-in"
-      leave-from-class="translate-x-0"
-      leave-to-class="-translate-x-full"
+    <Sheet
+      id="bridge-navigation-mobile"
+      ref="mobileSheet"
+      v-model:open="mobileMenuOpen"
+      aria-label="Bridge navigation"
+      class="starting:open:-translate-x-full left-0 right-auto ml-0 mr-auto w-72 -translate-x-full border-none bg-gray-50 shadow-2xl dark:bg-gray-950 md:hidden"
     >
       <BridgeWorkspaceSidebar
-        v-if="mobileMenuOpen"
         :app="page.props.app"
         :base-path="page.props.bridgeRequestBasePath"
         :workspace="page.props.bridgeWorkspace"
-        class="fixed inset-y-0 left-0 z-50 w-72 shadow-2xl md:hidden"
+        class="h-full w-72"
         @navigate="closeMobileMenu"
       />
-    </Transition>
+    </Sheet>
 
-    <BridgeWorkspaceSidebar
-      :app="page.props.app"
-      :base-path="page.props.bridgeRequestBasePath"
-      :workspace="page.props.bridgeWorkspace"
-      :class="[
-        'hidden shrink-0 transition-[width,border] duration-200 ease-out md:flex',
-        sidebarCollapsed ? 'w-0 overflow-hidden border-r-0' : 'w-56'
-      ]"
-    />
+    <Sidebar
+      id="bridge-navigation"
+      ref="desktopSidebar"
+      :default-open="defaultSidebarOpen"
+      aria-label="Bridge navigation"
+      class="hidden w-56 bg-gray-50 data-[state=closed]:w-0 data-[state=closed]:opacity-0 dark:bg-gray-950 md:flex"
+      @update:open="updateSidebarOpen"
+    >
+      <BridgeWorkspaceSidebar
+        :app="page.props.app"
+        :base-path="page.props.bridgeRequestBasePath"
+        :workspace="page.props.bridgeWorkspace"
+        class="w-56"
+      />
+    </Sidebar>
 
     <main class="min-w-0 flex-1 overflow-hidden">
       <slot />

--- a/assets/js/pages/dashboard/index.vue
+++ b/assets/js/pages/dashboard/index.vue
@@ -102,6 +102,8 @@ function cancelDeleteProject() {
       <div class="flex items-center space-x-3">
         <!-- Mobile menu button -->
         <button
+          data-test="mobile-sidebar-toggle"
+          aria-label="Open navigation"
           @click="toggleMobileMenu"
           class="rounded-md p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-800 dark:hover:text-white md:hidden"
         >
@@ -133,6 +135,8 @@ function cancelDeleteProject() {
         </button>
         <!-- Desktop sidebar toggle -->
         <button
+          data-test="desktop-sidebar-toggle"
+          :aria-label="sidebarCollapsed ? 'Show navigation' : 'Hide navigation'"
           @click="toggleSidebar"
           class="hidden text-gray-400 dark:text-gray-500 md:block"
         >

--- a/tests/e2e/pages/sidebar.test.js
+++ b/tests/e2e/pages/sidebar.test.js
@@ -1,0 +1,72 @@
+const { test } = require('sounding')
+
+test(
+  'application navigation uses the durable Klean Sidebar and native mobile Sheet',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.goto('/')
+    await page.raw.evaluate(() => {
+      localStorage.removeItem('klean:sidebar:primary-navigation:open')
+      localStorage.removeItem('slipway:sidebar-collapsed')
+    })
+    await page.reload()
+
+    const sidebar = page.raw.locator('#primary-navigation')
+    const desktopToggle = page.raw.locator(
+      '[data-test="desktop-sidebar-toggle"]'
+    )
+
+    await expect(sidebar).toHaveAttribute('data-slot', 'sidebar')
+    await expect(sidebar).toHaveAttribute('data-state', 'open')
+    await expect(sidebar).toBeVisible()
+
+    await desktopToggle.click()
+    await expect(sidebar).toHaveAttribute('data-state', 'closed')
+    await expect(sidebar).toHaveAttribute('aria-hidden', 'true')
+    await expect(sidebar).toHaveAttribute('inert', '')
+    expect(
+      await page.raw.evaluate(() =>
+        localStorage.getItem('klean:sidebar:primary-navigation:open')
+      )
+    ).toBe('false')
+
+    await page.reload()
+    await expect(sidebar).toHaveAttribute('data-state', 'closed')
+    await desktopToggle.click()
+    await expect(sidebar).toHaveAttribute('data-state', 'open')
+
+    await page.resize(390, 844)
+    const mobileToggle = page.raw.locator('[data-test="mobile-sidebar-toggle"]')
+    const sheet = page.raw.locator('#primary-navigation-mobile')
+
+    await mobileToggle.click()
+    await expect(sheet).toBeVisible()
+    await expect(sheet).toHaveAttribute('open', '')
+    await expect(sheet).toHaveAttribute('data-klean-sheet', '')
+
+    await page.key('Escape')
+    await expect(sheet).toBeHidden()
+    expect(
+      await page.raw.evaluate(() => document.activeElement?.dataset.test)
+    ).toBe('mobile-sidebar-toggle')
+
+    await mobileToggle.click()
+    await sheet.getByRole('link', { name: 'Lookout' }).click()
+    await expect(sheet).toBeHidden()
+    await expect(page.raw).toHaveURL(/\/lookout/)
+
+    expect(page).toHaveNoSmoke()
+  }
+)


### PR DESCRIPTION
## Summary
- adopt the source-owned Klean Sidebar for Slipway and Bridge desktop navigation
- compose the native Klean Sheet and Dialog for mobile navigation without changing product-owned routes or styling
- retain the existing injected toggle contract while Klean owns durable persistence and native modal behavior
- add browser coverage for persistence, inertness, focus return, Escape, and route cleanup

## Verification
- npm run check:consistency
- npm run lint
- npm test (460 passing)
- focused Sidebar and Bridge browser regressions (3 passing)

Closes #353