### PR TITLE
feat(ui): adopt Klean DataTable in Bridge

### DIFF
--- a/assets/js/components/ui/data-table/DataTable.vue
+++ b/assets/js/components/ui/data-table/DataTable.vue
@@ -1,0 +1,162 @@
+<script setup>
+import { computed, ref, useAttrs, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+import Table from '../table/Table.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  rows: { type: Array, default: () => [] },
+  rowKey: { type: [String, Function], default: 'id' },
+  selectable: { type: Function, default: () => true },
+  busy: { type: Boolean, default: false },
+  tableClass: { type: [String, Array, Object], default: undefined }
+})
+
+const selected = defineModel('selected', { default: () => [] })
+const attrs = useAttrs()
+const root = ref()
+
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    'data-slot': _dataSlot,
+    'data-busy': _dataBusy,
+    'data-empty': _dataEmpty,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function keyFor(row) {
+  return typeof props.rowKey === 'function'
+    ? props.rowKey(row)
+    : row?.[props.rowKey]
+}
+
+function canSelect(row) {
+  return props.selectable(row) !== false
+}
+
+const selectableKeys = computed(() => props.rows.filter(canSelect).map(keyFor))
+const selectableKeySet = computed(() => new Set(selectableKeys.value))
+const selectedKeySet = computed(() => new Set(selected.value))
+const selectedCount = computed(() => selectedKeySet.value.size)
+const allSelected = computed(
+  () =>
+    selectableKeys.value.length > 0 &&
+    selectableKeys.value.every((key) => selectedKeySet.value.has(key))
+)
+const someSelected = computed(
+  () => selectedCount.value > 0 && !allSelected.value
+)
+const status = computed(() => {
+  if (selectedCount.value === 0) return 'No rows selected.'
+  return `${selectedCount.value} row${
+    selectedCount.value === 1 ? '' : 's'
+  } selected.`
+})
+
+function setSelected(next) {
+  selected.value = [...new Set(next)]
+}
+
+function isSelected(row) {
+  return selectedKeySet.value.has(keyFor(row))
+}
+
+function setRowSelected(row, checked) {
+  if (props.busy || !canSelect(row)) return
+  const key = keyFor(row)
+  const next = new Set(selected.value)
+  if (checked) next.add(key)
+  else next.delete(key)
+  setSelected(next)
+}
+
+function setPageSelected(checked) {
+  if (props.busy) return
+  setSelected(checked ? selectableKeys.value : [])
+}
+
+function clearSelection() {
+  setSelected([])
+}
+
+function removeSelection(keys) {
+  const removed = new Set(Array.isArray(keys) ? keys : [keys])
+  setSelected(selected.value.filter((key) => !removed.has(key)))
+}
+
+function rowSelection(row, label) {
+  const key = keyFor(row)
+  return {
+    modelValue: selectedKeySet.value.has(key),
+    disabled: props.busy || !canSelect(row),
+    'aria-label': label || `Select row ${String(key)}`,
+    'onUpdate:modelValue': (checked) => setRowSelected(row, checked)
+  }
+}
+
+function pageSelection(label = 'Select all rows on this page') {
+  return {
+    modelValue: allSelected.value,
+    indeterminate: someSelected.value,
+    disabled: props.busy || selectableKeys.value.length === 0,
+    'aria-label': label,
+    'onUpdate:modelValue': setPageSelected
+  }
+}
+
+watch(
+  selectableKeySet,
+  (keys) => {
+    const next = selected.value.filter((key) => keys.has(key))
+    if (
+      next.length !== selected.value.length ||
+      next.some((key, index) => !Object.is(key, selected.value[index]))
+    ) {
+      setSelected(next)
+    }
+  },
+  { immediate: true, flush: 'sync' }
+)
+
+defineExpose({
+  root,
+  clearSelection,
+  removeSelection
+})
+</script>
+
+<template>
+  <div
+    ref="root"
+    v-bind="rootAttrs"
+    data-slot="data-table"
+    :data-busy="busy ? '' : undefined"
+    :data-empty="rows.length === 0 ? '' : undefined"
+    :class="twMerge('relative overflow-x-auto', attrs.class)"
+  >
+    <Table
+      :aria-busy="busy ? 'true' : undefined"
+      :class="twMerge('min-w-full', tableClass)"
+    >
+      <slot
+        :rows="rows"
+        :selected="selected"
+        :selected-count="selectedCount"
+        :all-selected="allSelected"
+        :some-selected="someSelected"
+        :is-selected="isSelected"
+        :row-selection="rowSelection"
+        :page-selection="pageSelection"
+        :clear-selection="clearSelection"
+        :remove-selection="removeSelection"
+      />
+    </Table>
+    <span class="sr-only" aria-live="polite" aria-atomic="true">{{
+      status
+    }}</span>
+  </div>
+</template>

--- a/assets/js/composables/useDataTableQuery.js
+++ b/assets/js/composables/useDataTableQuery.js
@@ -1,0 +1,178 @@
+import { computed, nextTick, onBeforeUnmount, ref, toValue, watch } from 'vue'
+import { router } from '@inertiajs/vue3'
+
+function sameValue(left, right) {
+  if (Object.is(left, right)) return true
+  if (left && right && typeof left === 'object' && typeof right === 'object') {
+    return JSON.stringify(left) === JSON.stringify(right)
+  }
+  return false
+}
+
+function queryValue(value) {
+  if (value === undefined || value === null || value === '') return undefined
+  if (typeof value === 'object') return JSON.stringify(value)
+  return String(value)
+}
+
+export function dataTableUrl(source, query, defaults = {}) {
+  const raw = source || '/'
+  const absolute = /^[a-z][a-z\d+.-]*:/i.test(raw)
+  const url = new URL(raw, 'http://klean.invalid')
+  const cleanDefaults = { page: 1, search: '', filters: {}, ...defaults }
+
+  for (const [key, value] of Object.entries(query || {})) {
+    if (sameValue(value, cleanDefaults[key])) {
+      url.searchParams.delete(key)
+      continue
+    }
+
+    const encoded = queryValue(value)
+    if (encoded === undefined) url.searchParams.delete(key)
+    else url.searchParams.set(key, encoded)
+  }
+
+  return absolute ? url.href : `${url.pathname}${url.search}${url.hash}`
+}
+
+function directionFor(sort, field) {
+  const [activeField, direction = 'ASC'] = String(sort || '').split(/\s+/)
+  return activeField === field ? direction.toUpperCase() : undefined
+}
+
+function restoreFocus(intent) {
+  if (!intent || typeof document === 'undefined') return
+  requestAnimationFrame(async () => {
+    await nextTick()
+    if (intent.element?.isConnected) {
+      intent.element.focus()
+      return
+    }
+    const candidate = [...document.querySelectorAll('[data-table-focus]')].find(
+      (element) => element.dataset.tableFocus === intent.key
+    )
+    candidate?.focus()
+  })
+}
+
+export function useDataTableQuery(options) {
+  const busy = ref(false)
+  const search = ref('')
+  const currentQuery = computed(() => toValue(options.query) || {})
+  const currentDefaults = computed(() => toValue(options.defaults) || {})
+  let searchTimer
+  let syncingSearch = false
+  let focusIntent
+
+  function cancelSearch() {
+    clearTimeout(searchTimer)
+    searchTimer = undefined
+  }
+
+  function visit(updates = {}, visitOptions = {}) {
+    cancelSearch()
+    const {
+      replace = false,
+      trigger,
+      onStart,
+      onFinish,
+      ...forwardedOptions
+    } = visitOptions
+    const next = {
+      ...currentQuery.value,
+      search: search.value,
+      ...updates
+    }
+    const href = dataTableUrl(toValue(options.url), next, currentDefaults.value)
+    const only = toValue(options.only) || []
+    const key = trigger?.dataset?.tableFocus
+    focusIntent = trigger ? { element: trigger, key } : undefined
+
+    router.visit(href, {
+      preserveState: true,
+      preserveScroll: true,
+      ...(only.length ? { only } : {}),
+      ...forwardedOptions,
+      replace,
+      onStart(event) {
+        busy.value = true
+        onStart?.(event)
+      },
+      onFinish(event) {
+        busy.value = false
+        const intent = focusIntent
+        focusIntent = undefined
+        restoreFocus(intent)
+        onFinish?.(event)
+      }
+    })
+
+    return href
+  }
+
+  function sort(field, trigger) {
+    if (busy.value) return
+    const direction = directionFor(currentQuery.value.sort, field)
+    const nextDirection = direction === 'ASC' ? 'DESC' : 'ASC'
+    return visit({ sort: `${field} ${nextDirection}`, page: 1 }, { trigger })
+  }
+
+  function ariaSort(field) {
+    const direction = directionFor(currentQuery.value.sort, field)
+    if (direction === 'ASC') return 'ascending'
+    if (direction === 'DESC') return 'descending'
+    return undefined
+  }
+
+  function sortButton(field, label = field) {
+    const direction = directionFor(currentQuery.value.sort, field)
+    const nextDirection = direction === 'ASC' ? 'descending' : 'ascending'
+    return {
+      type: 'button',
+      disabled: busy.value,
+      'data-table-focus': `sort:${field}`,
+      'aria-label': `Sort by ${label} ${nextDirection}`,
+      onClick: (event) => sort(field, event.currentTarget)
+    }
+  }
+
+  watch(
+    () => String(currentQuery.value.search ?? ''),
+    (value) => {
+      cancelSearch()
+      syncingSearch = true
+      search.value = value
+      syncingSearch = false
+    },
+    { immediate: true, flush: 'sync' }
+  )
+
+  watch(
+    search,
+    (value) => {
+      if (
+        syncingSearch ||
+        String(currentQuery.value.search ?? '') === String(value)
+      ) {
+        return
+      }
+      cancelSearch()
+      searchTimer = setTimeout(() => {
+        visit({ search: value, page: 1 }, { replace: true })
+      }, 300)
+    },
+    { flush: 'sync' }
+  )
+
+  onBeforeUnmount(cancelSearch)
+
+  return {
+    search,
+    busy,
+    visit,
+    sort,
+    ariaSort,
+    sortButton,
+    cancelSearch
+  }
+}

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -1,7 +1,7 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
 import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
-import { Link, Head, router, useForm } from '@inertiajs/vue3'
+import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, watch } from 'vue'
 import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
@@ -15,8 +15,9 @@ import BridgeFilterMenu from '@/components/bridge/BridgeFilterMenu.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 import Pagination from '@/components/ui/pagination/Pagination.vue'
 import Select from '@/components/ui/select/Select.vue'
-import Table from '@/components/ui/table/Table.vue'
+import DataTable from '@/components/ui/data-table/DataTable.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
+import { useDataTableQuery } from '@/composables/useDataTableQuery'
 
 defineOptions({
   layout: BridgePageLayout
@@ -91,13 +92,10 @@ const tableReloadProps = [
   'error'
 ]
 
-// Local state for UI
-const sortValue = ref(props.sort)
-const searchInput = ref(props.search)
+// Local state for app-owned filters, lenses, and actions.
 const filtersValue = ref(props.filterState || {})
 const lensValue = ref(props.activeLens?.id || allRecordsLensValue.value)
-const selectedIds = ref(new Set())
-const selectAll = ref(false)
+const selectedIds = ref([])
 const deleteModal = ref({ show: false, recordId: null })
 const bulkDeleteModal = ref({ show: false })
 const actionDialog = ref({ show: false, action: null, recordIds: [] })
@@ -177,14 +175,6 @@ function openDeleteModal(record) {
   }
 }
 
-// Debounced search
-let searchTimeout = null
-watch(searchInput, (val) => {
-  clearTimeout(searchTimeout)
-  searchTimeout = setTimeout(() => {
-    navigateWithParams({ search: val, page: 1 }, { replace: true })
-  }, 300)
-})
 watch(
   () => props.filterState,
   (value) => {
@@ -198,52 +188,36 @@ watch(
     lensValue.value = value?.id || allRecordsLensValue.value
   }
 )
-watch(
-  () => props.sort,
-  (value) => {
-    sortValue.value = value
-  }
-)
-// Navigate with updated params
-function navigateWithParams(updates, visitOptions = {}) {
-  const params = {
-    page: updates.page ?? props.currentPage,
-    sort: updates.sort ?? sortValue.value,
-    search: updates.search ?? searchInput.value,
-    filters: JSON.stringify(updates.filters ?? filtersValue.value),
-    lens: updates.lens ?? lensValue.value,
-    dashboard:
-      updates.dashboard ??
-      (props.dashboards?.length > 1 ? props.activeDashboard?.id : '')
-  }
-
-  // Clean up defaults
-  if (params.page === 1) delete params.page
-  const defaultSort = props.modelMeta
+const tableQuery = computed(() => ({
+  page: props.currentPage,
+  sort: props.sort || '',
+  search: props.search || '',
+  filters: filtersValue.value,
+  lens: lensValue.value,
+  dashboard: props.dashboards?.length > 1 ? props.activeDashboard?.id || '' : ''
+}))
+const tableDefaults = computed(() => ({
+  page: 1,
+  sort: props.modelMeta
     ? `${props.modelMeta.sort.field} ${props.modelMeta.sort.direction}`
-    : ''
-  if (!params.sort || params.sort === defaultSort) delete params.sort
-  if (!params.search) delete params.search
-  if (params.filters === '{}') delete params.filters
-  if (
-    !params.lens ||
-    params.lens === defaultLens.value?.id ||
-    (params.lens === '__all' && !defaultLens.value)
-  ) {
-    delete params.lens
-  }
-  if (!params.dashboard) delete params.dashboard
-
-  const query = new URLSearchParams(params).toString()
-  const basePath = `${bridgeBasePath.value}/${props.modelIdentity}`
-
-  router.visit(query ? `${basePath}?${query}` : basePath, {
-    preserveState: true,
-    preserveScroll: true,
-    only: visitOptions.only || tableReloadProps,
-    replace: visitOptions.replace === true
-  })
-}
+    : '',
+  search: '',
+  filters: {},
+  lens: defaultLens.value?.id || '',
+  dashboard: ''
+}))
+const {
+  search: searchInput,
+  busy: tableBusy,
+  visit: navigateWithParams,
+  ariaSort,
+  sortButton
+} = useDataTableQuery({
+  url: computed(() => `${bridgeBasePath.value}/${props.modelIdentity}`),
+  query: tableQuery,
+  defaults: tableDefaults,
+  only: tableReloadProps
+})
 
 // Visible columns
 const visibleColumns = computed(() => {
@@ -265,49 +239,14 @@ function applyFilters(filters) {
 function switchLens(lens) {
   lensValue.value = lens
   filtersValue.value = {}
-  sortValue.value = ''
   navigateWithParams({ lens, filters: {}, sort: '', page: 1 })
 }
 
-// Sort handling
-const sortAttr = computed(() => sortValue.value.split(' ')[0])
-const sortDir = computed(() => sortValue.value.split(' ')[1] || 'ASC')
-
-function toggleSort(attr) {
-  if (props.modelMeta?.attributes[attr]?.field?.sortable === false) return
-  let newSort
-  if (sortAttr.value === attr) {
-    newSort = `${attr} ${sortDir.value === 'ASC' ? 'DESC' : 'ASC'}`
-  } else {
-    newSort = `${attr} ASC`
-  }
-  sortValue.value = newSort
-  navigateWithParams({ sort: newSort, page: 1 })
-}
+const sortAttr = computed(() => String(props.sort || '').split(' ')[0])
+const sortDir = computed(() => String(props.sort || '').split(' ')[1] || 'ASC')
 
 function fieldLabel(name) {
   return props.modelMeta?.attributes[name]?.label || name
-}
-
-// Selection
-function toggleSelectAll() {
-  if (selectAll.value) {
-    selectedIds.value = new Set()
-    selectAll.value = false
-  } else {
-    selectedIds.value = new Set(
-      props.records.map((r) => r[props.modelMeta.primaryKey])
-    )
-    selectAll.value = true
-  }
-}
-
-function toggleSelect(id) {
-  const s = new Set(selectedIds.value)
-  if (s.has(id)) s.delete(id)
-  else s.add(id)
-  selectedIds.value = s
-  selectAll.value = s.size === props.records.length
 }
 
 // Delete single record
@@ -321,8 +260,7 @@ function confirmDelete() {
       onSuccess: () => {
         toast({ message: 'Record deleted.', type: 'success' })
         deleteModal.value = { show: false, recordId: null }
-        selectedIds.value = new Set()
-        selectAll.value = false
+        selectedIds.value = []
       },
       onError: (errors) => {
         toast({
@@ -336,7 +274,7 @@ function confirmDelete() {
 
 // Bulk delete
 function confirmBulkDelete() {
-  bulkDeleteForm.ids = Array.from(selectedIds.value)
+  bulkDeleteForm.ids = [...selectedIds.value]
   bulkDeleteForm.post(
     `${bridgeBasePath.value}/${props.modelIdentity}/bulk-delete`,
     {
@@ -347,8 +285,7 @@ function confirmBulkDelete() {
           type: 'success'
         })
         bulkDeleteModal.value = { show: false }
-        selectedIds.value = new Set()
-        selectAll.value = false
+        selectedIds.value = []
       },
       onError: (errors) => {
         toast({
@@ -422,13 +359,12 @@ function handleBulkAction(item) {
     return
   }
   runCustomAction(item.action, {
-    recordIds: Array.from(selectedIds.value)
+    recordIds: [...selectedIds.value]
   })
 }
 
 function clearSelection() {
-  selectedIds.value = new Set()
-  selectAll.value = false
+  selectedIds.value = []
 }
 
 function completeCustomAction() {
@@ -662,11 +598,11 @@ function createUrl() {
             leave-to-class="opacity-0"
           >
             <div
-              v-if="selectedIds.size > 0 && hasBulkActions"
+              v-if="selectedIds.length > 0 && hasBulkActions"
               class="flex items-center space-x-2"
             >
               <span class="text-xs text-gray-500 dark:text-gray-400"
-                >{{ selectedIds.size }} selected</span
+                >{{ selectedIds.length }} selected</span
               >
               <ActionMenu
                 :items="bulkMenuItems"
@@ -755,11 +691,17 @@ function createUrl() {
         </div>
 
         <!-- Table -->
-        <div
+        <DataTable
           v-else-if="modelMeta"
+          v-model:selected="selectedIds"
+          :rows="records"
+          :row-key="(record) => record[modelMeta.primaryKey]"
+          :selectable="() => hasBulkActions"
+          :busy="tableBusy"
           class="rounded-lg border border-gray-200 dark:border-gray-800"
+          table-class="w-full text-left text-sm"
         >
-          <Table class="w-full text-left text-sm">
+          <template #default="{ pageSelection, rowSelection }">
             <caption class="sr-only">
               {{
                 modelMeta.label || modelIdentity
@@ -772,9 +714,7 @@ function createUrl() {
               <tr>
                 <th v-if="hasBulkActions" scope="col" class="w-10 px-4 py-2">
                   <Checkbox
-                    :model-value="selectAll"
-                    :indeterminate="selectedIds.size > 0 && !selectAll"
-                    @change="toggleSelectAll"
+                    v-bind="pageSelection('Select all records on this page')"
                     class="h-3.5 w-3.5 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                   />
                 </th>
@@ -782,15 +722,18 @@ function createUrl() {
                   v-for="col in visibleColumns"
                   :key="col"
                   scope="col"
-                  @click="toggleSort(col)"
-                  :class="[
-                    'select-none whitespace-nowrap px-4 py-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400',
+                  :aria-sort="
                     modelMeta.attributes[col]?.field?.sortable === false
-                      ? ''
-                      : 'cursor-pointer hover:text-gray-900 dark:hover:text-white'
-                  ]"
+                      ? undefined
+                      : ariaSort(col)
+                  "
+                  class="select-none whitespace-nowrap px-4 py-2 text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-400"
                 >
-                  <span class="flex items-center space-x-1">
+                  <button
+                    v-if="modelMeta.attributes[col]?.field?.sortable !== false"
+                    v-bind="sortButton(col, fieldLabel(col))"
+                    class="flex cursor-pointer items-center space-x-1 hover:text-gray-900 disabled:cursor-wait dark:hover:text-white"
+                  >
                     <span>{{ fieldLabel(col) }}</span>
                     <svg
                       v-if="sortAttr === col"
@@ -798,6 +741,7 @@ function createUrl() {
                       fill="none"
                       stroke="currentColor"
                       viewBox="0 0 24 24"
+                      aria-hidden="true"
                     >
                       <path
                         v-if="sortDir === 'ASC'"
@@ -814,7 +758,8 @@ function createUrl() {
                         d="M19 9l-7 7-7-7"
                       />
                     </svg>
-                  </span>
+                  </button>
+                  <span v-else>{{ fieldLabel(col) }}</span>
                 </th>
                 <th v-if="hasRecordActions" scope="col" class="w-12 px-4 py-2">
                   <span class="sr-only">Actions</span>
@@ -851,8 +796,9 @@ function createUrl() {
               >
                 <td v-if="hasBulkActions" class="px-4 py-2">
                   <Checkbox
-                    :model-value="selectedIds.has(record[modelMeta.primaryKey])"
-                    @change="toggleSelect(record[modelMeta.primaryKey])"
+                    v-bind="
+                      rowSelection(record, `Select ${actionLabel(record)}`)
+                    "
                     class="h-3.5 w-3.5 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                   />
                 </td>
@@ -941,8 +887,8 @@ function createUrl() {
                 </td>
               </tr>
             </tbody>
-          </Table>
-        </div>
+          </template>
+        </DataTable>
       </div>
     </div>
 
@@ -979,7 +925,7 @@ function createUrl() {
   <ConfirmModal
     :show="bulkDeleteModal.show"
     title="Delete selected records"
-    :message="`Are you sure you want to delete ${selectedIds.size} record(s)? This action cannot be undone.`"
+    :message="`Are you sure you want to delete ${selectedIds.length} record(s)? This action cannot be undone.`"
     confirm-label="Delete all"
     :destructive="true"
     :loading="bulkDeleteForm.processing"

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -535,6 +535,42 @@ test(
       await expect(page).toSee('Course title')
       await expect(page).toSee('$34.99')
       expect(await page.raw.locator('input[type="checkbox"]').count()).toBe(4)
+      const dataTable = page.raw.locator('[data-slot="data-table"]')
+      await expect(dataTable).toBeVisible()
+      await expect(dataTable.locator('table')).toHaveAttribute(
+        'data-slot',
+        'table'
+      )
+      await expect(
+        dataTable.getByRole('checkbox', {
+          name: 'Select all records on this page'
+        })
+      ).toBeVisible()
+      expect(
+        await dataTable
+          .locator('tbody input[type="checkbox"]')
+          .first()
+          .getAttribute('aria-label')
+      ).toMatch(/^Select /)
+
+      const titleHeader = dataTable
+        .getByRole('columnheader')
+        .filter({ hasText: 'Course title' })
+      expect(await titleHeader.getAttribute('aria-sort')).toBe(null)
+      await titleHeader
+        .getByRole('button', { name: 'Sort by Course title ascending' })
+        .click()
+      await page.raw.waitForURL(
+        (url) => url.searchParams.get('sort') === 'title ASC'
+      )
+      await expect(titleHeader).toHaveAttribute('aria-sort', 'ascending')
+      expect(
+        await page.raw.evaluate(
+          () => document.activeElement?.dataset.tableFocus
+        )
+      ).toBe('sort:title')
+      await page.goto(coursePath)
+      await page.wait('text=Build a production Sails app')
       await page.screenshot(
         path.join(screenshotRoot, 'course-list-light.png'),
         {

--- a/tests/unit/assets/data-table-query.test.js
+++ b/tests/unit/assets/data-table-query.test.js
@@ -1,0 +1,32 @@
+const { test } = require('sounding')
+
+test('DataTable URLs keep app query state and remove conventional defaults', async ({
+  expect
+}) => {
+  const { dataTableUrl } = await import(
+    '../../../assets/js/composables/useDataTableQuery.js'
+  )
+
+  expect(
+    dataTableUrl(
+      '/bridge/course?dashboard=ops#records',
+      {
+        page: 1,
+        sort: 'title DESC',
+        search: '',
+        filters: {},
+        lens: 'recent'
+      },
+      { sort: 'createdAt DESC', lens: '' }
+    )
+  ).toBe('/bridge/course?dashboard=ops&sort=title+DESC&lens=recent#records')
+
+  expect(
+    dataTableUrl('/bridge/course', {
+      page: 3,
+      filters: { published: { operator: 'equals', value: true } }
+    })
+  ).toBe(
+    '/bridge/course?page=3&filters=%7B%22published%22%3A%7B%22operator%22%3A%22equals%22%2C%22value%22%3Atrue%7D%7D'
+  )
+})


### PR DESCRIPTION
## Summary
- install the source-owned Klean DataTable block and Inertia query adapter
- migrate Bridge resource tables while preserving typed cells, filters, lenses, row actions, bulk actions, pagination, and Slipway styling
- replace clickable headers with real sort buttons, truthful aria-sort, focus recovery, and named page/row selection
- reconcile selection across row and permission changes and retain selection on failed mutations
- keep the audit log as its truthful ordered timeline instead of forcing non-tabular details into a table

## Verification
- npm run lint
- npm run check:consistency
- npm test (461 passing)
- focused Bridge resource and pagination browser contracts (3 passing)

Closes #345