### PR TITLE
feat(ui): adopt Klean row actions

### DIFF
--- a/assets/js/components/ui/row-actions/RowActions.vue
+++ b/assets/js/components/ui/row-actions/RowActions.vue
@@ -1,0 +1,103 @@
+<script setup>
+import { computed, ref, useAttrs, useId, useSlots, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+import Menu from '../menu/Menu.vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Accessible name for this row's actions and overflow menu. */
+  label: { type: String, default: 'Actions' },
+  /** Prevents duplicate overflow interaction while application work is pending. */
+  busy: { type: Boolean, default: false },
+  /** Optional stable id for the overflow menu. */
+  id: { type: String, default: undefined },
+  /** Preferred logical menu placement. Collision handling may flip it. */
+  placement: { type: String, default: 'bottom-end' },
+  /** Space in pixels between the trigger and menu. */
+  offset: { type: Number, default: 4 }
+})
+
+const attrs = useAttrs()
+const slots = useSlots()
+const generatedId = useId().replace(/[^a-zA-Z0-9_-]/g, '')
+const menuId = computed(() => props.id ?? `klean-row-actions-${generatedId}`)
+const open = ref(false)
+const hasMenu = computed(() => Boolean(slots.menu))
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-label': _ariaLabel,
+    'aria-busy': _ariaBusy,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function stopPropagation(event) {
+  event.stopPropagation()
+}
+
+watch(
+  () => props.busy,
+  (busy) => {
+    if (busy) open.value = false
+  }
+)
+</script>
+
+<template>
+  <div
+    v-bind="rootAttrs"
+    role="group"
+    :aria-label="label"
+    :aria-busy="busy ? 'true' : undefined"
+    data-slot="row-actions"
+    :class="twMerge('inline-flex items-center gap-1', attrs.class)"
+    @pointerdown="stopPropagation"
+    @click="stopPropagation"
+  >
+    <slot />
+
+    <button
+      v-if="hasMenu"
+      type="button"
+      :disabled="busy"
+      :aria-label="label"
+      :aria-controls="menuId"
+      :aria-expanded="open ? 'true' : 'false'"
+      :popovertarget="menuId"
+      data-slot="row-actions-trigger"
+      class="size-9 inline-grid cursor-pointer place-items-center rounded-md text-current hover:bg-black/5 focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50 dark:hover:bg-white/10"
+    >
+      <slot name="trigger">
+        <svg
+          class="size-4"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"
+          />
+        </svg>
+      </slot>
+    </button>
+
+    <Menu
+      v-if="hasMenu"
+      :id="menuId"
+      v-model:open="open"
+      :aria-label="label"
+      :placement="placement"
+      :offset="offset"
+      data-row-actions-menu=""
+      class="min-w-40"
+      v-slot="{ close }"
+    >
+      <slot name="menu" :close="close" />
+    </Menu>
+  </div>
+</template>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -16,7 +16,7 @@ import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 import Pagination from '@/components/ui/pagination/Pagination.vue'
 import Select from '@/components/ui/select/Select.vue'
 import DataTable from '@/components/ui/data-table/DataTable.vue'
-import Menu from '@/components/ui/menu/Menu.vue'
+import RowActions from '@/components/ui/row-actions/RowActions.vue'
 import { useDataTableQuery } from '@/composables/useDataTableQuery'
 
 defineOptions({
@@ -829,61 +829,42 @@ function createUrl() {
                   />
                 </td>
                 <td v-if="hasRecordActions" class="px-4 py-2">
-                  <div class="relative flex justify-end" @click.stop>
-                    <button
-                      type="button"
-                      class="rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-200 dark:focus-visible:ring-gray-700"
-                      :aria-label="`Actions for ${actionLabel(record)}`"
-                      :popovertarget="`bridge-record-actions-${recordKey(
-                        record
-                      )}`"
-                    >
-                      <svg
-                        class="h-4 w-4"
-                        fill="currentColor"
-                        viewBox="0 0 20 20"
-                        aria-hidden="true"
-                      >
-                        <path
-                          d="M6 10a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Zm6 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0Z"
-                        />
-                      </svg>
-                    </button>
-
-                    <Menu
+                  <div class="flex justify-end">
+                    <RowActions
                       :id="`bridge-record-actions-${recordKey(record)}`"
-                      :aria-label="`Actions for ${actionLabel(record)}`"
-                      placement="bottom-end"
-                      :offset="4"
-                      class="w-36 rounded-md border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+                      :label="`Actions for ${actionLabel(record)}`"
+                      :data-test="`bridge-row-actions-${recordKey(record)}`"
+                      class="[&_[data-slot=row-actions-trigger]]:size-7 text-gray-400 dark:text-gray-500 [&_[data-row-actions-menu]]:w-36 [&_[data-row-actions-menu]]:min-w-0 [&_[data-row-actions-menu]]:rounded-md [&_[data-row-actions-menu]]:border-gray-200 [&_[data-row-actions-menu]]:bg-white [&_[data-row-actions-menu]]:px-0 [&_[data-row-actions-menu]]:py-1 [&_[data-row-actions-menu]]:shadow-lg dark:[&_[data-row-actions-menu]]:border-gray-700 dark:[&_[data-row-actions-menu]]:bg-gray-900 [&_[data-slot=row-actions-trigger]]:transition-colors [&_[data-slot=row-actions-trigger]]:hover:bg-gray-100 [&_[data-slot=row-actions-trigger]]:hover:text-gray-700 [&_[data-slot=row-actions-trigger]]:focus-visible:outline-none [&_[data-slot=row-actions-trigger]]:focus-visible:ring-2 [&_[data-slot=row-actions-trigger]]:focus-visible:ring-gray-300 dark:[&_[data-slot=row-actions-trigger]]:hover:bg-gray-800 dark:[&_[data-slot=row-actions-trigger]]:hover:text-gray-200 dark:[&_[data-slot=row-actions-trigger]]:focus-visible:ring-gray-700"
                     >
-                      <Link
-                        v-if="modelMeta.actions?.view !== false"
-                        :href="recordUrl(record[modelMeta.primaryKey])"
-                        prefetch
-                        role="menuitem"
-                        class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
-                      >
-                        View record
-                      </Link>
-                      <Link
-                        v-if="modelMeta.actions?.update !== false"
-                        :href="editUrl(record[modelMeta.primaryKey])"
-                        prefetch
-                        role="menuitem"
-                        class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
-                      >
-                        Edit record
-                      </Link>
-                      <button
-                        v-if="modelMeta.actions?.delete !== false"
-                        @click="openDeleteModal(record)"
-                        role="menuitem"
-                        class="flex w-full px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 focus:bg-red-50 focus:outline-none dark:text-red-400 dark:hover:bg-red-900/20 dark:focus:bg-red-900/20"
-                      >
-                        Delete record
-                      </button>
-                    </Menu>
+                      <template #menu>
+                        <Link
+                          v-if="modelMeta.actions?.view !== false"
+                          :href="recordUrl(record[modelMeta.primaryKey])"
+                          prefetch
+                          role="menuitem"
+                          class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+                        >
+                          View record
+                        </Link>
+                        <Link
+                          v-if="modelMeta.actions?.update !== false"
+                          :href="editUrl(record[modelMeta.primaryKey])"
+                          prefetch
+                          role="menuitem"
+                          class="flex w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 focus:bg-gray-50 focus:outline-none dark:text-gray-300 dark:hover:bg-gray-800 dark:focus:bg-gray-800"
+                        >
+                          Edit record
+                        </Link>
+                        <button
+                          v-if="modelMeta.actions?.delete !== false"
+                          @click="openDeleteModal(record)"
+                          role="menuitem"
+                          class="flex w-full px-3 py-2 text-left text-sm text-red-600 hover:bg-red-50 focus:bg-red-50 focus:outline-none dark:text-red-400 dark:hover:bg-red-900/20 dark:focus:bg-red-900/20"
+                        >
+                          Delete record
+                        </button>
+                      </template>
+                    </RowActions>
                   </div>
                 </td>
               </tr>

--- a/assets/js/pages/projects/service.vue
+++ b/assets/js/pages/projects/service.vue
@@ -8,7 +8,7 @@ import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import { useToast } from '@/composables/toast'
 import { useServiceActions } from '@/composables/service-actions'
 import LogViewer from '@/components/LogViewer.vue'
-import Menu from '@/components/ui/menu/Menu.vue'
+import RowActions from '@/components/ui/row-actions/RowActions.vue'
 
 defineOptions({
   layout: AppLayout
@@ -570,26 +570,21 @@ onUnmounted(() => {
 
           <div class="flex items-center space-x-2">
             <!-- More menu -->
-            <div class="relative">
-              <button
-                type="button"
-                :popovertarget="`service-actions-${service.id}`"
-                :aria-label="`Actions for ${serviceName}`"
-                class="rounded-md p-1.5 text-gray-400 hover:bg-gray-100 hover:text-gray-700 dark:hover:bg-gray-800 dark:hover:text-gray-200"
-              >
+            <RowActions
+              :id="`service-actions-${service.id}`"
+              :label="`Actions for ${serviceName}`"
+              :busy="stopping || restarting"
+              data-test="service-row-actions"
+              class="[&_[data-slot=row-actions-trigger]]:size-7 text-gray-400 [&_[data-row-actions-menu]]:w-40 [&_[data-row-actions-menu]]:rounded-lg [&_[data-row-actions-menu]]:border-gray-200 [&_[data-row-actions-menu]]:bg-white [&_[data-row-actions-menu]]:px-0 [&_[data-row-actions-menu]]:py-1 [&_[data-row-actions-menu]]:shadow-lg dark:[&_[data-row-actions-menu]]:border-gray-700 dark:[&_[data-row-actions-menu]]:bg-gray-900 [&_[data-slot=row-actions-trigger]]:hover:bg-gray-100 [&_[data-slot=row-actions-trigger]]:hover:text-gray-700 dark:[&_[data-slot=row-actions-trigger]]:hover:bg-gray-800 dark:[&_[data-slot=row-actions-trigger]]:hover:text-gray-200"
+            >
+              <template #trigger>
                 <svg class="h-4 w-4" fill="currentColor" viewBox="0 0 24 24">
                   <circle cx="12" cy="6" r="1.5" />
                   <circle cx="12" cy="12" r="1.5" />
                   <circle cx="12" cy="18" r="1.5" />
                 </svg>
-              </button>
-              <Menu
-                :id="`service-actions-${service.id}`"
-                :aria-label="`Actions for ${serviceName}`"
-                placement="bottom-end"
-                :offset="4"
-                class="w-40 rounded-lg border-gray-200 bg-white px-0 py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
-              >
+              </template>
+              <template #menu>
                 <div class="contents">
                   <button
                     v-if="serviceStatus === 'running'"
@@ -684,8 +679,8 @@ onUnmounted(() => {
                     Clear logs
                   </button>
                 </div>
-              </Menu>
-            </div>
+              </template>
+            </RowActions>
 
             <!-- Status badge -->
             <span

--- a/tests/e2e/pages/row-actions.test.js
+++ b/tests/e2e/pages/row-actions.test.js
@@ -1,0 +1,88 @@
+const { test } = require('sounding')
+
+test(
+  'service commands use durable Klean Row Actions without hiding app behavior',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'klean-row-actions',
+          name: 'Klean Row Actions'
+        }
+      }
+    }
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const service = await world.create('service').with({
+      name: 'primary-db',
+      type: 'postgresql',
+      version: '17',
+      status: 'running',
+      environment: current.environments.production.id,
+      internalHost: 'primary-db',
+      internalPort: 5432,
+      database: 'app',
+      username: 'slipway',
+      password: 'secret'
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.raw.addInitScript(() => {
+      window.EventSource = class MockEventSource {
+        constructor() {
+          setTimeout(() => this.onopen?.(), 0)
+        }
+
+        close() {}
+      }
+    })
+    await page.resize(1440, 900)
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/services/${service.id}`
+    )
+
+    const actions = page.raw.locator('[data-test="service-row-actions"]')
+    const trigger = actions.getByRole('button', {
+      name: 'Actions for primary-db'
+    })
+
+    await expect(actions).toHaveAttribute('data-slot', 'row-actions')
+    await expect(actions).toHaveAttribute('role', 'group')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'false')
+
+    await trigger.focus()
+    await page.key('Enter')
+    await expect(trigger).toHaveAttribute('aria-expanded', 'true')
+    await expect(page.raw.getByRole('menu')).toBeVisible()
+    await expect(page.raw.getByRole('menuitem', { name: 'Stop' })).toBeFocused()
+    await expect(
+      page.raw.getByRole('menuitem', { name: 'Settings' })
+    ).toHaveAttribute(
+      'href',
+      `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/services/${service.id}/settings`
+    )
+
+    await page.key('End')
+    await expect(
+      page.raw.getByRole('menuitem', { name: 'Clear logs' })
+    ).toBeFocused()
+    await page.key('Escape')
+    await expect(page.raw.getByRole('menu')).toBeHidden()
+    await expect(trigger).toBeFocused()
+
+    expect(page).toHaveNoSmoke()
+  }
+)


### PR DESCRIPTION
## Outcome

- copy the framework-native Klean RowActions source into Slipway
- migrate Bridge record actions and the service command menu without changing Slipway styling or app-owned behavior
- verify semantic grouping, native links, keyboard navigation, dismissal, and focus return in a real browser

## Verification

- `npx sounding test --file tests/e2e/pages/row-actions.test.js --test-timeout=600000 --compact`
- `npx sounding test --file tests/e2e/pages/projects/bridge-resource-contract.test.js --test-timeout=600000 --compact`
- `npm run lint`

Closes #348