### PR TITLE
feat(ui): adopt Klean bulk actions

### DIFF
--- a/assets/js/components/ui/bulk-actions/BulkActions.vue
+++ b/assets/js/components/ui/bulk-actions/BulkActions.vue
@@ -1,0 +1,104 @@
+<script setup>
+import { computed, nextTick, ref, useAttrs, watch } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Number of records in the caller-owned selection. */
+  count: { type: Number, default: 0 },
+  /** Accessible name for the selected-record action region. */
+  label: { type: String, default: 'Bulk actions' },
+  /** Truthful pending state for work that makes clearing unsafe. */
+  busy: { type: Boolean, default: false },
+  /** Visible and accessible copy for the default clear button. */
+  clearLabel: { type: String, default: 'Clear selection' }
+})
+
+const emit = defineEmits(['clear'])
+const attrs = useAttrs()
+const element = ref()
+const selectedCount = computed(() =>
+  Math.max(0, Math.trunc(Number(props.count) || 0))
+)
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-label': _ariaLabel,
+    'aria-busy': _ariaBusy,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function focusTarget(root) {
+  return root?.querySelector?.('[data-bulk-actions-focus]')
+}
+
+function clearSelection() {
+  if (props.busy) return
+  emit('clear')
+}
+
+watch(
+  selectedCount,
+  async (nextCount, previousCount) => {
+    if (previousCount <= 0 || nextCount > 0) return
+
+    const rootElement = element.value
+    const root = rootElement?.getRootNode?.() ?? document
+    const activeElement = root.activeElement ?? document.activeElement
+    const shouldRestore = rootElement?.contains(activeElement)
+
+    await nextTick()
+    if (shouldRestore) focusTarget(root)?.focus?.({ preventScroll: true })
+  },
+  { flush: 'pre' }
+)
+
+defineExpose({ clear: clearSelection, element })
+</script>
+
+<template>
+  <div
+    v-if="selectedCount > 0"
+    ref="element"
+    v-bind="rootAttrs"
+    role="region"
+    :aria-label="label"
+    :aria-busy="busy ? 'true' : undefined"
+    data-slot="bulk-actions"
+    :class="
+      twMerge(
+        'min-h-12 flex w-full flex-wrap items-center gap-3 rounded-lg border border-gray-200 bg-white px-3 py-2 text-gray-950 shadow-sm dark:border-gray-800 dark:bg-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <span
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-slot="bulk-actions-summary"
+      class="mr-auto text-sm font-medium tabular-nums"
+    >
+      <slot name="summary" :count="selectedCount">
+        {{ selectedCount }} selected
+      </slot>
+    </span>
+
+    <slot :count="selectedCount" :busy="busy" :clear="clearSelection" />
+
+    <button
+      type="button"
+      :disabled="busy"
+      data-slot="bulk-actions-clear"
+      class="min-h-9 cursor-pointer rounded-md px-3 text-sm font-medium text-gray-600 hover:bg-gray-100 hover:text-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white dark:focus-visible:outline-white"
+      @click="clearSelection"
+    >
+      {{ clearLabel }}
+    </button>
+  </div>
+</template>

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -17,6 +17,7 @@ import Pagination from '@/components/ui/pagination/Pagination.vue'
 import Select from '@/components/ui/select/Select.vue'
 import DataTable from '@/components/ui/data-table/DataTable.vue'
 import RowActions from '@/components/ui/row-actions/RowActions.vue'
+import BulkActions from '@/components/ui/bulk-actions/BulkActions.vue'
 import { useDataTableQuery } from '@/composables/useDataTableQuery'
 
 defineOptions({
@@ -598,13 +599,13 @@ function createUrl() {
             leave-from-class="opacity-100"
             leave-to-class="opacity-0"
           >
-            <div
-              v-if="selectedIds.length > 0 && hasBulkActions"
-              class="flex items-center space-x-2"
+            <BulkActions
+              :count="hasBulkActions ? selectedIds.length : 0"
+              :busy="quickActionForm.processing || bulkDeleteForm.processing"
+              label="Actions for selected records"
+              class="[&_[data-slot=bulk-actions-clear]]:min-h-7 min-h-0 w-auto gap-2 rounded-none border-0 bg-transparent p-0 text-gray-500 shadow-none dark:bg-transparent dark:text-gray-400 [&_[data-slot=bulk-actions-clear]]:whitespace-nowrap [&_[data-slot=bulk-actions-clear]]:px-2 [&_[data-slot=bulk-actions-clear]]:text-xs [&_[data-slot=bulk-actions-summary]]:text-xs [&_[data-slot=bulk-actions-summary]]:font-normal"
+              @clear="clearSelection"
             >
-              <span class="text-xs text-gray-500 dark:text-gray-400"
-                >{{ selectedIds.length }} selected</span
-              >
               <ActionMenu
                 :items="bulkMenuItems"
                 :disabled="quickActionForm.processing"
@@ -612,7 +613,7 @@ function createUrl() {
                 test-id="bridge-bulk-action-menu"
                 @select="handleBulkAction"
               />
-            </div>
+            </BulkActions>
           </Transition>
         </div>
         <div class="flex items-center space-x-4">
@@ -716,6 +717,7 @@ function createUrl() {
                 <th v-if="hasBulkActions" scope="col" class="w-10 px-4 py-2">
                   <Checkbox
                     v-bind="pageSelection('Select all records on this page')"
+                    data-bulk-actions-focus
                     class="h-3.5 w-3.5 rounded border-gray-300 text-gray-900 focus:ring-gray-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
                   />
                 </th>

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -729,6 +729,22 @@ test(
       const rowCheckboxes = page.raw.locator('tbody input[type="checkbox"]')
       await rowCheckboxes.nth(0).click()
       await rowCheckboxes.nth(1).click()
+      const bulkActions = page.raw.getByRole('region', {
+        name: 'Actions for selected records'
+      })
+      const pageSelection = page.raw.getByRole('checkbox', {
+        name: 'Select all records on this page'
+      })
+      await expect(bulkActions).toBeVisible()
+      await expect(bulkActions.getByRole('status')).toHaveText('2 selected')
+      await bulkActions.getByRole('button', { name: 'Clear selection' }).click()
+      await expect(bulkActions).toBeHidden()
+      await expect(pageSelection).toBeFocused()
+      expect(await rowCheckboxes.nth(0).isChecked()).toBe(false)
+      expect(await rowCheckboxes.nth(1).isChecked()).toBe(false)
+
+      await rowCheckboxes.nth(0).click()
+      await rowCheckboxes.nth(1).click()
       await page.raw
         .getByRole('button', { name: 'Actions for selected records' })
         .click()


### PR DESCRIPTION
## Outcome

- copy the framework-native Klean BulkActions source into Slipway
- migrate Bridge selected-record controls while keeping permissions, forms, dialogs, and mutations app-owned
- add a compact clear-selection control with deliberate focus recovery to the page-selection checkbox
- preserve Slipway styling, transitions, action menus, and light/dark behavior through caller Tailwind

## Verification

- `npx sounding test --file tests/e2e/pages/projects/bridge-resource-contract.test.js --test-timeout=600000 --compact`
- `npm run lint`
- `node ../klean-ui/bin/klean-ui.js check`

Closes #349