### PR TITLE
feat(ui): adopt Klean empty states

### DIFF
--- a/assets/js/components/ui/empty-state/EmptyState.vue
+++ b/assets/js/components/ui/empty-state/EmptyState.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+defineProps({
+  /** Native element or framework component that truthfully fits the document. */
+  as: { type: [String, Object, Function], default: 'div' }
+})
+
+const attrs = useAttrs()
+const element = ref()
+const rootAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <component
+    :is="as"
+    ref="element"
+    v-bind="rootAttrs"
+    data-slot="empty-state"
+    :class="
+      twMerge(
+        'min-h-48 flex w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </component>
+</template>

--- a/assets/js/pages/dashboard/index.vue
+++ b/assets/js/pages/dashboard/index.vue
@@ -2,10 +2,11 @@
 import Input from '@/components/ui/input/Input.vue'
 import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, useForm } from '@inertiajs/vue3'
-import { inject, ref, computed } from 'vue'
+import { inject, ref, computed, nextTick } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
+import EmptyState from '@/components/ui/empty-state/EmptyState.vue'
 
 defineOptions({
   layout: AppLayout
@@ -22,6 +23,7 @@ const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const searchQuery = ref('')
+const searchInput = ref()
 const copiedSlug = ref(null)
 
 const filteredProjects = computed(() => {
@@ -33,6 +35,12 @@ const filteredProjects = computed(() => {
       (project.description && project.description.toLowerCase().includes(query))
   )
 })
+
+async function clearProjectSearch() {
+  searchQuery.value = ''
+  await nextTick()
+  searchInput.value?.focus()
+}
 
 function timeAgo(date) {
   const seconds = Math.floor((new Date() - new Date(date)) / 1000)
@@ -230,6 +238,7 @@ function cancelDeleteProject() {
         <!-- Toolbar: Search + Create Button -->
         <div class="mb-4 flex items-center justify-between">
           <Input
+            ref="searchInput"
             v-model="searchQuery"
             type="text"
             placeholder="Search projects..."
@@ -489,18 +498,34 @@ function cancelDeleteProject() {
             </div>
 
             <!-- No results -->
-            <div
+            <EmptyState
               v-if="filteredProjects.length === 0"
-              class="px-6 py-8 text-center text-sm text-gray-500"
+              as="section"
+              aria-labelledby="projects-filtered-empty-title"
+              class="min-h-0 gap-2 px-6 py-8 text-sm text-gray-500 dark:text-gray-400"
             >
-              No projects found matching "{{ searchQuery }}"
-            </div>
+              <h2 id="projects-filtered-empty-title" class="font-medium">
+                No projects found matching "{{ searchQuery }}"
+              </h2>
+              <button
+                type="button"
+                class="cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 dark:text-gray-300 dark:hover:bg-gray-800"
+                @click="clearProjectSearch"
+              >
+                Clear search
+              </button>
+            </EmptyState>
           </div>
         </div>
       </div>
 
       <!-- Empty State -->
-      <div v-else class="flex flex-col items-center justify-center py-24">
+      <EmptyState
+        v-else
+        as="section"
+        aria-labelledby="projects-empty-title"
+        class="gap-0 p-0 py-24"
+      >
         <div
           class="mb-4 flex h-12 w-12 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-800"
         >
@@ -518,9 +543,12 @@ function cancelDeleteProject() {
             />
           </svg>
         </div>
-        <h3 class="mb-1 text-lg font-medium text-gray-900 dark:text-white">
+        <h1
+          id="projects-empty-title"
+          class="mb-1 text-lg font-medium text-gray-900 dark:text-white"
+        >
           No projects yet
-        </h3>
+        </h1>
         <p class="mb-6 text-sm text-gray-500">
           Get started by creating your first project.
         </p>
@@ -531,7 +559,7 @@ function cancelDeleteProject() {
           <span>+</span>
           <span>Create Project</span>
         </Link>
-      </div>
+      </EmptyState>
     </div>
 
     <ConfirmModal

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -18,6 +18,7 @@ import Select from '@/components/ui/select/Select.vue'
 import DataTable from '@/components/ui/data-table/DataTable.vue'
 import RowActions from '@/components/ui/row-actions/RowActions.vue'
 import BulkActions from '@/components/ui/bulk-actions/BulkActions.vue'
+import EmptyState from '@/components/ui/empty-state/EmptyState.vue'
 import { useDataTableQuery } from '@/composables/useDataTableQuery'
 
 defineOptions({
@@ -782,9 +783,18 @@ function createUrl() {
                   "
                   class="px-4 py-12 text-center text-sm text-gray-500 dark:text-gray-400"
                 >
-                  {{
-                    hasScopedQuery ? 'No matching records.' : 'No records yet.'
-                  }}
+                  <EmptyState
+                    data-test="bridge-empty"
+                    class="min-h-0 gap-0 p-0 text-sm text-gray-500 dark:text-gray-400"
+                  >
+                    <p>
+                      {{
+                        hasScopedQuery
+                          ? 'No matching records.'
+                          : 'No records yet.'
+                      }}
+                    </p>
+                  </EmptyState>
                 </td>
               </tr>
             </tbody>

--- a/assets/js/pages/settings/audit-log.vue
+++ b/assets/js/pages/settings/audit-log.vue
@@ -1,10 +1,11 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
 import { Head, Link, router } from '@inertiajs/vue3'
-import { computed, inject, onBeforeUnmount, ref, watch } from 'vue'
+import { computed, inject, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Pagination from '@/components/ui/pagination/Pagination.vue'
 import Select from '@/components/ui/select/Select.vue'
+import EmptyState from '@/components/ui/empty-state/EmptyState.vue'
 
 defineOptions({
   layout: AppLayout
@@ -31,7 +32,12 @@ const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
 const query = ref(props.filters.q || '')
 const group = ref(props.filters.group || 'all')
+const searchInput = ref()
 let searchTimer
+
+const hasAuditFilters = computed(
+  () => Boolean(query.value.trim()) || group.value !== 'all'
+)
 
 const actionLabels = {
   'deployment.triggered': 'Triggered deployment',
@@ -87,6 +93,13 @@ function refreshLogs() {
       only: ['logs', 'pagination', 'filters', 'helmAuditRetentionDays']
     }
   )
+}
+
+async function clearAuditFilters() {
+  query.value = ''
+  group.value = 'all'
+  await nextTick()
+  searchInput.value?.focus()
 }
 
 function actionLabel(action) {
@@ -264,6 +277,7 @@ function shortHash(hash) {
                 />
               </svg>
               <Input
+                ref="searchInput"
                 v-model="query"
                 data-test="audit-search"
                 type="search"
@@ -287,22 +301,35 @@ function shortHash(hash) {
           </div>
         </div>
 
-        <div
+        <EmptyState
           v-if="logs.length === 0"
+          as="section"
+          aria-labelledby="audit-empty-title"
           data-test="audit-empty"
-          class="min-h-56 flex flex-col items-center justify-center text-center"
+          class="min-h-56 gap-0 p-0"
         >
-          <p class="text-sm font-medium text-gray-700 dark:text-gray-300">
-            {{ query ? 'No matching events' : 'No audit events yet' }}
-          </p>
+          <h2
+            id="audit-empty-title"
+            class="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            {{ hasAuditFilters ? 'No matching events' : 'No audit events yet' }}
+          </h2>
           <p class="mt-1 text-xs text-gray-400 dark:text-gray-600">
             {{
-              query
+              hasAuditFilters
                 ? 'Try a person, action, resource, or IP address.'
                 : 'Important team activity will appear here.'
             }}
           </p>
-        </div>
+          <button
+            v-if="hasAuditFilters"
+            type="button"
+            class="mt-3 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-100 focus-visible:outline-2 focus-visible:outline-offset-2 dark:text-gray-300 dark:hover:bg-gray-800"
+            @click="clearAuditFilters"
+          >
+            Clear filters
+          </button>
+        </EmptyState>
 
         <ol v-else data-test="audit-events" class="mt-6">
           <li

--- a/tests/e2e/pages/empty-state.test.js
+++ b/tests/e2e/pages/empty-state.test.js
@@ -1,0 +1,77 @@
+const { test } = require('sounding')
+
+test(
+  'Klean Empty State preserves distinct first-use, filtered, and operational reasons',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'klean-empty-state',
+          name: 'Klean Empty State'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.goto('/')
+
+    const projectSearch = page.raw.getByPlaceholder('Search projects...')
+    await projectSearch.fill('no-such-project')
+    const filteredProjects = page.raw.getByRole('region', {
+      name: 'No projects found matching "no-such-project"'
+    })
+    await expect(filteredProjects).toHaveAttribute('data-slot', 'empty-state')
+    await filteredProjects.getByRole('button', { name: 'Clear search' }).click()
+    await expect(projectSearch).toBeFocused()
+    await expect(page.raw.getByText('Klean Empty State')).toBeVisible()
+
+    const otherTeam = await world.create('team').with({
+      name: 'A different team',
+      slug: 'a-different-team',
+      owner: current.users.genesisUser.id
+    })
+    await sails.models.project
+      .updateOne({ id: current.projects.deploymentTarget.id })
+      .set({ team: otherTeam.id })
+    await page.reload()
+
+    const firstProject = page.raw.getByRole('region', {
+      name: 'No projects yet'
+    })
+    await expect(firstProject).toHaveAttribute('data-slot', 'empty-state')
+    await expect(firstProject.getByRole('heading', { level: 1 })).toHaveText(
+      'No projects yet'
+    )
+    await expect(
+      firstProject.getByRole('link', { name: 'Create Project' })
+    ).toHaveAttribute('href', '/projects/new')
+
+    await page.goto('/settings/audit-log?q=no-such-event')
+    const auditEmpty = page.raw.locator('[data-test="audit-empty"]')
+    await expect(auditEmpty).toHaveAttribute('data-slot', 'empty-state')
+    await expect(
+      auditEmpty.getByRole('heading', { name: 'No matching events' })
+    ).toBeVisible()
+    await auditEmpty.getByRole('button', { name: 'Clear filters' }).click()
+    await page.raw.waitForURL((url) => !url.searchParams.has('q'))
+    await expect(page.raw.getByLabel('Search audit events')).toBeFocused()
+
+    expect(page).toHaveNoSmoke()
+  }
+)

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -315,13 +315,16 @@ test(
         })
       }
       if (code.includes('const total = await model.count(where);')) {
+        const where = readEmbeddedValue(code, 'where')
         resourceQueries.push({
-          where: readEmbeddedValue(code, 'where'),
+          where,
           criteria: readEmbeddedValue(code, 'criteria')
         })
+        const hasNoMatchSearch =
+          JSON.stringify(where).includes('no-matching-course')
         return successfulResult({
-          records,
-          total: records.length
+          records: hasNoMatchSearch ? [] : records,
+          total: hasNoMatchSearch ? 0 : records.length
         })
       }
       if (code.includes('await model.create(values).fetch();')) {
@@ -587,6 +590,18 @@ test(
         { fullPage: true }
       )
       await page.raw.emulateMedia({ colorScheme: 'light' })
+
+      const recordSearch = page.raw.getByPlaceholder('Search records...')
+      await recordSearch.fill('no-matching-course')
+      await page.raw.waitForURL(
+        (url) => url.searchParams.get('search') === 'no-matching-course'
+      )
+      const bridgeEmpty = page.raw.locator('[data-test="bridge-empty"]')
+      await expect(bridgeEmpty).toHaveAttribute('data-slot', 'empty-state')
+      await expect(bridgeEmpty).toHaveText('No matching records.')
+      await recordSearch.fill('')
+      await page.raw.waitForURL((url) => !url.searchParams.has('search'))
+      await page.wait('text=Build a production Sails app')
 
       await page.raw.locator('[data-test="bridge-filter-toggle"]').click()
       await expect(


### PR DESCRIPTION
## Summary
- add the copied Klean Empty State source to Slipway
- migrate dashboard, audit-log, and Bridge no-data experiences while preserving app-owned actions and styling
- cover first-use, filtered, keyboard focus-restoration, and Bridge query behavior

## Tests
- `npx sounding test tests/e2e/pages/empty-state.test.js`
- `npx sounding test tests/e2e/pages/projects/bridge-resource-contract.test.js`
- `npm run lint`
- `node ../klean-ui/bin/klean-ui.js check`

Closes #350