### PR TITLE
feat(ui): adopt Klean loading states

### DIFF
--- a/assets/js/components/ui/loading-state/LoadingState.vue
+++ b/assets/js/components/ui/loading-state/LoadingState.vue
@@ -1,0 +1,41 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
+const element = ref()
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-live': _ariaLive,
+    'aria-atomic': _ariaAtomic,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <div
+    ref="element"
+    v-bind="rootAttrs"
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    data-slot="loading-state"
+    :class="
+      twMerge(
+        'min-h-32 flex w-full flex-col items-center justify-center gap-3 p-6 text-center text-gray-600 dark:text-gray-300',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -24,6 +24,7 @@ import { highlightSQL } from '@/lib/highlightSQL'
 import { highlightJSON } from '@/lib/highlightJSON'
 import { formatHelmError, helmEditorDiagnostic } from '@/lib/helmResult'
 import Spinner from '@/components/SlipwaySpinner.vue'
+import LoadingState from '@/components/ui/loading-state/LoadingState.vue'
 import LogViewer from '@/components/LogViewer.vue'
 import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
 
@@ -1746,16 +1747,21 @@ onUnmounted(() => {
         </div>
 
         <!-- ═══ Migrate Tab ═══ -->
-        <div
+        <section
           v-if="activeTab === 'migrate'"
           data-slot="tab-panel"
           data-value="migrate"
+          aria-labelledby="bosun-migrate-title"
+          :aria-busy="diffLoading ? 'true' : undefined"
         >
           <div
             class="mb-6 flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
           >
             <div>
-              <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
+              <h1
+                id="bosun-migrate-title"
+                class="text-xl font-semibold text-gray-900 dark:text-white"
+              >
                 Migrate
               </h1>
               <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
@@ -1783,10 +1789,12 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <div v-if="diffLoading" role="status" class="py-16 text-center">
+          <LoadingState v-if="diffLoading" class="py-16">
             <Spinner class="mx-auto h-5 w-5 text-gray-400 dark:text-gray-600" />
-            <span class="sr-only">Loading migration diff</span>
-          </div>
+            <span class="text-sm text-gray-500 dark:text-gray-400"
+              >Loading migration diff…</span
+            >
+          </LoadingState>
 
           <div
             v-else-if="diffError"
@@ -2081,17 +2089,22 @@ onUnmounted(() => {
               </div>
             </div>
           </div>
-        </div>
+        </section>
 
         <!-- ═══ Activity Tab ═══ -->
-        <div
+        <section
           v-if="activeTab === 'activity'"
           data-slot="tab-panel"
           data-value="activity"
+          aria-labelledby="bosun-activity-title"
+          :aria-busy="activityLoading ? 'true' : undefined"
         >
           <div class="mb-6 flex items-start justify-between">
             <div>
-              <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
+              <h1
+                id="bosun-activity-title"
+                class="text-xl font-semibold text-gray-900 dark:text-white"
+              >
                 Activity
               </h1>
               <p class="mt-1 text-sm text-gray-500 dark:text-gray-400">
@@ -2125,10 +2138,12 @@ onUnmounted(() => {
           </div>
 
           <!-- Loading -->
-          <div v-if="activityLoading" role="status" class="py-16 text-center">
+          <LoadingState v-if="activityLoading" class="py-16">
             <Spinner class="mx-auto h-5 w-5 text-gray-400 dark:text-gray-600" />
-            <span class="sr-only">Loading migration activity</span>
-          </div>
+            <span class="text-sm text-gray-500 dark:text-gray-400"
+              >Loading activity…</span
+            >
+          </LoadingState>
 
           <!-- Empty state -->
           <div v-else-if="activities.length === 0" class="py-20 text-center">
@@ -2245,7 +2260,7 @@ onUnmounted(() => {
               </span>
             </div>
           </div>
-        </div>
+        </section>
       </div>
     </div>
     <ConfirmModal

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -19,6 +19,8 @@ import DataTable from '@/components/ui/data-table/DataTable.vue'
 import RowActions from '@/components/ui/row-actions/RowActions.vue'
 import BulkActions from '@/components/ui/bulk-actions/BulkActions.vue'
 import EmptyState from '@/components/ui/empty-state/EmptyState.vue'
+import LoadingState from '@/components/ui/loading-state/LoadingState.vue'
+import Spinner from '@/components/SlipwaySpinner.vue'
 import { useDataTableQuery } from '@/composables/useDataTableQuery'
 
 defineOptions({
@@ -559,7 +561,7 @@ function createUrl() {
 
     <!-- Toolbar -->
     <div class="px-4 py-4 sm:px-8">
-      <div class="mx-auto flex max-w-6xl items-center justify-between">
+      <div class="relative mx-auto flex max-w-6xl items-center justify-between">
         <div class="flex items-center space-x-3">
           <Input
             v-if="(modelMeta?.search || []).length > 0"
@@ -653,6 +655,15 @@ function createUrl() {
             New
           </Link>
         </div>
+        <LoadingState
+          v-if="tableBusy && !error && modelMeta"
+          id="bridge-records-loading"
+          data-test="bridge-loading"
+          class="pointer-events-none absolute -bottom-4 right-0 min-h-0 w-auto flex-row justify-end gap-2 p-0 text-right text-xs text-gray-500 dark:text-gray-400"
+        >
+          <Spinner class="size-3.5" />
+          <span>Refreshing records…</span>
+        </LoadingState>
       </div>
     </div>
 
@@ -701,6 +712,7 @@ function createUrl() {
           :row-key="(record) => record[modelMeta.primaryKey]"
           :selectable="() => hasBulkActions"
           :busy="tableBusy"
+          :aria-describedby="tableBusy ? 'bridge-records-loading' : undefined"
           class="rounded-lg border border-gray-200 dark:border-gray-800"
           table-class="w-full text-left text-sm"
         >

--- a/tests/e2e/pages/loading-state.test.js
+++ b/tests/e2e/pages/loading-state.test.js
@@ -1,0 +1,63 @@
+const { test } = require('sounding')
+
+test(
+  'Klean Loading State names a busy Bosun region and keeps Slippy decorative',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    let releaseDiff
+    let announceDiffRequest
+    const diffRequested = new Promise((resolve) => {
+      announceDiffRequest = resolve
+    })
+    const diffReleased = new Promise((resolve) => {
+      releaseDiff = resolve
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await page.raw.route('**/api/v1/bosun/diff?**', async (route) => {
+      announceDiffRequest()
+      await diffReleased
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          modelCount: 1,
+          hasPendingChanges: false,
+          statements: []
+        })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.resize(1440, 900)
+    await page.goto('/bosun')
+    await page.raw.getByRole('tab', { name: 'Migrate' }).click()
+    await diffRequested
+
+    const region = page.raw.getByRole('tabpanel', { name: 'Migrate' })
+    await expect(region).toHaveAttribute('aria-busy', 'true')
+    const status = region.getByRole('status')
+    await expect(status).toHaveAttribute('data-slot', 'loading-state')
+    await expect(status).toHaveText('Loading migration diff…')
+    await expect(status.locator('[data-slot="spinner"]')).toBeVisible()
+    await expect(status.locator('.slippy-loader')).toHaveAttribute(
+      'aria-hidden',
+      'true'
+    )
+
+    releaseDiff()
+    await expect(status).not.toBeVisible()
+    await expect(region).not.toHaveAttribute('aria-busy', 'true')
+    await expect(region.getByText('No pending schema changes')).toBeVisible()
+
+    expect(page).toHaveNoSmoke()
+  }
+)

--- a/tests/e2e/pages/projects/bridge-resource-contract.test.js
+++ b/tests/e2e/pages/projects/bridge-resource-contract.test.js
@@ -560,13 +560,19 @@ test(
         .getByRole('columnheader')
         .filter({ hasText: 'Course title' })
       expect(await titleHeader.getAttribute('aria-sort')).toBe(null)
-      await titleHeader
-        .getByRole('button', { name: 'Sort by Course title ascending' })
-        .click()
+      const titleSortButton = dataTable.locator(
+        '[data-table-focus="sort:title"]'
+      )
+      await expect(titleSortButton).toHaveAttribute(
+        'aria-label',
+        'Sort by Course title ascending'
+      )
+      await titleSortButton.click()
       await page.raw.waitForURL(
         (url) => url.searchParams.get('sort') === 'title ASC'
       )
       await expect(titleHeader).toHaveAttribute('aria-sort', 'ascending')
+      await expect(titleSortButton).toBeFocused()
       expect(
         await page.raw.evaluate(
           () => document.activeElement?.dataset.tableFocus
@@ -592,10 +598,39 @@ test(
       await page.raw.emulateMedia({ colorScheme: 'light' })
 
       const recordSearch = page.raw.getByPlaceholder('Search records...')
+      let releaseRecordRefresh
+      let announceRecordRefresh
+      const recordRefreshStarted = new Promise((resolve) => {
+        announceRecordRefresh = resolve
+      })
+      const recordRefreshReleased = new Promise((resolve) => {
+        releaseRecordRefresh = resolve
+      })
+      await page.raw.route(`**${coursePath}?**`, async (route) => {
+        const url = new URL(route.request().url())
+        if (url.searchParams.get('search') === 'no-matching-course') {
+          announceRecordRefresh()
+          await recordRefreshReleased
+        }
+        await route.continue()
+      })
       await recordSearch.fill('no-matching-course')
+      await recordRefreshStarted
+      await expect(
+        page.raw.getByText('Build a production Sails app')
+      ).toBeVisible()
+      const bridgeLoading = page.raw.locator('[data-test="bridge-loading"]')
+      await expect(bridgeLoading).toHaveAttribute('data-slot', 'loading-state')
+      await expect(bridgeLoading).toHaveText('Refreshing records…')
+      await expect(dataTable.locator('table')).toHaveAttribute(
+        'aria-busy',
+        'true'
+      )
+      releaseRecordRefresh()
       await page.raw.waitForURL(
         (url) => url.searchParams.get('search') === 'no-matching-course'
       )
+      await expect(bridgeLoading).not.toBeVisible()
       const bridgeEmpty = page.raw.locator('[data-test="bridge-empty"]')
       await expect(bridgeEmpty).toHaveAttribute('data-slot', 'empty-state')
       await expect(bridgeEmpty).toHaveText('No matching records.')


### PR DESCRIPTION
## Summary
- copy Klean Loading State into Slipway while keeping Spinner and request ownership separate
- migrate Bosun initial region loading with truthful busy semantics and the existing Slippy product mark
- preserve stale Bridge rows during partial reloads with a compact, non-shifting refresh status
- cover busy regions, decorative motion, stale content, focus restoration, and partial reload completion in browser tests

## Tests
- `npx sounding test tests/e2e/pages/loading-state.test.js`
- `npx sounding test tests/e2e/pages/projects/bridge-resource-contract.test.js`
- `npm run lint`
- `node ../klean-ui/bin/klean-ui.js check` (recognizes the locally owned component and reports local formatting changes as designed)

Closes #351