### PR TITLE
feat(ui): adopt Klean error states

### DIFF
--- a/api/controllers/project/view-content-manager.js
+++ b/api/controllers/project/view-content-manager.js
@@ -103,7 +103,9 @@ module.exports = {
           }
         }
       } catch (err) {
-        collectionsError = err.message
+        sails.log.error('Could not load content collections', err)
+        collectionsError =
+          'Slipway could not read this app’s content collections.'
       }
     }
 

--- a/assets/js/components/ui/error-state/ErrorState.vue
+++ b/assets/js/components/ui/error-state/ErrorState.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+defineProps({
+  /** Native element or framework component that truthfully fits the document. */
+  as: { type: [String, Object, Function], default: 'div' }
+})
+
+const attrs = useAttrs()
+const element = ref()
+const rootAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <component
+    :is="as"
+    ref="element"
+    v-bind="rootAttrs"
+    data-slot="error-state"
+    :class="
+      twMerge(
+        'min-h-48 flex w-full flex-col items-center justify-center gap-4 p-6 text-center text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </component>
+</template>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -25,6 +25,7 @@ import { highlightJSON } from '@/lib/highlightJSON'
 import { formatHelmError, helmEditorDiagnostic } from '@/lib/helmResult'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import LoadingState from '@/components/ui/loading-state/LoadingState.vue'
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 import LogViewer from '@/components/LogViewer.vue'
 import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
 
@@ -1090,13 +1091,19 @@ onUnmounted(() => {
         <template v-if="consoleMode === 'sql'">
           <!-- Error -->
           <div v-if="consoleError" class="p-4">
-            <div
-              class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/30"
+            <ErrorState
+              as="section"
+              role="alert"
+              aria-labelledby="bosun-query-error-title"
+              class="min-h-0 items-start gap-0 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-left dark:border-red-900/50 dark:bg-red-950/30"
             >
+              <h2 id="bosun-query-error-title" class="sr-only">
+                SQL query failed
+              </h2>
               <p class="font-mono text-sm text-red-600 dark:text-red-400">
                 {{ consoleError }}
               </p>
-            </div>
+            </ErrorState>
           </div>
 
           <!-- Results table/json -->
@@ -1796,17 +1803,30 @@ onUnmounted(() => {
             >
           </LoadingState>
 
-          <div
+          <ErrorState
             v-else-if="diffError"
-            class="rounded-lg border border-red-200 bg-red-50 px-5 py-4 dark:border-red-900/50 dark:bg-red-950/30"
+            as="section"
+            role="alert"
+            aria-labelledby="bosun-diff-error-title"
+            class="min-h-0 items-start gap-0 rounded-lg border border-red-200 bg-red-50 px-5 py-4 text-left dark:border-red-900/50 dark:bg-red-950/30"
           >
-            <p class="text-sm font-medium text-red-700 dark:text-red-300">
+            <h2
+              id="bosun-diff-error-title"
+              class="text-sm font-medium text-red-700 dark:text-red-300"
+            >
               Migrate diff failed
-            </p>
+            </h2>
             <p class="mt-1 text-sm text-red-600 dark:text-red-400">
               {{ diffError }}
             </p>
-          </div>
+            <button
+              type="button"
+              class="mt-3 cursor-pointer rounded-md bg-red-700 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-600 focus-visible:outline-2 focus-visible:outline-offset-2 dark:bg-red-300 dark:text-red-950 dark:hover:bg-red-200"
+              @click="fetchDiff"
+            >
+              Try again
+            </button>
+          </ErrorState>
 
           <div
             v-else-if="diff?.modelCount === 0"

--- a/assets/js/pages/errors/status.vue
+++ b/assets/js/pages/errors/status.vue
@@ -3,6 +3,7 @@ import { Head } from '@inertiajs/vue3'
 import { computed } from 'vue'
 import SlipwayLogo from '@/components/SlipwayLogo.vue'
 import SlippyLoader from '@/components/SlippyLoader.vue'
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 
 const FALLBACK_PAGES = {
   403: {
@@ -104,7 +105,11 @@ const page = computed(() => {
     <main
       class="mx-auto flex w-full max-w-6xl flex-1 flex-col justify-center gap-10 px-5 py-12 sm:px-8 lg:grid lg:grid-cols-[minmax(0,1fr)_17rem] lg:items-center lg:gap-24 lg:py-16"
     >
-      <section aria-labelledby="error-heading" class="max-w-2xl">
+      <ErrorState
+        as="section"
+        aria-labelledby="error-heading"
+        class="min-h-0 max-w-2xl items-start gap-0 p-0 text-left"
+      >
         <p
           class="font-mono text-sm font-semibold tabular-nums tracking-[0.14em] text-gray-400 dark:text-gray-500"
         >
@@ -140,7 +145,7 @@ const page = computed(() => {
             {{ action.label }}
           </a>
         </nav>
-      </section>
+      </ErrorState>
 
       <SlippyLoader
         class="text-brand dark:text-brand-400 order-first h-14 w-14 shrink-0 self-center lg:order-none lg:h-24 lg:w-24 lg:self-auto lg:justify-self-center"

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -15,6 +15,7 @@ import { containsRawHtml } from '@/lib/content/markdown.mjs'
 import { usePrecognitionValidation } from '@/composables/precognition'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 
 defineOptions({
   layout: BridgePageLayout
@@ -527,28 +528,35 @@ function recordUrl() {
     <!-- Content -->
     <div class="flex-1 overflow-y-auto px-4 py-6 sm:px-8 sm:py-8">
       <!-- Error -->
-      <div v-if="error" class="flex h-full items-center justify-center">
-        <div class="text-center">
-          <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+      <ErrorState
+        v-if="error"
+        as="section"
+        aria-labelledby="bridge-form-error-title"
+        class="h-full gap-0 p-0"
+      >
+        <div
+          class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+        >
+          <svg
+            class="h-8 w-8 text-red-500 dark:text-red-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
           >
-            <svg
-              class="h-8 w-8 text-red-500 dark:text-red-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
-          </div>
-          <p class="mt-4 text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
         </div>
-      </div>
+        <h1 id="bridge-form-error-title" class="sr-only">
+          This form could not load
+        </h1>
+        <p class="mt-4 text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+      </ErrorState>
 
       <!-- Form -->
       <div v-else-if="modelMeta" class="mx-auto max-w-xl">

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -20,6 +20,7 @@ import RowActions from '@/components/ui/row-actions/RowActions.vue'
 import BulkActions from '@/components/ui/bulk-actions/BulkActions.vue'
 import EmptyState from '@/components/ui/empty-state/EmptyState.vue'
 import LoadingState from '@/components/ui/loading-state/LoadingState.vue'
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import { useDataTableQuery } from '@/composables/useDataTableQuery'
 
@@ -679,30 +680,37 @@ function createUrl() {
         />
 
         <!-- Error -->
-        <div v-if="error" class="flex h-full items-center justify-center">
-          <div class="text-center">
-            <div
-              class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+        <ErrorState
+          v-if="error"
+          as="section"
+          aria-labelledby="bridge-records-error-title"
+          class="h-full gap-0 p-0"
+        >
+          <div
+            class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+          >
+            <svg
+              class="h-8 w-8 text-red-500 dark:text-red-400"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+              aria-hidden="true"
             >
-              <svg
-                class="h-8 w-8 text-red-500 dark:text-red-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1.5"
-                  d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-                />
-              </svg>
-            </div>
-            <p class="mt-4 text-sm text-red-600 dark:text-red-400">
-              {{ error }}
-            </p>
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="1.5"
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
           </div>
-        </div>
+          <h2 id="bridge-records-error-title" class="sr-only">
+            Records could not load
+          </h2>
+          <p class="mt-4 text-sm text-red-600 dark:text-red-400">
+            {{ error }}
+          </p>
+        </ErrorState>
 
         <!-- Table -->
         <DataTable

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -10,6 +10,7 @@ import BridgeCollectionManager from '@/components/bridge/BridgeCollectionManager
 import ActionMenu from '@/components/ActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 
 defineOptions({
   layout: BridgePageLayout
@@ -412,28 +413,35 @@ function relationshipMutationBaseUrl(relationship) {
     <!-- Content -->
     <div class="flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-950">
       <!-- Error -->
-      <div v-if="error" class="flex h-full items-center justify-center">
-        <div class="text-center">
-          <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+      <ErrorState
+        v-if="error"
+        as="section"
+        aria-labelledby="bridge-record-error-title"
+        class="h-full gap-0 p-0"
+      >
+        <div
+          class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+        >
+          <svg
+            class="h-8 w-8 text-red-500 dark:text-red-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
           >
-            <svg
-              class="h-8 w-8 text-red-500 dark:text-red-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
-          </div>
-          <p class="mt-4 text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
         </div>
-      </div>
+        <h1 id="bridge-record-error-title" class="sr-only">
+          This record could not load
+        </h1>
+        <p class="mt-4 text-sm text-red-600 dark:text-red-400">{{ error }}</p>
+      </ErrorState>
 
       <!-- Record detail -->
       <div v-else-if="record && modelMeta" class="p-4 sm:p-6">

--- a/assets/js/pages/projects/bridge.vue
+++ b/assets/js/pages/projects/bridge.vue
@@ -7,6 +7,7 @@ import BridgeDashboard from '@/components/bridge/BridgeDashboard.vue'
 import BridgePageHeader from '@/components/bridge/BridgePageHeader.vue'
 import Select from '@/components/ui/select/Select.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 
 defineOptions({
   layout: BridgePageLayout
@@ -179,55 +180,62 @@ function switchDashboard(id) {
       </div>
 
       <!-- Error -->
-      <div
+      <ErrorState
         v-else-if="modelsError"
-        class="flex h-full items-center justify-center"
+        as="section"
+        aria-labelledby="bridge-models-error-title"
+        data-test="bridge-models-error"
+        class="h-full gap-0 p-0"
       >
-        <div class="text-center">
-          <div
-            class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+        <div
+          class="mx-auto flex h-16 w-16 items-center justify-center rounded-2xl bg-red-50 dark:bg-red-950/30"
+        >
+          <svg
+            class="h-8 w-8 text-red-500 dark:text-red-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
           >
-            <svg
-              class="h-8 w-8 text-red-500 dark:text-red-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="1.5"
-                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
-              />
-            </svg>
-          </div>
-          <h3 class="mt-4 text-sm font-medium text-gray-900 dark:text-white">
-            Failed to load models
-          </h3>
-          <p class="mt-1 max-w-sm text-sm text-gray-500 dark:text-gray-400">
-            {{ modelsError }}
-          </p>
-          <button
-            @click="refresh"
-            class="mt-4 inline-flex items-center gap-1.5 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
-          >
-            <svg
-              class="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
-              />
-            </svg>
-            Retry
-          </button>
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="1.5"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+            />
+          </svg>
         </div>
-      </div>
+        <h2
+          id="bridge-models-error-title"
+          class="mt-4 text-sm font-medium text-gray-900 dark:text-white"
+        >
+          Failed to load models
+        </h2>
+        <p class="mt-1 max-w-sm text-sm text-gray-500 dark:text-gray-400">
+          {{ modelsError }}
+        </p>
+        <button
+          type="button"
+          class="mt-4 inline-flex cursor-pointer items-center gap-1.5 rounded-lg bg-gray-900 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+          @click="refresh"
+        >
+          <svg
+            class="h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15"
+            />
+          </svg>
+          Retry
+        </button>
+      </ErrorState>
 
       <!-- No models -->
       <div

--- a/assets/js/pages/projects/content-manager.vue
+++ b/assets/js/pages/projects/content-manager.vue
@@ -4,6 +4,7 @@ import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, onMounted, onUnmounted } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
+import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
@@ -304,20 +305,27 @@ function refresh() {
         </div>
 
         <!-- Error -->
-        <div
+        <ErrorState
           v-else-if="collectionsError"
-          class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 dark:border-red-900/50 dark:bg-red-950/20"
+          as="section"
+          aria-labelledby="content-collections-error-title"
+          data-test="content-collections-error"
+          class="min-h-0 items-start gap-0 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-left dark:border-red-900/50 dark:bg-red-950/20"
         >
+          <h2 id="content-collections-error-title" class="sr-only">
+            Content collections could not load
+          </h2>
           <p class="text-sm text-red-700 dark:text-red-400">
             {{ collectionsError }}
           </p>
           <button
+            type="button"
+            class="mt-2 cursor-pointer text-sm text-red-600 underline hover:text-red-500 dark:text-red-400"
             @click="refresh"
-            class="mt-2 text-sm text-red-600 underline hover:text-red-500 dark:text-red-400"
           >
             Try again
           </button>
-        </div>
+        </ErrorState>
 
         <!-- Collections -->
         <div v-else-if="collections.length > 0" class="space-y-6">

--- a/tests/e2e/pages/error-pages.test.js
+++ b/tests/e2e/pages/error-pages.test.js
@@ -42,6 +42,12 @@ test(
           await expect(page).toSee(headline)
           await expect(page).toSee('Slipway')
           expect(await hasDurableErrorLayout(page, status)).toBe(true)
+          await expect(
+            page.raw.locator('[data-slot="error-state"]')
+          ).toHaveCount(1)
+          await expect(
+            page.raw.locator('[data-slot="error-state"]')
+          ).not.toHaveAttribute('role', 'alert')
           expect(await hasVisibleSlippy(page)).toBe(true)
           if (viewport === 'mobile') {
             expect(await isSlippyAboveHeading(page)).toBe(true)

--- a/tests/e2e/pages/error-state.test.js
+++ b/tests/e2e/pages/error-state.test.js
@@ -1,0 +1,239 @@
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+
+const { test } = require('sounding')
+
+async function stubUpdateCheck(page) {
+  await page.raw.route('**/api/v1/system/check-update', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ updateAvailable: false })
+    })
+  })
+}
+
+test(
+  'Klean Error State announces one dynamic Bosun failure and retries the same database',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    const requestedDatabases = []
+
+    await stubUpdateCheck(page)
+    await page.raw.route('**/api/v1/bosun/diff?**', async (route) => {
+      const database = new URL(route.request().url()).searchParams.get(
+        'database'
+      )
+      requestedDatabases.push(database)
+
+      if (requestedDatabases.length < 3) {
+        await route.fulfill({
+          status: 503,
+          contentType: 'application/json',
+          body: JSON.stringify({ error: 'Schema service unavailable.' })
+        })
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          modelCount: 1,
+          hasPendingChanges: false,
+          statements: []
+        })
+      })
+    })
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.raw.waitForURL((url) => !url.pathname.startsWith('/login'), {
+      timeout: 10000
+    })
+    await page.resize(1440, 900)
+    await page.goto('/bosun')
+
+    const firstDiff = page.raw.waitForResponse((response) =>
+      response.url().includes('/api/v1/bosun/diff?')
+    )
+    await page.raw.getByRole('tab', { name: 'Migrate' }).click()
+    await firstDiff
+
+    const panel = page.raw.getByRole('tabpanel', { name: 'Migrate' })
+    let alert = panel.getByRole('alert')
+    await expect(alert).toHaveAttribute('data-slot', 'error-state')
+    await expect(
+      alert.getByRole('heading', { name: 'Migrate diff failed' })
+    ).toBeVisible()
+    await expect(alert).toContainText('Schema service unavailable.')
+
+    const secondDiff = page.raw.waitForResponse((response) => {
+      const url = new URL(response.url())
+      return (
+        url.pathname === '/api/v1/bosun/diff' &&
+        url.searchParams.get('database') === 'observability'
+      )
+    })
+    await panel.getByRole('button', { name: 'observability' }).click()
+    await secondDiff
+    alert = panel.getByRole('alert')
+    await expect(alert).toBeVisible()
+
+    const retryDiff = page.raw.waitForResponse((response) => {
+      const url = new URL(response.url())
+      return (
+        url.pathname === '/api/v1/bosun/diff' &&
+        url.searchParams.get('database') === 'observability'
+      )
+    })
+    await alert.getByRole('button', { name: 'Try again' }).click()
+    await retryDiff
+    await expect(alert).not.toBeVisible()
+    await expect(panel.getByText('No pending schema changes')).toBeVisible()
+    expect(requestedDatabases).toEqual([
+      'app',
+      'observability',
+      'observability'
+    ])
+
+    expect(page).toHaveNoJavascriptErrors()
+  }
+)
+
+test(
+  'Klean Error State keeps Bridge recovery native and quiet on initial render',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'bridge-error-state',
+          name: 'Bridge Error State'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const originalIntrospectModels = sails.helpers.bridge.introspectModels
+    let shouldFail = true
+
+    await sails.models.app
+      .updateOne({ id: current.apps.web.id })
+      .set({ status: 'running', containerName: 'bridge-error-state-web' })
+    sails.helpers.bridge.introspectModels = async () =>
+      shouldFail
+        ? { error: 'Bridge could not inspect this application.' }
+        : { models: {}, dashboards: {} }
+
+    try {
+      await stubUpdateCheck(page)
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await page.raw.waitForURL((url) => !url.pathname.startsWith('/login'), {
+        timeout: 10000
+      })
+      const bridgePath = `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}/bridge`
+      await page.goto(bridgePath)
+
+      const region = page.raw.getByRole('region', {
+        name: 'Failed to load models'
+      })
+      await expect(region).toHaveAttribute('data-slot', 'error-state')
+      await expect(region).not.toHaveAttribute('role', 'alert')
+      await expect(region).toContainText(
+        'Bridge could not inspect this application.'
+      )
+
+      shouldFail = false
+      await region.getByRole('button', { name: 'Retry' }).click()
+      await expect(region).not.toBeVisible()
+      await expect(page.raw.getByText('No resources available')).toBeVisible()
+
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.helpers.bridge.introspectModels = originalIntrospectModels
+    }
+  }
+)
+
+test(
+  'Klean Error State hides private content paths and retries without losing context',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'content-error-state',
+          name: 'Content Error State'
+        }
+      }
+    }
+  },
+  async ({ sails, world, login, page, expect }) => {
+    const current = world.current
+    const originalAppsDir = sails.config.custom.slipwayAppsDir
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'slipway-content-error-state-')
+    )
+    const projectRoot = path.join(
+      tempRoot,
+      current.projects.deploymentTarget.slug
+    )
+    const brokenContentPath = path.join(projectRoot, 'broken-content')
+
+    fs.mkdirSync(projectRoot, { recursive: true })
+    fs.writeFileSync(brokenContentPath, 'This should be a directory.\n')
+    sails.config.custom.slipwayAppsDir = tempRoot
+    await sails.models.environment
+      .updateOne({ id: current.environments.production.id })
+      .set({
+        features: {
+          'sails-content': {
+            version: '1.0.0',
+            contentDir: 'broken-content'
+          }
+        }
+      })
+
+    try {
+      await stubUpdateCheck(page)
+      await login.withPassword('genesisUser', page, {
+        password: current.auth.genesisUserPassword
+      })
+      await page.raw.waitForURL((url) => !url.pathname.startsWith('/login'), {
+        timeout: 10000
+      })
+      const contentPath = `/projects/${current.projects.deploymentTarget.slug}/content?appSlug=${current.apps.web.slug}`
+      await page.goto(contentPath)
+
+      const region = page.raw.getByRole('region', {
+        name: 'Content collections could not load'
+      })
+      await expect(region).toHaveAttribute('data-slot', 'error-state')
+      await expect(region).toContainText(
+        'Slipway could not read this app’s content collections.'
+      )
+      await expect(region).not.toContainText(tempRoot)
+
+      fs.rmSync(brokenContentPath)
+      fs.mkdirSync(brokenContentPath)
+      await region.getByRole('button', { name: 'Try again' }).click()
+      await expect(region).not.toBeVisible()
+      await expect(
+        page.raw.getByRole('heading', { name: 'No content collections found' })
+      ).toBeVisible()
+
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.config.custom.slipwayAppsDir = originalAppsDir
+      fs.rmSync(tempRoot, { recursive: true, force: true })
+    }
+  }
+)


### PR DESCRIPTION
## Summary
- compose recoverable Bridge, Bosun, Content Manager, and HTTP status failures with the copied Klean Error State source
- keep initial/static failures quiet while announcing dynamic Bosun failures once and preserving native Retry ownership
- prevent private content filesystem paths from reaching the UI while retaining server-side diagnostics

## Verification
- `npm run lint`
- `git diff --check`
- `npx sounding test tests/e2e/pages/error-state.test.js`
- `npx sounding test tests/e2e/pages/error-pages.test.js`
- `npx sounding test tests/e2e/pages/projects/bridge-resource.test.js`
- `node ../klean-ui/bin/klean-ui.js check` (expected local-source notices across adopted components)

Closes #352