### PR TITLE
feat(ui): compose deployment slide with Klean Slide

### DIFF
--- a/assets/js/components/SlideToDeploy.vue
+++ b/assets/js/components/SlideToDeploy.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { ref, computed, onBeforeUnmount } from 'vue'
+import { computed, ref } from 'vue'
+import Slide from '@/components/ui/slide/Slide.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 
 const props = defineProps({
@@ -18,147 +19,70 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['deploy'])
-
-const slideTrack = ref(null)
-const slideProgress = ref(0)
-const isSliding = ref(false)
 const deploying = ref(false)
 
-const envLabel = computed(() => {
-  return (
-    props.environmentName || (props.isProduction ? 'production' : 'staging')
-  )
-})
+const envLabel = computed(
+  () => props.environmentName || (props.isProduction ? 'production' : 'staging')
+)
+const label = computed(() =>
+  deploying.value
+    ? `Sliding to ${envLabel.value}...`
+    : `Slide to ${envLabel.value}`
+)
 
-const thumbColor = computed(() => {
-  if (slideProgress.value < 0.33)
-    return 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-  if (slideProgress.value < 0.66) return 'bg-yellow-500 text-white'
-  return 'bg-green-500 text-white'
-})
+const slideClasses = [
+  'h-10 min-h-10 w-full border-gray-200 bg-gray-100 p-0.5 text-xs text-gray-400 shadow-none dark:border-gray-800 dark:bg-gray-900 dark:text-gray-500',
+  'data-[state=dragging]:cursor-grabbing data-[state=pending]:opacity-100',
+  '**:data-[slot=slide-fill]:bg-transparent',
+  '**:data-[slot=slide-label]:px-10 **:data-[slot=slide-label]:whitespace-nowrap',
+  '**:data-[slot=slide-thumb]:inset-s-0.5 **:data-[slot=slide-thumb]:top-0.5 **:data-[slot=slide-thumb]:size-9 **:data-[slot=slide-thumb]:shadow-lg',
+  '[&[data-progress=middle]_[data-slot=slide-fill]]:bg-yellow-500/10',
+  '[&[data-progress=middle]_[data-slot=slide-thumb]]:bg-yellow-500 [&[data-progress=middle]_[data-slot=slide-thumb]]:text-white',
+  '[&[data-progress=ready]_[data-slot=slide-fill]]:bg-green-500/10 [&[data-progress=complete]_[data-slot=slide-fill]]:bg-green-500/10',
+  '[&[data-progress=ready]_[data-slot=slide-thumb]]:bg-green-500 [&[data-progress=complete]_[data-slot=slide-thumb]]:bg-green-500',
+  '[&[data-progress=ready]_[data-slot=slide-thumb]]:text-white [&[data-progress=complete]_[data-slot=slide-thumb]]:text-white'
+].join(' ')
 
-const trackFill = computed(() => {
-  if (slideProgress.value < 0.33) return 'bg-transparent'
-  if (slideProgress.value < 0.66) return 'bg-yellow-500/10'
-  return 'bg-green-500/10'
-})
-
-const label = computed(() => {
-  if (deploying.value) return `Sliding to ${envLabel.value}...`
-  if (slideProgress.value > 0.85) return 'Release to confirm'
-  return `Slide to ${envLabel.value}`
-})
-
-let cleanupSlide = null
-
-function startSlide(e) {
+function deploy() {
   if (deploying.value || props.disabled) return
-  isSliding.value = true
-  const startX = e.type === 'touchstart' ? e.touches[0].clientX : e.clientX
-  const track = slideTrack.value
-  const maxSlide = track.offsetWidth - 40
 
-  const onMove = (moveEvent) => {
-    const currentX =
-      moveEvent.type === 'touchmove'
-        ? moveEvent.touches[0].clientX
-        : moveEvent.clientX
-    const delta = currentX - startX
-    slideProgress.value = Math.max(0, Math.min(1, delta / maxSlide))
-  }
-
-  const onEnd = () => {
-    isSliding.value = false
-    if (slideProgress.value > 0.85) {
-      slideProgress.value = 1
-      deploying.value = true
-      emit('deploy')
-    } else {
-      slideProgress.value = 0
-    }
-    cleanup()
-  }
-
-  const cleanup = () => {
-    document.removeEventListener('mousemove', onMove)
-    document.removeEventListener('mouseup', onEnd)
-    document.removeEventListener('touchmove', onMove)
-    document.removeEventListener('touchend', onEnd)
-    cleanupSlide = null
-  }
-
-  document.addEventListener('mousemove', onMove)
-  document.addEventListener('mouseup', onEnd)
-  document.addEventListener('touchmove', onMove)
-  document.addEventListener('touchend', onEnd)
-  cleanupSlide = cleanup
+  deploying.value = true
+  emit('deploy')
 }
-
-onBeforeUnmount(() => {
-  if (cleanupSlide) cleanupSlide()
-})
 
 function reset() {
   deploying.value = false
-  slideProgress.value = 0
 }
 
 defineExpose({ reset })
 </script>
 
 <template>
-  <div
-    ref="slideTrack"
-    :class="[
-      'relative h-10 select-none overflow-hidden rounded-full border',
-      'border-gray-200 bg-gray-100 dark:border-gray-800 dark:bg-gray-900',
-      disabled ? 'cursor-not-allowed opacity-50' : ''
-    ]"
+  <Slide
+    :pending="deploying"
+    :disabled="disabled"
+    :class="slideClasses"
+    @confirm="deploy"
   >
-    <!-- Track fill (grows from left as thumb slides right) -->
-    <div
-      class="absolute inset-y-0 left-0"
-      :class="[trackFill, { 'transition-[width] duration-300': !isSliding }]"
-      :style="{ width: `${slideProgress * 100}%` }"
-    ></div>
+    {{ label }}
 
-    <!-- Label -->
-    <span
-      class="pointer-events-none absolute inset-0 flex items-center justify-center text-xs font-medium text-gray-400 dark:text-gray-500"
-    >
-      {{ label }}
-    </span>
-
-    <!-- Thumb (starts at left, slides right) -->
-    <div
-      class="absolute bottom-0.5 top-0.5 flex w-10 items-center justify-center rounded-full shadow-lg"
-      :class="[
-        deploying
-          ? 'cursor-not-allowed bg-green-500 text-white'
-          : thumbColor + ' cursor-grab active:cursor-grabbing',
-        { 'transition-all duration-300 ease-out': !isSliding }
-      ]"
-      :style="{
-        left: `calc(${slideProgress * 100}% - ${slideProgress * 2.5}rem)`
-      }"
-      @mousedown.prevent="startSlide"
-      @touchstart.prevent="startSlide"
-    >
+    <template #thumb="{ pending }">
+      <Spinner v-if="pending" class="size-4" />
       <svg
-        v-if="!deploying"
-        class="h-4 w-4"
+        v-else
+        class="size-4 rtl:rotate-180"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <path
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="2"
-          d="M9 5l7 7-7 7"
+          d="m9 5 7 7-7 7"
         />
       </svg>
-      <Spinner v-else class="h-4 w-4" />
-    </div>
-  </div>
+    </template>
+  </Slide>
 </template>

--- a/assets/js/components/ui/slide/Slide.vue
+++ b/assets/js/components/ui/slide/Slide.vue
@@ -1,0 +1,359 @@
+<script setup>
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  /** Prevents pointer and native button activation. */
+  disabled: { type: Boolean, default: false },
+  /** Truthful caller-owned action state. Also prevents duplicate confirmation. */
+  pending: { type: Boolean, default: false }
+})
+
+const emit = defineEmits(['confirm'])
+const attrs = useAttrs()
+const button = ref()
+const thumb = ref()
+const progress = ref(0)
+const travel = ref(0)
+const direction = ref(1)
+const pointerId = ref()
+const startX = ref(0)
+const startProgress = ref(0)
+const confirmed = ref(false)
+const status = ref('')
+let suppressClick = false
+let resizeObserver
+
+const CONFIRM_THRESHOLD = 0.85
+
+const baseClasses = [
+  'group/slide relative inline-grid min-h-11 w-56 max-w-full touch-none cursor-grab select-none overflow-hidden rounded-full border border-gray-300 bg-gray-100 p-1 text-sm font-medium text-gray-700 shadow-sm outline-none',
+  'focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2',
+  'disabled:cursor-not-allowed disabled:opacity-50',
+  'aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+  'dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 dark:focus-visible:ring-white'
+]
+
+const fillClasses = [
+  'pointer-events-none absolute inset-y-0 inset-s-0 bg-gray-200',
+  'transition-[width,background-color] duration-200 ease-out group-data-[state=dragging]/slide:transition-none motion-reduce:transition-none',
+  'dark:bg-gray-800'
+]
+
+const thumbClasses = [
+  'pointer-events-none absolute top-1 inset-s-1 z-20 flex size-9 items-center justify-center rounded-full bg-gray-950 text-white shadow-sm',
+  'transition-[transform,background-color,color] duration-200 ease-out group-data-[state=dragging]/slide:transition-none motion-reduce:transition-none',
+  'dark:bg-white dark:text-gray-950'
+]
+
+const isDragging = computed(() => pointerId.value !== undefined)
+const isReady = computed(() => progress.value >= CONFIRM_THRESHOLD)
+const state = computed(() =>
+  props.pending
+    ? 'pending'
+    : isDragging.value
+    ? 'dragging'
+    : confirmed.value
+    ? 'confirmed'
+    : 'idle'
+)
+const progressState = computed(() => {
+  if (props.pending || confirmed.value) return 'complete'
+  if (progress.value >= CONFIRM_THRESHOLD) return 'ready'
+  if (progress.value >= 0.33) return 'middle'
+  return 'start'
+})
+const buttonClasses = computed(() => twMerge(baseClasses, attrs.class))
+const buttonAttrs = computed(() => {
+  const {
+    class: _class,
+    type: _type,
+    disabled: _disabled,
+    'aria-busy': _ariaBusy,
+    'aria-disabled': _ariaDisabled,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-progress': _dataProgress,
+    onClick: _onClick,
+    onKeydown: _onKeydown,
+    onKeyDown: _onKeyDown,
+    onPointerdown: _onPointerdown,
+    onPointerDown: _onPointerDown,
+    onPointermove: _onPointermove,
+    onPointerMove: _onPointerMove,
+    onPointerup: _onPointerup,
+    onPointerUp: _onPointerUp,
+    onPointercancel: _onPointercancel,
+    onPointerCancel: _onPointerCancel,
+    onLostpointercapture: _onLostPointercapture,
+    onLostPointerCapture: _onLostPointerCapture,
+    ...rest
+  } = attrs
+
+  return rest
+})
+const thumbStyle = computed(() => ({
+  transform: `translateX(${direction.value * progress.value * travel.value}px)`
+}))
+const fillStyle = computed(() => ({ width: `${progress.value * 100}%` }))
+
+function callListener(listener, event) {
+  for (const callback of Array.isArray(listener) ? listener : [listener]) {
+    callback?.(event)
+  }
+}
+
+function measure() {
+  if (!button.value || !thumb.value || typeof getComputedStyle === 'undefined')
+    return
+
+  const buttonStyle = getComputedStyle(button.value)
+  const thumbStyle = getComputedStyle(thumb.value)
+  const inlineStart = Number.parseFloat(thumbStyle.insetInlineStart) || 0
+
+  direction.value =
+    button.value.dir === 'rtl' || buttonStyle.direction === 'rtl' ? -1 : 1
+  travel.value = Math.max(
+    0,
+    button.value.clientWidth - thumb.value.offsetWidth - inlineStart * 2
+  )
+}
+
+function setProgress(nextProgress) {
+  const wasReady = isReady.value
+  progress.value = Math.max(0, Math.min(1, nextProgress))
+
+  if (!wasReady && isReady.value) status.value = 'Release to confirm.'
+  else if (wasReady && !isReady.value) status.value = 'Keep sliding.'
+}
+
+function clearPointer(releaseCapture = true) {
+  const activePointer = pointerId.value
+  pointerId.value = undefined
+
+  if (
+    releaseCapture &&
+    activePointer !== undefined &&
+    button.value?.hasPointerCapture?.(activePointer)
+  ) {
+    button.value.releasePointerCapture(activePointer)
+  }
+}
+
+function reset(nextStatus = '') {
+  clearPointer()
+  confirmed.value = false
+  progress.value = 0
+  status.value = nextStatus
+}
+
+function cancel() {
+  if (!isDragging.value) return
+  reset('Slide cancelled.')
+}
+
+function confirm() {
+  if (props.disabled || props.pending || confirmed.value) return
+
+  clearPointer()
+  confirmed.value = true
+  progress.value = 1
+  status.value = 'Confirmed.'
+  emit('confirm')
+
+  nextTick(() => {
+    if (!props.pending) reset()
+  })
+}
+
+function handlePointerdown(event) {
+  callListener(attrs.onPointerdown ?? attrs.onPointerDown, event)
+  if (
+    event.defaultPrevented ||
+    props.disabled ||
+    props.pending ||
+    !event.isPrimary ||
+    (event.pointerType === 'mouse' && event.button !== 0)
+  ) {
+    return
+  }
+
+  event.preventDefault()
+  button.value?.focus({ preventScroll: true })
+  measure()
+  confirmed.value = false
+  pointerId.value = event.pointerId
+  startX.value = event.clientX
+  startProgress.value = progress.value
+  status.value = 'Sliding. Move to the end, then release to confirm.'
+  button.value?.setPointerCapture?.(event.pointerId)
+}
+
+function handlePointermove(event) {
+  callListener(attrs.onPointermove ?? attrs.onPointerMove, event)
+  if (event.pointerId !== pointerId.value || event.defaultPrevented) return
+
+  event.preventDefault()
+  measure()
+  const delta = direction.value * (event.clientX - startX.value)
+  setProgress(startProgress.value + (travel.value ? delta / travel.value : 0))
+}
+
+function handlePointerup(event) {
+  callListener(attrs.onPointerup ?? attrs.onPointerUp, event)
+  if (event.pointerId !== pointerId.value) return
+
+  suppressClick = true
+  queueMicrotask(() => {
+    suppressClick = false
+  })
+  if (isReady.value && !event.defaultPrevented) confirm()
+  else reset('Slide cancelled.')
+}
+
+function handlePointercancel(event) {
+  callListener(attrs.onPointercancel ?? attrs.onPointerCancel, event)
+  if (event.pointerId === pointerId.value) reset('Slide cancelled.')
+}
+
+function handleLostPointercapture(event) {
+  callListener(attrs.onLostpointercapture ?? attrs.onLostPointerCapture, event)
+  if (event.pointerId === pointerId.value) reset('Slide cancelled.')
+}
+
+function handleClick(event) {
+  if (suppressClick) {
+    suppressClick = false
+    event.preventDefault()
+    return
+  }
+
+  if (props.disabled || props.pending) {
+    event.preventDefault()
+    return
+  }
+
+  if (event.detail !== 0) {
+    event.preventDefault()
+    return
+  }
+
+  callListener(attrs.onClick, event)
+  if (!event.defaultPrevented) confirm()
+}
+
+function handleKeydown(event) {
+  callListener(attrs.onKeydown ?? attrs.onKeyDown, event)
+  if (event.defaultPrevented || event.key !== 'Escape') return
+
+  cancel()
+}
+
+watch(
+  () => props.pending,
+  (pending, wasPending) => {
+    if (pending) {
+      clearPointer()
+      confirmed.value = true
+      progress.value = 1
+      status.value = 'Action in progress.'
+    } else if (wasPending) {
+      reset()
+    }
+  },
+  { immediate: true }
+)
+
+watch(
+  () => props.disabled,
+  (disabled) => {
+    if (disabled) cancel()
+  }
+)
+
+onMounted(() => {
+  measure()
+  if (typeof ResizeObserver === 'undefined') return
+
+  resizeObserver = new ResizeObserver(measure)
+  if (button.value) resizeObserver.observe(button.value)
+  if (thumb.value) resizeObserver.observe(thumb.value)
+})
+
+onBeforeUnmount(() => {
+  clearPointer()
+  resizeObserver?.disconnect()
+})
+</script>
+
+<template>
+  <button
+    ref="button"
+    v-bind="buttonAttrs"
+    type="button"
+    :disabled="disabled"
+    :aria-busy="pending ? 'true' : attrs['aria-busy']"
+    :aria-disabled="pending ? 'true' : attrs['aria-disabled']"
+    data-slot="slide"
+    :data-state="state"
+    :data-progress="progressState"
+    :class="buttonClasses"
+    @click="handleClick"
+    @keydown="handleKeydown"
+    @pointerdown="handlePointerdown"
+    @pointermove="handlePointermove"
+    @pointerup="handlePointerup"
+    @pointercancel="handlePointercancel"
+    @lostpointercapture="handleLostPointercapture"
+  >
+    <span
+      aria-hidden="true"
+      data-slot="slide-fill"
+      :class="fillClasses"
+      :style="fillStyle"
+    />
+    <span
+      data-slot="slide-label"
+      class="pointer-events-none relative z-10 flex min-w-0 items-center justify-center px-11 text-center"
+    >
+      <span v-if="isReady && !pending">Release to confirm</span>
+      <slot v-else />
+    </span>
+    <span
+      ref="thumb"
+      aria-hidden="true"
+      data-slot="slide-thumb"
+      :class="thumbClasses"
+      :style="thumbStyle"
+    >
+      <slot name="thumb" :pending="pending" :progress="progressState">
+        <svg
+          class="size-4 rtl:rotate-180"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+        >
+          <path
+            d="m9 5 7 7-7 7"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </slot>
+    </span>
+    <span data-slot="slide-status" class="sr-only" aria-live="polite">
+      {{ status }}
+    </span>
+  </button>
+</template>

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -1469,7 +1469,7 @@ onBeforeUnmount(() => {
               ref="slideRef"
               :is-production="environment.isProduction"
               :environment-name="environment.name"
-              :disabled="deploying || !checklistAllGood || !sourceIsReady"
+              :disabled="!checklistAllGood || !sourceIsReady"
               @deploy="triggerDeploy"
             />
           </div>

--- a/assets/js/pages/projects/environment.vue
+++ b/assets/js/pages/projects/environment.vue
@@ -1571,7 +1571,6 @@ onBeforeUnmount(() => {
                             "
                             :is-production="environment.isProduction"
                             :environment-name="environment.name"
-                            :disabled="deployingAppId === appItem.id"
                             @deploy="deployApp(appItem)"
                           />
                           <Alert

--- a/tests/e2e/pages/projects/slide.test.js
+++ b/tests/e2e/pages/projects/slide.test.js
@@ -1,0 +1,190 @@
+const fs = require('node:fs')
+const os = require('node:os')
+const path = require('node:path')
+const { test } = require('sounding')
+
+test(
+  'deployment slide keeps pointer friction optional and pending state truthful',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'klean-slide-deployment',
+          name: 'Klean Slide deployment'
+        }
+      }
+    }
+  },
+  async ({ sails, world, page, expect }) => {
+    const current = world.current
+    const project = current.projects.deploymentTarget
+    const environment = current.environments.production
+    const app = current.apps.web
+    const originalAppsDir = sails.config.custom.slipwayAppsDir
+    const appsRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'slipway-slide-'))
+    const sourceRoot = path.join(appsRoot, project.slug)
+
+    fs.mkdirSync(sourceRoot, { recursive: true })
+    fs.writeFileSync(
+      path.join(sourceRoot, 'package.json'),
+      JSON.stringify({ name: 'slide-source', private: true })
+    )
+    sails.config.custom.slipwayAppsDir = appsRoot
+
+    try {
+      await sails.models.environment.updateOne({ id: environment.id }).set({
+        isProduction: false,
+        envVars: { SESSION_SECRET: 'sounding-slide-secret' }
+      })
+
+      await page.raw.route('**/api/v1/system/check-update', async (route) => {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ updateAvailable: false })
+        })
+      })
+      await page.raw.addInitScript(() => {
+        window.EventSource = class MockEventSource {
+          constructor() {
+            setTimeout(() => this.onopen?.(), 0)
+          }
+
+          close() {}
+        }
+      })
+
+      let deploymentRequests = 0
+      let announceFirstRequest
+      const firstRequest = new Promise((resolve) => {
+        announceFirstRequest = resolve
+      })
+      let releaseFirstRequest
+      const firstRequestRelease = new Promise((resolve) => {
+        releaseFirstRequest = resolve
+      })
+
+      await page.raw.route(
+        `**/api/v1/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/deploy`,
+        async (route) => {
+          deploymentRequests += 1
+          if (deploymentRequests === 1) {
+            announceFirstRequest()
+            await firstRequestRelease
+          }
+
+          await route.fulfill({
+            status: 503,
+            contentType: 'application/json',
+            body: JSON.stringify({ message: 'Deployment service unavailable' })
+          })
+        }
+      )
+
+      await page.goto('/login')
+      const csrf = await page.raw.evaluate(
+        () => window.__SLIPWAY_CSRF_TOKEN__ || ''
+      )
+      const loginResponse = await page.raw.request.post('/login', {
+        headers: { 'x-csrf-token': csrf },
+        form: {
+          email: current.users.genesisUser.email,
+          password: current.auth.genesisUserPassword
+        }
+      })
+      if (!loginResponse.ok()) {
+        throw new Error(
+          `Browser session setup failed (${loginResponse.status()}): ${await loginResponse.text()}`
+        )
+      }
+      await page.goto(
+        `/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}`
+      )
+
+      const slide = page.raw.locator('[data-slot="slide"]')
+      await expect(slide).toBeVisible()
+      await expect(slide).toHaveAccessibleName('Slide to Production')
+      await expect(slide).toHaveAttribute('data-slot', 'slide')
+      await expect(slide).toHaveAttribute('type', 'button')
+
+      const bounds = await slide.boundingBox()
+      if (!bounds) throw new Error('Slide geometry was unavailable')
+
+      await page.raw.mouse.move(bounds.x + 20, bounds.y + bounds.height / 2)
+      await page.raw.mouse.down()
+      await page.raw.mouse.move(bounds.x + bounds.width * 0.45, bounds.y + 20)
+      await page.raw.mouse.up()
+      expect(deploymentRequests).toBe(0)
+      await expect(slide).toHaveAttribute('data-progress', 'start')
+      await expect(slide).toBeFocused()
+
+      await page.raw.mouse.move(bounds.x + 20, bounds.y + bounds.height / 2)
+      await page.raw.mouse.down()
+      await page.raw.mouse.move(bounds.x + bounds.width - 5, bounds.y + 20)
+      await page.raw.mouse.up()
+      await firstRequest
+
+      expect(deploymentRequests).toBe(1)
+      await expect(slide).toBeDisabled()
+      await expect(slide).toHaveAttribute('aria-busy', 'true')
+      await expect(slide).toHaveAttribute('data-progress', 'complete')
+      await expect(slide).toContainText('Sliding to Production...')
+      await expect(
+        slide.locator('[data-slot="slide-thumb"] [data-slot="spinner"]')
+      ).toBeVisible()
+
+      await slide.press('Enter')
+      expect(deploymentRequests).toBe(1)
+
+      releaseFirstRequest()
+      await expect(slide).toBeEnabled()
+      await expect(slide).toContainText('Slide to Production')
+      await expect(slide).toHaveAttribute('data-progress', 'start')
+      await expect(slide).toBeFocused()
+
+      const keyboardResponse = page.raw.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST' &&
+          new URL(response.url()).pathname ===
+            `/api/v1/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/deploy`
+      )
+      await slide.press('Enter')
+      await keyboardResponse
+      expect(deploymentRequests).toBe(2)
+      await expect(slide).toBeEnabled()
+      await expect(slide).toBeFocused()
+
+      await page.goto(
+        `/projects/${project.slug}/environments/${environment.slug}?apps=1`
+      )
+      await page.raw.locator(`[data-test="app-actions-${app.slug}"]`).click()
+
+      const environmentSlide = page.raw
+        .locator(`[data-test="app-action-menu-${app.slug}"]`)
+        .locator('[data-slot="slide"]')
+      await expect(environmentSlide).toBeVisible()
+      await expect(environmentSlide).toHaveAccessibleName('Slide to Production')
+
+      const environmentResponse = page.raw.waitForResponse(
+        (response) =>
+          response.request().method() === 'POST' &&
+          new URL(response.url()).pathname ===
+            `/api/v1/projects/${project.slug}/environments/${environment.slug}/apps/${app.slug}/deploy`
+      )
+      await environmentSlide.focus()
+      await environmentSlide.press('Enter')
+      await environmentResponse
+
+      expect(deploymentRequests).toBe(3)
+      await expect(environmentSlide).toBeEnabled()
+      await expect(environmentSlide).toBeFocused()
+
+      expect(page).toHaveNoJavascriptErrors()
+    } finally {
+      sails.config.custom.slipwayAppsDir = originalAppsDir
+      fs.rmSync(appsRoot, { recursive: true, force: true })
+    }
+  }
+)


### PR DESCRIPTION
## What changed

- replace Slipway's document-level mouse/touch drag engine with copied Klean Slide source
- keep Slipway's existing deployment wording and yellow/green progress treatment as ordinary caller Tailwind
- preserve the animated Slippy mascot inside the pending thumb
- use declarative pending state instead of duplicate external disabling so focus survives deployment failure and reset
- cover both app and environment call sites with one real browser trial

## Durable behavior verified

- below-threshold release cancels without deploying
- full pointer release emits exactly once
- pending blocks duplicate native activation
- keyboard activation works without dragging
- focus survives confirmation, pending, failure, and reset
- pending exposes busy state and the Slippy spinner
- both real Slipway call sites retain the same contract

## Verification

- focused Slide E2E: 1 passing trial across both call sites
- `npm run test:unit`: 321 passing
- `npm run test:functional`: 105 passing
- `npm run lint`
- `npm run check:consistency`
- zero-config `klean-ui add slide --overwrite`
- Klean Slide source is revision 3; no local behavior fork

Closes #479

Depends on sailscastshq/klean-ui#125 and sailscastshq/klean-ui#127.