### PR TITLE
feat(ui): compose confirmation flows with Klean Dialog

### DIFF
--- a/assets/js/components/ConfirmModal.vue
+++ b/assets/js/components/ConfirmModal.vue
@@ -1,5 +1,6 @@
 <script setup>
-import { watch, onUnmounted } from 'vue'
+import { useId } from 'vue'
+import Dialog from '@/components/ui/dialog/Dialog.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 
 const props = defineProps({
@@ -34,103 +35,68 @@ const props = defineProps({
 })
 
 const emit = defineEmits(['confirm', 'cancel'])
+const instanceId = useId()
+const titleId = `confirm-modal-title-${instanceId}`
+const messageId = `confirm-modal-message-${instanceId}`
 
-// Handle escape key to close modal
-function handleKeydown(e) {
-  if (e.key === 'Escape' && !props.loading) {
-    emit('cancel')
-  }
+function cancel() {
+  if (!props.loading) emit('cancel')
 }
 
-watch(
-  () => props.show,
-  (isShown) => {
-    if (isShown) {
-      document.addEventListener('keydown', handleKeydown)
-    } else {
-      document.removeEventListener('keydown', handleKeydown)
-    }
-  },
-  { immediate: true }
-)
+function confirm() {
+  if (!props.loading) emit('confirm')
+}
 
-onUnmounted(() => {
-  document.removeEventListener('keydown', handleKeydown)
-})
+function handleOpenChange(open) {
+  if (!open) cancel()
+}
 </script>
 
 <template>
-  <Teleport to="body">
-    <Transition
-      enter-active-class="transition duration-200 ease-out"
-      enter-from-class="opacity-0"
-      enter-to-class="opacity-100"
-      leave-active-class="transition duration-150 ease-in"
-      leave-from-class="opacity-100"
-      leave-to-class="opacity-0"
-    >
-      <div
-        v-if="show"
-        class="fixed inset-0 z-50 flex items-center justify-center"
+  <Dialog
+    :open="show"
+    :dismissible="!loading"
+    :aria-labelledby="titleId"
+    :aria-describedby="messageId"
+    :aria-busy="loading ? 'true' : undefined"
+    data-test="confirm-modal"
+    class="transition-discrete starting:open:scale-95 starting:open:opacity-0 starting:open:backdrop:bg-black/0 z-50 max-w-sm scale-95 border-gray-200 bg-white p-6 text-gray-950 opacity-0 shadow-xl transition-[display,overlay,opacity,transform] duration-200 ease-out backdrop:bg-black/0 backdrop:transition-colors backdrop:duration-200 open:scale-100 open:opacity-100 open:backdrop:bg-black/50 motion-reduce:transition-none dark:border-gray-700 dark:bg-gray-900 dark:text-white"
+    @update:open="handleOpenChange"
+  >
+    <h3 :id="titleId" class="text-lg font-semibold">
+      {{ title }}
+    </h3>
+    <p :id="messageId" class="mt-2 text-sm text-gray-500 dark:text-gray-400">
+      {{ message }}
+    </p>
+    <slot name="form" />
+    <div class="mt-4 flex justify-end gap-3">
+      <button
+        type="button"
+        autofocus
+        :disabled="loading"
+        class="cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        @click="cancel"
       >
-        <div
-          class="fixed inset-0 bg-black/50"
-          @click="!loading && emit('cancel')"
-        />
-        <Transition
-          enter-active-class="transition duration-200 ease-out"
-          enter-from-class="scale-95 opacity-0"
-          enter-to-class="scale-100 opacity-100"
-          leave-active-class="transition duration-150 ease-in"
-          leave-from-class="scale-100 opacity-100"
-          leave-to-class="scale-95 opacity-0"
-        >
-          <div
-            v-if="show"
-            data-test="confirm-modal"
-            role="dialog"
-            aria-modal="true"
-            aria-labelledby="confirm-modal-title"
-            class="relative w-full max-w-sm rounded-lg border border-gray-200 bg-white p-6 shadow-xl dark:border-gray-700 dark:bg-gray-900"
-          >
-            <h3
-              id="confirm-modal-title"
-              class="text-lg font-semibold text-gray-900 dark:text-white"
-            >
-              {{ title }}
-            </h3>
-            <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
-              {{ message }}
-            </p>
-            <slot name="form" />
-            <div class="mt-4 flex justify-end space-x-3">
-              <button
-                @click="emit('cancel')"
-                :disabled="loading"
-                class="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-              >
-                {{ cancelLabel }}
-              </button>
-              <button
-                @click="emit('confirm')"
-                :disabled="loading"
-                :class="[
-                  'rounded-md px-3 py-1.5 text-sm font-medium text-white disabled:opacity-50',
-                  destructive
-                    ? 'bg-red-600 hover:bg-red-700'
-                    : 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
-                ]"
-              >
-                <span v-if="loading" class="flex items-center gap-2">
-                  <Spinner class="h-4 w-4" />
-                  Loading...
-                </span>
-                <span v-else>{{ confirmLabel }}</span>
-              </button>
-            </div>
-          </div>
-        </Transition>
-      </div>
-    </Transition>
-  </Teleport>
+        {{ cancelLabel }}
+      </button>
+      <button
+        type="button"
+        :disabled="loading"
+        :class="[
+          'cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50',
+          destructive
+            ? 'bg-red-600 hover:bg-red-700'
+            : 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
+        ]"
+        @click="confirm"
+      >
+        <span v-if="loading" class="flex items-center gap-2">
+          <Spinner class="size-4" />
+          Loading...
+        </span>
+        <span v-else>{{ confirmLabel }}</span>
+      </button>
+    </div>
+  </Dialog>
 </template>

--- a/assets/js/components/ui/dialog/Dialog.vue
+++ b/assets/js/components/ui/dialog/Dialog.vue
@@ -13,9 +13,13 @@ import { twMerge } from 'tailwind-merge'
 defineOptions({ inheritAttrs: false })
 
 const props = defineProps({
+  /** The native id targeted by a button's `commandfor` attribute. */
   id: { type: String, default: undefined },
+  /** Framework-native controlled state. Omit for native uncontrolled use. */
   open: { type: Boolean, default: undefined },
+  /** Initial state when `open` is not controlled. */
   defaultOpen: { type: Boolean, default: false },
+  /** Whether Escape, platform dismissal, and backdrop clicks may close it. */
   dismissible: { type: Boolean, default: true }
 })
 
@@ -62,6 +66,22 @@ let previousDocumentOverflow = ''
 let scrollLocked = false
 let fallbackInvoker
 
+function resolveInvoker(source, element) {
+  const activeElement =
+    typeof document === 'undefined' ? undefined : document.activeElement
+
+  return [source, activeElement].find(
+    (candidate) =>
+      candidate &&
+      candidate !== document.body &&
+      candidate !== document.documentElement &&
+      candidate !== element &&
+      !element.contains(candidate) &&
+      candidate.isConnected &&
+      typeof candidate.focus === 'function'
+  )
+}
+
 function callListener(listener, event) {
   for (const callback of Array.isArray(listener) ? listener : [listener]) {
     callback?.(event)
@@ -95,7 +115,7 @@ function showModal(source) {
   const element = dialog.value
   if (!element || element.open) return
 
-  fallbackInvoker = source
+  fallbackInvoker = resolveInvoker(source, element)
   element.showModal()
   observeNativeOpen(true)
 }

--- a/assets/js/pages/dashboard/profile.vue
+++ b/assets/js/pages/dashboard/profile.vue
@@ -464,10 +464,13 @@ function logout() {
     >
       <template #form>
         <div class="mt-4">
-          <label class="mb-1 block text-sm text-gray-700 dark:text-gray-300"
+          <label
+            for="delete-account-password"
+            class="mb-1 block text-sm text-gray-700 dark:text-gray-300"
             >Enter your password to confirm</label
           >
           <Input
+            id="delete-account-password"
             v-model="deleteAccountForm.password"
             type="password"
             autocomplete="current-password"

--- a/tests/e2e/pages/confirm-modal.test.js
+++ b/tests/e2e/pages/confirm-modal.test.js
@@ -1,0 +1,192 @@
+const { test } = require('sounding')
+
+test(
+  'confirmation dialogs use the native modal contract and return focus',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    const updateCheck = page.raw.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/v1/system/check-update'
+    )
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.raw.waitForURL((url) => url.pathname !== '/login')
+    await updateCheck
+    await page.goto('/profile')
+
+    const trigger = page.raw.getByRole('button', {
+      name: 'Delete account',
+      exact: true
+    })
+
+    await trigger.click()
+
+    const dialog = page.raw.getByRole('dialog', {
+      name: 'Delete account'
+    })
+    const cancel = dialog.getByRole('button', { name: 'Cancel', exact: true })
+
+    await expect(dialog).toBeVisible()
+    await expect(dialog).toHaveAttribute('data-slot', 'dialog')
+    await expect(dialog).toHaveAttribute('closedby', 'any')
+    await expect(dialog).not.toHaveAttribute('aria-busy', 'true')
+    await expect(cancel).toBeFocused()
+    await expect(
+      dialog.getByLabel('Enter your password to confirm')
+    ).toBeVisible()
+
+    const labelIds = await dialog.evaluate((element) => ({
+      labelledby: element.getAttribute('aria-labelledby'),
+      describedby: element.getAttribute('aria-describedby'),
+      title: document.getElementById(element.getAttribute('aria-labelledby'))
+        ?.textContent,
+      message: document.getElementById(element.getAttribute('aria-describedby'))
+        ?.textContent
+    }))
+    expect(labelIds.labelledby === 'confirm-modal-title').toBe(false)
+    expect(labelIds.title.trim()).toBe('Delete account')
+    expect(labelIds.message).toContain('permanently removed')
+
+    await page.raw.keyboard.press('Escape')
+    await expect(dialog).toBeHidden()
+    await expect(trigger).toBeFocused()
+
+    await trigger.click()
+    await expect(dialog).toBeVisible()
+    await page.raw.mouse.click(4, 4)
+    await expect(dialog).toBeHidden()
+    await expect(trigger).toBeFocused()
+
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'pending service confirmation stays busy, singular, and non-dismissible',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'klean-dialog-confirmation',
+          name: 'Klean Dialog confirmation'
+        }
+      }
+    }
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const service = await world.create('service').with({
+      name: 'primary-db',
+      type: 'postgresql',
+      version: '17',
+      status: 'running',
+      environment: current.environments.production.id,
+      internalHost: 'primary-db',
+      internalPort: 5432,
+      database: 'app',
+      username: 'slipway',
+      password: 'secret'
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await page.raw.addInitScript(() => {
+      window.EventSource = class MockEventSource {
+        constructor() {
+          setTimeout(() => this.onopen?.(), 0)
+        }
+
+        close() {}
+      }
+    })
+
+    let deletionRequests = 0
+    let announceDeletion
+    const deletionStarted = new Promise((resolve) => {
+      announceDeletion = resolve
+    })
+    let releaseDeletion
+    const deletionRelease = new Promise((resolve) => {
+      releaseDeletion = resolve
+    })
+
+    await page.raw.route(`**/api/v1/services/${service.id}`, async (route) => {
+      if (route.request().method() !== 'DELETE') {
+        await route.continue()
+        return
+      }
+
+      deletionRequests += 1
+      announceDeletion()
+      await deletionRelease
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ deleted: true })
+      })
+    })
+
+    const updateCheck = page.raw.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheck
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}`
+    )
+
+    await page.raw.getByRole('button', { name: /Services/ }).click()
+    await page.raw
+      .getByRole('button', { name: 'Actions for primary-db' })
+      .click()
+    await page.raw
+      .getByRole('menu', { name: 'Actions for primary-db' })
+      .getByRole('menuitem', { name: 'Delete', exact: true })
+      .click()
+
+    const dialog = page.raw.getByRole('dialog', { name: 'Delete service' })
+    const cancel = dialog.locator('button').first()
+    const confirm = dialog.locator('button').last()
+
+    await expect(dialog).toBeVisible()
+    await confirm.click()
+    await deletionStarted
+
+    expect(deletionRequests).toBe(1)
+    await expect(dialog).toHaveAttribute('aria-busy', 'true')
+    await expect(dialog).toHaveAttribute('closedby', 'none')
+    await expect(confirm).toBeDisabled()
+    await expect(cancel).toBeDisabled()
+    await expect(dialog.locator('[data-slot="spinner"]')).toBeVisible()
+
+    await page.raw.keyboard.press('Escape')
+    await page.raw.mouse.click(4, 4)
+    await expect(dialog).toBeVisible()
+    expect(deletionRequests).toBe(1)
+
+    releaseDeletion()
+    await expect(dialog).toBeHidden()
+    expect(deletionRequests).toBe(1)
+
+    expect(page).toHaveNoSmoke()
+  }
+)

--- a/tests/e2e/pages/projects/helm.test.js
+++ b/tests/e2e/pages/projects/helm.test.js
@@ -315,9 +315,11 @@ test(
 
     await page.click('@helm-scratchpad-actions-trigger')
     await page.click('@helm-scratchpad-actions-close')
-    await page.wait('@confirm-modal')
-    await page.raw
-      .locator('[data-test="confirm-modal"]')
+    const closeScratchpadDialog = page.raw.locator(
+      '[data-test="confirm-modal"][open]'
+    )
+    await closeScratchpadDialog.waitFor()
+    await closeScratchpadDialog
       .getByRole('button', { name: 'Close scratchpad', exact: true })
       .click()
     expect(await tabs.count()).toBe(2)
@@ -386,7 +388,7 @@ test(
     expect((await foreignTab.textContent()).includes('Production')).toBe(true)
     await foreignTab.click()
     await page.raw
-      .locator('[data-test="confirm-modal"]')
+      .locator('[data-test="confirm-modal"][open]')
       .waitFor({ state: 'visible' })
     expect(page).toSee('Open production scratchpad?')
     expect(page).toSee('Billing / Production / billing.app')
@@ -1242,13 +1244,14 @@ test(
     await page.wait(250)
 
     await page.click('@helm-clear-history')
-    await page.raw.locator('[data-test="confirm-modal"]').waitFor()
-    await page.raw
+    const clearHistoryDialog = page.raw.locator(
+      '[data-test="confirm-modal"][open]'
+    )
+    await clearHistoryDialog.waitFor()
+    await clearHistoryDialog
       .getByRole('button', { name: 'Clear history', exact: true })
       .click()
-    await page.raw
-      .locator('[data-test="confirm-modal"]')
-      .waitFor({ state: 'detached' })
+    await clearHistoryDialog.waitFor({ state: 'detached' })
     await page.raw.locator('[data-test="helm-history-entry"]').first().waitFor()
     expect(
       await page.raw.locator('[data-test="helm-history-entry"]').count()

--- a/tests/unit/assets/confirm-modal.test.js
+++ b/tests/unit/assets/confirm-modal.test.js
@@ -1,0 +1,23 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('sounding')
+
+const source = fs.readFileSync(
+  path.resolve('assets/js/components/ConfirmModal.vue'),
+  'utf8'
+)
+
+test('ConfirmModal composes Klean Dialog without rebuilding modal mechanics', ({
+  expect
+}) => {
+  expect(source).toContain(
+    "import Dialog from '@/components/ui/dialog/Dialog.vue'"
+  )
+  expect(source).toContain("import { useId } from 'vue'")
+  expect(source).toContain(':dismissible="!loading"')
+  expect(source).toContain(':aria-busy="loading ? \'true\' : undefined"')
+  expect(source).toContain('autofocus')
+  expect(source.includes('<Teleport')).toBe(false)
+  expect(source.includes('role="dialog"')).toBe(false)
+  expect(source.includes("document.addEventListener('keydown'")).toBe(false)
+})


### PR DESCRIPTION
## What changed

- replace Slipway's hand-built Teleport, overlay, Escape listener, and modal ARIA with copied Klean native Dialog
- keep the existing ConfirmModal application API, product styling, form slot, destructive treatment, and Slippy loading feedback
- generate unique accessible title and description relationships for every mounted confirmation
- preserve smooth caller-owned Tailwind motion while honoring reduced motion
- block Escape, backdrop, cancel, and duplicate confirmation while an action is pending
- restore the exact connected invoker after controlled dismissal
- associate the account confirmation password label with its field

## Browser proof

- native dialog naming, safest initial focus, Escape and backdrop dismissal, and exact focus return on Profile
- pending service deletion stays `aria-busy`, non-dismissible, disabled, singular, and visibly uses the Slippy spinner

## Verification

- `npm run lint`
- `npm run check:consistency`
- `npm run test:unit` (322 passing)
- `npm run test:functional` (105 passing)
- focused Dialog browser file (2 passing)

Closes #481