### PR TITLE
feat(ui): compose notifications with Klean Toast

### DIFF
--- a/assets/js/components/DeploymentToast.vue
+++ b/assets/js/components/DeploymentToast.vue
@@ -1,6 +1,6 @@
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
-import { Link, router } from '@inertiajs/vue3'
+import { Link } from '@inertiajs/vue3'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import { useEventSource } from '@/composables/sse'
 
@@ -15,8 +15,6 @@ const outcome = ref(props.deployment.outcome)
 const outcomeLabel = ref(props.deployment.outcomeLabel)
 const startTime = ref(props.deployment.startedAt || Date.now())
 const elapsed = ref(0)
-const dismissed = ref(false)
-const exiting = ref(false)
 let timerInterval = null
 
 const maritimeMessages = {
@@ -158,7 +156,6 @@ const { close: closeStream, connect: connectToStream } = useEventSource(
           ['running', 'stopped', 'failed', 'cancelled'].includes(data.status)
         ) {
           closeStream()
-          setTimeout(() => dismiss(), 5000)
         }
       }
     }
@@ -173,17 +170,7 @@ function startTimer() {
 }
 
 function dismiss() {
-  exiting.value = true
-  setTimeout(() => {
-    dismissed.value = true
-    emit('dismiss', props.deployment.id)
-  }, 300)
-}
-
-function goToDeployment() {
-  router.visit(
-    `/projects/${props.deployment.project.slug}/deployments/${props.deployment.id}`
-  )
+  emit('dismiss', props.deployment.id)
 }
 
 onMounted(() => {
@@ -193,6 +180,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  closeStream()
   if (timerInterval) clearInterval(timerInterval)
   stopMessageRotation()
 })
@@ -228,173 +216,165 @@ watch(status, (newStatus) => {
 </script>
 
 <template>
-  <Transition
-    enter-active-class="transition ease-out duration-300"
-    enter-from-class="translate-y-full opacity-0"
-    enter-to-class="translate-y-0 opacity-100"
-    leave-active-class="transition ease-in duration-200"
-    leave-from-class="translate-y-0 opacity-100"
-    leave-to-class="translate-y-full opacity-0"
+  <div
+    aria-live="off"
+    class="pointer-events-auto w-full overflow-hidden rounded-xl border border-gray-200 bg-white/95 shadow-2xl backdrop-blur-sm dark:border-gray-700/50 dark:bg-gray-900/95"
   >
-    <div
-      v-if="!dismissed"
-      :class="[
-        'pointer-events-auto w-80 overflow-hidden rounded-xl border shadow-2xl backdrop-blur-sm transition-all',
-        exiting ? 'translate-y-full opacity-0' : '',
-        'border-gray-200 bg-white/95 dark:border-gray-700/50 dark:bg-gray-900/95'
-      ]"
-    >
-      <!-- Progress bar at top -->
-      <div class="h-0.5 w-full bg-gray-200 dark:bg-gray-800">
-        <div
-          v-if="isActive"
-          :class="['h-full transition-all duration-300', statusConfig.bgColor]"
-          :style="{
-            width: isActive ? '100%' : '0%',
-            animation: isActive ? 'pulse 2s ease-in-out infinite' : 'none'
-          }"
-        ></div>
-        <div v-else :class="['h-full w-full', statusConfig.bgColor]"></div>
-      </div>
+    <!-- Progress bar at top -->
+    <div class="h-0.5 w-full bg-gray-200 dark:bg-gray-800" aria-hidden="true">
+      <div
+        v-if="isActive"
+        :class="['h-full transition-all duration-300', statusConfig.bgColor]"
+        :style="{
+          width: isActive ? '100%' : '0%',
+          animation: isActive ? 'pulse 2s ease-in-out infinite' : 'none'
+        }"
+      ></div>
+      <div v-else :class="['h-full w-full', statusConfig.bgColor]"></div>
+    </div>
 
-      <!-- Content -->
-      <div class="p-4">
-        <div class="flex items-start gap-3">
-          <!-- Status icon -->
-          <div
-            :class="[
-              'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg',
-              isActive
-                ? 'bg-gray-100 dark:bg-gray-800'
-                : isSuccessful
-                ? 'bg-emerald-500/20'
-                : 'bg-red-500/20'
-            ]"
+    <!-- Content -->
+    <div class="p-4">
+      <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+        {{ statusConfig.label }} deployment for {{ deployment.project.name }}
+        {{ deployment.environment.name }}
+      </p>
+      <div class="flex items-start gap-3">
+        <!-- Status icon -->
+        <div
+          :class="[
+            'flex h-10 w-10 shrink-0 items-center justify-center rounded-lg',
+            isActive
+              ? 'bg-gray-100 dark:bg-gray-800'
+              : isSuccessful
+              ? 'bg-emerald-500/20'
+              : 'bg-red-500/20'
+          ]"
+        >
+          <!-- Spinning loader for active states -->
+          <Spinner v-if="isActive" class="text-brand h-5 w-5 dark:text-white" />
+          <!-- Check for success -->
+          <svg
+            v-else-if="isSuccessful"
+            class="h-5 w-5 text-emerald-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
           >
-            <!-- Spinning loader for active states -->
-            <Spinner
-              v-if="isActive"
-              class="text-brand h-5 w-5 dark:text-white"
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M5 13l4 4L19 7"
             />
-            <!-- Check for success -->
-            <svg
-              v-else-if="isSuccessful"
-              class="h-5 w-5 text-emerald-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
+          </svg>
+          <!-- X for failed/cancelled -->
+          <svg
+            v-else
+            class="h-5 w-5 text-red-400"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </div>
+
+        <!-- Details -->
+        <div class="min-w-0 flex-1">
+          <div class="flex items-center justify-between">
+            <p :class="['text-sm font-medium', statusConfig.color]">
+              {{ statusConfig.label }}
+            </p>
+            <button
+              type="button"
+              @click.stop="dismiss"
+              class="cursor-pointer rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300 dark:focus-visible:ring-white"
+              :aria-label="`Dismiss ${statusConfig.label.toLowerCase()} deployment for ${
+                deployment.project.name
+              }`"
             >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M5 13l4 4L19 7"
-              />
-            </svg>
-            <!-- X for failed/cancelled -->
-            <svg
-              v-else
-              class="h-5 w-5 text-red-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+              <svg
+                class="h-4 w-4"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M6 18L18 6M6 6l12 12"
+                />
+              </svg>
+            </button>
           </div>
 
-          <!-- Details -->
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center justify-between">
-              <p :class="['text-sm font-medium', statusConfig.color]">
-                {{ statusConfig.label }}
-              </p>
-              <button
-                @click.stop="dismiss"
-                class="rounded p-0.5 text-gray-400 hover:bg-gray-100 hover:text-gray-600 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-300"
-              >
-                <svg
-                  class="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M6 18L18 6M6 6l12 12"
-                  />
-                </svg>
-              </button>
-            </div>
-
-            <button
-              @click="goToDeployment"
-              class="mt-0.5 block w-full truncate text-left text-sm font-medium text-gray-900 hover:underline dark:text-white"
-            >
-              {{ deployment.project.name }}
+          <Link
+            :href="`/projects/${deployment.project.slug}/deployments/${deployment.id}`"
+            class="mt-0.5 block w-full truncate text-left text-sm font-medium text-gray-900 hover:underline dark:text-white"
+          >
+            {{ deployment.project.name }}
+            <span class="text-gray-400 dark:text-gray-500">/</span>
+            {{ deployment.environment.name }}
+            <template v-if="deployment.app">
               <span class="text-gray-400 dark:text-gray-500">/</span>
-              {{ deployment.environment.name }}
-              <template v-if="deployment.app">
-                <span class="text-gray-400 dark:text-gray-500">/</span>
-                {{ deployment.app.name }}
-              </template>
-            </button>
+              {{ deployment.app.name }}
+            </template>
+          </Link>
 
-            <p
-              v-if="isActive && maritimeMessage"
-              class="mt-1 truncate text-xs text-gray-400 dark:text-gray-500"
-            >
-              {{ maritimeMessage }}
-            </p>
+          <p
+            v-if="isActive && maritimeMessage"
+            class="mt-1 truncate text-xs text-gray-400 dark:text-gray-500"
+          >
+            {{ maritimeMessage }}
+          </p>
 
-            <div
-              class="mt-2 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400"
-            >
-              <span v-if="deployment.gitBranch" class="flex items-center gap-1">
-                <svg
-                  class="h-3 w-3"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M13 10V3L4 14h7v7l9-11h-7z"
-                  />
-                </svg>
-                {{ deployment.gitBranch }}
-              </span>
-              <span class="flex items-center gap-1">
-                <svg
-                  class="h-3 w-3"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="2"
-                    d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                {{ elapsedFormatted }}
-              </span>
-            </div>
+          <div
+            class="mt-2 flex items-center gap-3 text-xs text-gray-500 dark:text-gray-400"
+          >
+            <span v-if="deployment.gitBranch" class="flex items-center gap-1">
+              <svg
+                class="h-3 w-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M13 10V3L4 14h7v7l9-11h-7z"
+                />
+              </svg>
+              {{ deployment.gitBranch }}
+            </span>
+            <span class="flex items-center gap-1">
+              <svg
+                class="h-3 w-3"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+              {{ elapsedFormatted }}
+            </span>
           </div>
         </div>
       </div>
     </div>
-  </Transition>
+  </div>
 </template>
 
 <style scoped>

--- a/assets/js/components/HelmResultViewer.vue
+++ b/assets/js/components/HelmResultViewer.vue
@@ -3,7 +3,7 @@ import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import HelmResultTreeNode from '@/components/HelmResultTreeNode.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
-import ToastContainer from '@/components/ToastContainer.vue'
+import { useToast } from '@/composables/toast'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Table from '@/components/ui/table/Table.vue'
 import { highlightJSON } from '@/lib/highlightJSON'
@@ -51,11 +51,10 @@ const emit = defineEmits(['clear', 'update:view'])
 const activeView = ref(props.view === 'auto' ? 'raw' : props.view)
 const logsOpen = ref(false)
 const queriesOpen = ref(false)
-const toasts = ref([])
+const toast = useToast()
 const runningDurationMs = ref(0)
 let runningStartedAt = 0
 let runningTimer
-let toastId = 0
 
 const value = computed(() => props.result?.value)
 const tableCompatible = computed(
@@ -372,13 +371,7 @@ function downloadCsv() {
 }
 
 function notify(message) {
-  const id = ++toastId
-  toasts.value.push({ id, message, type: 'success' })
-  setTimeout(() => dismissToast(id), 3500)
-}
-
-function dismissToast(id) {
-  toasts.value = toasts.value.filter((toast) => toast.id !== id)
+  toast({ message, type: 'success', duration: 3500 })
 }
 
 function queryLabel(entry) {
@@ -785,7 +778,5 @@ function queryDetail(entry) {
         @select="handleAction"
       />
     </footer>
-
-    <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
   </div>
 </template>

--- a/assets/js/components/HelmWorkspaceLibrary.vue
+++ b/assets/js/components/HelmWorkspaceLibrary.vue
@@ -7,7 +7,7 @@ import HelmSnippetDialog from '@/components/HelmSnippetDialog.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Tabs from '@/components/ui/tabs/Tabs.vue'
-import ToastContainer from '@/components/ToastContainer.vue'
+import { useToast } from '@/composables/toast'
 
 const props = defineProps({
   tab: {
@@ -49,10 +49,9 @@ const snippetDialog = ref({ show: false, snippet: null })
 const snippetSaving = ref(false)
 const confirm = ref({ show: false, type: '', item: null })
 const confirmLoading = ref(false)
-const toasts = ref([])
+const toast = useToast()
 let historySearchTimer
 let snippetSearchTimer
-let toastId = 0
 
 const activeQuery = computed({
   get: () =>
@@ -358,13 +357,7 @@ function relativeTime(timestamp) {
 }
 
 function notify(message, type = 'success') {
-  const id = ++toastId
-  toasts.value.push({ id, message, type })
-  window.setTimeout(() => dismissToast(id), 3500)
-}
-
-function dismissToast(id) {
-  toasts.value = toasts.value.filter((toast) => toast.id !== id)
+  toast({ message, type, duration: 3500 })
 }
 
 defineExpose({ refreshHistory, openSnippetDialog })
@@ -710,6 +703,4 @@ defineExpose({ refreshHistory, openSnippetDialog })
     @cancel="confirm = { show: false, type: '', item: null }"
     @confirm="confirmDestructiveAction"
   />
-
-  <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
 </template>

--- a/assets/js/components/ServiceActionToast.vue
+++ b/assets/js/components/ServiceActionToast.vue
@@ -55,8 +55,12 @@ onUnmounted(() => {
 
 <template>
   <div
-    class="flex w-80 items-start space-x-3 rounded-lg border border-gray-200 bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+    aria-live="off"
+    class="flex w-full items-start space-x-3 rounded-lg border border-gray-200 bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-900"
   >
+    <p class="sr-only" role="status" aria-live="polite" aria-atomic="true">
+      {{ actionLabel }} {{ action.serviceName }}
+    </p>
     <!-- Icon -->
     <div class="mt-0.5 shrink-0">
       <!-- Spinner for in progress -->
@@ -112,14 +116,17 @@ onUnmounted(() => {
 
     <!-- Dismiss -->
     <button
+      type="button"
       @click="dismiss"
-      class="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+      class="shrink-0 cursor-pointer text-gray-400 hover:text-gray-600 focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:hover:text-gray-300 dark:focus-visible:ring-white"
+      :aria-label="`Dismiss ${actionLabel} ${action.serviceName}`"
     >
       <svg
         class="h-4 w-4"
         fill="none"
         stroke="currentColor"
         viewBox="0 0 24 24"
+        aria-hidden="true"
       >
         <path
           stroke-linecap="round"

--- a/assets/js/components/ToastContainer.vue
+++ b/assets/js/components/ToastContainer.vue
@@ -1,12 +1,13 @@
 <script setup>
+import Toast from '@/components/ui/toast/Toast.vue'
+import DeploymentToast from '@/components/DeploymentToast.vue'
+import ServiceActionToast from '@/components/ServiceActionToast.vue'
+
 const props = defineProps({
-  toasts: {
-    type: Array,
-    default: () => []
-  }
+  controller: { type: Function, required: true }
 })
 
-const emit = defineEmits(['dismiss'])
+const emit = defineEmits(['deployment-status-change', 'dismiss-deployment'])
 
 const icons = {
   success: 'M5 13l4 4L19 7',
@@ -19,31 +20,105 @@ const colors = {
   error: 'text-red-500 dark:text-red-400',
   info: 'text-blue-500 dark:text-blue-400'
 }
+
+function dismissDeployment(item, dismiss) {
+  dismiss()
+  emit('dismiss-deployment', item.deployment.id)
+}
+
+function activateAction(item, event, dismiss) {
+  item.action?.onClick?.(event, item)
+  dismiss()
+}
 </script>
 
 <template>
-  <Teleport to="body">
-    <div
-      class="fixed bottom-4 right-4 z-50 flex flex-col-reverse space-y-2 space-y-reverse"
-      aria-live="polite"
-      aria-atomic="false"
-    >
-      <TransitionGroup
-        enter-active-class="transition duration-300 ease-out"
-        enter-from-class="translate-x-full opacity-0"
-        enter-to-class="translate-x-0 opacity-100"
-        leave-active-class="transition duration-200 ease-in"
-        leave-from-class="translate-x-0 opacity-100"
-        leave-to-class="translate-x-full opacity-0"
-      >
-        <div
-          v-for="toast in toasts"
-          :key="toast.id"
-          class="flex w-80 items-start space-x-3 rounded-lg border border-gray-200 bg-white p-4 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+  <Toast
+    :controller="props.controller"
+    position="bottom-right"
+    from="right"
+    to="right"
+    class="max-h-[calc(100dvh-2rem)] w-80 max-w-[calc(100vw-2rem)] overflow-y-auto overscroll-contain"
+  >
+    <template #default="{ item, dismiss }">
+      <DeploymentToast
+        v-if="item.kind === 'deployment'"
+        :deployment="item.deployment"
+        @status-change="emit('deployment-status-change', $event)"
+        @dismiss="dismissDeployment(item, dismiss)"
+      />
+      <ServiceActionToast
+        v-else-if="item.kind === 'service-action'"
+        :action="item.action"
+        @dismiss="dismiss"
+      />
+      <template v-else>
+        <svg
+          class="mt-0.5 h-5 w-5 shrink-0"
+          :class="colors[item.type] || colors.success"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            :d="icons[item.type] || icons.success"
+          />
+        </svg>
+        <p
+          v-if="!item.title && !item.action?.label"
+          class="flex-1 text-sm text-gray-900 dark:text-white"
+        >
+          {{ item.message }}
+        </p>
+        <div v-else class="min-w-0 flex-1">
+          <p
+            v-if="item.title"
+            class="text-sm font-medium text-gray-900 dark:text-white"
+          >
+            {{ item.title }}
+          </p>
+          <p
+            v-if="item.message"
+            :class="[
+              'text-sm text-gray-900 dark:text-white',
+              item.title && 'mt-0.5 text-gray-600 dark:text-gray-300'
+            ]"
+          >
+            {{ item.message }}
+          </p>
+          <a
+            v-if="item.action?.href"
+            :href="item.action.href"
+            class="min-h-8 mt-2 inline-flex items-center text-sm font-semibold text-gray-900 underline decoration-gray-300 underline-offset-4 hover:decoration-current focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:text-white dark:decoration-gray-600 dark:focus-visible:ring-white"
+            @click="activateAction(item, $event, dismiss)"
+          >
+            {{ item.action.label }}
+          </a>
+          <button
+            v-else-if="item.action?.label"
+            type="button"
+            class="min-h-8 mt-2 inline-flex cursor-pointer items-center text-sm font-semibold text-gray-900 hover:text-gray-600 focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:text-white dark:hover:text-gray-300 dark:focus-visible:ring-white"
+            @click="activateAction(item, $event, dismiss)"
+          >
+            {{ item.action.label }}
+          </button>
+        </div>
+        <button
+          v-if="item.dismissible !== false"
+          type="button"
+          class="shrink-0 cursor-pointer text-gray-400 hover:text-gray-600 focus-visible:rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:hover:text-gray-300 dark:focus-visible:ring-white"
+          :aria-label="
+            item.dismissLabel ||
+            `Dismiss ${item.title || item.message || 'notification'}`
+          "
+          @click="dismiss"
         >
           <svg
-            class="mt-0.5 h-5 w-5 shrink-0"
-            :class="colors[toast.type] || colors.success"
+            class="h-4 w-4"
             fill="none"
             stroke="currentColor"
             viewBox="0 0 24 24"
@@ -53,34 +128,11 @@ const colors = {
               stroke-linecap="round"
               stroke-linejoin="round"
               stroke-width="2"
-              :d="icons[toast.type] || icons.success"
+              d="M6 18L18 6M6 6l12 12"
             />
           </svg>
-          <p class="flex-1 text-sm text-gray-900 dark:text-white">
-            {{ toast.message }}
-          </p>
-          <button
-            @click="emit('dismiss', toast.id)"
-            class="shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
-            :aria-label="`Dismiss ${toast.message}`"
-          >
-            <svg
-              class="h-4 w-4"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              aria-hidden="true"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                stroke-width="2"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
-          </button>
-        </div>
-      </TransitionGroup>
-    </div>
-  </Teleport>
+        </button>
+      </template>
+    </template>
+  </Toast>
 </template>

--- a/assets/js/components/ui/toast/Toast.vue
+++ b/assets/js/components/ui/toast/Toast.vue
@@ -1,0 +1,452 @@
+<script setup>
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  useAttrs,
+  useTemplateRef,
+  watch
+} from 'vue'
+import { twMerge } from 'tailwind-merge'
+import { toast } from './toast.js'
+
+defineOptions({ inheritAttrs: false })
+
+const POSITIONS = {
+  'top-left': 'left-4 top-4 items-start',
+  'top-center': 'left-1/2 top-4 -translate-x-1/2 items-center',
+  'top-right': 'right-4 top-4 items-end',
+  'bottom-left': 'bottom-4 left-4 items-start',
+  'bottom-center': 'bottom-4 left-1/2 -translate-x-1/2 items-center',
+  'bottom-right': 'bottom-4 right-4 items-end'
+}
+
+const POSITION_EDGES = {
+  'top-left': ['top', 'left'],
+  'top-center': ['top'],
+  'top-right': ['top', 'right'],
+  'bottom-left': ['bottom', 'left'],
+  'bottom-center': ['bottom'],
+  'bottom-right': ['bottom', 'right']
+}
+
+const NEARBY_DURATION = { enter: 300, leave: 200 }
+const CROSS_VIEWPORT_DURATION = { enter: 450, leave: 320 }
+
+function motionVector(direction, position) {
+  if (direction === 'fade' || direction === 'none') {
+    return { x: '0px', y: '0px' }
+  }
+
+  const nearby = POSITION_EDGES[position]?.includes(direction)
+  const horizontal = direction === 'left' || direction === 'right'
+  const distance = nearby
+    ? 'calc(100% + 1rem)'
+    : horizontal
+    ? '100vw'
+    : '100dvh'
+  const negative = direction === 'left' || direction === 'top'
+  const signedDistance = negative
+    ? nearby
+      ? 'calc(-100% - 1rem)'
+      : horizontal
+      ? '-100vw'
+      : '-100dvh'
+    : distance
+
+  return horizontal
+    ? { x: signedDistance, y: '0px' }
+    : { x: '0px', y: signedDistance }
+}
+
+function motionDuration(phase, direction, position) {
+  if (direction === 'none') return 0
+  if (['fade', ...POSITION_EDGES[position]].includes(direction)) {
+    return NEARBY_DURATION[phase]
+  }
+  return CROSS_VIEWPORT_DURATION[phase]
+}
+
+const props = defineProps({
+  /** Optional isolated controller. The shared `toast` works without a provider. */
+  controller: { type: Function, default: undefined },
+  /** Fixed viewport position. */
+  position: {
+    type: String,
+    default: 'top-right',
+    validator: (value) =>
+      [
+        'top-left',
+        'top-center',
+        'top-right',
+        'bottom-left',
+        'bottom-center',
+        'bottom-right'
+      ].includes(value)
+  },
+  /** Direction new notifications enter from. */
+  from: {
+    type: String,
+    default: undefined,
+    validator: (value) =>
+      ['left', 'right', 'top', 'bottom', 'fade', 'none'].includes(value)
+  },
+  /** Direction dismissed notifications leave toward. */
+  to: {
+    type: String,
+    default: undefined,
+    validator: (value) =>
+      ['left', 'right', 'top', 'bottom', 'fade', 'none'].includes(value)
+  },
+  /** Accessible name for the persistent live region. */
+  label: { type: String, default: 'Notifications' }
+})
+
+const attrs = useAttrs()
+const items = ref([])
+const viewport = useTemplateRef('viewport')
+const activeController = computed(() => props.controller ?? toast)
+const defaultDirection = computed(() =>
+  props.position.endsWith('-left') ? 'left' : 'right'
+)
+const resolvedFrom = computed(() => props.from ?? defaultDirection.value)
+const resolvedTo = computed(() => props.to ?? defaultDirection.value)
+let unsubscribe = () => {}
+let promotedItemId
+
+const viewportClasses = computed(() =>
+  twMerge(
+    'pointer-events-none fixed inset-auto z-100 m-0 flex w-[min(24rem,calc(100vw-2rem))] flex-col border-0 bg-transparent p-0',
+    POSITIONS[props.position],
+    attrs.class
+  )
+)
+
+const viewportAttrs = computed(() => {
+  const {
+    class: _class,
+    style: _style,
+    'aria-label': _ariaLabel,
+    'aria-live': _ariaLive,
+    popover: _popover,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+
+  return rest
+})
+
+const motionStyle = computed(() => {
+  const enter = motionVector(resolvedFrom.value, props.position)
+  const leave = motionVector(resolvedTo.value, props.position)
+  const enterDuration = motionDuration(
+    'enter',
+    resolvedFrom.value,
+    props.position
+  )
+  const leaveDuration = motionDuration(
+    'leave',
+    resolvedTo.value,
+    props.position
+  )
+  const collapseDelay = Math.min(80, Math.round(leaveDuration * 0.4))
+
+  return {
+    '--klean-toast-enter-x': enter.x,
+    '--klean-toast-enter-y': enter.y,
+    '--klean-toast-leave-x': leave.x,
+    '--klean-toast-leave-y': leave.y,
+    '--klean-toast-enter-duration': `${enterDuration}ms`,
+    '--klean-toast-leave-duration': `${leaveDuration}ms`,
+    '--klean-toast-collapse-delay': `${collapseDelay}ms`,
+    '--klean-toast-collapse-duration': `${Math.max(
+      0,
+      leaveDuration - collapseDelay
+    )}ms`
+  }
+})
+
+function activateAction(item, event) {
+  item.action?.onClick?.(event, item)
+  activeController.value.dismiss(item.id)
+}
+
+function subscribe(controller) {
+  unsubscribe()
+  promotedItemId = undefined
+  const sync = () => {
+    const snapshot = controller.getSnapshot()
+    items.value = snapshot
+
+    const enteringItem = snapshot.findLast((item) => item.state === 'entering')
+    if (enteringItem && enteringItem.id !== promotedItemId) {
+      promotedItemId = enteringItem.id
+      hideTopLayer()
+      showTopLayer()
+    }
+
+    if (resolvedFrom.value === 'none' || resolvedTo.value === 'none') {
+      queueMicrotask(() => {
+        for (const item of controller.getSnapshot()) {
+          if (item.state === 'entering' && resolvedFrom.value === 'none') {
+            controller.completeEnter(item.id)
+          } else if (item.state === 'closing' && resolvedTo.value === 'none') {
+            controller.remove(item.id)
+          }
+        }
+      })
+    }
+  }
+
+  sync()
+  unsubscribe = controller.subscribe(sync)
+}
+
+function handleAnimationEnd(item, event) {
+  if (event.target !== event.currentTarget) return
+
+  if (item.state === 'entering') activeController.value.completeEnter(item.id)
+  else if (item.state === 'closing') activeController.value.remove(item.id)
+}
+
+function handleFocusOut(item, event) {
+  if (!event.currentTarget.contains(event.relatedTarget)) {
+    activeController.value.resume(item.id, 'focus')
+  }
+}
+
+function handleVisibility() {
+  if (document.hidden) activeController.value.pauseAll('page-hidden')
+  else activeController.value.resumeAll('page-hidden')
+}
+
+function handleWindowBlur() {
+  activeController.value.pauseAll('window-blur')
+}
+
+function handleWindowFocus() {
+  activeController.value.resumeAll('window-blur')
+}
+
+function showTopLayer() {
+  try {
+    viewport.value?.showPopover?.()
+  } catch {
+    // Already open or rejected by a partial Popover API implementation.
+  }
+}
+
+function hideTopLayer() {
+  try {
+    viewport.value?.hidePopover?.()
+  } catch {
+    // Already closed during teardown.
+  }
+}
+
+watch(activeController, subscribe)
+
+onMounted(() => {
+  showTopLayer()
+  subscribe(activeController.value)
+  document.addEventListener('visibilitychange', handleVisibility)
+  window.addEventListener('blur', handleWindowBlur)
+  window.addEventListener('focus', handleWindowFocus)
+  handleVisibility()
+})
+
+onBeforeUnmount(() => {
+  hideTopLayer()
+  unsubscribe()
+  document.removeEventListener('visibilitychange', handleVisibility)
+  window.removeEventListener('blur', handleWindowBlur)
+  window.removeEventListener('focus', handleWindowFocus)
+  activeController.value.resumeAll('page-hidden')
+  activeController.value.resumeAll('window-blur')
+})
+</script>
+
+<template>
+  <section
+    ref="viewport"
+    v-bind="viewportAttrs"
+    popover="manual"
+    data-slot="toast-viewport"
+    :data-position="position"
+    :data-from="resolvedFrom"
+    :data-to="resolvedTo"
+    :aria-label="label"
+    aria-live="polite"
+    aria-atomic="false"
+    aria-relevant="additions text"
+    :class="viewportClasses"
+    :style="[motionStyle, attrs.style]"
+  >
+    <ol data-slot="toast-list" class="m-0 flex w-full list-none flex-col p-0">
+      <li
+        v-for="item in items"
+        :key="item.id"
+        data-klean-toast-row
+        :data-state="item.state"
+        aria-atomic="true"
+        class="grid grid-rows-[1fr] pb-3"
+        @mouseenter="activeController.pause(item.id, 'hover')"
+        @mouseleave="activeController.resume(item.id, 'hover')"
+        @focusin="activeController.pause(item.id, 'focus')"
+        @focusout="handleFocusOut(item, $event)"
+      >
+        <div
+          data-slot="toast"
+          data-klean-toast-item
+          :data-state="item.state"
+          :data-from="resolvedFrom"
+          :data-to="resolvedTo"
+          :class="
+            twMerge(
+              'dark:ring-white/15 pointer-events-auto grid min-h-0 w-full grid-cols-[minmax(0,1fr)_auto] items-start gap-3 overflow-hidden rounded-xl bg-white px-4 py-3 text-gray-950 shadow-xl ring-1 ring-gray-950/10 dark:bg-gray-950 dark:text-white',
+              item.class
+            )
+          "
+          @animationend="handleAnimationEnd(item, $event)"
+        >
+          <slot :item="item" :dismiss="() => activeController.dismiss(item.id)">
+            <div class="min-w-0 pt-0.5">
+              <p
+                v-if="item.title"
+                data-slot="toast-title"
+                class="text-sm font-semibold leading-5"
+              >
+                {{ item.title }}
+              </p>
+              <p
+                v-if="item.message"
+                data-slot="toast-message"
+                :class="
+                  twMerge(
+                    'text-sm leading-5 text-gray-600 dark:text-gray-300',
+                    item.title && 'mt-0.5'
+                  )
+                "
+              >
+                {{ item.message }}
+              </p>
+              <a
+                v-if="item.action?.href"
+                data-slot="toast-action"
+                :href="item.action.href"
+                :class="
+                  twMerge(
+                    'min-h-8 mt-2 inline-flex items-center text-sm font-semibold text-gray-950 underline decoration-gray-300 underline-offset-4 hover:decoration-current focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:text-white dark:decoration-gray-600 dark:focus-visible:ring-white',
+                    item.action.class
+                  )
+                "
+                @click="activateAction(item, $event)"
+              >
+                {{ item.action.label }}
+              </a>
+              <button
+                v-else-if="item.action?.label"
+                type="button"
+                data-slot="toast-action"
+                :class="
+                  twMerge(
+                    'min-h-8 mt-2 inline-flex cursor-pointer items-center text-sm font-semibold text-gray-950 hover:text-gray-600 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:text-white dark:hover:text-gray-300 dark:focus-visible:ring-white',
+                    item.action.class
+                  )
+                "
+                @click="activateAction(item, $event)"
+              >
+                {{ item.action.label }}
+              </button>
+            </div>
+            <button
+              v-if="item.dismissible !== false"
+              type="button"
+              data-slot="toast-dismiss"
+              class="size-9 -mr-2 -mt-1 grid cursor-pointer place-items-center rounded-lg text-lg leading-none text-gray-400 hover:bg-gray-100 hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-white dark:focus-visible:ring-white"
+              :aria-label="
+                item.dismissLabel ?? `Dismiss ${item.title || 'notification'}`
+              "
+              @click="activeController.dismiss(item.id)"
+            >
+              <span aria-hidden="true">×</span>
+            </button>
+          </slot>
+        </div>
+      </li>
+    </ol>
+  </section>
+</template>
+
+<style>
+@keyframes klean-toast-enter {
+  0% {
+    opacity: 0;
+    transform: translate3d(
+        var(--klean-toast-enter-x),
+        var(--klean-toast-enter-y),
+        0
+      )
+      scale(0.98);
+  }
+  100% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes klean-toast-leave {
+  0% {
+    opacity: 1;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translate3d(
+        var(--klean-toast-leave-x),
+        var(--klean-toast-leave-y),
+        0
+      )
+      scale(0.98);
+  }
+}
+
+@keyframes klean-toast-collapse {
+  0% {
+    grid-template-rows: 1fr;
+    padding-block-end: 0.75rem;
+  }
+  100% {
+    grid-template-rows: 0fr;
+    padding-block-end: 0;
+  }
+}
+
+[data-klean-toast-item][data-state='entering'] {
+  animation: klean-toast-enter var(--klean-toast-enter-duration) ease-out both;
+}
+
+[data-klean-toast-item][data-state='closing'] {
+  animation: klean-toast-leave var(--klean-toast-leave-duration) ease-in both;
+  pointer-events: none;
+}
+
+[data-klean-toast-row][data-state='closing'] {
+  animation: klean-toast-collapse var(--klean-toast-collapse-duration) ease-in
+    var(--klean-toast-collapse-delay) both;
+  overflow: hidden;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-klean-toast-item][data-state] {
+    animation-duration: 1ms;
+    animation-timing-function: linear;
+  }
+
+  [data-klean-toast-row][data-state='closing'] {
+    animation-delay: 0ms;
+    animation-duration: 1ms;
+  }
+}
+</style>

--- a/assets/js/components/ui/toast/toast.js
+++ b/assets/js/components/ui/toast/toast.js
@@ -1,0 +1,266 @@
+const DEFAULT_DURATION = 5000
+const DEFAULT_MAX = 4
+const ENTER_FALLBACK = 500
+const LEAVE_FALLBACK = 450
+
+function normalizeDuration(value, fallback) {
+  if (value === false || value === 0) return 0
+
+  const duration = Number(value)
+  return Number.isFinite(duration) && duration > 0 ? duration : fallback
+}
+
+export function createToast({
+  duration = DEFAULT_DURATION,
+  max = DEFAULT_MAX
+} = {}) {
+  const listeners = new Set()
+  const timers = new Map()
+  const lifecycleTimers = new Map()
+  const pauseReasons = new Map()
+  const globalPauseReasons = new Set()
+  let items = []
+  let nextId = 0
+
+  function getSnapshot() {
+    return items
+  }
+
+  function subscribe(listener) {
+    listeners.add(listener)
+    return () => listeners.delete(listener)
+  }
+
+  function publish(nextItems) {
+    items = nextItems
+    for (const listener of listeners) listener()
+  }
+
+  function clearTimer(id) {
+    const timer = timers.get(id)
+    if (!timer?.timeout) return
+
+    clearTimeout(timer.timeout)
+    timer.timeout = null
+  }
+
+  function clearLifecycleTimer(id) {
+    const timeout = lifecycleTimers.get(id)
+    if (timeout) clearTimeout(timeout)
+    lifecycleTimers.delete(id)
+  }
+
+  function reasonsFor(id) {
+    if (!pauseReasons.has(id)) {
+      pauseReasons.set(id, new Set(globalPauseReasons))
+    }
+
+    return pauseReasons.get(id)
+  }
+
+  function schedule(id) {
+    const timer = timers.get(id)
+    const item = items.find((candidate) => candidate.id === id)
+
+    if (
+      !timer ||
+      !item ||
+      item.state === 'closing' ||
+      timer.remaining <= 0 ||
+      reasonsFor(id).size > 0
+    ) {
+      return
+    }
+
+    timer.startedAt = Date.now()
+    timer.timeout = setTimeout(() => dismiss(id), timer.remaining)
+  }
+
+  function resetTimer(id, itemDuration) {
+    clearTimer(id)
+    timers.delete(id)
+
+    if (!itemDuration) return
+
+    timers.set(id, {
+      remaining: itemDuration,
+      startedAt: 0,
+      timeout: null
+    })
+    schedule(id)
+  }
+
+  function completeEnter(id) {
+    clearLifecycleTimer(id)
+    const index = items.findIndex((item) => item.id === id)
+    if (index === -1 || items[index].state !== 'entering') return false
+
+    const nextItems = [...items]
+    nextItems[index] = { ...nextItems[index], state: 'open' }
+    publish(nextItems)
+    return true
+  }
+
+  function remove(id) {
+    const exists = items.some((item) => item.id === id)
+    if (!exists) return false
+
+    clearTimer(id)
+    timers.delete(id)
+    clearLifecycleTimer(id)
+    pauseReasons.delete(id)
+    publish(items.filter((item) => item.id !== id))
+    return true
+  }
+
+  function dismiss(id) {
+    const index = items.findIndex((item) => item.id === id)
+    if (index === -1 || items[index].state === 'closing') return false
+
+    clearTimer(id)
+    timers.delete(id)
+    clearLifecycleTimer(id)
+
+    const nextItems = [...items]
+    nextItems[index] = { ...nextItems[index], state: 'closing' }
+    publish(nextItems)
+
+    lifecycleTimers.set(
+      id,
+      setTimeout(() => remove(id), LEAVE_FALLBACK)
+    )
+    return true
+  }
+
+  function pause(id, reason = 'interaction') {
+    if (!items.some((item) => item.id === id)) return false
+
+    const reasons = reasonsFor(id)
+    if (reasons.has(reason)) return false
+    reasons.add(reason)
+
+    const timer = timers.get(id)
+    if (timer?.timeout) {
+      timer.remaining = Math.max(
+        0,
+        timer.remaining - (Date.now() - timer.startedAt)
+      )
+      clearTimer(id)
+    }
+
+    return true
+  }
+
+  function resume(id, reason = 'interaction') {
+    const reasons = pauseReasons.get(id)
+    if (!reasons?.has(reason)) return false
+
+    reasons.delete(reason)
+    schedule(id)
+    return true
+  }
+
+  function pauseAll(reason = 'page') {
+    globalPauseReasons.add(reason)
+    for (const item of items) pause(item.id, reason)
+  }
+
+  function resumeAll(reason = 'page') {
+    globalPauseReasons.delete(reason)
+    for (const item of items) resume(item.id, reason)
+  }
+
+  function update(id, patch = {}) {
+    const index = items.findIndex((item) => item.id === id)
+    if (index === -1 || items[index].state === 'closing') return false
+
+    const current = items[index]
+    const itemDuration =
+      patch.duration === undefined
+        ? current.duration
+        : normalizeDuration(patch.duration, duration)
+    const nextItems = [...items]
+
+    nextItems[index] = {
+      ...current,
+      ...patch,
+      id,
+      duration: itemDuration,
+      state: current.state
+    }
+    publish(nextItems)
+
+    if (patch.duration !== undefined) resetTimer(id, itemDuration)
+    return true
+  }
+
+  function clear() {
+    for (const item of [...items]) dismiss(item.id)
+  }
+
+  function destroy() {
+    for (const id of [...timers.keys()]) clearTimer(id)
+    for (const id of [...lifecycleTimers.keys()]) clearLifecycleTimer(id)
+    timers.clear()
+    pauseReasons.clear()
+    globalPauseReasons.clear()
+    items = []
+    listeners.clear()
+  }
+
+  function notify(input = {}, options = {}) {
+    const item =
+      typeof input === 'string' ? { ...options, message: input } : { ...input }
+    const id = item.id ?? `toast-${++nextId}`
+    const existing = items.find(
+      (candidate) => candidate.id === id && candidate.state !== 'closing'
+    )
+
+    if (existing) {
+      update(id, item)
+      return id
+    }
+
+    const openItems = items.filter((candidate) => candidate.state !== 'closing')
+    if (max > 0 && openItems.length >= max) dismiss(openItems[0].id)
+
+    const itemDuration = normalizeDuration(item.duration, duration)
+    const nextItem = {
+      id,
+      title: '',
+      message: '',
+      class: '',
+      ...item,
+      duration: itemDuration,
+      state: 'entering'
+    }
+
+    pauseReasons.set(id, new Set(globalPauseReasons))
+    publish([...items, nextItem])
+    resetTimer(id, itemDuration)
+    lifecycleTimers.set(
+      id,
+      setTimeout(() => completeEnter(id), ENTER_FALLBACK)
+    )
+    return id
+  }
+
+  Object.assign(notify, {
+    clear,
+    completeEnter,
+    destroy,
+    dismiss,
+    getSnapshot,
+    pause,
+    pauseAll,
+    remove,
+    resume,
+    resumeAll,
+    subscribe,
+    update
+  })
+
+  return notify
+}
+
+export const toast = createToast()

--- a/assets/js/components/ui/tooltip/Tooltip.vue
+++ b/assets/js/components/ui/tooltip/Tooltip.vue
@@ -82,7 +82,7 @@ const contentAttrs = computed(() => {
 const contentClasses = computed(() =>
   twMerge(
     [
-      'z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
+      'pointer-events-none z-50 m-0 w-max max-w-[calc(100vw-1rem)] overflow-visible rounded-md border border-gray-950 bg-gray-950 px-2.5 py-1.5 text-xs font-medium leading-none text-white shadow-md outline-none',
       'transition-opacity duration-100 starting:opacity-0 motion-reduce:transition-none',
       'dark:border-white dark:bg-white dark:text-gray-950',
       'forced-colors:border forced-colors:border-[CanvasText] forced-colors:bg-[Canvas] forced-colors:text-[CanvasText]'
@@ -337,8 +337,6 @@ onBeforeUnmount(() => {
       :hidden="!supportsNative && !isOpen"
       :class="contentClasses"
       :style="[positionStyle, attrs.style]"
-      @pointerenter="clearTimeout(closeTimer)"
-      @pointerleave="scheduleClose"
       @toggle="handleNativeToggle"
     >
       {{ text }}

--- a/assets/js/composables/service-actions.js
+++ b/assets/js/composables/service-actions.js
@@ -1,12 +1,17 @@
-import { ref, provide, inject } from 'vue'
+import { provide, inject } from 'vue'
 
 const SERVICE_ACTIONS_KEY = Symbol('serviceActions')
+const OPERATIONAL_TOAST_CLASS =
+  'block overflow-visible bg-transparent p-0 shadow-none ring-0 dark:bg-transparent'
+
+function toastId(id) {
+  return `service-action-${id}`
+}
 
 /**
  * Creates the service actions state (used in AppLayout)
  */
-export function createServiceActions() {
-  const actions = ref([])
+export function createServiceActions(toast) {
   let actionId = 0
 
   function startAction({
@@ -17,7 +22,7 @@ export function createServiceActions() {
     environmentName
   }) {
     const id = ++actionId
-    actions.value.push({
+    const actionState = {
       id,
       serviceName,
       serviceType,
@@ -26,26 +31,39 @@ export function createServiceActions() {
       environmentName,
       status: 'in_progress',
       startedAt: Date.now()
+    }
+
+    toast({
+      id: toastId(id),
+      kind: 'service-action',
+      action: actionState,
+      class: OPERATIONAL_TOAST_CLASS,
+      dismissible: false,
+      duration: false
     })
     return id
   }
 
   function completeAction(id, success = true) {
-    const action = actions.value.find((a) => a.id === id)
-    if (action) {
-      action.status = success ? 'success' : 'failed'
-      // Auto-dismiss after 4 seconds
-      setTimeout(() => {
-        dismissAction(id)
-      }, 4000)
-    }
+    const item = toast
+      .getSnapshot()
+      .find((candidate) => candidate.id === toastId(id))
+    if (!item) return
+
+    toast.update(toastId(id), {
+      action: {
+        ...item.action,
+        status: success ? 'success' : 'failed'
+      },
+      duration: 4000
+    })
   }
 
   function dismissAction(id) {
-    actions.value = actions.value.filter((a) => a.id !== id)
+    toast.dismiss(toastId(id))
   }
 
-  return { actions, startAction, completeAction, dismissAction }
+  return { startAction, completeAction, dismissAction }
 }
 
 /**

--- a/assets/js/composables/toast.js
+++ b/assets/js/composables/toast.js
@@ -1,27 +1,32 @@
-import { ref, inject, provide } from 'vue'
+import { inject, provide } from 'vue'
+import { createToast as createKleanToast } from '@/components/ui/toast/toast.js'
 
 const TOAST_KEY = Symbol('toast')
+const ORDINARY_TOAST_CLASS =
+  'flex items-start space-x-3 rounded-lg border border-gray-200 bg-white p-4 shadow-lg ring-0 dark:border-gray-700 dark:bg-gray-900'
 
-export function createToast() {
-  const toasts = ref([])
-  let nextId = 0
+export function createToast(options = {}) {
+  const controller = createKleanToast({ duration: 4000, ...options })
 
-  function toast({ message, type = 'success', duration = 4000 }) {
-    const id = nextId++
-    toasts.value.push({ id, message, type })
+  function toast(input = {}, toastOptions = {}) {
+    const item =
+      typeof input === 'string'
+        ? { ...toastOptions, message: input }
+        : { ...input }
 
-    setTimeout(() => {
-      dismiss(id)
-    }, duration)
+    return controller({
+      type: 'success',
+      ...item,
+      class: [item.kind ? '' : ORDINARY_TOAST_CLASS, item.class]
+        .filter(Boolean)
+        .join(' ')
+    })
   }
 
-  function dismiss(id) {
-    toasts.value = toasts.value.filter((t) => t.id !== id)
-  }
+  Object.assign(toast, controller)
 
   provide(TOAST_KEY, toast)
-
-  return { toasts, toast, dismiss }
+  return toast
 }
 
 export function useToast() {

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -6,8 +6,6 @@ import { createDeploymentFaviconManager } from '@/lib/deployment-favicon.mjs'
 import ToastContainer from '@/components/ToastContainer.vue'
 import UpdateBanner from '@/components/UpdateBanner.vue'
 import UpdateModal from '@/components/UpdateModal.vue'
-import DeploymentToast from '@/components/DeploymentToast.vue'
-import ServiceActionToast from '@/components/ServiceActionToast.vue'
 import CommandPalette from '@/components/CommandPalette.vue'
 import Avatar from '@/components/ui/avatar/Avatar.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
@@ -172,16 +170,12 @@ function openCommandPaletteFromUserMenu() {
 }
 
 // Toast system
-const { toasts, toast, dismiss } = createToast()
+const toast = createToast({ max: 0 })
 useFlashToast(toast)
 
 // Service actions (global tracking for service start/stop/restart)
-const {
-  actions: serviceActions,
-  startAction,
-  completeAction,
-  dismissAction
-} = createServiceActions()
+const { startAction, completeAction, dismissAction } =
+  createServiceActions(toast)
 provideServiceActions({ startAction, completeAction, dismissAction })
 
 // Command palette (Cmd+K)
@@ -192,8 +186,40 @@ const { updateInfo } = useUpdateCheck()
 const showUpdateModal = ref(false)
 
 // Active deployments tracking (SSE-based — no polling)
-const activeDeployments = ref([])
+const activeDeployments = new Map()
 const deploymentFavicon = createDeploymentFaviconManager()
+const operationalToastClass =
+  'block overflow-visible bg-transparent p-0 shadow-none ring-0 dark:bg-transparent'
+
+function deploymentToastId(id) {
+  return `deployment-${id}`
+}
+
+function showDeployment(deployment) {
+  const id = String(deployment.id)
+  activeDeployments.set(id, deployment)
+  toast({
+    id: deploymentToastId(id),
+    kind: 'deployment',
+    deployment,
+    class: operationalToastClass,
+    dismissible: false,
+    duration: false
+  })
+}
+
+const unsubscribeToast = toast.subscribe(() => {
+  const visibleIds = new Set(
+    toast
+      .getSnapshot()
+      .filter((item) => item.kind === 'deployment')
+      .map((item) => String(item.deployment.id))
+  )
+
+  for (const id of activeDeployments.keys()) {
+    if (!visibleIds.has(id)) activeDeployments.delete(id)
+  }
+})
 
 const { close: disconnectDeploymentStream } = useEventSource(
   loggedInUser ? '/api/v1/deployments/active/stream' : null,
@@ -206,9 +232,7 @@ const { close: disconnectDeploymentStream } = useEventSource(
         // Only add new deployments, don't remove ones we're already tracking
         // (DeploymentToast handles its own lifecycle via per-deployment SSE)
         for (const dep of data.deployments) {
-          if (!activeDeployments.value.find((d) => d.id === dep.id)) {
-            activeDeployments.value.push(dep)
-          }
+          if (!activeDeployments.has(String(dep.id))) showDeployment(dep)
         }
       }
     }
@@ -216,18 +240,26 @@ const { close: disconnectDeploymentStream } = useEventSource(
 )
 
 function updateDeploymentStatus({ deploymentId, ...state }) {
-  const deployment = activeDeployments.value.find(
-    ({ id }) => String(id) === String(deploymentId)
-  )
+  const id = String(deploymentId)
+  const deployment = activeDeployments.get(id)
   if (deployment) Object.assign(deployment, state)
+
+  toast.update(deploymentToastId(id), {
+    deployment,
+    duration: ['running', 'stopped', 'failed', 'cancelled'].includes(
+      state.status
+    )
+      ? 5000
+      : false
+  })
 
   deploymentFavicon.noteDeploymentStatus(deploymentId, state.status)
 }
 
 function dismissDeployment(deploymentId) {
-  activeDeployments.value = activeDeployments.value.filter(
-    (d) => d.id !== deploymentId
-  )
+  const id = String(deploymentId)
+  activeDeployments.delete(id)
+  toast.dismiss(deploymentToastId(id))
 }
 
 function acknowledgeDeploymentFavicon() {
@@ -246,6 +278,8 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  unsubscribeToast()
+  toast.destroy()
   desktopMediaQuery?.removeEventListener('change', handleDesktopViewport)
   disconnectDeploymentStream()
   deploymentFavicon.destroy()
@@ -1176,26 +1210,11 @@ watch(() => page.url, closeMobileMenu)
     </main>
 
     <!-- Toasts -->
-    <ToastContainer :toasts="toasts" @dismiss="dismiss" />
-
-    <!-- Persistent Deployment & Service Action Toasts -->
-    <div
-      class="pointer-events-none fixed bottom-4 right-4 z-50 flex flex-col gap-3"
-    >
-      <ServiceActionToast
-        v-for="action in serviceActions"
-        :key="'service-' + action.id"
-        :action="action"
-        @dismiss="dismissAction"
-      />
-      <DeploymentToast
-        v-for="deployment in activeDeployments"
-        :key="'deploy-' + deployment.id"
-        :deployment="deployment"
-        @status-change="updateDeploymentStatus"
-        @dismiss="dismissDeployment"
-      />
-    </div>
+    <ToastContainer
+      :controller="toast"
+      @deployment-status-change="updateDeploymentStatus"
+      @dismiss-deployment="dismissDeployment"
+    />
 
     <!-- Command Palette (Cmd+K) -->
     <CommandPalette v-if="loggedInUser" />

--- a/assets/js/layouts/BridgeWorkspaceLayout.vue
+++ b/assets/js/layouts/BridgeWorkspaceLayout.vue
@@ -2,8 +2,10 @@
 import { usePage } from '@inertiajs/vue3'
 import { computed, onMounted, onUnmounted, provide, ref, watch } from 'vue'
 import BridgeWorkspaceSidebar from '@/components/bridge/BridgeWorkspaceSidebar.vue'
+import ToastContainer from '@/components/ToastContainer.vue'
 import Sheet from '@/components/ui/sheet/Sheet.vue'
 import Sidebar from '@/components/ui/sidebar/Sidebar.vue'
+import { createToast } from '@/composables/toast'
 
 const STORAGE_KEY = 'slipway:bridge-sidebar-collapsed'
 const page = usePage()
@@ -13,6 +15,7 @@ const desktopSidebar = ref()
 const sidebarOpen = ref(true)
 const sidebarCollapsed = computed(() => !sidebarOpen.value)
 let desktopMediaQuery
+const toast = createToast()
 
 function toggleMobileMenu(event) {
   if (mobileMenuOpen.value) {
@@ -63,6 +66,7 @@ onMounted(() => {
 })
 
 onUnmounted(() => {
+  toast.destroy()
   desktopMediaQuery?.removeEventListener('change', handleDesktopViewport)
 })
 
@@ -109,5 +113,7 @@ watch(() => page.url, closeMobileMenu)
     <main class="min-w-0 flex-1 overflow-hidden">
       <slot />
     </main>
+
+    <ToastContainer :controller="toast" />
   </div>
 </template>

--- a/assets/js/pages/auth/check-email.vue
+++ b/assets/js/pages/auth/check-email.vue
@@ -14,7 +14,7 @@ const props = defineProps({
   }
 })
 
-const { toasts, toast, dismiss } = createToast()
+const toast = createToast()
 useFlashToast(toast)
 
 const resendSecondsRemaining = ref(props.resendCooldownSecondsRemaining)
@@ -42,7 +42,10 @@ onMounted(() => {
   }, 1000)
 })
 
-onBeforeUnmount(() => clearInterval(countdownInterval))
+onBeforeUnmount(() => {
+  clearInterval(countdownInterval)
+  toast.destroy()
+})
 </script>
 
 <template>
@@ -123,5 +126,5 @@ onBeforeUnmount(() => clearInterval(countdownInterval))
     </main>
   </div>
 
-  <ToastContainer :toasts="toasts" @dismiss="dismiss" />
+  <ToastContainer :controller="toast" />
 </template>

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -14,7 +14,7 @@ import {
 import { useEventSource } from '@/composables/sse'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
-import ToastContainer from '@/components/ToastContainer.vue'
+import { useToast } from '@/composables/toast'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Table from '@/components/ui/table/Table.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
@@ -145,18 +145,10 @@ const canExecuteHelm = computed(() => {
   return Boolean(helmCode.value.trim())
 })
 
-// Toast state
-const toasts = ref([])
-let toastId = 0
+const toast = useToast()
 
 function showToast(message, type = 'success') {
-  const id = ++toastId
-  toasts.value.push({ id, message, type })
-  setTimeout(() => dismissToast(id), 5000)
-}
-
-function dismissToast(id) {
-  toasts.value = toasts.value.filter((t) => t.id !== id)
+  toast({ message, type, duration: 5000 })
 }
 
 async function loadHelmCompletionMetadata() {
@@ -2296,6 +2288,5 @@ onUnmounted(() => {
       @confirm="applyMigration"
       @cancel="showMigrateConfirm = false"
     />
-    <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
   </Tabs>
 </template>

--- a/assets/js/pages/projects/bridge-form.vue
+++ b/assets/js/pages/projects/bridge-form.vue
@@ -2,8 +2,7 @@
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, onMounted } from 'vue'
 import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
-import ToastContainer from '@/components/ToastContainer.vue'
-import { createToast } from '@/composables/toast'
+import { useToast } from '@/composables/toast'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import BridgeFieldInput from '@/components/bridge/BridgeFieldInput.vue'
 import {
@@ -43,7 +42,7 @@ const props = defineProps({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
-const { toasts, toast, dismiss } = createToast()
+const toast = useToast()
 const bridgeBasePath = computed(
   () =>
     props.bridgeRequestBasePath ||
@@ -369,8 +368,6 @@ function recordUrl() {
       modelMeta?.singularLabel || modelIdentity
     } - Bridge | Slipway`"
   ></Head>
-  <ToastContainer :toasts="toasts" @dismiss="dismiss" />
-
   <div class="flex h-full flex-col">
     <BridgePageHeader
       v-if="hostBridgeOrigin"

--- a/assets/js/pages/projects/bridge-model.vue
+++ b/assets/js/pages/projects/bridge-model.vue
@@ -5,8 +5,7 @@ import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, watch } from 'vue'
 import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
-import ToastContainer from '@/components/ToastContainer.vue'
-import { createToast } from '@/composables/toast'
+import { useToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
 import BridgeActionDialog from '@/components/bridge/BridgeActionDialog.vue'
@@ -61,7 +60,7 @@ const props = defineProps({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
-const { toasts, toast, dismiss } = createToast()
+const toast = useToast()
 const bridgeBasePath = computed(
   () =>
     props.bridgeRequestBasePath ||
@@ -407,8 +406,6 @@ function createUrl() {
   <Head
     :title="`${modelMeta?.label || modelIdentity} - Bridge | Slipway`"
   ></Head>
-  <ToastContainer :toasts="toasts" @dismiss="dismiss" />
-
   <div class="flex h-full flex-col">
     <BridgePageHeader
       v-if="hostBridgeOrigin"

--- a/assets/js/pages/projects/bridge-record.vue
+++ b/assets/js/pages/projects/bridge-record.vue
@@ -3,8 +3,7 @@ import { Link, Head, router, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import BridgePageLayout from '@/layouts/BridgePageLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
-import ToastContainer from '@/components/ToastContainer.vue'
-import { createToast } from '@/composables/toast'
+import { useToast } from '@/composables/toast'
 import BridgeFieldValue from '@/components/bridge/BridgeFieldValue.vue'
 import BridgeCollectionManager from '@/components/bridge/BridgeCollectionManager.vue'
 import ActionMenu from '@/components/ActionMenu.vue'
@@ -37,7 +36,7 @@ const props = defineProps({
 const toggleMobileMenu = inject('toggleMobileMenu')
 const toggleSidebar = inject('toggleSidebar')
 const sidebarCollapsed = inject('sidebarCollapsed')
-const { toasts, toast, dismiss } = createToast()
+const toast = useToast()
 const bridgeBasePath = computed(
   () =>
     props.bridgeRequestBasePath ||
@@ -228,8 +227,6 @@ function relationshipMutationBaseUrl(relationship) {
       modelMeta?.singularLabel || modelIdentity
     } ${recordId} - Bridge | Slipway`"
   ></Head>
-  <ToastContainer :toasts="toasts" @dismiss="dismiss" />
-
   <div class="flex h-full flex-col">
     <BridgePageHeader
       v-if="hostBridgeOrigin"

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -13,7 +13,7 @@ import {
 } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import ConfirmModal from '@/components/ConfirmModal.vue'
-import ToastContainer from '@/components/ToastContainer.vue'
+import { useToast } from '@/composables/toast'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Select from '@/components/ui/select/Select.vue'
 import Table from '@/components/ui/table/Table.vue'
@@ -264,18 +264,10 @@ const importLoading = ref(false)
 const showImportModal = ref(false)
 const showImportConfirm = ref(false)
 
-// Toast state
-const toasts = ref([])
-let toastId = 0
+const toast = useToast()
 
 function showToast(message, type = 'success') {
-  const id = ++toastId
-  toasts.value.push({ id, message, type })
-  setTimeout(() => dismissToast(id), 5000)
-}
-
-function dismissToast(id) {
-  toasts.value = toasts.value.filter((t) => t.id !== id)
+  toast({ message, type, duration: 5000 })
 }
 
 // Tables state
@@ -2962,8 +2954,5 @@ onUnmounted(() => {
       @confirm="executeImport"
       @cancel="showImportConfirm = false"
     />
-
-    <!-- Toasts -->
-    <ToastContainer :toasts="toasts" @dismiss="dismissToast" />
   </div>
 </template>

--- a/tests/e2e/pages/toast.test.js
+++ b/tests/e2e/pages/toast.test.js
@@ -1,0 +1,185 @@
+const { test } = require('sounding')
+
+test(
+  'notifications use one pause-aware Klean Toast viewport',
+  { browser: true, world: 'configured-slipway' },
+  async ({ world, login, page, expect }) => {
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    const updateCheck = page.raw.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/v1/system/check-update'
+    )
+
+    await login.withPassword('genesisUser', page, {
+      password: world.current.auth.genesisUserPassword
+    })
+    await page.raw.waitForURL((url) => url.pathname !== '/login')
+    await updateCheck
+    await page.goto('/profile')
+
+    const inertiaPage = await page.raw.evaluate(
+      () => window.history.state?.page || window.history.state
+    )
+    await page.raw.route('**/profile', async (route) => {
+      if (route.request().method() !== 'PATCH') {
+        await route.continue()
+        return
+      }
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        headers: { 'X-Inertia': 'true' },
+        body: JSON.stringify({ ...inertiaPage, url: '/profile' })
+      })
+    })
+
+    const name = page.raw.locator('#profile-full-name')
+    await name.fill(`${await name.inputValue()} Toast`)
+    await page.raw
+      .getByRole('button', { name: 'Save changes', exact: true })
+      .first()
+      .click()
+
+    const viewport = page.raw.locator('[data-slot="toast-viewport"]')
+    const notification = viewport.locator('[data-slot="toast"]', {
+      hasText: 'Profile updated'
+    })
+
+    await expect(viewport).toHaveCount(1)
+    await expect(viewport).toHaveAttribute('aria-live', 'polite')
+    await expect(viewport).toHaveAttribute('data-position', 'bottom-right')
+    await expect(viewport).toHaveAttribute('data-from', 'right')
+    await expect(viewport).toHaveAttribute('data-to', 'right')
+    await expect(notification).toBeVisible()
+
+    await notification.hover()
+    await page.raw.waitForTimeout(4250)
+    await expect(notification).toBeVisible()
+
+    await page.raw.mouse.move(1, 1)
+    await expect(notification).toBeHidden({ timeout: 5000 })
+
+    expect(page).toHaveNoSmoke()
+  }
+)
+
+test(
+  'service operations update one persistent toast and inherit paused dismissal',
+  {
+    browser: true,
+    world: {
+      name: 'configured-slipway',
+      context: {
+        deploymentTarget: {
+          slug: 'klean-toast-service-action',
+          name: 'Klean Toast service action'
+        }
+      }
+    }
+  },
+  async ({ world, login, page, expect }) => {
+    const current = world.current
+    const service = await world.create('service').with({
+      name: 'primary-db',
+      type: 'postgresql',
+      version: '17',
+      status: 'stopped',
+      environment: current.environments.production.id,
+      internalHost: 'primary-db',
+      internalPort: 5432,
+      database: 'app',
+      username: 'slipway',
+      password: 'secret'
+    })
+
+    await page.raw.route('**/api/v1/system/check-update', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ updateAvailable: false })
+      })
+    })
+    await page.raw.addInitScript(() => {
+      window.EventSource = class MockEventSource {
+        constructor() {
+          setTimeout(() => this.onopen?.(), 0)
+        }
+
+        close() {}
+      }
+    })
+
+    let releaseStart
+    const startRelease = new Promise((resolve) => {
+      releaseStart = resolve
+    })
+    let announceStart
+    const startRequested = new Promise((resolve) => {
+      announceStart = resolve
+    })
+
+    await page.raw.route(
+      `**/api/v1/services/${service.id}/start`,
+      async (route) => {
+        announceStart()
+        await startRelease
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ started: true })
+        })
+      }
+    )
+
+    const updateCheck = page.raw.waitForResponse(
+      (response) =>
+        new URL(response.url()).pathname === '/api/v1/system/check-update'
+    )
+    await login.withPassword('genesisUser', page, {
+      password: current.auth.genesisUserPassword
+    })
+    await updateCheck
+    await page.goto(
+      `/projects/${current.projects.deploymentTarget.slug}/environments/${current.environments.production.slug}`
+    )
+
+    await page.raw.getByRole('button', { name: /Services/ }).click()
+    await page.raw
+      .getByRole('button', { name: 'Actions for primary-db' })
+      .click()
+    await page.raw
+      .getByRole('menu', { name: 'Actions for primary-db' })
+      .getByRole('menuitem', { name: 'Start', exact: true })
+      .click()
+    await startRequested
+
+    const viewport = page.raw.locator('[data-slot="toast-viewport"]')
+    const operation = viewport.locator('[data-slot="toast"]', {
+      hasText: 'primary-db'
+    })
+
+    await expect(viewport).toHaveCount(1)
+    await expect(operation).toHaveCount(1)
+    await expect(operation).toContainText('Starting')
+    await expect(operation.locator('[data-slot="spinner"]')).toBeVisible()
+
+    releaseStart()
+    await expect(operation).toContainText('Started')
+    await expect(operation.locator('[data-slot="spinner"]')).toHaveCount(0)
+
+    await operation.hover()
+    await page.raw.waitForTimeout(4250)
+    await expect(operation).toBeVisible()
+    await page.raw.mouse.move(1, 1)
+    await expect(operation).toBeHidden({ timeout: 5000 })
+
+    expect(page).toHaveNoSmoke()
+  }
+)

--- a/tests/unit/assets/toast.test.js
+++ b/tests/unit/assets/toast.test.js
@@ -1,0 +1,55 @@
+const fs = require('node:fs')
+const path = require('node:path')
+const { test } = require('sounding')
+
+function source(file) {
+  return fs.readFileSync(path.resolve(file), 'utf8')
+}
+
+const container = source('assets/js/components/ToastContainer.vue')
+const toastComposable = source('assets/js/composables/toast.js')
+const serviceActions = source('assets/js/composables/service-actions.js')
+const deployment = source('assets/js/components/DeploymentToast.vue')
+const appLayout = source('assets/js/layouts/AppLayout.vue')
+
+test('Slipway composes one Klean Toast viewport without rebuilding lifecycle mechanics', ({
+  expect
+}) => {
+  expect(container).toContain(
+    "import Toast from '@/components/ui/toast/Toast.vue'"
+  )
+  expect(container).toContain('position="bottom-right"')
+  expect(container).toContain('from="right"')
+  expect(container).toContain('to="right"')
+  expect(container.includes('<Teleport')).toBe(false)
+  expect(container.includes('<TransitionGroup')).toBe(false)
+
+  expect(toastComposable).toContain(
+    "import { createToast as createKleanToast } from '@/components/ui/toast/toast.js'"
+  )
+  expect(toastComposable.includes('setTimeout')).toBe(false)
+  expect(appLayout.match(/<ToastContainer/g)?.length).toBe(1)
+  expect(appLayout.includes('v-for="action in serviceActions"')).toBe(false)
+  expect(appLayout.includes('v-for="deployment in activeDeployments"')).toBe(
+    false
+  )
+})
+
+test('operational notifications keep product UI but delegate durable timing and motion', ({
+  expect
+}) => {
+  expect(serviceActions).toContain("kind: 'service-action'")
+  expect(serviceActions).toContain('duration: false')
+  expect(serviceActions).toContain('duration: 4000')
+  expect(serviceActions.includes('setTimeout')).toBe(false)
+
+  expect(appLayout).toContain("kind: 'deployment'")
+  expect(appLayout).toContain('duration: false')
+  expect(appLayout).toContain('? 5000')
+  expect(deployment).toContain("import { Link } from '@inertiajs/vue3'")
+  expect(deployment).toContain('closeStream()')
+  expect(deployment).toContain('role="status"')
+  expect(deployment.includes('<Transition')).toBe(false)
+  expect(deployment.includes('setTimeout')).toBe(false)
+  expect(deployment.includes('router.visit')).toBe(false)
+})


### PR DESCRIPTION
## Summary

- adopt the copied Klean Toast source and one app-owned notification shelf
- preserve Slipway deployment progress, service actions, Slippy loading treatment, and ordinary product styling
- replace duplicated page timers and viewports with one pause-aware controller per layout
- keep deployment and service progress in one notification updated in place
- sync the Klean Tooltip pointer contract so notification actions remain reachable
- cover ordinary notifications and persistent service operations in real browser flows

## Verification

- 324/324 unit tests
- 105/105 functional tests
- 47/47 E2E tests
- focused Dock, Helm, deployment-history, and Toast regressions
- npm run lint
- npm run check:consistency

Closes #480