### PR TITLE
test(e2e): isolate Sounding app lifecycles

### DIFF
--- a/api/hooks/custom/index.js
+++ b/api/hooks/custom/index.js
@@ -5,13 +5,35 @@
  * @docs        :: https://sailsjs.com/docs/concepts/extending-sails/hooks
  */
 
+const createInFlightWork = require('../../lib/in-flight-work')
+
 module.exports = function defineCustomHook(sails) {
+  const sharedPropWork = createInFlightWork()
+
+  function resolveSharedProp(callback, shutdownFallback) {
+    return () => sharedPropWork.run(callback, shutdownFallback)
+  }
+
   return {
     /**
      * Runs when this Sails app loads/lifts.
      */
     initialize: async function () {
       sails.log.info('Initializing custom hook (`custom`)')
+
+      const existingBeforeShutdown = sails.config.beforeShutdown
+      sails.config.beforeShutdown = function beforeShutdown(done) {
+        sharedPropWork
+          .drain()
+          .then(() => {
+            if (typeof existingBeforeShutdown === 'function') {
+              existingBeforeShutdown(done)
+              return
+            }
+            done()
+          })
+          .catch(done)
+      }
     },
     routes: {
       before: {
@@ -28,155 +50,170 @@ module.exports = function defineCustomHook(sails) {
               const userId = req.session.userId
               sails.inertia.share(
                 'loggedInUser',
-                sails.inertia.once(async () => {
-                  if (!userId) {
-                    return null
-                  }
-                  const user = await User.findOne({
-                    id: userId
-                  })
-                    .select([
-                      'email',
-                      'fullName',
-                      'initials',
-                      'team',
-                      'teamRole'
-                    ])
-                    .populate('team')
+                sails.inertia.once(
+                  resolveSharedProp(async () => {
+                    if (!userId) {
+                      return null
+                    }
+                    const user = await User.findOne({
+                      id: userId
+                    })
+                      .select([
+                        'email',
+                        'fullName',
+                        'initials',
+                        'team',
+                        'teamRole'
+                      ])
+                      .populate('team')
 
-                  if (!user) {
-                    sails.log.warn(
-                      'Somehow, the user record for the logged-in user (`' +
-                        req.session.userId +
-                        '`) has gone missing....'
-                    )
-                    delete req.session.userId
-                    return null
-                  }
+                    if (!user) {
+                      sails.log.warn(
+                        'Somehow, the user record for the logged-in user (`' +
+                          req.session.userId +
+                          '`) has gone missing....'
+                      )
+                      delete req.session.userId
+                      return null
+                    }
 
-                  // Also fetch teams owned by this user (for team switching)
-                  const ownedTeams = await Team.find({ owner: user.id }).select(
-                    ['id', 'name', 'slug', 'logoUrl']
-                  )
+                    // Also fetch teams owned by this user (for team switching)
+                    const ownedTeams = await Team.find({
+                      owner: user.id
+                    }).select(['id', 'name', 'slug', 'logoUrl'])
 
-                  return { ...user, ownedTeams }
-                })
+                    return { ...user, ownedTeams }
+                  }, null)
+                )
               )
 
-              sails.inertia.share('navProjects', async () => {
-                const user = await User.findOne({ id: userId }).select(['team'])
-                if (!user || !user.team) {
-                  return []
-                }
-                return await Project.find({ team: user.team })
-                  .select(['name', 'slug'])
-                  .sort('name ASC')
-              })
-
-              sails.inertia.share('navApps', async () => {
-                try {
+              sails.inertia.share(
+                'navProjects',
+                resolveSharedProp(async () => {
                   const user = await User.findOne({ id: userId }).select([
                     'team'
                   ])
                   if (!user || !user.team) {
                     return []
                   }
-                  const projects = await Project.find({
-                    team: user.team
-                  }).select(['id', 'name', 'slug'])
-                  const projectIds = projects.map((p) => p.id)
-                  const environments = await Environment.find({
-                    project: projectIds
-                  }).select(['id', 'slug', 'name', 'project', 'domain'])
-                  const envIds = environments.map((e) => e.id)
-                  const apps = await App.find({ environment: envIds }).select([
-                    'name',
-                    'slug',
-                    'environment'
-                  ])
-                  const wildcardDomain = await sails.helpers.setting.get(
-                    'wildcardDomain'
-                  )
-                  const slipwayDomain = sails.config.custom.slipwayDomain
-                  const accessByEnvironment = new Map(
-                    await Promise.all(
-                      environments.map(async (environment) => {
-                        const project = projects.find(
-                          (candidate) => candidate.id === environment.project
-                        )
-                        const access = project
-                          ? await Environment.resolveAppUrls(
-                              { ...environment, project },
-                              { wildcardDomain, slipwayDomain }
-                            )
-                          : { primaryUrl: null }
-                        return [environment.id, access]
-                      })
-                    )
-                  )
-                  return apps.map((app) => {
-                    const env = environments.find(
-                      (e) => e.id === app.environment
-                    )
-                    const project = projects.find((p) => p.id === env?.project)
-                    const url =
-                      accessByEnvironment.get(app.environment)?.primaryUrl ||
-                      null
-                    return {
-                      name: app.name,
-                      slug: app.slug,
-                      projectName: project?.name,
-                      projectSlug: project?.slug,
-                      envName: env?.name,
-                      envSlug: env?.slug,
-                      url
-                    }
-                  })
-                } catch (err) {
-                  sails.log.error('navApps shared prop error:', err)
-                  return []
-                }
-              })
+                  return await Project.find({ team: user.team })
+                    .select(['name', 'slug'])
+                    .sort('name ASC')
+                }, [])
+              )
 
-              sails.inertia.share('navServices', async () => {
-                try {
-                  const user = await User.findOne({ id: userId }).select([
-                    'team'
-                  ])
-                  if (!user || !user.team) {
+              sails.inertia.share(
+                'navApps',
+                resolveSharedProp(async () => {
+                  try {
+                    const user = await User.findOne({ id: userId }).select([
+                      'team'
+                    ])
+                    if (!user || !user.team) {
+                      return []
+                    }
+                    const projects = await Project.find({
+                      team: user.team
+                    }).select(['id', 'name', 'slug'])
+                    const projectIds = projects.map((p) => p.id)
+                    const environments = await Environment.find({
+                      project: projectIds
+                    }).select(['id', 'slug', 'name', 'project', 'domain'])
+                    const envIds = environments.map((e) => e.id)
+                    const apps = await App.find({ environment: envIds }).select(
+                      ['name', 'slug', 'environment']
+                    )
+                    const wildcardDomain = await sails.helpers.setting.get(
+                      'wildcardDomain'
+                    )
+                    const slipwayDomain = sails.config.custom.slipwayDomain
+                    const accessByEnvironment = new Map(
+                      await Promise.all(
+                        environments.map(async (environment) => {
+                          const project = projects.find(
+                            (candidate) => candidate.id === environment.project
+                          )
+                          const access = project
+                            ? await Environment.resolveAppUrls(
+                                { ...environment, project },
+                                { wildcardDomain, slipwayDomain }
+                              )
+                            : { primaryUrl: null }
+                          return [environment.id, access]
+                        })
+                      )
+                    )
+                    return apps.map((app) => {
+                      const env = environments.find(
+                        (e) => e.id === app.environment
+                      )
+                      const project = projects.find(
+                        (p) => p.id === env?.project
+                      )
+                      const url =
+                        accessByEnvironment.get(app.environment)?.primaryUrl ||
+                        null
+                      return {
+                        name: app.name,
+                        slug: app.slug,
+                        projectName: project?.name,
+                        projectSlug: project?.slug,
+                        envName: env?.name,
+                        envSlug: env?.slug,
+                        url
+                      }
+                    })
+                  } catch (err) {
+                    sails.log.error('navApps shared prop error:', err)
                     return []
                   }
-                  const projects = await Project.find({
-                    team: user.team
-                  }).select(['id', 'name', 'slug'])
-                  const projectIds = projects.map((p) => p.id)
-                  const environments = await Environment.find({
-                    project: projectIds
-                  }).select(['id', 'slug', 'name', 'project'])
-                  const envIds = environments.map((e) => e.id)
-                  const services = await Service.find({
-                    environment: envIds
-                  }).select(['id', 'name', 'type', 'environment'])
-                  return services.map((service) => {
-                    const env = environments.find(
-                      (e) => e.id === service.environment
-                    )
-                    const project = projects.find((p) => p.id === env?.project)
-                    return {
-                      id: service.id,
-                      name: service.name,
-                      type: service.type,
-                      projectName: project?.name,
-                      projectSlug: project?.slug,
-                      envName: env?.name,
-                      envSlug: env?.slug
+                }, [])
+              )
+
+              sails.inertia.share(
+                'navServices',
+                resolveSharedProp(async () => {
+                  try {
+                    const user = await User.findOne({ id: userId }).select([
+                      'team'
+                    ])
+                    if (!user || !user.team) {
+                      return []
                     }
-                  })
-                } catch (err) {
-                  sails.log.error('navServices shared prop error:', err)
-                  return []
-                }
-              })
+                    const projects = await Project.find({
+                      team: user.team
+                    }).select(['id', 'name', 'slug'])
+                    const projectIds = projects.map((p) => p.id)
+                    const environments = await Environment.find({
+                      project: projectIds
+                    }).select(['id', 'slug', 'name', 'project'])
+                    const envIds = environments.map((e) => e.id)
+                    const services = await Service.find({
+                      environment: envIds
+                    }).select(['id', 'name', 'type', 'environment'])
+                    return services.map((service) => {
+                      const env = environments.find(
+                        (e) => e.id === service.environment
+                      )
+                      const project = projects.find(
+                        (p) => p.id === env?.project
+                      )
+                      return {
+                        id: service.id,
+                        name: service.name,
+                        type: service.type,
+                        projectName: project?.name,
+                        projectSlug: project?.slug,
+                        envName: env?.name,
+                        envSlug: env?.slug
+                      }
+                    })
+                  } catch (err) {
+                    sails.log.error('navServices shared prop error:', err)
+                    return []
+                  }
+                }, [])
+              )
 
               res.setHeader('Cache-Control', 'no-cache, no-store')
               return next()

--- a/api/lib/in-flight-work.js
+++ b/api/lib/in-flight-work.js
@@ -1,0 +1,67 @@
+/**
+ * Track asynchronous application work that must finish before shutdown.
+ *
+ * Once draining begins, new work resolves to its shutdown fallback instead of
+ * starting against resources that Sails is about to tear down.
+ *
+ * @returns {{
+ *   run<T>(work: () => T | Promise<T>, fallback: T): Promise<T>,
+ *   drain(): Promise<void>,
+ *   readonly pending: number,
+ *   readonly draining: boolean
+ * }}
+ */
+module.exports = function createInFlightWork() {
+  const active = new Set()
+  const waiters = new Set()
+  let draining = false
+
+  function resolveWaitersWhenIdle() {
+    if (!draining || active.size !== 0) {
+      return
+    }
+
+    for (const resolve of waiters) {
+      resolve()
+    }
+    waiters.clear()
+  }
+
+  return {
+    async run(work, fallback) {
+      if (draining) {
+        return fallback
+      }
+
+      const pendingWork = Promise.resolve().then(work)
+      active.add(pendingWork)
+
+      try {
+        return await pendingWork
+      } finally {
+        active.delete(pendingWork)
+        resolveWaitersWhenIdle()
+      }
+    },
+
+    drain() {
+      draining = true
+
+      if (active.size === 0) {
+        return Promise.resolve()
+      }
+
+      return new Promise((resolve) => {
+        waiters.add(resolve)
+      })
+    },
+
+    get pending() {
+      return active.size
+    },
+
+    get draining() {
+      return draining
+    }
+  }
+}

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -4,7 +4,9 @@ const {
 } = require('../../api/lib/error-pages')
 
 module.exports = {
-  port: 3333,
+  // Port zero asks the OS for an unused listener. Sounding reads the actual
+  // bound address after lift, so sequential worlds never share a fixed port.
+  port: 0,
   hooks: {
     lookout: false,
     quest: false

--- a/config/sounding.js
+++ b/config/sounding.js
@@ -1,14 +1,7 @@
-const soundingPort =
-  Number(process.env.SOUNDING_PORT) || 30000 + (process.pid % 20000)
-
 module.exports.sounding = {
   app: {
     liftOptions: {
       explicitHost: '127.0.0.1',
-      port: soundingPort,
-      custom: {
-        baseUrl: `http://127.0.0.1:${soundingPort}`
-      },
       hooks: {
         sockets: true
       }

--- a/tests/unit/config/sounding.test.js
+++ b/tests/unit/config/sounding.test.js
@@ -1,0 +1,11 @@
+const { test } = require('sounding')
+
+const { sounding } = require('../../../config/sounding')
+const testEnvironment = require('../../../config/env/test')
+
+test('Sounding lets the OS allocate an unused HTTP port', ({ expect }) => {
+  expect(testEnvironment.port).toBe(0)
+  expect(sounding.app.liftOptions.port).toBe(undefined)
+  expect(sounding.app.liftOptions.custom?.baseUrl).toBe(undefined)
+  expect(sounding.browser.baseUrl).toBe(undefined)
+})

--- a/tests/unit/lib/in-flight-work.test.js
+++ b/tests/unit/lib/in-flight-work.test.js
@@ -1,0 +1,49 @@
+const { test } = require('sounding')
+
+const createInFlightWork = require('../../../api/lib/in-flight-work')
+
+test('drain waits for work that already started', async ({ expect }) => {
+  const tracker = createInFlightWork()
+  let finishWork
+  let drained = false
+
+  const work = tracker.run(
+    () =>
+      new Promise((resolve) => {
+        finishWork = resolve
+      }),
+    null
+  )
+  const drain = tracker.drain().then(() => {
+    drained = true
+  })
+
+  await Promise.resolve()
+  expect(tracker.pending).toBe(1)
+  expect(drained).toBe(false)
+
+  finishWork('complete')
+
+  expect(await work).toBe('complete')
+  await drain
+  expect(tracker.pending).toBe(0)
+  expect(drained).toBe(true)
+})
+
+test('work registered after draining begins uses its shutdown fallback', async ({
+  expect
+}) => {
+  const tracker = createInFlightWork()
+  let started = false
+
+  await tracker.drain()
+  const result = await tracker.run(() => {
+    started = true
+    return ['late query']
+  }, [])
+
+  expect(result).toEqual([])
+  expect(started).toBe(false)
+  expect(tracker.draining).toBe(true)
+  expect(tracker.pending).toBe(0)
+})


### PR DESCRIPTION
Closes #483

## Summary
- let the OS assign a free HTTP port to every Sounding test app
- drain active database-backed Inertia shared props before Sails tears down Waterline
- return inert navigation fallbacks for shared work that arrives after shutdown begins
- cover the port and event-driven drain contracts without sleeps

## Verification
- unit: 327/327
- functional: 105/105
- E2E: 47/47 twice without reruns
- focused Helm and precognition: 9/9
- Prettier and documentation consistency checks