### PR TITLE
feat(ui): adopt Klean FileUpload

### DIFF
--- a/assets/js/components/bridge/BridgeFieldInput.vue
+++ b/assets/js/components/bridge/BridgeFieldInput.vue
@@ -7,6 +7,7 @@ import MarkdownEditor from '@/components/content/MarkdownEditor.vue'
 import BridgeRelationshipCombobox from '@/components/bridge/BridgeRelationshipCombobox.vue'
 import Select from '@/components/ui/select/Select.vue'
 import Switch from '@/components/ui/switch/Switch.vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
 import {
   bridgeFieldType,
   bridgeSelectOptions,
@@ -77,7 +78,6 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue', 'blur', 'clear-error'])
 
-const fileInput = ref(null)
 const uploading = ref(false)
 const uploadError = ref('')
 const uploadPhase = ref('')
@@ -258,12 +258,16 @@ function toggleRichTextMode() {
   richTextEditor.value?.setMode(next)
 }
 
-async function uploadFile(event) {
-  const file = event.target.files?.[0]
-  event.target.value = ''
-  if (!file) return
+function validateUploadFile(file) {
+  if (file.size > maxBytes.value) {
+    return `Choose a file no larger than ${formatBridgeBytes(maxBytes.value)}.`
+  }
+  if (!props.uploadUrl) return 'This Bridge upload field is not configured.'
+  return true
+}
 
-  await beginUpload(file)
+function handleUploadReject(rejection) {
+  uploadError.value = rejection.message
 }
 
 async function beginUpload(file) {
@@ -955,20 +959,18 @@ function defaultPlaceholder(fieldType) {
         @blur="handleBlur"
       ></textarea>
 
-      <div
+      <FileUpload
         v-else-if="['file', 'image', 'upload'].includes(type)"
         class="space-y-3"
+        v-model="pendingUploadFile"
+        :accept="accept || undefined"
+        :disabled="field.readOnly || uploading"
+        :validate="validateUploadFile"
+        :data-test="`${fieldId}-upload`"
+        @change="beginUpload"
+        @reject="handleUploadReject"
+        v-slot="upload"
       >
-        <input
-          :id="fieldId"
-          ref="fileInput"
-          type="file"
-          class="sr-only"
-          :accept="accept || undefined"
-          :disabled="field.readOnly || uploading"
-          :data-test="`${fieldId}-input`"
-          @change="uploadFile"
-        />
         <div
           v-if="uploading"
           class="space-y-2 rounded-lg bg-gray-50 p-3 dark:bg-gray-900"
@@ -986,7 +988,7 @@ function defaultPlaceholder(fieldType) {
             <button
               v-if="uploadPhase === 'uploading' && uploadAbortController"
               type="button"
-              class="shrink-0 text-xs font-medium text-gray-500 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-400 dark:hover:text-white dark:focus-visible:ring-gray-600"
+              class="shrink-0 cursor-pointer text-xs font-medium text-gray-500 hover:text-gray-900 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-400 dark:hover:text-white dark:focus-visible:ring-gray-600"
               @click="cancelUpload"
             >
               Cancel
@@ -1038,8 +1040,10 @@ function defaultPlaceholder(fieldType) {
           <button
             type="button"
             :disabled="field.readOnly || uploading"
-            class="shrink-0 text-xs font-medium text-gray-500 hover:text-gray-900 disabled:opacity-50 dark:text-gray-400 dark:hover:text-white"
-            @click="fileInput?.click()"
+            :aria-invalid="visibleError ? 'true' : undefined"
+            :aria-describedby="describedBy"
+            class="shrink-0 cursor-pointer text-xs font-medium text-gray-500 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50 dark:text-gray-400 dark:hover:text-white"
+            @click="upload.choose"
           >
             Replace
           </button>
@@ -1048,8 +1052,10 @@ function defaultPlaceholder(fieldType) {
           <button
             type="button"
             :disabled="field.readOnly"
-            class="inline-flex h-10 items-center rounded-md bg-gray-100 px-3 text-sm font-medium text-gray-700 hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-600"
-            @click="fileInput?.click()"
+            :aria-invalid="visibleError ? 'true' : undefined"
+            :aria-describedby="describedBy"
+            class="inline-flex h-10 cursor-pointer items-center rounded-md bg-gray-100 px-3 text-sm font-medium text-gray-700 hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 dark:focus-visible:ring-gray-600"
+            @click="upload.choose"
           >
             {{ isImageUpload ? 'Choose image' : 'Choose file' }}
           </button>
@@ -1063,25 +1069,28 @@ function defaultPlaceholder(fieldType) {
         >
           <button
             type="button"
-            class="text-xs font-medium text-gray-700 hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-300 dark:hover:text-white dark:focus-visible:ring-gray-600"
+            class="cursor-pointer text-xs font-medium text-gray-700 hover:text-gray-950 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-300 dark:hover:text-white dark:focus-visible:ring-gray-600"
             @click="retryUpload"
           >
             Retry upload
           </button>
           <button
             type="button"
-            class="text-xs text-gray-400 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-500 dark:hover:text-gray-300 dark:focus-visible:ring-gray-600"
-            @click="fileInput?.click()"
+            :aria-invalid="visibleError ? 'true' : undefined"
+            :aria-describedby="describedBy"
+            class="cursor-pointer text-xs text-gray-400 hover:text-gray-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-300 dark:text-gray-500 dark:hover:text-gray-300 dark:focus-visible:ring-gray-600"
+            @click="upload.choose"
           >
             Choose another file
           </button>
         </div>
-      </div>
+      </FileUpload>
     </template>
 
     <p
       v-if="visibleError"
       :id="errorId"
+      :role="uploadError ? 'alert' : undefined"
       class="text-xs text-red-600 dark:text-red-400"
     >
       {{ visibleError }}

--- a/assets/js/components/content/MarkdownEditor.vue
+++ b/assets/js/components/content/MarkdownEditor.vue
@@ -1,6 +1,13 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
-import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  ref,
+  shallowRef,
+  watch
+} from 'vue'
 import { EditorContent, useEditor } from '@tiptap/vue-3'
 import { BubbleMenu } from '@tiptap/vue-3/menus'
 import StarterKit from '@tiptap/starter-kit'
@@ -11,6 +18,7 @@ import { Markdown } from '@tiptap/markdown'
 import DOMPurify from 'dompurify'
 import Alert from '@/components/ui/alert/Alert.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
 import {
   inspectMarkdown,
   looksLikeImageUrl,
@@ -109,8 +117,9 @@ const imageAlt = ref('')
 const uploading = ref(false)
 const uploadMessage = ref('')
 const uploadKind = ref('status')
-const uploadInput = ref(null)
+const selectedUploadImages = shallowRef([])
 let uploadMessageTimeout
+let selectionRejection = ''
 
 const isField = computed(() => props.variant === 'field')
 const uploadAcceptValue = computed(() => props.uploadAccept.join(','))
@@ -509,23 +518,52 @@ async function uploadImages(files, position, currentEditor) {
       images.length === 1 ? 'Image added.' : `${images.length} images added.`,
       { timeout: 3000 }
     )
+    return true
   } catch (error) {
     showUploadMessage(error.message || 'The image could not be uploaded.', {
       kind: 'alert',
       timeout: 5000
     })
+    return false
   } finally {
     uploading.value = false
   }
 }
 
-function chooseImage() {
-  uploadInput.value?.click()
+function validateUploadImage(file) {
+  if (
+    !file.type.startsWith('image/') ||
+    (props.uploadAccept.length > 0 && !props.uploadAccept.includes(file.type))
+  ) {
+    return 'That image type is not accepted.'
+  }
+  if (file.size > props.maxUploadBytes) {
+    return `${file.name} is larger than ${formatUploadBytes(
+      props.maxUploadBytes
+    )}.`
+  }
+  if (!props.uploadsConfigured || !props.uploadUrl) {
+    return 'Image uploads are not configured. Paste a public image URL or configure uploads in Settings.'
+  }
+  return true
 }
 
-async function uploadSelectedImages(event) {
-  await uploadImages(event.target.files, null, editor.value)
-  event.target.value = ''
+function handleUploadImageReject(rejection) {
+  selectionRejection = rejection.message
+  showUploadMessage(rejection.message, { kind: 'alert', timeout: 5000 })
+  queueMicrotask(() => {
+    selectionRejection = ''
+  })
+}
+
+async function uploadSelectedImages(files) {
+  const rejection = selectionRejection
+  selectionRejection = ''
+  const uploaded = await uploadImages(files, null, editor.value)
+  selectedUploadImages.value = []
+  if (uploaded && rejection) {
+    showUploadMessage(rejection, { kind: 'alert', timeout: 5000 })
+  }
 }
 
 function formatUploadBytes(bytes) {
@@ -646,24 +684,25 @@ defineExpose({
       ></textarea>
     </div>
 
-    <div
+    <FileUpload
       v-if="mode === 'visual' && showUploadControl && uploadsConfigured"
+      v-model="selectedUploadImages"
+      multiple
+      :accept="uploadAcceptValue"
+      :disabled="uploading"
+      :validate="validateUploadImage"
+      :data-test="testHandle('image-upload')"
+      @change="uploadSelectedImages"
+      @reject="handleUploadImageReject"
+      v-slot="upload"
       class="min-h-9 mt-2 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400"
     >
-      <input
-        ref="uploadInput"
-        :data-test="testHandle('image-input')"
-        type="file"
-        :accept="uploadAcceptValue"
-        multiple
-        class="sr-only"
-        @change="uploadSelectedImages"
-      />
       <button
         type="button"
         :disabled="uploading"
-        class="min-h-9 inline-flex items-center gap-1.5 rounded-lg px-2 text-xs font-medium text-gray-700 transition hover:bg-gray-100 disabled:cursor-wait disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-900"
-        @click="chooseImage"
+        :data-test="testHandle('image-button')"
+        class="min-h-9 inline-flex cursor-pointer items-center gap-1.5 rounded-lg px-2 text-xs font-medium text-gray-700 transition hover:bg-gray-100 disabled:cursor-wait disabled:opacity-50 dark:text-gray-300 dark:hover:bg-gray-900"
+        @click="upload.choose"
       >
         <svg
           class="size-4"
@@ -682,7 +721,7 @@ defineExpose({
         {{ uploading ? 'Uploading…' : 'Add image' }}
       </button>
       <span>or paste and drop</span>
-    </div>
+    </FileUpload>
 
     <BubbleMenu
       v-if="editor"

--- a/assets/js/components/ui/file-upload/FileUpload.vue
+++ b/assets/js/components/ui/file-upload/FileUpload.vue
@@ -1,0 +1,310 @@
+<script setup>
+import {
+  computed,
+  onBeforeUnmount,
+  ref,
+  shallowRef,
+  useAttrs,
+  watch
+} from 'vue'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  accept: { type: String, default: undefined },
+  capture: { type: [String, Boolean], default: undefined },
+  multiple: { type: Boolean, default: false },
+  disabled: { type: Boolean, default: false },
+  validate: { type: Function, default: () => true }
+})
+
+const emit = defineEmits(['change', 'reject'])
+const file = defineModel({ default: null })
+const attrs = useAttrs()
+const root = ref()
+const input = ref()
+const previewEntries = shallowRef([])
+const dragging = ref(false)
+let dragDepth = 0
+
+const files = computed(() => {
+  const current = file.value
+  if (props.multiple) {
+    return Array.isArray(current)
+      ? current.filter(Boolean)
+      : current
+      ? [current]
+      : []
+  }
+  return current ? [current] : []
+})
+const singleFile = computed(() =>
+  props.multiple ? null : files.value[0] ?? null
+)
+const previews = computed(() =>
+  previewEntries.value.map(({ file: candidate, url }) => ({
+    file: candidate,
+    previewUrl: url
+  }))
+)
+const previewUrl = computed(() => previews.value[0]?.previewUrl ?? '')
+
+const rootAttrs = computed(() => {
+  const {
+    class: _class,
+    'data-slot': _dataSlot,
+    'data-state': _dataState,
+    'data-dragging': _dataDragging,
+    'data-disabled': _dataDisabled,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function resetInput() {
+  if (input.value) input.value.value = ''
+}
+
+function revokeEntry(entry) {
+  if (entry?.url && typeof URL.revokeObjectURL === 'function') {
+    URL.revokeObjectURL(entry.url)
+  }
+}
+
+function createPreviewEntry(candidate) {
+  const canPreview =
+    candidate &&
+    typeof Blob !== 'undefined' &&
+    candidate instanceof Blob &&
+    typeof URL.createObjectURL === 'function'
+  return {
+    file: candidate,
+    url: canPreview ? URL.createObjectURL(candidate) : ''
+  }
+}
+
+function syncPreviews(candidates) {
+  const remaining = [...previewEntries.value]
+  const next = candidates.map((candidate) => {
+    const index = remaining.findIndex((entry) =>
+      Object.is(entry.file, candidate)
+    )
+    if (index === -1) return createPreviewEntry(candidate)
+    return remaining.splice(index, 1)[0]
+  })
+  for (const entry of remaining) revokeEntry(entry)
+  previewEntries.value = next
+}
+
+function revokePreviews() {
+  for (const entry of previewEntries.value) revokeEntry(entry)
+  previewEntries.value = []
+}
+
+function validationResult(candidate, acceptedFiles) {
+  if (!acceptedByAttribute(candidate)) {
+    reject(candidate, 'accept', 'That file type is not accepted.')
+    return false
+  }
+
+  let result
+  try {
+    result = props.validate(candidate, {
+      files: [...acceptedFiles],
+      multiple: props.multiple
+    })
+  } catch {
+    reject(candidate, 'validate', 'That file could not be validated.')
+    return false
+  }
+
+  if (result === true || result === undefined) return true
+  reject(
+    candidate,
+    typeof result === 'object' && result?.reason ? result.reason : 'validate',
+    typeof result === 'string' && result
+      ? result
+      : typeof result === 'object' && result?.message
+      ? result.message
+      : 'That file is not valid.'
+  )
+  return false
+}
+
+function acceptedByAttribute(candidate) {
+  const rules = props.accept
+    ?.split(',')
+    .map((rule) => rule.trim().toLowerCase())
+    .filter(Boolean)
+  if (!rules?.length) return true
+
+  const type = candidate.type?.toLowerCase() ?? ''
+  const name = candidate.name?.toLowerCase() ?? ''
+  return rules.some((rule) => {
+    if (rule.startsWith('.')) return name.endsWith(rule)
+    if (rule.endsWith('/*')) return type.startsWith(rule.slice(0, -1))
+    return type === rule
+  })
+}
+
+function reject(candidate, reason, message, files = undefined) {
+  const detail = { file: candidate ?? null, reason, message }
+  if (files) detail.files = files
+  emit('reject', detail)
+  resetInput()
+  return false
+}
+
+function setFile(candidate) {
+  file.value = candidate
+  emit('change', candidate)
+  resetInput()
+  return true
+}
+
+function select(selection) {
+  if (props.disabled) return false
+  const candidates = Array.from(selection ?? [])
+  if (!candidates.length) return false
+  if (!props.multiple && candidates.length > 1) {
+    reject(candidates[0], 'multiple', 'Choose one file at a time.', candidates)
+    resetInput()
+    return false
+  }
+
+  const accepted = []
+  const current = props.multiple ? [...files.value] : []
+  for (const candidate of candidates) {
+    if (validationResult(candidate, [...current, ...accepted])) {
+      accepted.push(candidate)
+    }
+  }
+
+  if (!accepted.length) {
+    resetInput()
+    return false
+  }
+
+  return setFile(props.multiple ? [...current, ...accepted] : accepted[0])
+}
+
+function choose() {
+  if (props.disabled || !input.value) return
+  resetInput()
+  if (typeof input.value.showPicker === 'function') {
+    try {
+      input.value.showPicker()
+      return
+    } catch {
+      // The native click path covers browsers that restrict showPicker().
+    }
+  }
+  input.value.click()
+}
+
+function clear() {
+  if (props.disabled) return
+  setFile(props.multiple ? [] : null)
+}
+
+function remove(candidate) {
+  if (props.disabled) return false
+  if (!props.multiple) return setFile(null)
+  const index = files.value.findIndex((entry) => Object.is(entry, candidate))
+  if (index === -1) return false
+  const next = [...files.value]
+  next.splice(index, 1)
+  return setFile(next)
+}
+
+function hasFiles(event) {
+  return Array.from(event.dataTransfer?.types ?? []).includes('Files')
+}
+
+function handleDragEnter(event) {
+  if (props.disabled || !hasFiles(event)) return
+  event.preventDefault()
+  dragDepth += 1
+  dragging.value = true
+}
+
+function handleDragOver(event) {
+  if (props.disabled || !hasFiles(event)) return
+  event.preventDefault()
+  if (event.dataTransfer) event.dataTransfer.dropEffect = 'copy'
+  dragging.value = true
+}
+
+function handleDragLeave(event) {
+  if (props.disabled || !hasFiles(event)) return
+  event.preventDefault()
+  dragDepth = Math.max(0, dragDepth - 1)
+  if (dragDepth === 0) dragging.value = false
+}
+
+function handleDrop(event) {
+  if (!hasFiles(event)) return
+  event.preventDefault()
+  dragDepth = 0
+  dragging.value = false
+  if (!props.disabled) select(event.dataTransfer?.files)
+}
+
+const dropzone = computed(() => ({
+  'data-dragging': dragging.value ? '' : undefined,
+  'data-disabled': props.disabled ? '' : undefined,
+  onDragenter: handleDragEnter,
+  onDragover: handleDragOver,
+  onDragleave: handleDragLeave,
+  onDrop: handleDrop
+}))
+
+watch(
+  files,
+  (candidates) => {
+    syncPreviews(candidates)
+  },
+  { immediate: true, flush: 'sync' }
+)
+
+onBeforeUnmount(() => {
+  revokePreviews()
+})
+
+defineExpose({ root, choose, clear, remove })
+</script>
+
+<template>
+  <div
+    ref="root"
+    v-bind="rootAttrs"
+    data-slot="file-upload"
+    :data-state="files.length ? 'ready' : 'empty'"
+    :data-dragging="dragging ? '' : undefined"
+    :data-disabled="disabled ? '' : undefined"
+    :class="attrs.class"
+  >
+    <input
+      ref="input"
+      type="file"
+      hidden
+      data-part="input"
+      :accept="accept"
+      :capture="capture"
+      :multiple="multiple"
+      :disabled="disabled"
+      @change="select($event.currentTarget.files)"
+    />
+    <slot
+      :file="singleFile"
+      :files="files"
+      :preview-url="previewUrl"
+      :previews="previews"
+      :dragging="dragging"
+      :choose="choose"
+      :clear="clear"
+      :remove="remove"
+      :dropzone="dropzone"
+    />
+  </div>
+</template>

--- a/assets/js/pages/bearing/feedback.vue
+++ b/assets/js/pages/bearing/feedback.vue
@@ -3,10 +3,19 @@ import Textarea from '@/components/ui/textarea/Textarea.vue'
 import Input from '@/components/ui/input/Input.vue'
 import Radio from '@/components/ui/radio/Radio.vue'
 import { Head, InfiniteScroll, router, useForm } from '@inertiajs/vue3'
-import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onMounted,
+  onUnmounted,
+  ref,
+  shallowRef,
+  watch
+} from 'vue'
 import ShareLinkButton from '@/components/ShareLinkButton.vue'
 import Select from '@/components/ui/select/Select.vue'
 import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
 import { useBearingRealtime } from '@/composables/useBearingRealtime'
 import { useFormDraft } from '@/composables/useFormDraft'
 
@@ -56,10 +65,7 @@ const ACCEPTED_IMAGE_TYPES = new Set([
   'image/webp'
 ])
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024
-const imageInput = ref(null)
-const previewUrls = ref(new Map())
-const isDraggingImages = ref(false)
-let imageDragDepth = 0
+const attachedImages = shallowRef([])
 const form = useForm({
   category: activeCategories.value[0]?.key || 'feature',
   title: '',
@@ -75,15 +81,8 @@ form.transform((data) => ({
       ([field, value]) => !IMAGE_FIELDS.includes(field) || isImageFile(value)
     )
   ),
-  imageCount: selectedImages.value.length
+  imageCount: attachedImages.value.length
 }))
-const selectedImages = computed(() =>
-  IMAGE_FIELDS.filter((field) => isImageFile(form[field])).map((field) => ({
-    field,
-    file: form[field],
-    previewUrl: previewUrls.value.get(field)
-  }))
-)
 const canShare = computed(() => Boolean(form.title.trim()) && !form.processing)
 const { clear: clearDraft, restored: draftRestored } = useFormDraft(
   `slipway.bearing.feedback-draft.${props.app.feedbackPath}`,
@@ -227,7 +226,6 @@ onMounted(revealFocusedFeedback)
 onUnmounted(() => {
   window.clearTimeout(filterTimer)
   for (const timer of highlightTimers.values()) window.clearTimeout(timer)
-  revokeImagePreviews()
 })
 
 function reconcileFeedback(snapshot, syncedAt) {
@@ -477,11 +475,6 @@ function discardDraft() {
   clearDraft()
 }
 
-function handleImageInput(event) {
-  addImages(event.target.files)
-  event.target.value = ''
-}
-
 function handleImagePaste(event) {
   const files = Array.from(event.clipboardData?.items || [])
     .filter((item) => item.kind === 'file' && item.type.startsWith('image/'))
@@ -489,97 +482,92 @@ function handleImagePaste(event) {
     .filter(Boolean)
   if (!files.length) return
   event.preventDefault()
-  addImages(files)
+  addPastedImages(files)
 }
 
-function handleImageDragEnter() {
-  imageDragDepth += 1
-  isDraggingImages.value = true
-}
-
-function handleImageDragLeave() {
-  imageDragDepth = Math.max(0, imageDragDepth - 1)
-  if (imageDragDepth === 0) isDraggingImages.value = false
-}
-
-function handleImageDrop(event) {
-  imageDragDepth = 0
-  isDraggingImages.value = false
-  addImages(event.dataTransfer?.files)
-}
-
-function addImages(fileList) {
+function addPastedImages(fileList) {
   const incoming = Array.from(fileList || [])
   if (!incoming.length) return
 
   form.clearErrors('images')
-  const existingSignatures = new Set(
-    selectedImages.value.map(({ file }) => imageSignature(file))
-  )
-  const availableFields = IMAGE_FIELDS.filter(
-    (field) => !isImageFile(form[field])
-  )
-  let added = 0
+  const accepted = [...attachedImages.value]
   let rejection = ''
 
   for (const file of incoming) {
-    if (!ACCEPTED_IMAGE_TYPES.has(file.type)) {
-      rejection = 'Choose AVIF, GIF, JPEG, PNG, or WebP images.'
-      continue
+    const result = validateImage(file, { files: accepted })
+    if (result === true) {
+      accepted.push(file)
+    } else {
+      rejection = typeof result === 'string' ? result : result.message
     }
-    if (file.size > MAX_IMAGE_BYTES) {
-      rejection = 'Each image must be 5 MB or smaller.'
-      continue
-    }
-    if (existingSignatures.has(imageSignature(file))) continue
-    const field = availableFields.shift()
-    if (!field) {
-      rejection = 'You can attach up to 4 images.'
-      break
-    }
-
-    form[field] = file
-    existingSignatures.add(imageSignature(file))
-    const nextPreviews = new Map(previewUrls.value)
-    nextPreviews.set(field, URL.createObjectURL(file))
-    previewUrls.value = nextPreviews
-    added += 1
   }
 
-  if (rejection) form.setError('images', rejection)
-  if (added) {
-    liveAnnouncement.value = `${added} ${
-      added === 1 ? 'image' : 'images'
-    } attached.`
+  if (accepted.length !== attachedImages.value.length) {
+    attachedImages.value = accepted
+    handleImagesChange(accepted)
+  }
+  if (rejection) {
+    form.setError('images', rejection)
+    liveAnnouncement.value = rejection
   }
 }
 
-function removeImage(field) {
-  const url = previewUrls.value.get(field)
-  if (url) URL.revokeObjectURL(url)
-  const remaining = selectedImages.value.filter(
-    (image) => image.field !== field
-  )
-  for (const imageField of IMAGE_FIELDS) form[imageField] = null
-  const nextPreviews = new Map()
-  remaining.forEach((image, index) => {
-    const imageField = IMAGE_FIELDS[index]
-    form[imageField] = image.file
-    nextPreviews.set(imageField, image.previewUrl)
+function validateImage(file, { files }) {
+  if (!ACCEPTED_IMAGE_TYPES.has(file.type)) {
+    return 'Choose AVIF, GIF, JPEG, PNG, or WebP images.'
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return 'Each image must be 5 MB or smaller.'
+  }
+  if (
+    files.some(
+      (candidate) => imageSignature(candidate) === imageSignature(file)
+    )
+  ) {
+    return { reason: 'duplicate', message: 'That image is already attached.' }
+  }
+  if (files.length >= IMAGE_FIELDS.length) {
+    return `You can attach up to ${IMAGE_FIELDS.length} images.`
+  }
+  return true
+}
+
+function handleImagesChange(files) {
+  syncImageFields(files)
+  form.clearErrors('images')
+  liveAnnouncement.value = `${files.length} ${
+    files.length === 1 ? 'image' : 'images'
+  } attached.`
+}
+
+function handleImageReject(rejection) {
+  const message =
+    rejection.reason === 'accept'
+      ? 'Choose AVIF, GIF, JPEG, PNG, or WebP images.'
+      : rejection.message
+  nextTick(() => {
+    form.setError('images', message)
+    liveAnnouncement.value = message
   })
-  previewUrls.value = nextPreviews
+}
+
+function syncImageFields(files) {
+  for (const imageField of IMAGE_FIELDS) form[imageField] = null
+  files.slice(0, IMAGE_FIELDS.length).forEach((file, index) => {
+    form[IMAGE_FIELDS[index]] = file
+  })
+}
+
+function removeImage(upload, file) {
+  upload.remove(file)
   form.clearErrors('images')
   liveAnnouncement.value = 'Image removed.'
 }
 
 function clearSelectedImages() {
-  revokeImagePreviews()
-  for (const field of IMAGE_FIELDS) form[field] = null
-}
-
-function revokeImagePreviews() {
-  for (const url of previewUrls.value.values()) URL.revokeObjectURL(url)
-  previewUrls.value = new Map()
+  attachedImages.value = []
+  syncImageFields([])
+  form.clearErrors('images')
 }
 
 function imageSignature(file) {
@@ -740,260 +728,263 @@ function shortDate(value) {
           :class="embedded ? 'mt-0' : 'mt-10'"
           aria-labelledby="share-feedback-heading"
         >
-          <form
+          <FileUpload
             v-if="canSubmit"
-            :class="[
-              'max-w-2xl transition duration-200',
-              isDraggingImages
-                ? '-mx-4 rounded-2xl bg-gray-50 px-4 ring-2 ring-gray-300 dark:bg-gray-900 dark:ring-gray-700'
-                : ''
-            ]"
-            @submit.prevent="submit"
-            @dragenter.prevent="handleImageDragEnter"
-            @dragover.prevent
-            @dragleave.prevent="handleImageDragLeave"
-            @drop.prevent="handleImageDrop"
-            @paste="handleImagePaste"
-            novalidate
+            v-model="attachedImages"
+            multiple
+            accept="image/avif,image/gif,image/jpeg,image/png,image/webp"
+            :disabled="form.processing"
+            :validate="validateImage"
+            @change="handleImagesChange"
+            @reject="handleImageReject"
+            v-slot="upload"
           >
-            <div>
-              <h2 id="share-feedback-heading" class="sr-only">
-                Share feedback
-              </h2>
+            <form
+              v-bind="upload.dropzone"
+              :class="[
+                'max-w-2xl transition duration-200',
+                upload.dragging
+                  ? '-mx-4 rounded-2xl bg-gray-50 px-4 ring-2 ring-gray-300 dark:bg-gray-900 dark:ring-gray-700'
+                  : ''
+              ]"
+              @submit.prevent="submit"
+              @paste="handleImagePaste"
+              novalidate
+            >
+              <div>
+                <h2 id="share-feedback-heading" class="sr-only">
+                  Share feedback
+                </h2>
 
-              <div class="flex items-center gap-3">
-                <Tooltip :text="`Posting as ${participantName}`">
-                  <span
-                    role="img"
-                    :aria-label="`Posting as ${participantName}`"
-                    tabindex="0"
-                    class="size-10 flex shrink-0 items-center justify-center rounded-full bg-gray-950 text-xs font-semibold text-white dark:bg-white dark:text-gray-950"
-                  >
-                    <span aria-hidden="true">{{ participantInitials }}</span>
-                  </span>
-                </Tooltip>
-
-                <svg
-                  aria-hidden="true"
-                  viewBox="0 0 16 16"
-                  class="size-4 shrink-0 text-gray-300 dark:text-gray-700"
-                  fill="none"
-                >
-                  <path
-                    d="m6 3.5 4.5 4.5L6 12.5"
-                    stroke="currentColor"
-                    stroke-linecap="round"
-                    stroke-linejoin="round"
-                    stroke-width="1.5"
-                  />
-                </svg>
-
-                <div
-                  class="[&_[data-slot=select-content]]:min-w-44 max-w-[16rem] [&>[data-slot=select]]:w-auto [&_[data-slot=select-content]]:rounded-xl [&_[data-slot=select-content]]:shadow-xl [&_[data-slot=select-content]]:shadow-gray-950/10 dark:[&_[data-slot=select-content]]:shadow-black/30"
-                >
-                  <Select
-                    id="bearing-feedback-category"
-                    v-model="form.category"
-                    aria-label="Category"
-                    :options="categoryOptions"
-                    class="min-h-10 w-auto max-w-[16rem] rounded-lg border-0 bg-gray-100 px-3.5 py-2 text-sm font-semibold text-gray-950 shadow-none hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:ring-white dark:focus-visible:ring-offset-gray-950"
-                  />
-                </div>
-              </div>
-
-              <label class="mt-7 block" for="bearing-feedback-title">
-                <span class="sr-only">Summary</span>
-                <Input
-                  id="bearing-feedback-title"
-                  ref="titleInput"
-                  v-model="form.title"
-                  type="text"
-                  maxlength="140"
-                  required
-                  :placeholder="summaryPlaceholder"
-                  :aria-invalid="Boolean(form.errors.title)"
-                  :aria-describedby="
-                    form.errors.title
-                      ? 'bearing-feedback-title-error'
-                      : undefined
-                  "
-                  class="bearing-feedback-composer-field w-full border-0 bg-transparent p-0 text-xl font-semibold tracking-tight text-gray-950 caret-gray-950 placeholder:font-medium placeholder:text-gray-300 dark:text-white dark:caret-white dark:placeholder:text-gray-500 sm:text-2xl"
-                  @input="handleTitleInput"
-                />
-              </label>
-
-              <p
-                v-if="form.errors.title"
-                id="bearing-feedback-title-error"
-                class="mt-2 text-sm font-medium text-red-600"
-              >
-                {{ form.errors.title }}
-              </p>
-              <p
-                v-else-if="form.title.length >= 100"
-                class="mt-2 text-xs text-gray-400"
-              >
-                {{ 140 - form.title.length }} characters left
-              </p>
-
-              <label class="mt-3 block" for="bearing-feedback-details">
-                <span class="sr-only">Details (optional)</span>
-                <Textarea
-                  id="bearing-feedback-details"
-                  v-model="form.details"
-                  rows="2"
-                  maxlength="5000"
-                  placeholder="Add details (optional)"
-                  class="bearing-feedback-composer-field w-full resize-none border-0 bg-transparent p-0 text-sm leading-6 text-gray-700 caret-gray-950 placeholder:text-gray-300 dark:text-gray-300 dark:caret-white dark:placeholder:text-gray-600"
-                />
-              </label>
-
-              <div
-                v-if="selectedImages.length"
-                class="mt-5 grid grid-cols-2 gap-2 sm:grid-cols-4"
-              >
-                <figure
-                  v-for="image in selectedImages"
-                  :key="image.field"
-                  class="group/image relative aspect-[4/3] overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-900"
-                >
-                  <img
-                    :src="image.previewUrl"
-                    :alt="image.file.name"
-                    class="h-full w-full object-cover"
-                  />
-                  <Tooltip :text="`Remove ${image.file.name}`">
-                    <button
-                      type="button"
-                      :aria-label="`Remove ${image.file.name}`"
-                      class="size-8 absolute right-2 top-2 flex items-center justify-center rounded-full bg-gray-950/80 text-white shadow-sm backdrop-blur transition hover:bg-gray-950 focus-visible:ring-2 focus-visible:ring-white"
-                      @click="removeImage(image.field)"
+                <div class="flex items-center gap-3">
+                  <Tooltip :text="`Posting as ${participantName}`">
+                    <span
+                      role="img"
+                      :aria-label="`Posting as ${participantName}`"
+                      tabindex="0"
+                      class="size-10 flex shrink-0 items-center justify-center rounded-full bg-gray-950 text-xs font-semibold text-white dark:bg-white dark:text-gray-950"
                     >
-                      <svg
-                        aria-hidden="true"
-                        viewBox="0 0 16 16"
-                        class="size-3.5"
-                        fill="none"
-                      >
-                        <path
-                          d="m4.25 4.25 7.5 7.5m0-7.5-7.5 7.5"
-                          stroke="currentColor"
-                          stroke-linecap="round"
-                          stroke-width="1.5"
-                        />
-                      </svg>
-                    </button>
+                      <span aria-hidden="true">{{ participantInitials }}</span>
+                    </span>
                   </Tooltip>
-                </figure>
-              </div>
 
-              <p
-                v-if="form.errors.images"
-                id="bearing-feedback-images-error"
-                class="mt-3 text-sm font-medium text-red-600"
-              >
-                {{ form.errors.images }}
-              </p>
-            </div>
-
-            <div
-              v-if="form.progress"
-              class="mt-5"
-              role="status"
-              aria-live="polite"
-            >
-              <div
-                class="flex items-center justify-between text-xs text-gray-400"
-              >
-                <span>Uploading images</span>
-                <span>{{ form.progress.percentage }}%</span>
-              </div>
-              <div
-                class="mt-2 h-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-900"
-              >
-                <span
-                  class="block h-full rounded-full bg-gray-950 transition-[width] duration-200 dark:bg-white"
-                  :style="{ width: `${form.progress.percentage}%` }"
-                ></span>
-              </div>
-            </div>
-
-            <div
-              class="min-h-10 mt-5 flex flex-wrap items-center justify-between gap-4"
-            >
-              <div class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2">
-                <label
-                  for="bearing-feedback-images"
-                  class="min-h-10 inline-flex items-center gap-2 rounded-lg px-2 text-sm font-medium text-gray-500 transition hover:bg-gray-50 hover:text-gray-950 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-white"
-                >
                   <svg
                     aria-hidden="true"
-                    viewBox="0 0 20 20"
-                    class="size-4"
+                    viewBox="0 0 16 16"
+                    class="size-4 shrink-0 text-gray-300 dark:text-gray-700"
                     fill="none"
                   >
                     <path
-                      d="M3.75 5.75A2.25 2.25 0 0 1 6 3.5h8A2.25 2.25 0 0 1 16.25 5.75v8.5A2.25 2.25 0 0 1 14 16.5H6a2.25 2.25 0 0 1-2.25-2.25v-8.5Z"
-                      stroke="currentColor"
-                      stroke-width="1.4"
-                    />
-                    <path
-                      d="m5.75 14 3.1-3.25 2.1 2.1 1.35-1.35 1.95 2.5M7.2 7.75h.01"
+                      d="m6 3.5 4.5 4.5L6 12.5"
                       stroke="currentColor"
                       stroke-linecap="round"
                       stroke-linejoin="round"
-                      stroke-width="1.4"
+                      stroke-width="1.5"
                     />
                   </svg>
-                  <span>Add images</span>
-                  <input
-                    id="bearing-feedback-images"
-                    ref="imageInput"
-                    type="file"
-                    multiple
-                    accept="image/avif,image/gif,image/jpeg,image/png,image/webp"
-                    class="sr-only"
+
+                  <div
+                    class="[&_[data-slot=select-content]]:min-w-44 max-w-[16rem] [&>[data-slot=select]]:w-auto [&_[data-slot=select-content]]:rounded-xl [&_[data-slot=select-content]]:shadow-xl [&_[data-slot=select-content]]:shadow-gray-950/10 dark:[&_[data-slot=select-content]]:shadow-black/30"
+                  >
+                    <Select
+                      id="bearing-feedback-category"
+                      v-model="form.category"
+                      aria-label="Category"
+                      :options="categoryOptions"
+                      class="min-h-10 w-auto max-w-[16rem] rounded-lg border-0 bg-gray-100 px-3.5 py-2 text-sm font-semibold text-gray-950 shadow-none hover:bg-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 dark:bg-gray-900 dark:text-white dark:hover:bg-gray-800 dark:focus-visible:ring-white dark:focus-visible:ring-offset-gray-950"
+                    />
+                  </div>
+                </div>
+
+                <label class="mt-7 block" for="bearing-feedback-title">
+                  <span class="sr-only">Summary</span>
+                  <Input
+                    id="bearing-feedback-title"
+                    ref="titleInput"
+                    v-model="form.title"
+                    type="text"
+                    maxlength="140"
+                    required
+                    :placeholder="summaryPlaceholder"
+                    :aria-invalid="Boolean(form.errors.title)"
+                    :aria-describedby="
+                      form.errors.title
+                        ? 'bearing-feedback-title-error'
+                        : undefined
+                    "
+                    class="bearing-feedback-composer-field w-full border-0 bg-transparent p-0 text-xl font-semibold tracking-tight text-gray-950 caret-gray-950 placeholder:font-medium placeholder:text-gray-300 dark:text-white dark:caret-white dark:placeholder:text-gray-500 sm:text-2xl"
+                    @input="handleTitleInput"
+                  />
+                </label>
+
+                <p
+                  v-if="form.errors.title"
+                  id="bearing-feedback-title-error"
+                  class="mt-2 text-sm font-medium text-red-600"
+                >
+                  {{ form.errors.title }}
+                </p>
+                <p
+                  v-else-if="form.title.length >= 100"
+                  class="mt-2 text-xs text-gray-400"
+                >
+                  {{ 140 - form.title.length }} characters left
+                </p>
+
+                <label class="mt-3 block" for="bearing-feedback-details">
+                  <span class="sr-only">Details (optional)</span>
+                  <Textarea
+                    id="bearing-feedback-details"
+                    v-model="form.details"
+                    rows="2"
+                    maxlength="5000"
+                    placeholder="Add details (optional)"
+                    class="bearing-feedback-composer-field w-full resize-none border-0 bg-transparent p-0 text-sm leading-6 text-gray-700 caret-gray-950 placeholder:text-gray-300 dark:text-gray-300 dark:caret-white dark:placeholder:text-gray-600"
+                  />
+                </label>
+
+                <div
+                  v-if="upload.previews.length"
+                  class="mt-5 grid grid-cols-2 gap-2 sm:grid-cols-4"
+                >
+                  <figure
+                    v-for="preview in upload.previews"
+                    :key="imageSignature(preview.file)"
+                    class="group/image relative aspect-[4/3] overflow-hidden rounded-xl bg-gray-100 dark:bg-gray-900"
+                  >
+                    <img
+                      :src="preview.previewUrl"
+                      :alt="preview.file.name"
+                      class="h-full w-full object-cover"
+                    />
+                    <Tooltip :text="`Remove ${preview.file.name}`">
+                      <button
+                        type="button"
+                        :aria-label="`Remove ${preview.file.name}`"
+                        class="size-8 absolute right-2 top-2 flex cursor-pointer items-center justify-center rounded-full bg-gray-950/80 text-white shadow-sm backdrop-blur transition hover:bg-gray-950 focus-visible:ring-2 focus-visible:ring-white"
+                        @click="removeImage(upload, preview.file)"
+                      >
+                        <svg
+                          aria-hidden="true"
+                          viewBox="0 0 16 16"
+                          class="size-3.5"
+                          fill="none"
+                        >
+                          <path
+                            d="m4.25 4.25 7.5 7.5m0-7.5-7.5 7.5"
+                            stroke="currentColor"
+                            stroke-linecap="round"
+                            stroke-width="1.5"
+                          />
+                        </svg>
+                      </button>
+                    </Tooltip>
+                  </figure>
+                </div>
+
+                <p
+                  v-if="form.errors.images"
+                  id="bearing-feedback-images-error"
+                  role="alert"
+                  class="mt-3 text-sm font-medium text-red-600"
+                >
+                  {{ form.errors.images }}
+                </p>
+              </div>
+
+              <div
+                v-if="form.progress"
+                class="mt-5"
+                role="status"
+                aria-live="polite"
+              >
+                <div
+                  class="flex items-center justify-between text-xs text-gray-400"
+                >
+                  <span>Uploading images</span>
+                  <span>{{ form.progress.percentage }}%</span>
+                </div>
+                <div
+                  class="mt-2 h-1 overflow-hidden rounded-full bg-gray-100 dark:bg-gray-900"
+                >
+                  <span
+                    class="block h-full rounded-full bg-gray-950 transition-[width] duration-200 dark:bg-white"
+                    :style="{ width: `${form.progress.percentage}%` }"
+                  ></span>
+                </div>
+              </div>
+
+              <div
+                class="min-h-10 mt-5 flex flex-wrap items-center justify-between gap-4"
+              >
+                <div
+                  class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-2"
+                >
+                  <button
+                    type="button"
+                    class="min-h-10 inline-flex cursor-pointer items-center gap-2 rounded-lg px-2 text-sm font-medium text-gray-500 transition hover:bg-gray-50 hover:text-gray-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-950 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-white dark:focus-visible:outline-white"
                     :aria-invalid="Boolean(form.errors.images)"
                     :aria-describedby="
                       form.errors.images
                         ? 'bearing-feedback-images-error'
                         : 'bearing-feedback-images-help'
                     "
-                    @change="handleImageInput"
-                  />
-                </label>
-                <span
-                  id="bearing-feedback-images-help"
-                  class="text-xs text-gray-400"
-                >
-                  Paste or drop · {{ selectedImages.length }}/4
-                </span>
-                <p
-                  v-if="draftRestored"
-                  class="text-xs text-gray-500 dark:text-gray-400"
-                  role="status"
-                >
-                  Draft restored.
-                  <button
-                    type="button"
-                    class="font-semibold text-gray-950 hover:underline dark:text-white"
-                    @click="discardDraft"
+                    @click="upload.choose"
                   >
-                    Discard
+                    <svg
+                      aria-hidden="true"
+                      viewBox="0 0 20 20"
+                      class="size-4"
+                      fill="none"
+                    >
+                      <path
+                        d="M3.75 5.75A2.25 2.25 0 0 1 6 3.5h8A2.25 2.25 0 0 1 16.25 5.75v8.5A2.25 2.25 0 0 1 14 16.5H6a2.25 2.25 0 0 1-2.25-2.25v-8.5Z"
+                        stroke="currentColor"
+                        stroke-width="1.4"
+                      />
+                      <path
+                        d="m5.75 14 3.1-3.25 2.1 2.1 1.35-1.35 1.95 2.5M7.2 7.75h.01"
+                        stroke="currentColor"
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.4"
+                      />
+                    </svg>
+                    <span>Add images</span>
                   </button>
-                </p>
-              </div>
+                  <span
+                    id="bearing-feedback-images-help"
+                    class="text-xs text-gray-400"
+                  >
+                    Paste or drop · {{ upload.files.length }}/4
+                  </span>
+                  <p
+                    v-if="draftRestored"
+                    class="text-xs text-gray-500 dark:text-gray-400"
+                    role="status"
+                  >
+                    Draft restored.
+                    <button
+                      type="button"
+                      class="font-semibold text-gray-950 hover:underline dark:text-white"
+                      @click="discardDraft"
+                    >
+                      Discard
+                    </button>
+                  </p>
+                </div>
 
-              <button
-                type="submit"
-                :disabled="!canShare"
-                :aria-busy="form.processing"
-                class="min-h-10 inline-flex shrink-0 items-center justify-center rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-30 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100 dark:focus-visible:ring-white dark:focus-visible:ring-offset-gray-950"
-              >
-                {{ form.processing ? 'Sharing…' : 'Share' }}
-              </button>
-            </div>
-          </form>
+                <button
+                  type="submit"
+                  :disabled="!canShare"
+                  :aria-busy="form.processing"
+                  class="min-h-10 inline-flex shrink-0 items-center justify-center rounded-lg bg-gray-950 px-4 text-sm font-semibold text-white shadow-sm transition hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-gray-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-30 dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100 dark:focus-visible:ring-white dark:focus-visible:ring-offset-gray-950"
+                >
+                  {{ form.processing ? 'Sharing…' : 'Share' }}
+                </button>
+              </div>
+            </form>
+          </FileUpload>
 
           <div
             v-else-if="bearing.acceptFeedback"

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -18,6 +18,7 @@ import Tooltip from '@/components/ui/tooltip/Tooltip.vue'
 import Select from '@/components/ui/select/Select.vue'
 import Table from '@/components/ui/table/Table.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
 import Breadcrumb from '@/components/ui/breadcrumb/Breadcrumb.vue'
 import Tabs from '@/components/ui/tabs/Tabs.vue'
 import CodeEditor from '@/components/CodeEditor.vue'
@@ -259,6 +260,7 @@ const selectedExportTables = ref(new Set())
 const exportMode = ref('full') // 'full', 'schema', 'data'
 const importMode = ref('paste') // 'paste' or 'upload'
 const importSql = ref('')
+const importSelection = ref(null)
 const importFile = ref(null) // Raw File object for binary .dmp uploads
 const importLoading = ref(false)
 const showImportModal = ref(false)
@@ -661,6 +663,7 @@ const initialImport = new URLSearchParams(window.location.search).get('import')
 
 function openImportModal() {
   importSql.value = ''
+  importSelection.value = null
   importFile.value = null
   importMode.value = 'paste'
   showImportModal.value = true
@@ -677,6 +680,7 @@ function openImportModalFromExportActions() {
 function closeImportModal() {
   showImportModal.value = false
   importSql.value = ''
+  importSelection.value = null
   importFile.value = null
   const url = new URL(window.location)
   url.searchParams.delete('import')
@@ -701,8 +705,7 @@ const importFileLabel = computed(() => {
   return 'Upload a .sql file'
 })
 
-async function handleFileUpload(event) {
-  const file = event.target.files[0]
+async function handleFileUpload(file) {
   if (!file) return
 
   try {
@@ -719,6 +722,7 @@ async function handleFileUpload(event) {
       showToast(`Loaded ${file.name} (${formatBytes(file.size)})`, 'success')
     }
   } catch (e) {
+    importSelection.value = null
     showToast('Failed to read file', 'error')
   }
 }
@@ -2834,9 +2838,23 @@ onUnmounted(() => {
           </div>
 
           <!-- Upload mode -->
-          <div v-else>
+          <FileUpload
+            v-else
+            v-model="importSelection"
+            :accept="importAccept"
+            :disabled="importLoading"
+            @change="handleFileUpload"
+            @reject="showToast($event.message, 'error')"
+            v-slot="upload"
+          >
             <div
-              class="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-gray-200 bg-gray-50 px-6 py-10 dark:border-gray-700 dark:bg-gray-800"
+              v-bind="upload.dropzone"
+              :class="[
+                'flex flex-col items-center justify-center rounded-lg border-2 border-dashed bg-gray-50 px-6 py-10 transition-colors duration-150 motion-reduce:transition-none dark:bg-gray-800',
+                upload.dragging
+                  ? 'border-gray-900 bg-gray-100 dark:border-white dark:bg-gray-700'
+                  : 'border-gray-200 dark:border-gray-700'
+              ]"
             >
               <svg
                 class="h-10 w-10 text-gray-400"
@@ -2854,12 +2872,15 @@ onUnmounted(() => {
               <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">
                 {{ importFileLabel }}
               </p>
-              <input
-                type="file"
-                :accept="importAccept"
-                @change="handleFileUpload"
-                class="mt-3 text-sm text-gray-500 file:mr-3 file:rounded-md file:border-0 file:bg-gray-900 file:px-3 file:py-1.5 file:text-sm file:font-medium file:text-white hover:file:bg-gray-800 dark:file:bg-white dark:file:text-gray-900"
-              />
+              <button
+                type="button"
+                class="mt-3 cursor-pointer rounded-md bg-gray-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-gray-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-900 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-200 dark:focus-visible:outline-white"
+                :disabled="importLoading"
+                @click="upload.choose"
+              >
+                {{ upload.file ? 'Choose another file' : 'Choose file' }}
+              </button>
+              <p class="mt-2 text-xs text-gray-400">or drop it here</p>
             </div>
             <div v-if="isBinaryImport" class="mt-4">
               <div
@@ -2906,7 +2927,7 @@ onUnmounted(() => {
                 "
               ></pre>
             </div>
-          </div>
+          </FileUpload>
 
           <!-- Info -->
           <p class="mt-3 text-xs text-gray-500 dark:text-gray-400">

--- a/assets/js/pages/settings/team-profile.vue
+++ b/assets/js/pages/settings/team-profile.vue
@@ -5,6 +5,7 @@ import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import Avatar from '@/components/ui/avatar/Avatar.vue'
+import FileUpload from '@/components/ui/file-upload/FileUpload.vue'
 import { usePrecognitionValidation } from '@/composables/precognition'
 
 defineOptions({
@@ -46,41 +47,36 @@ function save() {
   })
 }
 
-function handleLogoUpload(event) {
-  const file = event.target.files?.[0]
+function validateLogo(file) {
+  if (!file.type.startsWith('image/')) return 'Please select an image file'
+  if (file.size > 5 * 1024 * 1024) return 'Image must be smaller than 5MB'
+  return true
+}
+
+function handleLogoUpload(file) {
   if (!file) return
 
   logoForm.clearErrors()
   removeLogoForm.clearErrors()
-
-  if (!file.type.startsWith('image/')) {
-    logoForm.setError('logo', 'Please select an image file')
-    return
-  }
-
-  if (file.size > 5 * 1024 * 1024) {
-    logoForm.setError('logo', 'Image must be smaller than 5MB')
-    return
-  }
-
-  const reader = new FileReader()
-  reader.onload = (e) => {
-    logoPreview.value = e.target.result
-  }
-  reader.readAsDataURL(file)
-
-  logoForm.logo = file
   logoForm.post('/settings/team-profile/logo', {
     forceFormData: true,
     preserveScroll: true,
-    onError: () => {
-      logoPreview.value = props.team.logoUrl
+    onSuccess: (page) => {
+      logoPreview.value = page.props.team?.logoUrl || props.team.logoUrl
     },
     onFinish: () => {
       logoForm.logo = null
-      event.target.value = ''
     }
   })
+}
+
+function handleLogoReject(rejection) {
+  logoForm.setError(
+    'logo',
+    rejection.reason === 'accept'
+      ? 'Please select an image file'
+      : rejection.message
+  )
 }
 
 function removeLogo() {
@@ -263,94 +259,102 @@ const initials = computed(() => {
             </p>
           </div>
           <div class="border-t border-gray-200 px-4 py-4 dark:border-gray-800">
-            <div class="flex items-center gap-4">
-              <!-- Logo preview -->
-              <div class="relative">
-                <Avatar
-                  data-test="team-profile-avatar"
-                  :src="logoPreview"
-                  :alt="`${props.team.name} team logo`"
-                  :class="[
-                    'bg-brand h-16 w-16 rounded-lg object-cover text-xl font-semibold text-white',
-                    logoPreview
-                      ? 'border border-gray-200 dark:border-gray-700'
-                      : ''
-                  ]"
-                >
-                  {{ initials }}
-                </Avatar>
-                <!-- Uploading overlay -->
-                <div
-                  v-if="uploading"
-                  role="status"
-                  class="absolute inset-0 flex items-center justify-center rounded-lg bg-black/50"
-                >
-                  <Spinner class="h-5 w-5 text-white" />
-                  <span class="sr-only">Uploading team logo</span>
+            <FileUpload
+              v-model="logoForm.logo"
+              accept="image/*"
+              :disabled="uploading || !uploadsConfigured"
+              :validate="validateLogo"
+              @change="handleLogoUpload"
+              @reject="handleLogoReject"
+              v-slot="upload"
+            >
+              <div class="flex items-center gap-4">
+                <!-- Logo preview -->
+                <div class="relative">
+                  <Avatar
+                    data-test="team-profile-avatar"
+                    :src="upload.previewUrl || logoPreview"
+                    :alt="`${props.team.name} team logo`"
+                    :class="[
+                      'bg-brand h-16 w-16 rounded-lg object-cover text-xl font-semibold text-white',
+                      upload.previewUrl || logoPreview
+                        ? 'border border-gray-200 dark:border-gray-700'
+                        : ''
+                    ]"
+                  >
+                    {{ initials }}
+                  </Avatar>
+                  <!-- Uploading overlay -->
+                  <div
+                    v-if="uploading"
+                    role="status"
+                    class="absolute inset-0 flex items-center justify-center rounded-lg bg-black/50"
+                  >
+                    <Spinner class="h-5 w-5 text-white" />
+                    <span class="sr-only">Uploading team logo</span>
+                  </div>
+                </div>
+
+                <!-- Upload controls -->
+                <div class="flex flex-col gap-2">
+                  <template v-if="uploadsConfigured">
+                    <div class="flex items-center gap-2">
+                      <button
+                        type="button"
+                        class="cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+                        :disabled="uploading"
+                        @click="upload.choose"
+                      >
+                        {{ logoPreview ? 'Change' : 'Upload' }}
+                      </button>
+                      <button
+                        v-if="logoPreview"
+                        type="button"
+                        @click="removeLogo"
+                        :disabled="uploading"
+                        class="cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-gray-600 dark:text-red-400 dark:hover:bg-red-900/20"
+                      >
+                        Remove
+                      </button>
+                    </div>
+                    <p
+                      v-if="uploadError"
+                      role="alert"
+                      class="text-xs text-red-600 dark:text-red-400"
+                    >
+                      {{ uploadError }}
+                    </p>
+                  </template>
+                  <template v-else>
+                    <div
+                      class="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50/50 px-3 py-2 dark:border-amber-900/50 dark:bg-amber-950/20"
+                    >
+                      <svg
+                        class="h-4 w-4 text-amber-500"
+                        fill="none"
+                        stroke="currentColor"
+                        viewBox="0 0 24 24"
+                      >
+                        <path
+                          stroke-linecap="round"
+                          stroke-linejoin="round"
+                          stroke-width="2"
+                          d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                        />
+                      </svg>
+                      <span class="text-sm text-amber-700 dark:text-amber-400">
+                        <Link
+                          href="/settings/uploads"
+                          class="underline hover:no-underline"
+                          >Configure file storage</Link
+                        >
+                        {{ ' ' }}to enable logo uploads.
+                      </span>
+                    </div>
+                  </template>
                 </div>
               </div>
-
-              <!-- Upload controls -->
-              <div class="flex flex-col gap-2">
-                <template v-if="uploadsConfigured">
-                  <div class="flex items-center gap-2">
-                    <label
-                      class="cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
-                    >
-                      <span>{{ logoPreview ? 'Change' : 'Upload' }}</span>
-                      <input
-                        type="file"
-                        accept="image/*"
-                        class="hidden"
-                        @change="handleLogoUpload"
-                        :disabled="uploading"
-                      />
-                    </label>
-                    <button
-                      v-if="logoPreview"
-                      @click="removeLogo"
-                      :disabled="uploading"
-                      class="rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-red-600 hover:bg-red-50 dark:border-gray-600 dark:text-red-400 dark:hover:bg-red-900/20"
-                    >
-                      Remove
-                    </button>
-                  </div>
-                  <p
-                    v-if="uploadError"
-                    class="text-xs text-red-600 dark:text-red-400"
-                  >
-                    {{ uploadError }}
-                  </p>
-                </template>
-                <template v-else>
-                  <div
-                    class="flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50/50 px-3 py-2 dark:border-amber-900/50 dark:bg-amber-950/20"
-                  >
-                    <svg
-                      class="h-4 w-4 text-amber-500"
-                      fill="none"
-                      stroke="currentColor"
-                      viewBox="0 0 24 24"
-                    >
-                      <path
-                        stroke-linecap="round"
-                        stroke-linejoin="round"
-                        stroke-width="2"
-                        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
-                      />
-                    </svg>
-                    <span class="text-sm text-amber-700 dark:text-amber-400">
-                      <Link
-                        href="/settings/uploads"
-                        class="underline hover:no-underline"
-                        >Configure file storage</Link
-                      >
-                      {{ ' ' }}to enable logo uploads.
-                    </span>
-                  </div>
-                </template>
-              </div>
-            </div>
+            </FileUpload>
           </div>
         </div>
 

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -306,6 +306,9 @@ test(
         page.raw.locator('[data-test="bearing-update-body-visual-editor"] img')
       ).toHaveAttribute('src', updateImageUrl, { timeout: 10_000 })
       await expect(page.raw.getByRole('status')).toHaveText('Image added.')
+      await expect(
+        page.raw.locator('[data-test="bearing-update-body-image-button"]')
+      ).toBeEnabled()
       const updateTitle = page.raw.locator('#bearing-update-title')
       const updateExcerpt = page.raw.locator('#bearing-update-excerpt')
       await updateTitle.fill('Rich updates can carry images')
@@ -675,7 +678,19 @@ test(
     expect(
       await composer.getByRole('button', { name: 'Share' }).isDisabled()
     ).toBe(false)
-    await page.raw.waitForTimeout(600)
+    await page.raw.waitForFunction(() => {
+      const draft = JSON.parse(
+        window.localStorage.getItem(
+          'slipway.bearing.feedback-draft./bearing/feedback'
+        ) || 'null'
+      )
+      return (
+        draft?.data?.category === 'bug' &&
+        draft.data.title === 'Keep unfinished feedback safe' &&
+        draft.data.details ===
+          'This draft should survive an accidental refresh.'
+      )
+    })
     await page.raw.reload()
     await expect(
       composer.getByRole('combobox', { name: 'Category' })

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -693,6 +693,9 @@ test(
     })
     await page.raw.reload()
     await expect(
+      page.raw.getByRole('status').filter({ hasText: 'Draft restored.' })
+    ).toBeVisible({ timeout: 15_000 })
+    await expect(
       composer.getByRole('combobox', { name: 'Category' })
     ).toContainText('Bug')
     await expect(composer.getByPlaceholder('Describe the problem')).toHaveValue(
@@ -701,7 +704,6 @@ test(
     await expect(
       composer.getByPlaceholder('Add details (optional)')
     ).toHaveValue('This draft should survive an accidental refresh.')
-    await expect(page).toSee('Draft restored.')
     await composer.getByRole('button', { name: 'Discard' }).click()
     expect(
       await composer.getByRole('button', { name: 'Share' }).isDisabled()

--- a/tests/e2e/pages/projects/bearing.test.js
+++ b/tests/e2e/pages/projects/bearing.test.js
@@ -293,7 +293,9 @@ test(
         'base64'
       )
       await page.raw
-        .locator('[data-test="bearing-update-body-image-input"]')
+        .locator(
+          '[data-test="bearing-update-body-image-upload"] input[type="file"]'
+        )
         .setInputFiles({
           name: 'update-image.png',
           mimeType: 'image/png',
@@ -732,11 +734,15 @@ test(
     )
 
     try {
-      await composer.locator('input[type="file"]').setInputFiles({
-        name: 'picked-screenshot.png',
-        mimeType: 'image/png',
-        buffer: onePixelPng
-      })
+      await page.raw
+        .locator(
+          '[data-slot="file-upload"] input[data-part="input"][type="file"]'
+        )
+        .setInputFiles({
+          name: 'picked-screenshot.png',
+          mimeType: 'image/png',
+          buffer: onePixelPng
+        })
       await composer.evaluate((element) => {
         const bytes = Uint8Array.from(
           atob(
@@ -755,7 +761,16 @@ test(
             clipboardData: clipboard
           })
         )
+      })
+      await expect(composer.locator('figure')).toHaveCount(2)
 
+      await composer.evaluate((element) => {
+        const bytes = Uint8Array.from(
+          atob(
+            'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADElEQVR42mNk+M/wHwAF/gL+Xhc4VQAAAABJRU5ErkJggg=='
+          ),
+          (character) => character.charCodeAt(0)
+        )
         const dragged = new DataTransfer()
         dragged.items.add(
           new File([bytes], 'dropped-screenshot.png', { type: 'image/png' })

--- a/tests/unit/assets/klean-file-upload-adoption.test.js
+++ b/tests/unit/assets/klean-file-upload-adoption.test.js
@@ -1,0 +1,62 @@
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+const { test } = require('sounding')
+
+const SURFACES = [
+  'assets/js/pages/bearing/feedback.vue',
+  'assets/js/pages/projects/dock.vue',
+  'assets/js/pages/settings/team-profile.vue',
+  'assets/js/components/bridge/BridgeFieldInput.vue',
+  'assets/js/components/content/MarkdownEditor.vue'
+]
+
+function source(path) {
+  return readFileSync(resolve(path), 'utf8')
+}
+
+test('Slipway routes every application file picker through Klean FileUpload', ({
+  expect
+}) => {
+  for (const path of SURFACES) {
+    const contents = source(path)
+    expect(contents).toContain(
+      "import FileUpload from '@/components/ui/file-upload/FileUpload.vue'"
+    )
+    expect(contents).toContain('<FileUpload')
+    expect(/<input[\s\S]*?type=["']file["']/.test(contents)).toBe(false)
+  }
+
+  const fileUpload = source(
+    'assets/js/components/ui/file-upload/FileUpload.vue'
+  )
+  expect(fileUpload).toContain('data-slot="file-upload"')
+  expect(fileUpload).toContain('data-part="input"')
+  expect(fileUpload).toContain('type="file"')
+  expect(fileUpload).toContain(':multiple="multiple"')
+  expect(fileUpload).toContain(':previews="previews"')
+  expect(fileUpload).toContain(':remove="remove"')
+  expect(fileUpload).toContain('input.value.showPicker()')
+})
+
+test('Klean selection state leaves Slipway upload transport application-owned', ({
+  expect
+}) => {
+  expect(source('assets/js/pages/bearing/feedback.vue')).toContain(
+    'form.post(props.app.feedbackPath'
+  )
+  expect(source('assets/js/pages/projects/dock.vue')).toContain(
+    "fetch(apiUrl('/import')"
+  )
+  expect(source('assets/js/pages/settings/team-profile.vue')).toContain(
+    "logoForm.post('/settings/team-profile/logo'"
+  )
+
+  const bridge = source('assets/js/components/bridge/BridgeFieldInput.vue')
+  expect(bridge).toContain('uploadMultipartParts')
+  expect(bridge).toContain('new AbortController()')
+  expect(bridge).toContain('Retry upload')
+
+  const editor = source('assets/js/components/content/MarkdownEditor.vue')
+  expect(editor).toContain('const formData = new FormData()')
+  expect(editor).toContain('await fetch(props.uploadUrl')
+})


### PR DESCRIPTION
Closes #490

Upstream: sailscastshq/klean-ui#144
Canonical docs: sailscastshq/docs.sailscasts.com#248

## Summary
- copy the zero-config Klean FileUpload source into Slipway
- route Bearing attachments, team logos, Dock imports, Bridge direct uploads, and Markdown image selection through it
- preserve every application-owned endpoint, FormData request, direct-object-storage session, progress state, retry, cancellation, paste path, and product Tailwind treatment
- remove duplicated picker, drag-depth, object-preview, and same-file reset plumbing
- keep partial multi-file rejection, wrapping previews, removal announcements, and browse/drop parity accessible

## Verification
- `npm run lint`
- 327/327 existing unit tests
- 2/2 focused Klean adoption tests
- 105/105 functional tests
- Bearing settings browser flow passes
- Bearing public browse + paste + drop + submit browser flow passes
- Bridge full resource-contract browser flow passes
- `klean-ui check` reports FileUpload current
- light desktop attachment UI reviewed with no visual regression