### PR TITLE
feat(ui): adopt Klean Badge

### DIFF
--- a/assets/js/components/DeploymentHistory.vue
+++ b/assets/js/components/DeploymentHistory.vue
@@ -2,6 +2,7 @@
 import { Link, router } from '@inertiajs/vue3'
 import { onBeforeUnmount, ref, watch } from 'vue'
 import DeploymentOutcome from '@/components/DeploymentOutcome.vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 const props = defineProps({
   history: {
@@ -238,12 +239,12 @@ function deploymentTestId(deployment) {
               {{ deployment.environment?.name || 'Unknown' }}
             </span>
             <DeploymentOutcome v-if="showStatus" :deployment="deployment" />
-            <span
+            <Badge
               v-if="deployment.app?.name"
-              class="inline-flex rounded bg-gray-100 px-1.5 py-0.5 text-[10px] font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+              class="rounded bg-gray-100 px-1.5 py-0.5 text-[10px] text-gray-500 dark:bg-gray-800 dark:text-gray-400"
             >
               {{ deployment.app.name }}
-            </span>
+            </Badge>
             <span
               v-if="deployment.gitBranch"
               class="hidden text-xs text-gray-500 dark:text-gray-400 sm:inline"

--- a/assets/js/components/DeploymentOutcome.vue
+++ b/assets/js/components/DeploymentOutcome.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed } from 'vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 const props = defineProps({
   deployment: {
@@ -37,15 +38,15 @@ const isCurrent = computed(
 
 <template>
   <span class="inline-flex shrink-0 items-center gap-1.5">
-    <span
+    <Badge
       data-test="deployment-outcome"
       :class="[
-        'inline-flex h-5 items-center whitespace-nowrap rounded-[5px] px-1.5 text-[11px] font-medium leading-none ring-1 ring-inset',
+        'h-5 rounded-[5px] px-1.5 text-[11px] leading-none ring-1 ring-inset',
         presentation.classes
       ]"
     >
       {{ presentation.label }}
-    </span>
+    </Badge>
     <span
       v-if="isCurrent"
       data-test="current-deployment-marker"

--- a/assets/js/components/bridge/BridgeFieldValue.vue
+++ b/assets/js/components/bridge/BridgeFieldValue.vue
@@ -5,6 +5,7 @@ import {
   formatBridgeFieldValue
 } from '@/lib/bridge/fields.mjs'
 import { resolveBridgeFieldComponent } from '@/lib/bridge/field-components.mjs'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 const props = defineProps({
   name: {
@@ -66,17 +67,17 @@ const fieldType = computed(() => bridgeFieldType(props.attribute))
     <span class="sr-only">{{ formatted.display }}</span>
   </span>
 
-  <span
+  <Badge
     v-else-if="formatted.kind === 'boolean'"
     :class="[
-      'inline-flex rounded-full px-2 py-0.5 text-xs font-medium',
+      'px-2 py-0.5 text-xs',
       formatted.value
         ? 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-400'
         : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
     ]"
   >
     {{ formatted.display }}
-  </span>
+  </Badge>
 
   <a
     v-else-if="formatted.kind === 'image' && formatted.url"

--- a/assets/js/components/bridge/BridgeFilterMenu.vue
+++ b/assets/js/components/bridge/BridgeFilterMenu.vue
@@ -4,6 +4,7 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref } from 'vue'
 import BridgeRelationshipCombobox from '@/components/bridge/BridgeRelationshipCombobox.vue'
 import Select from '@/components/ui/select/Select.vue'
 import FilterBar from '@/components/ui/filter-bar/FilterBar.vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 const props = defineProps({
   definitions: {
@@ -270,12 +271,12 @@ onBeforeUnmount(() => {
         />
       </svg>
       Filter
-      <span
+      <Badge
         v-if="activeCount"
-        class="min-w-4 flex h-4 items-center justify-center rounded-full bg-gray-900 px-1 text-[10px] font-semibold text-white dark:bg-white dark:text-gray-900"
+        class="min-w-4 h-4 justify-center bg-gray-900 px-1 text-[10px] font-semibold tabular-nums text-white dark:bg-white dark:text-gray-900"
       >
         {{ activeCount }}
-      </span>
+      </Badge>
     </button>
 
     <div

--- a/assets/js/components/ui/badge/Badge.vue
+++ b/assets/js/components/ui/badge/Badge.vue
@@ -1,0 +1,32 @@
+<script setup>
+import { computed, ref, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const attrs = useAttrs()
+const element = ref()
+
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+defineExpose({ element })
+</script>
+
+<template>
+  <span
+    ref="element"
+    v-bind="forwardedAttrs"
+    data-slot="badge"
+    :class="
+      twMerge(
+        'text-nowrap forced-colors:border-current inline-flex items-center gap-1.5 rounded-full border border-transparent bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-800 dark:text-gray-300',
+        attrs.class
+      )
+    "
+  >
+    <slot />
+  </span>
+</template>

--- a/assets/js/layouts/AppLayout.vue
+++ b/assets/js/layouts/AppLayout.vue
@@ -11,6 +11,7 @@ import Avatar from '@/components/ui/avatar/Avatar.vue'
 import Menu from '@/components/ui/menu/Menu.vue'
 import Sheet from '@/components/ui/sheet/Sheet.vue'
 import Sidebar from '@/components/ui/sidebar/Sidebar.vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 import { createToast } from '@/composables/toast'
 import { useFlashToast } from '@/composables/flash-toast'
 import {
@@ -648,10 +649,11 @@ watch(() => page.url, closeMobileMenu)
                   />
                 </svg>
                 <span class="flex-1">Update available</span>
-                <span
-                  class="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                  >{{ updateInfo.latestVersion }}</span
+                <Badge
+                  class="bg-gray-100 px-2 py-0.5 text-[10px] text-gray-600 dark:bg-gray-800 dark:text-gray-400"
                 >
+                  {{ updateInfo.latestVersion }}
+                </Badge>
               </button>
               <button
                 @click="openCommandPaletteFromMobileMenu"
@@ -1089,10 +1091,11 @@ watch(() => page.url, closeMobileMenu)
                 />
               </svg>
               <span class="flex-1">Update available</span>
-              <span
-                class="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-                >{{ updateInfo.latestVersion }}</span
+              <Badge
+                class="bg-gray-100 px-2 py-0.5 text-[10px] text-gray-600 dark:bg-gray-800 dark:text-gray-400"
               >
+                {{ updateInfo.latestVersion }}
+              </Badge>
             </button>
             <button
               @click="openCommandPaletteFromUserMenu"

--- a/assets/js/pages/bosun/index.vue
+++ b/assets/js/pages/bosun/index.vue
@@ -28,6 +28,7 @@ import LoadingState from '@/components/ui/loading-state/LoadingState.vue'
 import ErrorState from '@/components/ui/error-state/ErrorState.vue'
 import LogViewer from '@/components/LogViewer.vue'
 import { cancelHelmExecution, cancelledHelmResult } from '@/lib/helmExecution'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 defineOptions({
   layout: AppLayout
@@ -1620,11 +1621,11 @@ onUnmounted(() => {
               <h2 class="text-sm font-medium text-gray-900 dark:text-white">
                 Environment variables
               </h2>
-              <span
-                class="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500 dark:bg-gray-800 dark:text-gray-400"
+              <Badge
+                class="bg-gray-100 px-2 py-0.5 text-xs tabular-nums text-gray-500 dark:bg-gray-800 dark:text-gray-400"
               >
                 {{ sortedEnvKeys.length }}
-              </span>
+              </Badge>
             </div>
 
             <!-- Variable rows -->
@@ -2210,14 +2211,15 @@ onUnmounted(() => {
                     class="truncate text-sm font-medium text-gray-900 dark:text-white"
                     >{{ activity.description }}</span
                   >
-                  <span
+                  <Badge
                     v-if="activity.status"
                     :class="[
-                      'inline-flex shrink-0 rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                      'shrink-0 px-1.5 py-0.5 text-[10px]',
                       statusColor(activity.status)
                     ]"
-                    >{{ activity.status }}</span
                   >
+                    {{ activity.status }}
+                  </Badge>
                 </div>
                 <div
                   class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400"

--- a/assets/js/pages/lookout/index.vue
+++ b/assets/js/pages/lookout/index.vue
@@ -3,6 +3,7 @@ import Input from '@/components/ui/input/Input.vue'
 import { Link, Head, router, usePoll } from '@inertiajs/vue3'
 import { inject, ref, computed } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 defineOptions({
   layout: AppLayout
@@ -436,16 +437,16 @@ function envTelemetry(container) {
                   Root volume usage across this Slipway host.
                 </p>
               </div>
-              <span
+              <Badge
                 :class="[
-                  'inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium',
+                  'px-2.5 py-1 text-xs',
                   props.hostDisk
                     ? 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
                     : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
                 ]"
               >
                 {{ diskStatusLabel }}
-              </span>
+              </Badge>
             </div>
           </div>
 

--- a/assets/js/pages/projects/app.vue
+++ b/assets/js/pages/projects/app.vue
@@ -25,6 +25,7 @@ import Spinner from '@/components/SlipwaySpinner.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
 import { configVariableSummary } from '@/lib/config-variables.mjs'
 import LogViewer from '@/components/LogViewer.vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 defineOptions({
   layout: AppLayout
@@ -1400,19 +1401,14 @@ onBeforeUnmount(() => {
                 </div>
               </Menu>
             </div>
-            <span
-              :class="[
-                'inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-medium',
-                appStatusClasses(app).bg
-              ]"
-            >
+            <Badge :class="['px-3 py-1 text-xs', appStatusClasses(app).bg]">
               <span
                 :class="['h-1.5 w-1.5 rounded-full', appStatusClasses(app).dot]"
               ></span>
               <span :class="appStatusClasses(app).text">{{
                 appStatusLabel(app)
               }}</span>
-            </span>
+            </Badge>
           </div>
         </div>
 
@@ -1949,14 +1945,14 @@ onBeforeUnmount(() => {
                       </div>
                     </div>
                     <div class="flex items-center space-x-2">
-                      <span
+                      <Badge
                         :class="[
-                          'inline-flex items-center rounded-md px-2 py-0.5 text-[10px] font-medium',
+                          'rounded-md px-2 py-0.5 text-[10px]',
                           statusBadge(service.status).classes
                         ]"
                       >
                         {{ statusBadge(service.status).label }}
-                      </span>
+                      </Badge>
                       <Tooltip
                         v-if="
                           ['postgresql', 'mysql', 'mongodb', 'redis'].includes(

--- a/assets/js/pages/projects/dock.vue
+++ b/assets/js/pages/projects/dock.vue
@@ -26,6 +26,7 @@ import DockResultStatusIcon from '@/components/DockResultStatusIcon.vue'
 import { highlightSQL } from '@/lib/highlightSQL'
 import { highlightJSON } from '@/lib/highlightJSON'
 import Spinner from '@/components/SlipwaySpinner.vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 defineOptions({
   layout: AppLayout
@@ -1159,18 +1160,18 @@ onUnmounted(() => {
           </svg>
         </div>
         <!-- Single DB badge -->
-        <span
+        <Badge
           v-else-if="databaseService && isRedis"
-          class="inline-flex h-6 w-6 items-center justify-center rounded bg-red-100 text-[9px] font-bold text-red-600 dark:bg-red-900/30 dark:text-red-400 sm:inline-flex"
+          class="size-6 justify-center rounded bg-red-100 p-0 text-[9px] font-bold text-red-600 dark:bg-red-900/30 dark:text-red-400"
         >
           Rd
-        </span>
-        <span
+        </Badge>
+        <Badge
           v-else-if="databaseService"
-          class="hidden rounded bg-gray-100 px-2 py-1 text-xs font-medium text-gray-600 dark:bg-gray-800 dark:text-gray-400 sm:inline-block"
+          class="hidden rounded bg-gray-100 px-2 py-1 text-xs text-gray-600 dark:bg-gray-800 dark:text-gray-400 sm:inline-flex"
         >
           {{ databaseService.type }}
-        </span>
+        </Badge>
         <!-- Redis connection status -->
         <span
           v-if="isRedis && databaseService?.status === 'running'"

--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -9,6 +9,7 @@ import Tabs from '@/components/ui/tabs/Tabs.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 import { useQueryState } from '@/composables/useQueryState'
 import { useEventSource } from '@/composables/sse'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 defineOptions({
   layout: AppLayout
@@ -842,16 +843,17 @@ async function copyToken() {
               ]"
             >
               <span>{{ tab.label }}</span>
-              <span
+              <Badge
                 v-if="tab.count !== undefined"
                 :class="[
-                  'rounded-full px-1.5 py-0.5 text-[10px] font-medium',
+                  'px-1.5 py-0.5 text-[10px] tabular-nums',
                   activeTab === tab.id
                     ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
                     : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
                 ]"
-                >{{ compactNumber(tab.count) }}</span
               >
+                {{ compactNumber(tab.count) }}
+              </Badge>
             </button>
           </nav>
         </div>
@@ -2074,11 +2076,11 @@ async function copyToken() {
                 class="flex w-full items-center gap-3 p-4 text-left"
               >
                 <!-- Count badge -->
-                <span
-                  class="inline-flex h-7 min-w-[1.75rem] shrink-0 items-center justify-center rounded-full bg-red-50 px-2 text-xs font-bold text-red-600 dark:bg-red-900/20 dark:text-red-400"
+                <Badge
+                  class="min-w-7 h-7 shrink-0 justify-center bg-red-50 px-2 text-xs font-bold tabular-nums text-red-600 dark:bg-red-900/20 dark:text-red-400"
                 >
                   {{ group.count }}
-                </span>
+                </Badge>
 
                 <!-- Exception info -->
                 <div class="min-w-0 flex-1">

--- a/assets/js/pages/projects/show.vue
+++ b/assets/js/pages/projects/show.vue
@@ -3,6 +3,7 @@ import { Link, Head } from '@inertiajs/vue3'
 import { inject } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
 import DeploymentHistory from '@/components/DeploymentHistory.vue'
+import Badge from '@/components/ui/badge/Badge.vue'
 
 defineOptions({
   layout: AppLayout
@@ -261,20 +262,20 @@ function timeAgo(date) {
               <span class="font-medium text-gray-900 dark:text-white">{{
                 env.name
               }}</span>
-              <span
+              <Badge
                 v-if="env.isProduction"
-                class="inline-flex rounded bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
+                class="rounded bg-amber-100 px-1.5 py-0.5 text-[10px] text-amber-700 dark:bg-amber-900/30 dark:text-amber-400"
               >
                 Production
-              </span>
-              <span
+              </Badge>
+              <Badge
                 :class="[
-                  'inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium',
+                  'rounded-md px-2 py-0.5 text-xs',
                   badgeClasses(statusBadge(env).color)
                 ]"
               >
                 {{ statusBadge(env).label }}
-              </span>
+              </Badge>
             </div>
             <div class="flex items-center space-x-4">
               <span class="text-sm text-gray-500 dark:text-gray-400">

--- a/tests/unit/assets/klean-badge-adoption.test.js
+++ b/tests/unit/assets/klean-badge-adoption.test.js
@@ -1,0 +1,60 @@
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+const { test } = require('sounding')
+
+const SURFACES = [
+  'assets/js/pages/projects/show.vue',
+  'assets/js/pages/projects/app.vue',
+  'assets/js/pages/lookout/index.vue',
+  'assets/js/pages/projects/lookout.vue',
+  'assets/js/pages/bosun/index.vue',
+  'assets/js/pages/projects/dock.vue',
+  'assets/js/layouts/AppLayout.vue',
+  'assets/js/components/DeploymentOutcome.vue',
+  'assets/js/components/DeploymentHistory.vue',
+  'assets/js/components/bridge/BridgeFieldValue.vue',
+  'assets/js/components/bridge/BridgeFilterMenu.vue'
+]
+
+function source(path) {
+  return readFileSync(resolve(path), 'utf8')
+}
+
+test('Slipway composes passive status, count, and type metadata with Klean Badge', ({
+  expect
+}) => {
+  for (const path of SURFACES) {
+    const contents = source(path)
+    expect(contents).toContain(
+      "import Badge from '@/components/ui/badge/Badge.vue'"
+    )
+    expect(contents).toContain('<Badge')
+    expect(/<Badge[^>]*\bvariant=/.test(contents)).toBe(false)
+  }
+
+  const badge = source('assets/js/components/ui/badge/Badge.vue')
+  expect(badge).toContain('data-slot="badge"')
+  expect(badge).toContain('<span')
+  expect(badge.includes('href')).toBe(false)
+  expect(badge.includes('@click')).toBe(false)
+})
+
+test('Badge callers retain application-owned meaning and presentation', ({
+  expect
+}) => {
+  const project = source('assets/js/pages/projects/show.vue')
+  expect(project).toContain('badgeClasses(statusBadge(env).color)')
+  expect(project).toContain('<Link')
+
+  const app = source('assets/js/pages/projects/app.vue')
+  expect(app).toContain('appStatusClasses(app).bg')
+  expect(app).toContain('statusBadge(service.status).classes')
+
+  const deployment = source('assets/js/components/DeploymentOutcome.vue')
+  expect(deployment).toContain('presentation.classes')
+  expect(deployment).toContain('currently serving traffic')
+
+  const bosun = source('assets/js/pages/bosun/index.vue')
+  expect(bosun).toContain('statusColor(activity.status)')
+  expect(bosun).toContain('tabular-nums')
+})


### PR DESCRIPTION
Closes #488

## Summary
- copy the zero-configuration Klean Badge into Slipway
- replace repeated passive status, count, environment, and type metadata across project, deployment, Lookout, Bosun, Dock, Bridge, and layout surfaces
- preserve every existing link and button while callers retain their application-owned Tailwind classes and meaning

## Verification
- npm run lint
- 331 unit tests
- 105 functional tests
- representative Deployment History, Dock, Lookout, and Bosun browser trials
- focused Klean Badge adoption contract