### PR TITLE
feat(ui): adopt Klean telemetry charts

### DIFF
--- a/assets/js/components/ui/line-chart/LineChart.vue
+++ b/assets/js/components/ui/line-chart/LineChart.vue
@@ -1,0 +1,334 @@
+<script setup>
+import { computed, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  data: { type: Array, default: () => [] },
+  caption: { type: String, required: true },
+  emptyLabel: { type: String, default: 'No data' },
+  formatValue: { type: Function, default: (value) => String(value) }
+})
+
+const attrs = useAttrs()
+const width = 640
+const height = 200
+const inset = 8
+const cornerRadius = 20
+const guides = [inset, height / 2, height - inset]
+
+function finiteValue(point) {
+  return Number.isFinite(point?.value) ? point.value : undefined
+}
+
+function geometry(data) {
+  const values = data.map(finiteValue).filter((value) => value !== undefined)
+  if (!values.length) {
+    return { segments: [], points: [], minimum: undefined, maximum: undefined }
+  }
+
+  const minimum = Math.min(...values)
+  const maximum = Math.max(...values)
+  let domainMinimum = minimum
+  let domainMaximum = maximum
+  if (domainMinimum === domainMaximum) {
+    const padding = Math.max(Math.abs(domainMinimum) * 0.1, 1)
+    domainMinimum -= padding
+    domainMaximum += padding
+  }
+
+  const x = (index) =>
+    data.length === 1
+      ? width / 2
+      : inset + (index / (data.length - 1)) * (width - inset * 2)
+  const y = (value) =>
+    inset +
+    ((domainMaximum - value) / (domainMaximum - domainMinimum)) *
+      (height - inset * 2)
+
+  const segments = []
+  const points = []
+  let segment = []
+
+  data.forEach((point, index) => {
+    const value = finiteValue(point)
+    if (value === undefined) {
+      if (segment.length) segments.push(segment)
+      segment = []
+      return
+    }
+
+    const coordinate = { x: x(index), y: y(value), index }
+    points.push(coordinate)
+    segment.push(coordinate)
+  })
+  if (segment.length) segments.push(segment)
+
+  return { segments, points, minimum, maximum }
+}
+
+const chart = computed(() => geometry(props.data))
+const hasValues = computed(() => chart.value.points.length > 0)
+const firstLabel = computed(() => props.data[0]?.label ?? '')
+const middleLabel = computed(() =>
+  props.data.length > 2
+    ? props.data[Math.floor((props.data.length - 1) / 2)]?.label ?? ''
+    : ''
+)
+const lastLabel = computed(() =>
+  props.data.length > 1 ? props.data.at(-1)?.label ?? '' : ''
+)
+const currentPoint = computed(() => chart.value.points.at(-1))
+const forwardedAttrs = computed(() => {
+  const { class: _class, 'data-slot': _dataSlot, ...rest } = attrs
+  return rest
+})
+
+function compact(value) {
+  return Number(value.toFixed(2))
+}
+
+function roundedPath(segment) {
+  if (segment.length < 2) return ''
+
+  let path = `M ${compact(segment[0].x)} ${compact(segment[0].y)}`
+
+  for (let index = 1; index < segment.length - 1; index += 1) {
+    const previous = segment[index - 1]
+    const point = segment[index]
+    const next = segment[index + 1]
+    const previousDistance = Math.hypot(
+      point.x - previous.x,
+      point.y - previous.y
+    )
+    const nextDistance = Math.hypot(next.x - point.x, next.y - point.y)
+    const radius = Math.min(
+      cornerRadius,
+      previousDistance / 3,
+      nextDistance / 3
+    )
+    const before = {
+      x: point.x + ((previous.x - point.x) / previousDistance) * radius,
+      y: point.y + ((previous.y - point.y) / previousDistance) * radius
+    }
+    const after = {
+      x: point.x + ((next.x - point.x) / nextDistance) * radius,
+      y: point.y + ((next.y - point.y) / nextDistance) * radius
+    }
+
+    path += ` L ${compact(before.x)} ${compact(before.y)} Q ${compact(
+      point.x
+    )} ${compact(point.y)} ${compact(after.x)} ${compact(after.y)}`
+  }
+
+  const last = segment.at(-1)
+  return `${path} L ${compact(last.x)} ${compact(last.y)}`
+}
+
+function exactValue(point) {
+  if (point?.detail) return point.detail
+  const value = finiteValue(point)
+  return value === undefined ? props.emptyLabel : props.formatValue(value)
+}
+
+function pointLabel(point) {
+  const value = exactValue(point)
+  return point?.detail || !point?.label ? value : `${point.label}: ${value}`
+}
+
+function pointStyle(point) {
+  return {
+    left: `${(point.x / width) * 100}%`,
+    top: `${(point.y / height) * 100}%`
+  }
+}
+
+function tipPosition(point) {
+  const horizontal =
+    point.x <= width * 0.2
+      ? 'left-1/2'
+      : point.x >= width * 0.8
+      ? 'right-1/2'
+      : 'left-1/2 -translate-x-1/2'
+  const vertical =
+    point.y <= height * 0.32 ? 'top-full mt-1.5' : 'bottom-full mb-1.5'
+
+  return [
+    'pointer-events-none absolute z-10 w-max max-w-52 rounded-md bg-gray-950 px-2.5 py-1.5 text-xs font-medium text-white opacity-0 shadow-lg group-hover:opacity-100 group-focus:opacity-100 dark:bg-white dark:text-gray-950',
+    horizontal,
+    vertical
+  ]
+}
+</script>
+
+<template>
+  <figure
+    v-bind="forwardedAttrs"
+    data-slot="line-chart"
+    :class="
+      twMerge(
+        'grid h-56 grid-cols-[auto_minmax(0,1fr)] grid-rows-[auto_minmax(0,1fr)_auto] gap-x-3 gap-y-2 text-gray-950 dark:text-white',
+        attrs.class
+      )
+    "
+  >
+    <figcaption
+      data-slot="line-chart-caption"
+      class="col-span-2 text-sm font-semibold"
+    >
+      {{ caption }}
+    </figcaption>
+
+    <div
+      v-if="hasValues"
+      data-slot="line-chart-scale"
+      :class="[
+        'min-w-8 row-start-2 grid text-right text-[11px] tabular-nums leading-none text-gray-500 dark:text-gray-400',
+        chart.minimum === chart.maximum
+          ? 'place-items-center'
+          : 'content-between'
+      ]"
+    >
+      <span>{{ formatValue(chart.maximum) }}</span>
+      <span v-if="chart.minimum !== chart.maximum">
+        {{ formatValue(chart.minimum) }}
+      </span>
+    </div>
+
+    <div
+      v-if="hasValues"
+      data-slot="line-chart-plot"
+      class="relative col-start-2 row-start-2 min-h-0"
+    >
+      <svg
+        data-slot="line-chart-graphic"
+        aria-hidden="true"
+        focusable="false"
+        viewBox="0 0 640 200"
+        preserveAspectRatio="none"
+        fill="none"
+        class="h-full w-full overflow-visible"
+      >
+        <g
+          data-slot="line-chart-guides"
+          class="text-gray-200 dark:text-gray-800"
+        >
+          <line
+            v-for="guide in guides"
+            :key="guide"
+            data-slot="line-chart-guide"
+            :x1="inset"
+            :x2="width - inset"
+            :y1="guide"
+            :y2="guide"
+            stroke="currentColor"
+            stroke-width="1"
+            vector-effect="non-scaling-stroke"
+          />
+        </g>
+        <template v-for="(segment, index) in chart.segments" :key="index">
+          <path
+            v-if="segment.length > 1"
+            data-slot="line-chart-line"
+            :d="roundedPath(segment)"
+            stroke="currentColor"
+            stroke-width="2.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            vector-effect="non-scaling-stroke"
+          />
+        </template>
+        <circle
+          v-for="point in chart.points"
+          :key="point.index"
+          data-slot="line-chart-point"
+          :cx="point.x"
+          :cy="point.y"
+          r="2.25"
+          fill="currentColor"
+          opacity="0.38"
+          vector-effect="non-scaling-stroke"
+        />
+        <template v-if="currentPoint">
+          <circle
+            data-slot="line-chart-current-halo"
+            :cx="currentPoint.x"
+            :cy="currentPoint.y"
+            r="7"
+            fill="currentColor"
+            opacity="0.14"
+            vector-effect="non-scaling-stroke"
+          />
+          <circle
+            data-slot="line-chart-current"
+            :cx="currentPoint.x"
+            :cy="currentPoint.y"
+            r="3.5"
+            fill="currentColor"
+            vector-effect="non-scaling-stroke"
+          />
+        </template>
+      </svg>
+
+      <div
+        data-slot="line-chart-values"
+        role="list"
+        :aria-label="`${caption} values`"
+        class="pointer-events-none absolute inset-0"
+      >
+        <span v-for="point in chart.points" :key="point.index" role="listitem">
+          <button
+            type="button"
+            data-slot="line-chart-hit"
+            :aria-label="`Inspect ${pointLabel(data[point.index])}`"
+            :style="pointStyle(point)"
+            class="size-7 group pointer-events-auto absolute -translate-x-1/2 -translate-y-1/2 cursor-crosshair rounded-full outline-none focus-visible:ring-2 focus-visible:ring-current focus-visible:ring-offset-2 dark:focus-visible:ring-offset-gray-950"
+          >
+            <span
+              data-slot="line-chart-hover-point"
+              aria-hidden="true"
+              class="size-2.5 absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-current opacity-0 ring-2 ring-white group-hover:opacity-100 group-focus:opacity-100 dark:ring-gray-950"
+            />
+            <span
+              data-slot="line-chart-tip"
+              aria-hidden="true"
+              :class="tipPosition(point)"
+            >
+              {{ pointLabel(data[point.index]) }}
+            </span>
+          </button>
+        </span>
+        <template v-for="(point, index) in data" :key="`missing-${index}`">
+          <span
+            v-if="finiteValue(point) === undefined"
+            role="listitem"
+            class="sr-only"
+          >
+            {{ pointLabel(point) }}
+          </span>
+        </template>
+      </div>
+    </div>
+    <p
+      v-else
+      data-slot="line-chart-empty"
+      class="min-h-32 col-span-2 grid place-items-center text-sm text-gray-500 dark:text-gray-400"
+    >
+      {{ emptyLabel }}
+    </p>
+
+    <div
+      v-if="hasValues"
+      data-slot="line-chart-labels"
+      :class="[
+        'col-start-2 row-start-3 flex text-xs tabular-nums text-gray-500 dark:text-gray-400',
+        lastLabel ? 'justify-between' : 'justify-center'
+      ]"
+    >
+      <span>{{ firstLabel }}</span>
+      <span v-if="middleLabel">{{ middleLabel }}</span>
+      <span v-if="lastLabel">{{ lastLabel }}</span>
+    </div>
+  </figure>
+</template>

--- a/assets/js/components/ui/sparkline/Sparkline.vue
+++ b/assets/js/components/ui/sparkline/Sparkline.vue
@@ -1,0 +1,113 @@
+<script setup>
+import { computed, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({ inheritAttrs: false })
+
+const props = defineProps({
+  data: { type: Array, default: () => [] },
+  label: { type: String, default: undefined }
+})
+
+const attrs = useAttrs()
+const width = 120
+const height = 24
+const inset = 1.5
+
+function finiteValue(point) {
+  return Number.isFinite(point?.value) ? point.value : undefined
+}
+
+function geometry(data) {
+  const values = data.map(finiteValue).filter((value) => value !== undefined)
+  if (!values.length) return { segments: [], points: [] }
+
+  let minimum = Math.min(0, ...values)
+  let maximum = Math.max(0, ...values)
+  if (minimum === maximum) {
+    minimum -= 1
+    maximum += 1
+  }
+
+  const x = (index) =>
+    data.length === 1
+      ? width / 2
+      : inset + (index / (data.length - 1)) * (width - inset * 2)
+  const y = (value) =>
+    inset + ((maximum - value) / (maximum - minimum)) * (height - inset * 2)
+
+  const segments = []
+  const points = []
+  let segment = []
+
+  data.forEach((point, index) => {
+    const value = finiteValue(point)
+    if (value === undefined) {
+      if (segment.length) segments.push(segment)
+      segment = []
+      return
+    }
+
+    const coordinate = { x: x(index), y: y(value) }
+    points.push(coordinate)
+    segment.push(coordinate)
+  })
+  if (segment.length) segments.push(segment)
+
+  return { segments, points }
+}
+
+const chart = computed(() => geometry(props.data))
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    role: _role,
+    'aria-label': _ariaLabel,
+    'aria-hidden': _ariaHidden,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+  return rest
+})
+
+function coordinates(segment) {
+  return segment.map((point) => `${point.x},${point.y}`).join(' ')
+}
+</script>
+
+<template>
+  <svg
+    v-bind="forwardedAttrs"
+    data-slot="sparkline"
+    :role="label ? 'img' : undefined"
+    :aria-label="label"
+    :aria-hidden="label ? undefined : 'true'"
+    focusable="false"
+    viewBox="0 0 120 24"
+    preserveAspectRatio="none"
+    fill="none"
+    :class="twMerge('w-30 h-6 overflow-visible', attrs.class)"
+  >
+    <template v-for="(segment, index) in chart.segments" :key="index">
+      <polyline
+        v-if="segment.length > 1"
+        data-slot="sparkline-line"
+        :points="coordinates(segment)"
+        stroke="currentColor"
+        stroke-width="1.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        vector-effect="non-scaling-stroke"
+      />
+      <circle
+        v-else
+        data-slot="sparkline-point"
+        :cx="segment[0].x"
+        :cy="segment[0].y"
+        r="1.75"
+        fill="currentColor"
+        vector-effect="non-scaling-stroke"
+      />
+    </template>
+  </svg>
+</template>

--- a/assets/js/lib/telemetry-chart-data.mjs
+++ b/assets/js/lib/telemetry-chart-data.mjs
@@ -1,0 +1,24 @@
+export function toPercentChartData(
+  samples,
+  valueKey,
+  timestampKey,
+  formatTime
+) {
+  return (samples || []).map((sample) => {
+    const rawValue = sample[valueKey]
+    const value =
+      rawValue === null || rawValue === '' ? undefined : Number(rawValue)
+    const timestamp = sample[timestampKey]
+    const label =
+      timestamp === undefined || timestamp === null ? '' : formatTime(timestamp)
+    const formattedValue = Number.isFinite(value)
+      ? `${value.toFixed(1)}%`
+      : 'sample unavailable'
+
+    return {
+      label,
+      value: Number.isFinite(value) ? value : undefined,
+      detail: label ? `${label}, ${formattedValue}` : formattedValue
+    }
+  })
+}

--- a/assets/js/pages/projects/lookout.vue
+++ b/assets/js/pages/projects/lookout.vue
@@ -10,6 +10,9 @@ import Spinner from '@/components/SlipwaySpinner.vue'
 import { useQueryState } from '@/composables/useQueryState'
 import { useEventSource } from '@/composables/sse'
 import Badge from '@/components/ui/badge/Badge.vue'
+import LineChart from '@/components/ui/line-chart/LineChart.vue'
+import Sparkline from '@/components/ui/sparkline/Sparkline.vue'
+import { toPercentChartData } from '@/lib/telemetry-chart-data.mjs'
 
 defineOptions({
   layout: AppLayout
@@ -473,18 +476,12 @@ function hitRateColor(rate) {
   return 'text-red-600 dark:text-red-400'
 }
 
-function sparklinePoints(history, key, width = 120, height = 24) {
-  if (!history || history.length < 2) return ''
-  const values = history.map((h) => h[key])
-  const max = Math.max(...values, 1)
-  const step = width / (values.length - 1)
-  return values
-    .map((v, i) => `${i * step},${height - (v / max) * height}`)
-    .join(' ')
+function metricChartData(samples, key, timestampKey) {
+  return toPercentChartData(samples, key, timestampKey, formatTime)
 }
 
-function sparklineColor(key) {
-  return key === 'cpu' ? '#10b981' : '#3b82f6'
+function formatPercent(value) {
+  return `${Number(value).toFixed(1)}%`
 }
 
 function highlightQuery(query) {
@@ -512,119 +509,6 @@ function highlightQuery(query) {
 function cleanIp(ip) {
   if (!ip) return ''
   return ip.replace(/^::ffff:/, '')
-}
-
-// Chart hover (throttled to one update per animation frame)
-const chartHover = ref(null)
-let hoverRaf = null
-
-function onChartHover(event, data, key, chartId) {
-  if (hoverRaf) return
-  // Capture event values synchronously — currentTarget is null after handler returns
-  const svg = event.currentTarget
-  const clientX = event.clientX
-  hoverRaf = requestAnimationFrame(() => {
-    hoverRaf = null
-    if (!svg) return
-    const rect = svg.getBoundingClientRect()
-    const fraction = Math.max(
-      0,
-      Math.min(1, (clientX - rect.left) / rect.width)
-    )
-    const nearest = Math.round(fraction * (data.length - 1))
-    // Snap to local peak within ±5 points so spikes are easier to inspect
-    const lo = Math.max(0, nearest - 5)
-    const hi = Math.min(data.length - 1, nearest + 5)
-    let index = nearest
-    for (let i = lo; i <= hi; i++) {
-      if (data[i][key] > data[index][key]) index = i
-    }
-    const item = data[index]
-    if (!item) return
-    const value = item[key]
-    const wrapper = svg.parentElement
-    const wrapperRect = wrapper.getBoundingClientRect()
-    const x = clientX - wrapperRect.left
-    const w = wrapperRect.width
-    // Clamp tooltip center so it stays within chart bounds
-    const isDetail = chartId.startsWith('detail-')
-    const tipHalf = isDetail ? 70 : 25
-    const tipX = Math.max(tipHalf, Math.min(x, w - tipHalf))
-    chartHover.value = {
-      chartId,
-      index,
-      x: tipX,
-      value: typeof value === 'number' ? value.toFixed(1) : value,
-      label: item.recordedAt ? formatTime(item.recordedAt) : null
-    }
-  })
-}
-
-function onChartLeave() {
-  if (hoverRaf) {
-    cancelAnimationFrame(hoverRaf)
-    hoverRaf = null
-  }
-  chartHover.value = null
-}
-
-// Cached max values — recomputed only when data changes, not on every mousemove
-const sparklineMaxCache = new WeakMap()
-
-function getSparklineMax(history, key) {
-  let cache = sparklineMaxCache.get(history)
-  if (!cache) {
-    cache = {}
-    sparklineMaxCache.set(history, cache)
-  }
-  if (cache[key] === undefined) {
-    let max = 1
-    for (let i = 0; i < history.length; i++) {
-      if (history[i][key] > max) max = history[i][key]
-    }
-    cache[key] = max
-  }
-  return cache[key]
-}
-
-function sparklineHoverPoint(history, key, index, width = 120, height = 24) {
-  const max = getSparklineMax(history, key)
-  const step = width / (history.length - 1)
-  return { x: index * step, y: height - (history[index][key] / max) * height }
-}
-
-const detailMaxCache = new WeakMap()
-
-function getDetailMax(data, key) {
-  let cache = detailMaxCache.get(data)
-  if (!cache) {
-    cache = {}
-    detailMaxCache.set(data, cache)
-  }
-  if (cache[key] === undefined) {
-    let max = 1
-    for (let i = 0; i < data.length; i++) {
-      if (data[i][key] > max) max = data[i][key]
-    }
-    cache[key] = max
-  }
-  return cache[key]
-}
-
-function detailHoverPoint(data, key, index) {
-  const max = getDetailMax(data, key)
-  const x = (index / (data.length - 1)) * 400
-  const y = 80 - (data[index][key] / max) * 80
-  return { x, y }
-}
-
-function detailChartPoints(data, key) {
-  const max = getDetailMax(data, key)
-  return data
-    .map(
-      (m, i) => `${(i / (data.length - 1)) * 400},${80 - (m[key] / max) * 80}`
-    )
-    .join(' ')
 }
 
 const copiedTraceId = ref(null)
@@ -896,8 +780,11 @@ async function copyToken() {
             >
               <!-- Card header -->
               <button
+                type="button"
+                data-test="lookout-container"
+                :data-container="container.name"
                 @click="toggleExpand(container.name)"
-                class="flex w-full items-center justify-between p-4 text-left"
+                class="flex w-full cursor-pointer items-center justify-between p-4 text-left"
               >
                 <div class="flex items-center space-x-3">
                   <span
@@ -930,140 +817,26 @@ async function copyToken() {
                 <div class="flex items-center space-x-6">
                   <!-- Sparklines -->
                   <div
-                    v-if="container.history && container.history.length >= 2"
+                    v-if="container.history && container.history.length"
                     class="hidden items-center space-x-3 sm:flex"
                   >
                     <div class="flex flex-col items-end">
                       <span class="text-[10px] text-gray-400 dark:text-gray-500"
                         >CPU</span
                       >
-                      <div class="relative">
-                        <svg
-                          width="120"
-                          height="24"
-                          class="overflow-visible"
-                          @mousemove="
-                            onChartHover(
-                              $event,
-                              container.history,
-                              'cpu',
-                              'spark-cpu-' + container.name
-                            )
-                          "
-                          @mouseleave="onChartLeave"
-                        >
-                          <polyline
-                            :points="sparklinePoints(container.history, 'cpu')"
-                            fill="none"
-                            :stroke="sparklineColor('cpu')"
-                            stroke-width="1.5"
-                            stroke-linejoin="round"
-                          />
-                          <circle
-                            v-if="
-                              chartHover?.chartId ===
-                              'spark-cpu-' + container.name
-                            "
-                            :cx="
-                              sparklineHoverPoint(
-                                container.history,
-                                'cpu',
-                                chartHover.index
-                              ).x
-                            "
-                            :cy="
-                              sparklineHoverPoint(
-                                container.history,
-                                'cpu',
-                                chartHover.index
-                              ).y
-                            "
-                            r="3"
-                            fill="#10b981"
-                          />
-                        </svg>
-                        <div
-                          v-if="
-                            chartHover?.chartId ===
-                            'spark-cpu-' + container.name
-                          "
-                          class="pointer-events-none absolute z-10 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white shadow-lg dark:bg-white dark:text-gray-900"
-                          :style="{
-                            left: chartHover.x + 'px',
-                            bottom: '100%',
-                            transform: 'translateX(-50%)',
-                            marginBottom: '4px'
-                          }"
-                        >
-                          {{ chartHover.value }}%
-                        </div>
-                      </div>
+                      <Sparkline
+                        :data="metricChartData(container.history, 'cpu', 't')"
+                        class="w-30 h-6 text-emerald-500"
+                      />
                     </div>
                     <div class="flex flex-col items-end">
                       <span class="text-[10px] text-gray-400 dark:text-gray-500"
                         >Mem</span
                       >
-                      <div class="relative">
-                        <svg
-                          width="120"
-                          height="24"
-                          class="overflow-visible"
-                          @mousemove="
-                            onChartHover(
-                              $event,
-                              container.history,
-                              'mem',
-                              'spark-mem-' + container.name
-                            )
-                          "
-                          @mouseleave="onChartLeave"
-                        >
-                          <polyline
-                            :points="sparklinePoints(container.history, 'mem')"
-                            fill="none"
-                            :stroke="sparklineColor('mem')"
-                            stroke-width="1.5"
-                            stroke-linejoin="round"
-                          />
-                          <circle
-                            v-if="
-                              chartHover?.chartId ===
-                              'spark-mem-' + container.name
-                            "
-                            :cx="
-                              sparklineHoverPoint(
-                                container.history,
-                                'mem',
-                                chartHover.index
-                              ).x
-                            "
-                            :cy="
-                              sparklineHoverPoint(
-                                container.history,
-                                'mem',
-                                chartHover.index
-                              ).y
-                            "
-                            r="3"
-                            fill="#3b82f6"
-                          />
-                        </svg>
-                        <div
-                          v-if="
-                            chartHover?.chartId ===
-                            'spark-mem-' + container.name
-                          "
-                          class="pointer-events-none absolute z-10 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white shadow-lg dark:bg-white dark:text-gray-900"
-                          :style="{
-                            left: chartHover.x + 'px',
-                            bottom: '100%',
-                            transform: 'translateX(-50%)',
-                            marginBottom: '4px'
-                          }"
-                        >
-                          {{ chartHover.value }}%
-                        </div>
-                      </div>
+                      <Sparkline
+                        :data="metricChartData(container.history, 'mem', 't')"
+                        class="w-30 h-6 text-blue-500"
+                      />
                     </div>
                   </div>
 
@@ -1271,243 +1044,39 @@ async function copyToken() {
                       </div>
 
                       <!-- 24h chart -->
-                      <div v-if="detailMetrics && detailMetrics.length >= 2">
+                      <div v-if="detailMetrics">
                         <h3
                           class="mb-3 text-sm font-medium text-gray-700 dark:text-gray-300"
                         >
                           24-Hour History
                         </h3>
                         <div class="grid gap-4 sm:grid-cols-2">
-                          <div
-                            class="rounded-md border border-gray-100 p-3 dark:border-gray-800"
-                          >
-                            <div
-                              class="mb-2 text-xs text-gray-500 dark:text-gray-400"
-                            >
-                              CPU %
-                            </div>
-                            <div class="relative">
-                              <svg
-                                :viewBox="`0 0 400 80`"
-                                class="w-full overflow-visible"
-                                preserveAspectRatio="none"
-                                @mousemove="
-                                  onChartHover(
-                                    $event,
-                                    detailMetrics,
-                                    'cpuPercent',
-                                    'detail-cpu'
-                                  )
-                                "
-                                @mouseleave="onChartLeave"
-                              >
-                                <polyline
-                                  :points="
-                                    detailChartPoints(
-                                      detailMetrics,
-                                      'cpuPercent'
-                                    )
-                                  "
-                                  fill="none"
-                                  stroke="#10b981"
-                                  stroke-width="1.5"
-                                  vector-effect="non-scaling-stroke"
-                                />
-                                <template
-                                  v-if="chartHover?.chartId === 'detail-cpu'"
-                                >
-                                  <line
-                                    :x1="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'cpuPercent',
-                                        chartHover.index
-                                      ).x
-                                    "
-                                    :x2="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'cpuPercent',
-                                        chartHover.index
-                                      ).x
-                                    "
-                                    y1="0"
-                                    y2="80"
-                                    stroke="#9ca3af"
-                                    stroke-width="1"
-                                    stroke-dasharray="3 2"
-                                    vector-effect="non-scaling-stroke"
-                                  />
-                                  <circle
-                                    :cx="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'cpuPercent',
-                                        chartHover.index
-                                      ).x
-                                    "
-                                    :cy="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'cpuPercent',
-                                        chartHover.index
-                                      ).y
-                                    "
-                                    r="4"
-                                    fill="#10b981"
-                                    stroke="white"
-                                    stroke-width="2"
-                                    vector-effect="non-scaling-stroke"
-                                  />
-                                </template>
-                              </svg>
-                              <div
-                                v-if="chartHover?.chartId === 'detail-cpu'"
-                                class="pointer-events-none absolute z-10 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white shadow-lg dark:bg-white dark:text-gray-900"
-                                :style="{
-                                  left: chartHover.x + 'px',
-                                  bottom: '100%',
-                                  transform: 'translateX(-50%)',
-                                  marginBottom: '12px'
-                                }"
-                              >
-                                {{ chartHover.value }}%
-                                <span
-                                  v-if="chartHover.label"
-                                  class="ml-1 text-gray-400 dark:text-gray-500"
-                                  >{{ chartHover.label }}</span
-                                >
-                              </div>
-                            </div>
-                            <div
-                              class="mt-1 flex justify-between text-[10px] text-gray-400"
-                            >
-                              <span>{{
-                                formatTime(detailMetrics[0].recordedAt)
-                              }}</span>
-                              <span>{{
-                                formatTime(
-                                  detailMetrics[detailMetrics.length - 1]
-                                    .recordedAt
-                                )
-                              }}</span>
-                            </div>
-                          </div>
-                          <div
-                            class="rounded-md border border-gray-100 p-3 dark:border-gray-800"
-                          >
-                            <div
-                              class="mb-2 text-xs text-gray-500 dark:text-gray-400"
-                            >
-                              Memory %
-                            </div>
-                            <div class="relative">
-                              <svg
-                                :viewBox="`0 0 400 80`"
-                                class="w-full overflow-visible"
-                                preserveAspectRatio="none"
-                                @mousemove="
-                                  onChartHover(
-                                    $event,
-                                    detailMetrics,
-                                    'memoryPercent',
-                                    'detail-mem'
-                                  )
-                                "
-                                @mouseleave="onChartLeave"
-                              >
-                                <polyline
-                                  :points="
-                                    detailChartPoints(
-                                      detailMetrics,
-                                      'memoryPercent'
-                                    )
-                                  "
-                                  fill="none"
-                                  stroke="#3b82f6"
-                                  stroke-width="1.5"
-                                  vector-effect="non-scaling-stroke"
-                                />
-                                <template
-                                  v-if="chartHover?.chartId === 'detail-mem'"
-                                >
-                                  <line
-                                    :x1="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'memoryPercent',
-                                        chartHover.index
-                                      ).x
-                                    "
-                                    :x2="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'memoryPercent',
-                                        chartHover.index
-                                      ).x
-                                    "
-                                    y1="0"
-                                    y2="80"
-                                    stroke="#9ca3af"
-                                    stroke-width="1"
-                                    stroke-dasharray="3 2"
-                                    vector-effect="non-scaling-stroke"
-                                  />
-                                  <circle
-                                    :cx="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'memoryPercent',
-                                        chartHover.index
-                                      ).x
-                                    "
-                                    :cy="
-                                      detailHoverPoint(
-                                        detailMetrics,
-                                        'memoryPercent',
-                                        chartHover.index
-                                      ).y
-                                    "
-                                    r="4"
-                                    fill="#3b82f6"
-                                    stroke="white"
-                                    stroke-width="2"
-                                    vector-effect="non-scaling-stroke"
-                                  />
-                                </template>
-                              </svg>
-                              <div
-                                v-if="chartHover?.chartId === 'detail-mem'"
-                                class="pointer-events-none absolute z-10 whitespace-nowrap rounded bg-gray-900 px-2 py-1 text-xs text-white shadow-lg dark:bg-white dark:text-gray-900"
-                                :style="{
-                                  left: chartHover.x + 'px',
-                                  bottom: '100%',
-                                  transform: 'translateX(-50%)',
-                                  marginBottom: '12px'
-                                }"
-                              >
-                                {{ chartHover.value }}%
-                                <span
-                                  v-if="chartHover.label"
-                                  class="ml-1 text-gray-400 dark:text-gray-500"
-                                  >{{ chartHover.label }}</span
-                                >
-                              </div>
-                            </div>
-                            <div
-                              class="mt-1 flex justify-between text-[10px] text-gray-400"
-                            >
-                              <span>{{
-                                formatTime(detailMetrics[0].recordedAt)
-                              }}</span>
-                              <span>{{
-                                formatTime(
-                                  detailMetrics[detailMetrics.length - 1]
-                                    .recordedAt
-                                )
-                              }}</span>
-                            </div>
-                          </div>
+                          <LineChart
+                            :data="
+                              metricChartData(
+                                detailMetrics,
+                                'cpuPercent',
+                                'recordedAt'
+                              )
+                            "
+                            caption="CPU %"
+                            empty-label="No CPU metrics yet"
+                            :format-value="formatPercent"
+                            class="**:data-[slot=line-chart-caption]:font-normal **:data-[slot=line-chart-caption]:text-gray-500 **:data-[slot=line-chart-labels]:text-[10px] **:data-[slot=line-chart-scale]:text-[10px] dark:**:data-[slot=line-chart-caption]:text-gray-400 h-40 rounded-md border border-gray-100 p-3 text-emerald-500 dark:border-gray-800 dark:text-emerald-400"
+                          />
+                          <LineChart
+                            :data="
+                              metricChartData(
+                                detailMetrics,
+                                'memoryPercent',
+                                'recordedAt'
+                              )
+                            "
+                            caption="Memory %"
+                            empty-label="No memory metrics yet"
+                            :format-value="formatPercent"
+                            class="**:data-[slot=line-chart-caption]:font-normal **:data-[slot=line-chart-caption]:text-gray-500 **:data-[slot=line-chart-labels]:text-[10px] **:data-[slot=line-chart-scale]:text-[10px] dark:**:data-[slot=line-chart-caption]:text-gray-400 h-40 rounded-md border border-gray-100 p-3 text-blue-500 dark:border-gray-800 dark:text-blue-400"
+                          />
                         </div>
                       </div>
                     </div>

--- a/tests/e2e/pages/projects/lookout-telemetry-state.test.js
+++ b/tests/e2e/pages/projects/lookout-telemetry-state.test.js
@@ -30,6 +30,7 @@ test(
         app: app.id
       })
       .fetch()
+    const containerName = 'lookout-runtime-state-web'
     const screenshotRoot = path.resolve(
       '.tmp/screenshots/issue-376-lookout-runtime-state'
     )
@@ -37,7 +38,8 @@ test(
 
     await sails.models.app.updateOne({ id: app.id }).set({
       currentDeployment: deployment.id,
-      status: 'running'
+      status: 'running',
+      containerName
     })
     await sails.models.environment.updateOne({ id: environment.id }).set({
       features: { 'sails-hook-slipway': { version: '^0.0.9' } }
@@ -55,6 +57,28 @@ test(
         lastSeenAt: Date.now()
       })
       .fetch()
+    const recordedAt = Date.now()
+    await sails.models.containermetric.createEach(
+      [
+        { cpuPercent: 12, memoryPercent: 31 },
+        { cpuPercent: 27, memoryPercent: 39 },
+        { cpuPercent: 19, memoryPercent: 36 },
+        { cpuPercent: 44, memoryPercent: 48 }
+      ].map((metric, index) => ({
+        containerName,
+        containerType: 'app',
+        cpuPercent: metric.cpuPercent,
+        memoryUsage: (256 + index * 24) * 1024 * 1024,
+        memoryLimit: 1024 * 1024 * 1024,
+        memoryPercent: metric.memoryPercent,
+        netIO: `${index + 1}MB / ${index + 2}MB`,
+        blockIO: `${index + 3}MB / ${index + 4}MB`,
+        pids: 12 + index,
+        recordedAt: recordedAt - (3 - index) * 10 * 60_000,
+        environment: environment.id,
+        app: app.id
+      }))
+    )
 
     await login.withPassword('genesisUser', page, {
       password: current.auth.genesisUserPassword
@@ -66,11 +90,66 @@ test(
 
     await expect(page).toSee('Connected — waiting for traffic')
     await expect(page).not.toSee('Installation')
+    await expect(page.raw.locator('[data-slot="sparkline"]')).toHaveCount(2)
+    await expect(
+      page.raw.locator('[data-slot="sparkline"]').first()
+    ).toHaveAttribute('aria-hidden', 'true')
+    await page.raw
+      .locator(
+        `[data-test="lookout-container"][data-container="${containerName}"]`
+      )
+      .click()
+    const lineCharts = page.raw.locator('[data-slot="line-chart"]')
+    await expect(lineCharts).toHaveCount(2, { timeout: 15_000 })
+    await page.raw.waitForTimeout(250)
+    await expect(page).toSee('24-Hour History')
+    const chartPoints = page.raw.locator('[data-slot="line-chart-hit"]')
+    await expect(chartPoints).toHaveCount(8)
+    await chartPoints.first().focus()
+    await expect(chartPoints.first()).toBeFocused()
+    await expect(chartPoints.first()).toHaveAttribute(
+      'aria-label',
+      /Inspect .*12\.0%/
+    )
     expect(page).toHaveNoJavascriptErrors()
     await page.screenshot(path.join(screenshotRoot, 'connected-quiet.png'), {
       fullPage: true,
       animations: 'disabled'
     })
+    await page.inDarkMode()
+    await page.screenshot(
+      path.join(screenshotRoot, 'connected-quiet-dark.png'),
+      {
+        fullPage: true,
+        animations: 'disabled'
+      }
+    )
+    await page.resize(390, 844)
+    const mobileChartBoxes = await lineCharts.evaluateAll((charts) =>
+      charts.map((chart) => {
+        const box = chart.getBoundingClientRect()
+        return { left: box.left, right: box.right }
+      })
+    )
+    expect(
+      mobileChartBoxes.every(({ left, right }) => left >= 0 && right <= 390)
+    ).toBe(true)
+    await page.screenshot(
+      path.join(screenshotRoot, 'connected-quiet-mobile-dark.png'),
+      {
+        fullPage: true,
+        animations: 'disabled'
+      }
+    )
+    await page.inLightMode()
+    await page.screenshot(
+      path.join(screenshotRoot, 'connected-quiet-mobile.png'),
+      {
+        fullPage: true,
+        animations: 'disabled'
+      }
+    )
+    await page.resize(1440, 900)
 
     await sails.models.telemetryconnection
       .updateOne({ id: connection.id })

--- a/tests/unit/assets/telemetry-chart-data.test.js
+++ b/tests/unit/assets/telemetry-chart-data.test.js
@@ -1,0 +1,75 @@
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+const { test } = require('sounding')
+
+test('normalizes Slipway telemetry into exact Klean chart points', async ({
+  expect
+}) => {
+  const { toPercentChartData } = await import(
+    '../../../assets/js/lib/telemetry-chart-data.mjs'
+  )
+  const points = toPercentChartData(
+    [
+      { cpu: 4, t: 100 },
+      { cpu: '9.25', t: 200 },
+      { cpu: null, t: 300 },
+      { cpu: Number.NaN, t: 400 }
+    ],
+    'cpu',
+    't',
+    (timestamp) => `T${timestamp}`
+  )
+
+  expect(points).toEqual([
+    { label: 'T100', value: 4, detail: 'T100, 4.0%' },
+    { label: 'T200', value: 9.25, detail: 'T200, 9.3%' },
+    {
+      label: 'T300',
+      value: undefined,
+      detail: 'T300, sample unavailable'
+    },
+    {
+      label: 'T400',
+      value: undefined,
+      detail: 'T400, sample unavailable'
+    }
+  ])
+  expect(toPercentChartData(undefined, 'cpu', 't', String)).toEqual([])
+})
+
+test('Lookout delegates chart rendering to copied Klean source', ({
+  expect
+}) => {
+  const source = readFileSync(
+    resolve('assets/js/pages/projects/lookout.vue'),
+    'utf8'
+  )
+
+  expect(source).toContain(
+    "import LineChart from '@/components/ui/line-chart/LineChart.vue'"
+  )
+  expect(source).toContain(
+    "import Sparkline from '@/components/ui/sparkline/Sparkline.vue'"
+  )
+  expect(source).toContain("'cpuPercent',")
+  expect(source).toContain("'memoryPercent',")
+  expect(source).toContain(':format-value="formatPercent"')
+  expect(source.includes('function sparklinePoints')).toBe(false)
+  expect(source.includes('function detailChartPoints')).toBe(false)
+  expect(source.includes('function onChartHover')).toBe(false)
+
+  const lineChart = readFileSync(
+    resolve('assets/js/components/ui/line-chart/LineChart.vue'),
+    'utf8'
+  )
+  expect(lineChart).toContain('data-slot="line-chart-hit"')
+  expect(lineChart).toContain('group-focus:opacity-100')
+  expect(lineChart).toContain('role="list"')
+
+  const sparkline = readFileSync(
+    resolve('assets/js/components/ui/sparkline/Sparkline.vue'),
+    'utf8'
+  )
+  expect(sparkline).toContain('data-slot="sparkline"')
+  expect(sparkline).toContain(':aria-hidden="label ? undefined : \'true\'"')
+})


### PR DESCRIPTION
Closes #491

## Summary
- copy zero-configuration Klean Sparkline and Line Chart source into Slipway
- replace Lookout's duplicated SVG geometry and hover state while retaining live SSE, one-hour and 24-hour windows, percent meaning, and app-owned green/blue styling
- keep compact trends quiet beside exact current values and make every detailed sample keyboard inspectable with timestamp/value text and boundary-clamped tooltips
- preserve empty, single, flat, missing, responsive, light, and dark chart behavior through the Klean sources

## Verification
- npm run lint
- focused telemetry normalization and adoption unit contract: 2/2
- focused real Lookout browser trial: desktop/mobile, light/dark, sparklines, line charts, focus points, and viewport containment
- klean-ui check reports line-chart and sparkline current