### PR TITLE
feat(ui): adopt Klean Button on app actions

### DIFF
--- a/assets/js/components/ConfirmModal.vue
+++ b/assets/js/components/ConfirmModal.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { useId } from 'vue'
+import Button from '@/components/ui/button/Button.vue'
 import Dialog from '@/components/ui/dialog/Dialog.vue'
 import Spinner from '@/components/SlipwaySpinner.vue'
 
@@ -71,23 +72,24 @@ function handleOpenChange(open) {
     </p>
     <slot name="form" />
     <div class="mt-4 flex justify-end gap-3">
-      <button
+      <Button
         type="button"
         autofocus
         :disabled="loading"
-        class="cursor-pointer rounded-md border border-gray-300 px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:text-gray-300 dark:hover:bg-gray-800"
+        class="min-h-0 min-w-0 cursor-pointer rounded-md border border-gray-300 bg-transparent px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 active:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-gray-600 dark:bg-transparent dark:text-gray-300 dark:hover:bg-gray-800 dark:active:bg-gray-700"
         @click="cancel"
       >
         {{ cancelLabel }}
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
         :disabled="loading"
+        :aria-busy="loading ? 'true' : undefined"
         :class="[
-          'cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50',
+          'min-h-0 min-w-0 cursor-pointer rounded-md px-3 py-1.5 text-sm font-medium text-white disabled:cursor-not-allowed disabled:opacity-50',
           destructive
-            ? 'bg-red-600 hover:bg-red-700'
-            : 'bg-gray-900 hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100'
+            ? 'bg-red-600 hover:bg-red-700 active:bg-red-800 dark:bg-red-600 dark:text-white dark:hover:bg-red-700 dark:active:bg-red-800'
+            : 'bg-gray-900 hover:bg-gray-800 active:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 dark:active:bg-gray-200'
         ]"
         @click="confirm"
       >
@@ -96,7 +98,7 @@ function handleOpenChange(open) {
           Loading...
         </span>
         <span v-else>{{ confirmLabel }}</span>
-      </button>
+      </Button>
     </div>
   </Dialog>
 </template>

--- a/assets/js/components/ui/button/Button.vue
+++ b/assets/js/components/ui/button/Button.vue
@@ -1,0 +1,107 @@
+<script setup>
+import { computed, useAttrs } from 'vue'
+import { twMerge } from 'tailwind-merge'
+
+defineOptions({
+  inheritAttrs: false
+})
+
+const props = defineProps({
+  /**
+   * The rendered element. Pass an Inertia Link component directly when the
+   * destination should retain navigation semantics.
+   */
+  as: {
+    type: [String, Object, Function],
+    default: 'button',
+    validator: (value) =>
+      typeof value !== 'string' || ['button', 'a'].includes(value)
+  },
+  /** Native button type. Ignored when `as` does not render a button. */
+  type: {
+    type: String,
+    default: 'button',
+    validator: (value) => ['button', 'submit', 'reset'].includes(value)
+  },
+  /**
+   * Uses the native disabled attribute for buttons and accessible disabled
+   * link semantics for anchors or component links.
+   */
+  disabled: {
+    type: Boolean,
+    default: false
+  }
+})
+
+const attrs = useAttrs()
+
+const baseClasses = [
+  'inline-flex min-h-11 min-w-11 cursor-pointer select-none items-center justify-center gap-2 rounded-md no-underline',
+  'bg-gray-950 px-4 py-2 text-sm font-medium text-nowrap text-white',
+  'transition-colors duration-150 ease-out',
+  'hover:bg-gray-800 active:bg-gray-700',
+  'focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-500 dark:focus-visible:outline-gray-400',
+  'disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
+  'aria-disabled:pointer-events-none aria-disabled:cursor-not-allowed aria-disabled:opacity-50',
+  'dark:bg-white dark:text-gray-950 dark:hover:bg-gray-100 dark:active:bg-gray-200',
+  'motion-reduce:transition-none'
+]
+
+const isNativeButton = computed(() => props.as === 'button')
+
+const forwardedAttrs = computed(() => {
+  const {
+    class: _class,
+    tabindex: _tabindex,
+    'aria-disabled': _ariaDisabled,
+    'data-slot': _dataSlot,
+    ...rest
+  } = attrs
+
+  return rest
+})
+
+const buttonClasses = computed(() => twMerge(baseClasses, attrs.class))
+
+const managedAriaDisabled = computed(() => {
+  if (isNativeButton.value) return undefined
+  if (props.disabled) return 'true'
+  return attrs['aria-disabled']
+})
+
+const managedTabindex = computed(() => {
+  if (!isNativeButton.value && props.disabled) return -1
+  return attrs.tabindex
+})
+
+function guardDisabledClick(event) {
+  if (!props.disabled || isNativeButton.value) return
+
+  event.preventDefault()
+  event.stopImmediatePropagation()
+}
+
+function guardDisabledKeydown(event) {
+  if (!['Enter', ' '].includes(event.key)) return
+
+  guardDisabledClick(event)
+}
+</script>
+
+<template>
+  <component
+    :is="as"
+    v-bind="forwardedAttrs"
+    :type="isNativeButton ? type : undefined"
+    :disabled="isNativeButton ? disabled : undefined"
+    :aria-disabled="managedAriaDisabled"
+    :tabindex="managedTabindex"
+    :data-disabled="disabled ? '' : undefined"
+    data-slot="button"
+    :class="buttonClasses"
+    @click.capture="guardDisabledClick"
+    @keydown.capture="guardDisabledKeydown"
+  >
+    <slot />
+  </component>
+</template>

--- a/assets/js/pages/dashboard/index.vue
+++ b/assets/js/pages/dashboard/index.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Button from '@/components/ui/button/Button.vue'
 import Checkbox from '@/components/ui/checkbox/Checkbox.vue'
 import { Link, Head, useForm } from '@inertiajs/vue3'
 import { inject, ref, computed, nextTick } from 'vue'
@@ -244,14 +245,15 @@ function cancelDeleteProject() {
             placeholder="Search projects..."
             class="focus:border-brand w-full border-b border-dashed border-gray-200 bg-transparent px-1 py-1.5 text-sm text-gray-900 placeholder-gray-400 focus:outline-none dark:border-gray-700 dark:text-white dark:placeholder-gray-500 sm:w-64"
           />
-          <Link
+          <Button
+            :as="Link"
             href="/projects/new"
-            class="flex items-center space-x-1 rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+            class="min-h-0 min-w-0 gap-1 rounded-md bg-gray-900 px-3 py-2 text-sm font-medium text-white hover:bg-gray-800 active:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 dark:active:bg-gray-200"
           >
             <span>+</span>
             <span class="hidden sm:inline">Create Project</span>
             <span class="sm:hidden">New</span>
-          </Link>
+          </Button>
         </div>
 
         <!-- Table -->
@@ -552,13 +554,14 @@ function cancelDeleteProject() {
         <p class="mb-6 text-sm text-gray-500">
           Get started by creating your first project.
         </p>
-        <Link
+        <Button
+          :as="Link"
           href="/projects/new"
-          class="flex items-center space-x-1 rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+          class="min-h-0 min-w-0 gap-1 rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 active:bg-gray-700 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 dark:active:bg-gray-200"
         >
           <span>+</span>
           <span>Create Project</span>
-        </Link>
+        </Button>
       </EmptyState>
     </div>
 

--- a/assets/js/pages/teams/create.vue
+++ b/assets/js/pages/teams/create.vue
@@ -1,5 +1,6 @@
 <script setup>
 import Input from '@/components/ui/input/Input.vue'
+import Button from '@/components/ui/button/Button.vue'
 import { useForm, Head, Link } from '@inertiajs/vue3'
 import { inject } from 'vue'
 import AppLayout from '@/layouts/AppLayout.vue'
@@ -175,19 +176,21 @@ const sidebarCollapsed = inject('sidebarCollapsed')
             />
 
             <div class="flex items-center justify-end space-x-3 pt-4">
-              <Link
+              <Button
+                :as="Link"
                 href="/"
-                class="rounded-md px-3 py-1.5 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+                class="min-h-0 min-w-0 bg-transparent px-3 py-1.5 text-sm font-normal text-gray-500 hover:bg-transparent hover:text-gray-900 active:bg-transparent dark:bg-transparent dark:text-gray-400 dark:hover:bg-transparent dark:hover:text-white dark:active:bg-transparent"
               >
                 Cancel
-              </Link>
-              <button
+              </Button>
+              <Button
                 type="submit"
                 :disabled="form.processing || !form.name"
-                class="rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100"
+                :aria-busy="form.processing ? 'true' : undefined"
+                class="min-h-0 min-w-0 rounded-md bg-gray-900 px-4 py-2 text-sm font-medium text-white hover:bg-gray-800 active:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-white dark:text-gray-900 dark:hover:bg-gray-100 dark:active:bg-gray-200"
               >
                 {{ form.processing ? 'Creating...' : 'Create team' }}
-              </button>
+              </Button>
             </div>
           </form>
         </div>

--- a/tests/unit/assets/confirm-modal.test.js
+++ b/tests/unit/assets/confirm-modal.test.js
@@ -13,6 +13,9 @@ test('ConfirmModal composes Klean Dialog without rebuilding modal mechanics', ({
   expect(source).toContain(
     "import Dialog from '@/components/ui/dialog/Dialog.vue'"
   )
+  expect(source).toContain(
+    "import Button from '@/components/ui/button/Button.vue'"
+  )
   expect(source).toContain("import { useId } from 'vue'")
   expect(source).toContain(':dismissible="!loading"')
   expect(source).toContain(':aria-busy="loading ? \'true\' : undefined"')
@@ -20,4 +23,5 @@ test('ConfirmModal composes Klean Dialog without rebuilding modal mechanics', ({
   expect(source.includes('<Teleport')).toBe(false)
   expect(source.includes('role="dialog"')).toBe(false)
   expect(source.includes("document.addEventListener('keydown'")).toBe(false)
+  expect(source).toContain('<Button')
 })

--- a/tests/unit/assets/klean-button-adoption.test.js
+++ b/tests/unit/assets/klean-button-adoption.test.js
@@ -1,0 +1,64 @@
+const { readFileSync } = require('node:fs')
+const { resolve } = require('node:path')
+const { test } = require('sounding')
+
+function source(path) {
+  return readFileSync(resolve(path), 'utf8')
+}
+
+test('Slipway composes button-shaped navigation with Klean Button and Inertia Link', ({
+  expect
+}) => {
+  const teams = source('assets/js/pages/teams/create.vue')
+  const dashboard = source('assets/js/pages/dashboard/index.vue')
+
+  for (const contents of [teams, dashboard]) {
+    expect(contents).toContain(
+      "import Button from '@/components/ui/button/Button.vue'"
+    )
+    expect(contents).toContain(':as="Link"')
+    expect(contents).toContain('<Button')
+  }
+
+  expect(teams).toContain('href="/"')
+  expect(dashboard).toContain('href="/projects/new"')
+  expect(dashboard).toContain('<button')
+})
+
+test('Klean Button keeps form and confirmation behavior application-owned', ({
+  expect
+}) => {
+  const teams = source('assets/js/pages/teams/create.vue')
+  const confirmModal = source('assets/js/components/ConfirmModal.vue')
+
+  expect(teams).toContain('type="submit"')
+  expect(teams).toContain(':disabled="form.processing || !form.name"')
+  expect(teams).toContain(':aria-busy="form.processing ? \'true\' : undefined"')
+  expect(teams).toContain("form.post('/teams')")
+
+  expect(confirmModal).toContain(
+    "import Button from '@/components/ui/button/Button.vue'"
+  )
+  expect(confirmModal).toContain(
+    "import Spinner from '@/components/SlipwaySpinner.vue'"
+  )
+  expect(confirmModal).toContain(':disabled="loading"')
+  expect(confirmModal).toContain(':aria-busy="loading ? \'true\' : undefined"')
+  expect(confirmModal).toContain("emit('confirm')")
+  expect(confirmModal).toContain("emit('cancel')")
+  expect(confirmModal).toContain('bg-red-600')
+})
+
+test('the copied Button preserves native and disabled link semantics', ({
+  expect
+}) => {
+  const button = source('assets/js/components/ui/button/Button.vue')
+
+  expect(button).toContain("default: 'button'")
+  expect(button).toContain(':type="isNativeButton ? type : undefined"')
+  expect(button).toContain(':disabled="isNativeButton ? disabled : undefined"')
+  expect(button).toContain(':aria-disabled="managedAriaDisabled"')
+  expect(button).toContain(':tabindex="managedTabindex"')
+  expect(button).toContain('event.preventDefault()')
+  expect(button).toContain('twMerge(baseClasses, attrs.class)')
+})


### PR DESCRIPTION
Closes #492

## What changed
- install the copied Klean Button source in Slipway
- compose representative dashboard and team navigation with Inertia Link through the as prop
- adopt Button for native submit and confirmation actions while keeping Slipway-owned labels, density, colors, and mascot spinner
- keep icon, toggle, tab, and menu buttons native where Klean Button adds no behavior
- add focused Sounding contracts for native, disabled-link, form, and confirmation semantics

## Verification
- focused unit contracts: 4 passed
- focused browser trials: 3 passed
- Prettier: clean
- klean-ui check: button current